### PR TITLE
InstCountCI: Support f64 reduced precision mode tests

### DIFF
--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -1,0 +1,11706 @@
+{
+  "Features": {
+    "Env": {
+      "FEX_X87REDUCEDPRECISION": "1"
+    },
+    "Bitness": 64,
+    "EnabledHostFeatures": [],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256"
+    ]
+  },
+  "Instructions": {
+    "fadd dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 !11b /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr s2, [x4]",
+        "fcvt d2, s2",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 !11b /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr s2, [x4]",
+        "fcvt d2, s2",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fcom dword [rax]": {
+      "ExpectedInstructionCount": 22,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 !11b /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr s2, [x4]",
+        "fcvt d2, s2",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fcomp dword [rax]": {
+      "ExpectedInstructionCount": 30,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 !11b /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr s2, [x4]",
+        "fcvt d2, s2",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fsub dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 !11b /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr s2, [x4]",
+        "fcvt d2, s2",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 !11b /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr s2, [x4]",
+        "fcvt d2, s2",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 !11b /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr s2, [x4]",
+        "fcvt d2, s2",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 !11b /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr s2, [x4]",
+        "fcvt d2, s2",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st0, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc0 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st0, st1": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc1 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st0, st2": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc2 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st0, st3": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc3 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st0, st4": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc4 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st0, st5": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc5 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st0, st6": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc6 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st0, st7": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc7 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st0, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc8 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st0, st1": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc9 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st0, st2": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xca /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st0, st3": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xcb /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st0, st4": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xcc /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st0, st5": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xcd /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st0, st6": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xce /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st0, st7": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xcf /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fcom st0, st0": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xd0 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x0",
+        "add w22, w20, #0x0 (0)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x22, x20, #1, #1",
+        "ubfx x23, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w22, w22, w20",
+        "orr w23, w23, w20",
+        "strb w22, [x28, #744]",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w23, [x28, #750]"
+      ]
+    },
+    "fcom st0, st1": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xd1 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fcom st0, st2": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xd2 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fcom st0, st3": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xd3 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fcom st0, st4": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xd4 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fcom st0, st5": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xd5 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fcom st0, st6": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xd6 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fcom st0, st7": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xd7 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fcomp st0, st0": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xd8 /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x0",
+        "add w22, w20, #0x0 (0)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x22, eq",
+        "csinc x22, x22, xzr, vc",
+        "cset x1, lt",
+        "bfi x22, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x22, x1, #2, #1",
+        "ubfx x23, x22, #1, #1",
+        "ubfx x24, x22, #0, #1",
+        "ubfx x22, x22, #2, #1",
+        "orr w23, w23, w22",
+        "orr w24, w24, w22",
+        "strb w23, [x28, #744]",
+        "strb w21, [x28, #745]",
+        "strb w22, [x28, #746]",
+        "strb w24, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fcomp st0, st1": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xd9 /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x22, eq",
+        "csinc x22, x22, xzr, vc",
+        "cset x1, lt",
+        "bfi x22, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x22, x1, #2, #1",
+        "ubfx x23, x22, #1, #1",
+        "ubfx x24, x22, #0, #1",
+        "ubfx x22, x22, #2, #1",
+        "orr w23, w23, w22",
+        "orr w24, w24, w22",
+        "strb w23, [x28, #744]",
+        "mov w23, #0x0",
+        "strb w23, [x28, #745]",
+        "strb w22, [x28, #746]",
+        "strb w24, [x28, #750]",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fcomp st0, st2": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xda /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fcomp st0, st3": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xdb /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fcomp st0, st4": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xdc /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fcomp st0, st5": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xdd /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fcomp st0, st6": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xde /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fcomp st0, st7": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xdf /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fsub st0, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xe0 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st0, st1": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xe1 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st0, st2": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xe2 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st0, st3": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xe3 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st0, st4": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xe4 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st0, st5": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xe5 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st0, st6": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xe6 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st0, st7": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xe7 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st0, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xe8 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st0, st1": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xe9 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st0, st2": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xea /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st0, st3": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xeb /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st0, st4": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xec /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st0, st5": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xed /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st0, st6": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xee /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st0, st7": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xef /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st0, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xf0 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st0, st1": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xf1 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st0, st2": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xf2 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st0, st3": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xf3 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st0, st4": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xf4 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st0, st5": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xf5 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st0, st6": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xf6 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st0, st7": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xf7 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st0, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xf8 /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st0, st1": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xf9 /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st0, st2": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xfa /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st0, st3": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xfb /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st0, st4": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xfc /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st0, st5": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xfd /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st0, st6": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xfe /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st0, st7": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xff /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fld dword [rax]": {
+      "ExpectedInstructionCount": 13,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 !11b /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr s2, [x4]",
+        "fcvt d2, s2",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fst dword [rax]": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 !11b /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "fcvt s2, d2",
+        "str s2, [x4]"
+      ]
+    },
+    "fstp dword [rax]": {
+      "ExpectedInstructionCount": 13,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 !11b /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "fcvt s2, d2",
+        "str s2, [x4]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fldenv [rax]": {
+      "ExpectedInstructionCount": 55,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 !11b /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrh w20, [x4]",
+        "lsr w21, w20, #10",
+        "and w21, w21, #0x3",
+        "rbit w1, w21",
+        "lsr w1, w1, #30",
+        "mrs x0, fpcr",
+        "bfi x0, x1, #22, #2",
+        "lsr x1, x21, #2",
+        "bfi x0, x1, #24, #1",
+        "msr fpcr, x0",
+        "strh w20, [x28, #1008]",
+        "ldr w20, [x4, #4]",
+        "ubfx w21, w20, #11, #3",
+        "strb w21, [x28, #747]",
+        "ubfx w21, w20, #8, #1",
+        "ubfx w22, w20, #9, #1",
+        "ubfx w23, w20, #10, #1",
+        "ubfx w20, w20, #14, #1",
+        "strb w21, [x28, #744]",
+        "strb w22, [x28, #745]",
+        "strb w23, [x28, #746]",
+        "strb w20, [x28, #750]",
+        "ldr w20, [x4, #8]",
+        "ubfx w21, w20, #0, #2",
+        "cmp x21, #0x3 (3)",
+        "cset x21, ne",
+        "ubfx w22, w20, #2, #2",
+        "cmp x22, #0x3 (3)",
+        "cset x22, ne",
+        "orr w21, w21, w22, lsl #1",
+        "ubfx w22, w20, #4, #2",
+        "cmp x22, #0x3 (3)",
+        "cset x22, ne",
+        "orr w21, w21, w22, lsl #2",
+        "ubfx w22, w20, #6, #2",
+        "cmp x22, #0x3 (3)",
+        "cset x22, ne",
+        "orr w21, w21, w22, lsl #3",
+        "ubfx w22, w20, #8, #2",
+        "cmp x22, #0x3 (3)",
+        "cset x22, ne",
+        "orr w21, w21, w22, lsl #4",
+        "ubfx w22, w20, #10, #2",
+        "cmp x22, #0x3 (3)",
+        "cset x22, ne",
+        "orr w21, w21, w22, lsl #5",
+        "ubfx w22, w20, #12, #2",
+        "cmp x22, #0x3 (3)",
+        "cset x22, ne",
+        "orr w21, w21, w22, lsl #6",
+        "ubfx w20, w20, #14, #2",
+        "cmp x20, #0x3 (3)",
+        "cset x20, ne",
+        "orr w20, w21, w20, lsl #7",
+        "strb w20, [x28, #1010]"
+      ]
+    },
+    "fldcw [rax]": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 !11b /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrh w20, [x4]",
+        "lsr w21, w20, #10",
+        "and w21, w21, #0x3",
+        "rbit w1, w21",
+        "lsr w1, w1, #30",
+        "mrs x0, fpcr",
+        "bfi x0, x1, #22, #2",
+        "lsr x1, x21, #2",
+        "bfi x0, x1, #24, #1",
+        "msr fpcr, x0",
+        "strh w20, [x28, #1008]"
+      ]
+    },
+    "fnstenv [rax]": {
+      "ExpectedInstructionCount": 62,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 !11b /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrh w20, [x28, #1008]",
+        "str w20, [x4]",
+        "mov w20, #0x0",
+        "ldrb w21, [x28, #747]",
+        "mov x0, x20",
+        "bfi x0, x21, #11, #3",
+        "mov x21, x0",
+        "ldrb w22, [x28, #744]",
+        "ldrb w23, [x28, #745]",
+        "ldrb w24, [x28, #746]",
+        "ldrb w25, [x28, #750]",
+        "orr x21, x21, x22, lsl #8",
+        "orr x21, x21, x23, lsl #9",
+        "orr x21, x21, x24, lsl #10",
+        "orr x21, x21, x25, lsl #14",
+        "str w21, [x4, #4]",
+        "ldrb w21, [x28, #1010]",
+        "and w22, w21, #0x1",
+        "mov w23, #0x3",
+        "cmp x22, #0x0 (0)",
+        "csel x22, x23, x20, eq",
+        "orr w22, w20, w22",
+        "lsr w24, w21, #1",
+        "and w24, w24, #0x1",
+        "cmp x24, #0x0 (0)",
+        "csel x24, x23, x20, eq",
+        "orr w22, w22, w24, lsl #2",
+        "lsr w24, w21, #2",
+        "and w24, w24, #0x1",
+        "cmp x24, #0x0 (0)",
+        "csel x24, x23, x20, eq",
+        "orr w22, w22, w24, lsl #4",
+        "lsr w24, w21, #3",
+        "and w24, w24, #0x1",
+        "cmp x24, #0x0 (0)",
+        "csel x24, x23, x20, eq",
+        "orr w22, w22, w24, lsl #6",
+        "lsr w24, w21, #4",
+        "and w24, w24, #0x1",
+        "cmp x24, #0x0 (0)",
+        "csel x24, x23, x20, eq",
+        "orr w22, w22, w24, lsl #8",
+        "lsr w24, w21, #5",
+        "and w24, w24, #0x1",
+        "cmp x24, #0x0 (0)",
+        "csel x24, x23, x20, eq",
+        "orr w22, w22, w24, lsl #10",
+        "lsr w24, w21, #6",
+        "and w24, w24, #0x1",
+        "cmp x24, #0x0 (0)",
+        "csel x24, x23, x20, eq",
+        "orr w22, w22, w24, lsl #12",
+        "lsr w21, w21, #7",
+        "and w21, w21, #0x1",
+        "cmp x21, #0x0 (0)",
+        "csel x21, x23, x20, eq",
+        "orr w21, w22, w21, lsl #14",
+        "str w21, [x4, #8]",
+        "str w20, [x4, #12]",
+        "str w20, [x4, #16]",
+        "str w20, [x4, #20]",
+        "str w20, [x4, #24]"
+      ]
+    },
+    "fnstcw [rax]": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xd9 !11b /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrh w20, [x28, #1008]",
+        "strh w20, [x4]"
+      ]
+    },
+    "fld st0": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xc0 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fld st1": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xc1 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fld st2": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xc2 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fld st3": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xc3 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fld st4": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xc4 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fld st5": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xc5 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fld st6": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xc6 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fld st7": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xc7 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fxch st0, st0": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xc8 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "str q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fxch st0, st1": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xc9 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "str q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fxch st0, st2": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xca /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "str q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fxch st0, st3": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xcb /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "str q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fxch st0, st4": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xcc /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "str q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fxch st0, st5": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xcd /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "str q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fxch st0, st6": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xce /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "str q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fxch st0, st7": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xcf /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "str q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fnop": {
+      "ExpectedInstructionCount": 0,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xd9 11b 0xd0 /2"
+      ],
+      "ExpectedArm64ASM": []
+    },
+    "fchs": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xe0 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov x21, #0x8000000000000000",
+        "fmov d3, x21",
+        "eor v2.16b, v2.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fabs": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xe1 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "orr x21, xzr, #0x7fffffffffffffff",
+        "fmov d3, x21",
+        "and v2.16b, v2.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "ftst": {
+      "ExpectedInstructionCount": 21,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xe4 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov w20, #0x0",
+        "fmov d3, x20",
+        "fcmp d2, d3",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "strb w20, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]"
+      ]
+    },
+    "fxam": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xe5 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov x21, v2.d[0]",
+        "lsr x21, x21, #63",
+        "strb w21, [x28, #745]",
+        "ldrb w21, [x28, #1010]",
+        "lsr w20, w21, w20",
+        "mov w21, #0x1",
+        "and w20, w20, #0x1",
+        "mov w22, #0x0",
+        "cmp x20, #0x1 (1)",
+        "csel x21, x22, x21, eq",
+        "strb w21, [x28, #744]",
+        "strb w20, [x28, #746]",
+        "strb w21, [x28, #750]"
+      ]
+    },
+    "fld1": {
+      "ExpectedInstructionCount": 13,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xe8 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "mov x21, #0x3ff0000000000000",
+        "fmov d2, x21",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fldl2t": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xe9 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "mov x21, #0xa372",
+        "movk x21, #0x979, lsl #16",
+        "movk x21, #0x934f, lsl #32",
+        "movk x21, #0x400a, lsl #48",
+        "fmov d2, x21",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fldl2e": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xea /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "mov x21, #0x82fe",
+        "movk x21, #0x652b, lsl #16",
+        "movk x21, #0x1547, lsl #32",
+        "movk x21, #0x3ff7, lsl #48",
+        "fmov d2, x21",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fldpi": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xeb /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "mov x21, #0x2d18",
+        "movk x21, #0x5444, lsl #16",
+        "movk x21, #0x21fb, lsl #32",
+        "movk x21, #0x4009, lsl #48",
+        "fmov d2, x21",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fldlg2": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xec /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "mov x21, #0x79ff",
+        "movk x21, #0x509f, lsl #16",
+        "movk x21, #0x4413, lsl #32",
+        "movk x21, #0x3fd3, lsl #48",
+        "fmov d2, x21",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fldln2": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xed /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "mov x21, #0x39ef",
+        "movk x21, #0xfefa, lsl #16",
+        "movk x21, #0x2e42, lsl #32",
+        "movk x21, #0x3fe6, lsl #48",
+        "fmov d2, x21",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fldz": {
+      "ExpectedInstructionCount": 13,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xee /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "mov w21, #0x0",
+        "fmov d2, x21",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "f2xm1": {
+      "ExpectedInstructionCount": 48,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xf0 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1488]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fyl2x": {
+      "ExpectedInstructionCount": 59,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xf1 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "strb w21, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr d3, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "mov v1.8b, v3.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1496]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fptan": {
+      "ExpectedInstructionCount": 62,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xf2 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "ldrb w23, [x28, #1010]",
+        "lsl w21, w21, w22",
+        "orr w21, w23, w21",
+        "strb w21, [x28, #1010]",
+        "strb w22, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1472]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "mov x21, #0x3ff0000000000000",
+        "fmov d3, x21",
+        "mov w21, #0x0",
+        "strb w21, [x28, #746]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]",
+        "add x0, x28, x22, lsl #4",
+        "str d3, [x0, #752]"
+      ]
+    },
+    "fpatan": {
+      "ExpectedInstructionCount": 59,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xf3 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "strb w21, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr d3, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v3.8b",
+        "mov v1.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1480]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fxtract": {
+      "ExpectedInstructionCount": 23,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xf4 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "ldrb w23, [x28, #1010]",
+        "lsl w21, w21, w22",
+        "orr w21, w23, w21",
+        "strb w21, [x28, #1010]",
+        "strb w22, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "mov x21, v2.d[0]",
+        "and x23, x21, #0x7ff0000000000000",
+        "lsr x23, x23, #52",
+        "sub x23, x23, #0x3ff (1023)",
+        "scvtf d2, x23",
+        "and x21, x21, #0x800fffffffffffff",
+        "orr x21, x21, #0x3ff0000000000000",
+        "fmov d3, x21",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]",
+        "add x0, x28, x22, lsl #4",
+        "str d3, [x0, #752]"
+      ]
+    },
+    "fprem1": {
+      "ExpectedInstructionCount": 55,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xf5 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr d3, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "mov v1.8b, v3.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1512]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "mov w21, #0x0",
+        "strb w21, [x28, #746]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdecstp": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xd9 11b 0xf6 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fincstp": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xd9 11b 0xf7 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fprem": {
+      "ExpectedInstructionCount": 55,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xf8 /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr d3, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "mov v1.8b, v3.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1504]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "mov w21, #0x0",
+        "strb w21, [x28, #746]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fyl2xp1": {
+      "ExpectedInstructionCount": 62,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xf9 /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "strb w21, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr d3, [x0, #752]",
+        "mov x20, #0x3ff0000000000000",
+        "fmov d4, x20",
+        "fadd d2, d2, d4",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "mov v1.8b, v3.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1496]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsqrt": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xfa /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "fsqrt d2, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsincos": {
+      "ExpectedInstructionCount": 103,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xfb /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "ldrb w23, [x28, #1010]",
+        "lsl w21, w21, w22",
+        "orr w21, w23, w21",
+        "strb w21, [x28, #1010]",
+        "strb w22, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1456]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v3.8b, v0.8b",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1464]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "mov w21, #0x0",
+        "strb w21, [x28, #746]",
+        "add x0, x28, x20, lsl #4",
+        "str d3, [x0, #752]",
+        "add x0, x28, x22, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "frndint": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xfc /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "frinti d2, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fscale": {
+      "ExpectedInstructionCount": 53,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xfd /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr d3, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "mov v1.8b, v3.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1520]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsin": {
+      "ExpectedInstructionCount": 50,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xfe /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1456]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "mov w21, #0x0",
+        "strb w21, [x28, #746]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fcos": {
+      "ExpectedInstructionCount": 50,
+      "Optimal": "No",
+      "Comment": [
+        "0xd9 11b 0xff /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1464]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "mov w21, #0x0",
+        "strb w21, [x28, #746]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fiadd dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xda !11b /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr w21, [x4]",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fimul dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xda !11b /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr w21, [x4]",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "ficom dword [rax]": {
+      "ExpectedInstructionCount": 22,
+      "Optimal": "No",
+      "Comment": [
+        "0xda !11b /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr w21, [x4]",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "ficomp dword [rax]": {
+      "ExpectedInstructionCount": 30,
+      "Optimal": "No",
+      "Comment": [
+        "0xda !11b /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr w21, [x4]",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fisub dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xda !11b /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr w21, [x4]",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fisubr dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xda !11b /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr w21, [x4]",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fidiv dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xda !11b /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr w21, [x4]",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fidivr dword [rax]": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xda !11b /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr w21, [x4]",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fcmovb st0, st0": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xc0 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovb st0, st1": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xc1 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovb st0, st2": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xc2 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovb st0, st3": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xc3 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovb st0, st4": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xc4 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovb st0, st5": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xc5 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovb st0, st6": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xc6 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovb st0, st7": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xc7 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmove st0, st0": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xc8 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmove st0, st1": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xc9 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmove st0, st2": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xca /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmove st0, st3": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xcb /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmove st0, st4": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xcc /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmove st0, st5": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xcd /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmove st0, st6": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xce /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmove st0, st7": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xcf /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovbe st0, st0": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xd0 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovbe st0, st1": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xd1 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovbe st0, st2": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xd2 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovbe st0, st3": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xd3 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovbe st0, st4": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xd4 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovbe st0, st5": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xd5 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovbe st0, st6": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xd6 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovbe st0, st7": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xd7 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovu st0, st0": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xd8 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovu st0, st1": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xd9 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovu st0, st2": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xda /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovu st0, st3": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xdb /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovu st0, st4": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xdc /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovu st0, st5": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xdd /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovu st0, st6": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xde /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovu st0, st7": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xdf /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fucompp": {
+      "ExpectedInstructionCount": 37,
+      "Optimal": "No",
+      "Comment": [
+        "0xda 11b 0xe9 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x22, eq",
+        "csinc x22, x22, xzr, vc",
+        "cset x1, lt",
+        "bfi x22, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x22, x1, #2, #1",
+        "ubfx x23, x22, #1, #1",
+        "ubfx x24, x22, #0, #1",
+        "ubfx x22, x22, #2, #1",
+        "orr w23, w23, w22",
+        "orr w24, w24, w22",
+        "strb w23, [x28, #744]",
+        "mov w23, #0x0",
+        "strb w23, [x28, #745]",
+        "strb w22, [x28, #746]",
+        "strb w24, [x28, #750]",
+        "ldrb w22, [x28, #1010]",
+        "lsl w23, w21, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "lsl w21, w21, w20",
+        "bic w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fild dword [rax]": {
+      "ExpectedInstructionCount": 13,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf !11b /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "ldr w21, [x4]",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fisttp dword [rax]": {
+      "ExpectedInstructionCount": 13,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb !11b /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "fcvtzs w21, d2",
+        "str w21, [x4]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fist dword [rax]": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb !11b /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "frinti d0, d2",
+        "fcvtzs w20, d0",
+        "str w20, [x4]"
+      ]
+    },
+    "fistp dword [rax]": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf !11b /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "frinti d0, d2",
+        "fcvtzs w21, d0",
+        "str w21, [x4]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fld tword [rax]": {
+      "ExpectedInstructionCount": 56,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb !11b /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr q2, [x4]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v2.d[0]",
+        "umov w2, v2.h[4]",
+        "ldr x3, [x28, #1168]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fstp tword [rax]": {
+      "ExpectedInstructionCount": 59,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb !11b /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1152]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "str d2, [x4]",
+        "mov x21, v2.d[1]",
+        "strh w21, [x4, #8]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fcmovnb st0, st0": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xc0 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnb st0, st1": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xc1 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnb st0, st2": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xc2 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnb st0, st3": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xc3 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnb st0, st4": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xc4 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnb st0, st5": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xc5 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnb st0, st6": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xc6 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnb st0, st7": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xc7 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x20000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovne st0, st0": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xc8 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovne st0, st1": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xc9 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovne st0, st2": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xca /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovne st0, st3": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xcb /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovne st0, st4": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xcc /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovne st0, st5": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xcd /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovne st0, st6": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xce /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovne st0, st7": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xcf /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x40000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnbe st0, st0": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xd0 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnbe st0, st1": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xd1 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnbe st0, st2": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xd2 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnbe st0, st3": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xd3 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnbe st0, st4": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xd4 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnbe st0, st5": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xd5 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnbe st0, st6": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xd6 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnbe st0, st7": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xd7 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #728]",
+        "tst w20, #0x60000000",
+        "csetm x20, eq",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnu st0, st0": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xd8 /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnu st0, st1": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xd9 /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnu st0, st2": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xda /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnu st0, st3": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xdb /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnu st0, st4": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xdc /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnu st0, st5": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xdd /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnu st0, st6": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xde /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fcmovnu st0, st7": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xdf /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #706]",
+        "fmov s2, w20",
+        "cnt v2.16b, v2.16b",
+        "umov w20, v2.b[0]",
+        "tst w20, #0x1",
+        "csetm x20, ne",
+        "dup v2.2d, x20",
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q3, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "ldr q4, [x0, #752]",
+        "bsl v2.16b, v4.16b, v3.16b",
+        "add x0, x28, x20, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fnclex": {
+      "ExpectedInstructionCount": 0,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xe2 /4"
+      ],
+      "ExpectedArm64ASM": []
+    },
+    "fninit": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xe3 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w20, #0x37f",
+        "mov w21, #0x0",
+        "rbit w1, w21",
+        "lsr w1, w1, #30",
+        "mrs x0, fpcr",
+        "bfi x0, x1, #22, #2",
+        "lsr x1, x21, #2",
+        "bfi x0, x1, #24, #1",
+        "msr fpcr, x0",
+        "strh w20, [x28, #1008]",
+        "strb w21, [x28, #747]",
+        "strb w21, [x28, #744]",
+        "strb w21, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w21, [x28, #750]",
+        "strb w21, [x28, #1010]"
+      ]
+    },
+    "fucomi st0, st0": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xe8 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fucomi st0, st1": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xe9 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fucomi st0, st2": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xea /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fucomi st0, st3": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xeb /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fucomi st0, st4": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xec /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fucomi st0, st5": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xed /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fucomi st0, st6": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xee /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fucomi st0, st7": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xef /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fcomi st0, st0": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xf0 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fcomi st0, st1": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xf1 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fcomi st0, st2": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xf2 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fcomi st0, st3": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xf3 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fcomi st0, st4": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xf4 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fcomi st0, st5": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xf5 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fcomi st0, st6": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xf6 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fcomi st0, st7": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdb 11b 0xf7 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "lsl x21, x21, #29",
+        "orr w21, w21, w22, lsl #30",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "str w21, [x28, #728]"
+      ]
+    },
+    "fadd qword [rax]": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc !11b /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr d2, [x4]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul qword [rax]": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc !11b /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr d2, [x4]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fcom qword [rax]": {
+      "ExpectedInstructionCount": 21,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc !11b /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr d2, [x4]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fcomp qword [rax]": {
+      "ExpectedInstructionCount": 29,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc !11b /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr d2, [x4]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fsub qword [rax]": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc !11b /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr d2, [x4]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr qword [rax]": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc !11b /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr d2, [x4]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv qword [rax]": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc !11b /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr d2, [x4]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr qword [rax]": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc !11b /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr d2, [x4]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "db 0xdc, 0xc0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "fadd st0, st0",
+        "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
+        "0xdc 11b 0xc0 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st1, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xc1 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st2, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xc2 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st3, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xc3 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st4, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xc4 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st5, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xc5 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st6, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xc6 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fadd st7, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xc7 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "db 0xdc, 0xc8": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "fmul st0, st0",
+        "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
+        "0xdc 11b 0xc8 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st1, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xc9 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st2, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xca /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st3, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xcb /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st4, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xcc /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st5, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xcd /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st6, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xce /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmul st7, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xcf /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "db 0xdc, 0xe0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "fsubr st0, st0",
+        "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
+        "0xdc 11b 0xe0 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st1, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xe1 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st2, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xe2 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st3, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xe3 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st4, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xe4 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st5, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xe5 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st6, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xe6 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubr st7, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xe7 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "db 0xdc, 0xe8": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "fsub st0, st0",
+        "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
+        "0xdc 11b 0xe8 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st1, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xe9 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st2, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xea /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st3, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xeb /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st4, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xec /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st5, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xed /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st6, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xee /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsub st7, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xef /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "db 0xdc, 0xf0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "fdivr st0, st0",
+        "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
+        "0xdc 11b 0xf0 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st1, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xf1 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st2, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xf2 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st3, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xf3 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st4, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xf4 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st5, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xf5 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st6, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xf6 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivr st7, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xf7 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "db 0xdc, 0xf8": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "fdiv st0, st0",
+        "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
+        "0xdc 11b 0xf8 /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st1, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xf9 /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st2, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xfa /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st3, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xfb /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st4, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xfc /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st5, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xfd /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st6, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xfe /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdiv st7, st0": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "0xdc 11b 0xff /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fld qword [rax]": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd !11b /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldr d2, [x4]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fisttp qword [rax]": {
+      "ExpectedInstructionCount": 13,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd !11b /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "fcvtzs x21, d2",
+        "str x21, [x4]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fst qword [rax]": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd !11b /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "str d2, [x4]"
+      ]
+    },
+    "fstp qword [rax]": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd !11b /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "str d2, [x4]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "frstor [rax]": {
+      "ExpectedInstructionCount": 467,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd !11b /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrh w20, [x4]",
+        "lsr w21, w20, #10",
+        "and w21, w21, #0x3",
+        "rbit w1, w21",
+        "lsr w1, w1, #30",
+        "mrs x0, fpcr",
+        "bfi x0, x1, #22, #2",
+        "lsr x1, x21, #2",
+        "bfi x0, x1, #24, #1",
+        "msr fpcr, x0",
+        "strh w20, [x28, #1008]",
+        "strh w20, [x28, #1008]",
+        "ldr w20, [x4, #4]",
+        "ubfx w21, w20, #11, #3",
+        "strb w21, [x28, #747]",
+        "ubfx w22, w20, #8, #1",
+        "ubfx w23, w20, #9, #1",
+        "ubfx w24, w20, #10, #1",
+        "ubfx w20, w20, #14, #1",
+        "strb w22, [x28, #744]",
+        "strb w23, [x28, #745]",
+        "strb w24, [x28, #746]",
+        "strb w20, [x28, #750]",
+        "ldr w20, [x4, #8]",
+        "ubfx w22, w20, #0, #2",
+        "cmp x22, #0x3 (3)",
+        "cset x22, ne",
+        "ubfx w23, w20, #2, #2",
+        "cmp x23, #0x3 (3)",
+        "cset x23, ne",
+        "orr w22, w22, w23, lsl #1",
+        "ubfx w23, w20, #4, #2",
+        "cmp x23, #0x3 (3)",
+        "cset x23, ne",
+        "orr w22, w22, w23, lsl #2",
+        "ubfx w23, w20, #6, #2",
+        "cmp x23, #0x3 (3)",
+        "cset x23, ne",
+        "orr w22, w22, w23, lsl #3",
+        "ubfx w23, w20, #8, #2",
+        "cmp x23, #0x3 (3)",
+        "cset x23, ne",
+        "orr w22, w22, w23, lsl #4",
+        "ubfx w23, w20, #10, #2",
+        "cmp x23, #0x3 (3)",
+        "cset x23, ne",
+        "orr w22, w22, w23, lsl #5",
+        "ubfx w23, w20, #12, #2",
+        "cmp x23, #0x3 (3)",
+        "cset x23, ne",
+        "orr w22, w22, w23, lsl #6",
+        "ubfx w20, w20, #14, #2",
+        "cmp x20, #0x3 (3)",
+        "cset x20, ne",
+        "orr w20, w22, w20, lsl #7",
+        "strb w20, [x28, #1010]",
+        "add x20, x4, #0x1c (28)",
+        "mov x22, #0xffffffffffffffff",
+        "mov w23, #0xffff",
+        "fmov d2, x22",
+        "mov v2.d[1], x23",
+        "ldur q3, [x4, #28]",
+        "and v3.16b, v3.16b, v2.16b",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v3.d[0]",
+        "umov w2, v3.h[4]",
+        "ldr x3, [x28, #1168]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v3.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d3, [x0, #752]",
+        "add x22, x20, #0xa (10)",
+        "add w21, w21, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "ldur q3, [x20, #10]",
+        "and v3.16b, v3.16b, v2.16b",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v3.d[0]",
+        "umov w2, v3.h[4]",
+        "ldr x3, [x28, #1168]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v3.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d3, [x0, #752]",
+        "add x20, x22, #0xa (10)",
+        "add w21, w21, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "ldur q3, [x22, #10]",
+        "and v3.16b, v3.16b, v2.16b",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v3.d[0]",
+        "umov w2, v3.h[4]",
+        "ldr x3, [x28, #1168]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v3.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d3, [x0, #752]",
+        "add x22, x20, #0xa (10)",
+        "add w21, w21, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "ldur q3, [x20, #10]",
+        "and v3.16b, v3.16b, v2.16b",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v3.d[0]",
+        "umov w2, v3.h[4]",
+        "ldr x3, [x28, #1168]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v3.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d3, [x0, #752]",
+        "add x20, x22, #0xa (10)",
+        "add w21, w21, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "ldur q3, [x22, #10]",
+        "and v3.16b, v3.16b, v2.16b",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v3.d[0]",
+        "umov w2, v3.h[4]",
+        "ldr x3, [x28, #1168]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v3.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d3, [x0, #752]",
+        "add x22, x20, #0xa (10)",
+        "add w21, w21, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "ldur q3, [x20, #10]",
+        "and v3.16b, v3.16b, v2.16b",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v3.d[0]",
+        "umov w2, v3.h[4]",
+        "ldr x3, [x28, #1168]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v3.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d3, [x0, #752]",
+        "add x20, x22, #0xa (10)",
+        "add w21, w21, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "ldur q3, [x22, #10]",
+        "and v2.16b, v3.16b, v2.16b",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v2.d[0]",
+        "umov w2, v2.h[4]",
+        "ldr x3, [x28, #1168]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]",
+        "add x22, x20, #0xa (10)",
+        "add w21, w21, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "ldur d2, [x20, #10]",
+        "ldr h3, [x22, #8]",
+        "mov v2.h[4], v3.h[0]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v2.d[0]",
+        "umov w2, v2.h[4]",
+        "ldr x3, [x28, #1168]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fnsave [rax]": {
+      "ExpectedInstructionCount": 478,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd !11b /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrh w21, [x28, #1008]",
+        "str w21, [x4]",
+        "mov w21, #0x0",
+        "mov x0, x21",
+        "bfi x0, x20, #11, #3",
+        "mov x22, x0",
+        "ldrb w23, [x28, #744]",
+        "ldrb w24, [x28, #745]",
+        "ldrb w25, [x28, #746]",
+        "ldrb w26, [x28, #750]",
+        "orr x22, x22, x23, lsl #8",
+        "orr x22, x22, x24, lsl #9",
+        "orr x22, x22, x25, lsl #10",
+        "orr x22, x22, x26, lsl #14",
+        "str w22, [x4, #4]",
+        "ldrb w22, [x28, #1010]",
+        "and w23, w22, #0x1",
+        "mov w24, #0x3",
+        "cmp x23, #0x0 (0)",
+        "csel x23, x24, x21, eq",
+        "orr w23, w21, w23",
+        "lsr w25, w22, #1",
+        "and w25, w25, #0x1",
+        "cmp x25, #0x0 (0)",
+        "csel x25, x24, x21, eq",
+        "orr w23, w23, w25, lsl #2",
+        "lsr w25, w22, #2",
+        "and w25, w25, #0x1",
+        "cmp x25, #0x0 (0)",
+        "csel x25, x24, x21, eq",
+        "orr w23, w23, w25, lsl #4",
+        "lsr w25, w22, #3",
+        "and w25, w25, #0x1",
+        "cmp x25, #0x0 (0)",
+        "csel x25, x24, x21, eq",
+        "orr w23, w23, w25, lsl #6",
+        "lsr w25, w22, #4",
+        "and w25, w25, #0x1",
+        "cmp x25, #0x0 (0)",
+        "csel x25, x24, x21, eq",
+        "orr w23, w23, w25, lsl #8",
+        "lsr w25, w22, #5",
+        "and w25, w25, #0x1",
+        "cmp x25, #0x0 (0)",
+        "csel x25, x24, x21, eq",
+        "orr w23, w23, w25, lsl #10",
+        "lsr w25, w22, #6",
+        "and w25, w25, #0x1",
+        "cmp x25, #0x0 (0)",
+        "csel x25, x24, x21, eq",
+        "orr w23, w23, w25, lsl #12",
+        "lsr w22, w22, #7",
+        "and w22, w22, #0x1",
+        "cmp x22, #0x0 (0)",
+        "csel x22, x24, x21, eq",
+        "orr w22, w23, w22, lsl #14",
+        "str w22, [x4, #8]",
+        "str w21, [x4, #12]",
+        "str w21, [x4, #16]",
+        "str w21, [x4, #20]",
+        "str w21, [x4, #24]",
+        "add x22, x4, #0x1c (28)",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1152]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "stur q2, [x4, #28]",
+        "add x23, x22, #0xa (10)",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1152]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "stur q2, [x22, #10]",
+        "add x22, x23, #0xa (10)",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1152]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "stur q2, [x23, #10]",
+        "add x23, x22, #0xa (10)",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1152]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "stur q2, [x22, #10]",
+        "add x22, x23, #0xa (10)",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1152]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "stur q2, [x23, #10]",
+        "add x23, x22, #0xa (10)",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1152]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "stur q2, [x22, #10]",
+        "add x22, x23, #0xa (10)",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1152]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "stur q2, [x23, #10]",
+        "add x23, x22, #0xa (10)",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1152]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "stur d2, [x22, #10]",
+        "dup v2.8h, v2.h[4]",
+        "str h2, [x23, #8]",
+        "mov w20, #0x37f",
+        "strh w20, [x28, #1008]",
+        "strb w21, [x28, #747]",
+        "strb w21, [x28, #744]",
+        "strb w21, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w21, [x28, #750]",
+        "strb w21, [x28, #1010]"
+      ]
+    },
+    "fnstsw [rax]": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd !11b /7"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w20, #0x0",
+        "ldrb w21, [x28, #747]",
+        "bfi x20, x21, #11, #3",
+        "ldrb w21, [x28, #744]",
+        "ldrb w22, [x28, #745]",
+        "ldrb w23, [x28, #746]",
+        "ldrb w24, [x28, #750]",
+        "orr x20, x20, x21, lsl #8",
+        "orr x20, x20, x22, lsl #9",
+        "orr x20, x20, x23, lsl #10",
+        "orr x20, x20, x24, lsl #14",
+        "strh w20, [x4]"
+      ]
+    },
+    "ffree st0": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xc0 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x0 (0)",
+        "and w20, w20, #0x7",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1010]"
+      ]
+    },
+    "ffree st1": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xc1 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w20, w21, w20",
+        "bic w20, w22, w20",
+        "strb w20, [x28, #1010]"
+      ]
+    },
+    "ffree st2": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xc2 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x2 (2)",
+        "and w20, w20, #0x7",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1010]"
+      ]
+    },
+    "ffree st3": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xc3 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x3 (3)",
+        "and w20, w20, #0x7",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1010]"
+      ]
+    },
+    "ffree st4": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xc4 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x4 (4)",
+        "and w20, w20, #0x7",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1010]"
+      ]
+    },
+    "ffree st5": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xc5 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x5 (5)",
+        "and w20, w20, #0x7",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1010]"
+      ]
+    },
+    "ffree st6": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xc6 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x6 (6)",
+        "and w20, w20, #0x7",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1010]"
+      ]
+    },
+    "ffree st7": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xc7 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x7 (7)",
+        "and w20, w20, #0x7",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1010]"
+      ]
+    },
+    "fst st0": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xd0 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fst st1": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdd 11b 0xd1 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fst st2": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdd 11b 0xd2 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fst st3": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdd 11b 0xd3 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fst st4": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdd 11b 0xd4 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fst st5": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdd 11b 0xd5 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fst st6": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdd 11b 0xd6 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fst st7": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdd 11b 0xd7 /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]"
+      ]
+    },
+    "fstp st0": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xd8 /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fstp st1": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xd9 /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x22, lsl #4",
+        "str q2, [x0, #752]",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fstp st2": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xda /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fstp st3": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xdb /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fstp st4": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xdc /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fstp st5": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xdd /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fstp st6": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xde /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fstp st7": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xdf /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x20, lsl #4",
+        "ldr q2, [x0, #752]",
+        "add x0, x28, x21, lsl #4",
+        "str q2, [x0, #752]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fucom st0": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xe0 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x0",
+        "add w22, w20, #0x0 (0)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x22, x20, #1, #1",
+        "ubfx x23, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w22, w22, w20",
+        "orr w23, w23, w20",
+        "strb w22, [x28, #744]",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w23, [x28, #750]"
+      ]
+    },
+    "fucom st1": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xe1 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fucom st2": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xe2 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fucom st3": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xe3 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fucom st4": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xe4 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fucom st5": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xe5 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fucom st6": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xe6 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fucom st7": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xe7 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "fucomp st0": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xe8 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x0",
+        "add w22, w20, #0x0 (0)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x22, eq",
+        "csinc x22, x22, xzr, vc",
+        "cset x1, lt",
+        "bfi x22, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x22, x1, #2, #1",
+        "ubfx x23, x22, #1, #1",
+        "ubfx x24, x22, #0, #1",
+        "ubfx x22, x22, #2, #1",
+        "orr w23, w23, w22",
+        "orr w24, w24, w22",
+        "strb w23, [x28, #744]",
+        "strb w21, [x28, #745]",
+        "strb w22, [x28, #746]",
+        "strb w24, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fucomp st1": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xe9 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x22, eq",
+        "csinc x22, x22, xzr, vc",
+        "cset x1, lt",
+        "bfi x22, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x22, x1, #2, #1",
+        "ubfx x23, x22, #1, #1",
+        "ubfx x24, x22, #0, #1",
+        "ubfx x22, x22, #2, #1",
+        "orr w23, w23, w22",
+        "orr w24, w24, w22",
+        "strb w23, [x28, #744]",
+        "mov w23, #0x0",
+        "strb w23, [x28, #745]",
+        "strb w22, [x28, #746]",
+        "strb w24, [x28, #750]",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fucomp st2": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xea /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fucomp st3": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xeb /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fucomp st4": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xec /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fucomp st5": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xed /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fucomp st6": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xee /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fucomp st7": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdd 11b 0xef /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fiadd word [rax]": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": [
+        "0xde !11b /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrh w21, [x4]",
+        "sxth x21, w21",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fimul word [rax]": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": [
+        "0xde !11b /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrh w21, [x4]",
+        "sxth x21, w21",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "ficom word [rax]": {
+      "ExpectedInstructionCount": 23,
+      "Optimal": "No",
+      "Comment": [
+        "0xde !11b /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrh w21, [x4]",
+        "sxth x21, w21",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x20, eq",
+        "csinc x20, x20, xzr, vc",
+        "cset x1, lt",
+        "bfi x20, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x20, x1, #2, #1",
+        "ubfx x21, x20, #1, #1",
+        "ubfx x22, x20, #0, #1",
+        "ubfx x20, x20, #2, #1",
+        "orr w21, w21, w20",
+        "orr w22, w22, w20",
+        "strb w21, [x28, #744]",
+        "mov w21, #0x0",
+        "strb w21, [x28, #745]",
+        "strb w20, [x28, #746]",
+        "strb w22, [x28, #750]"
+      ]
+    },
+    "ficomp word [rax]": {
+      "ExpectedInstructionCount": 31,
+      "Optimal": "No",
+      "Comment": [
+        "0xde !11b /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrh w21, [x4]",
+        "sxth x21, w21",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "strb w22, [x28, #744]",
+        "mov w22, #0x0",
+        "strb w22, [x28, #745]",
+        "strb w21, [x28, #746]",
+        "strb w23, [x28, #750]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fisub word [rax]": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": [
+        "0xde !11b /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrh w21, [x4]",
+        "sxth x21, w21",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fisubr word [rax]": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": [
+        "0xde !11b /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrh w21, [x4]",
+        "sxth x21, w21",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fidiv word [rax]": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": [
+        "0xde !11b /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrh w21, [x4]",
+        "sxth x21, w21",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fidivr word [rax]": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": [
+        "0xde !11b /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "ldrh w21, [x4]",
+        "sxth x21, w21",
+        "scvtf d2, w21",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "faddp st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xd8 11b 0xc0 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "faddp st1": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xc1 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "ldrb w23, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w23, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x22, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "faddp st2": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xc2 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "faddp st3": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xc3 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "faddp st4": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xc4 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "faddp st5": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xc5 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "faddp st6": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xc6 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "faddp st7": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xc7 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fadd d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmulp st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xc8 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmulp st1": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xc9 /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "ldrb w23, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w23, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x22, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmulp st2": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xca /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmulp st3": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xcb /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmulp st4": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xcc /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmulp st5": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xcd /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmulp st6": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xce /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fmulp st7": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xcf /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fmul d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fcompp": {
+      "ExpectedInstructionCount": 37,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xd9 /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x22, eq",
+        "csinc x22, x22, xzr, vc",
+        "cset x1, lt",
+        "bfi x22, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x22, x1, #2, #1",
+        "ubfx x23, x22, #1, #1",
+        "ubfx x24, x22, #0, #1",
+        "ubfx x22, x22, #2, #1",
+        "orr w23, w23, w22",
+        "orr w24, w24, w22",
+        "strb w23, [x28, #744]",
+        "mov w23, #0x0",
+        "strb w23, [x28, #745]",
+        "strb w22, [x28, #746]",
+        "strb w24, [x28, #750]",
+        "ldrb w22, [x28, #1010]",
+        "lsl w23, w21, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "lsl w21, w21, w20",
+        "bic w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "db 0xde, 0xe0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "fsubrp st0, st0",
+        "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
+        "0xde 11b 0xe0 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubrp st1, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xe1 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "ldrb w23, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w23, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x22, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubrp st2, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xe2 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubrp st3, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xe3 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubrp st4, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xe4 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubrp st5, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xe5 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubrp st6, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xe6 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubrp st7, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xe7 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "db 0xde, 0xe8": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "fsubp st0, st0",
+        "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
+        "0xde 11b 0xe8 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubp st1, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xe9 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "ldrb w23, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w23, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x22, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubp st2, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xea /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubp st3, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xeb /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubp st4, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xec /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubp st5, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xed /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubp st6, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xee /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fsubp st7, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xef /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fsub d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "db 0xde, 0xf0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "fdivrp st0, st0",
+        "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
+        "0xde 11b 0xf0 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivrp st1, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xf1 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "ldrb w23, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w23, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x22, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivrp st2, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xf2 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivrp st3, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xf3 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivrp st4, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xf4 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivrp st5, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xf5 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivrp st6, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xf6 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivrp st7, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xf7 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d3, d2",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "db 0xde, 0xf8": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "fdivp st0, st0",
+        "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
+        "0xde 11b 0xf8 /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivp st1, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xf9 /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "ldrb w23, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w23, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x22, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivp st2, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xfa /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivp st3, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xfb /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivp st4, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xfc /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivp st5, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xfd /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivp st6, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xfe /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fdivp st7, st0": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "0xde 11b 0xff /7"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fdiv d2, d2, d3",
+        "ldrb w22, [x28, #1010]",
+        "mov w23, #0x1",
+        "lsl w23, w23, w20",
+        "bic w22, w22, w23",
+        "strb w22, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "add x0, x28, x21, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fild word [rax]": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf !11b /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "ldrh w21, [x4]",
+        "sxth x21, w21",
+        "scvtf d2, x21",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fisttp word [rax]": {
+      "ExpectedInstructionCount": 13,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf !11b /1"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "fcvtzs x21, d2",
+        "strh w21, [x4]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fist word [rax]": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf !11b /2"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "frinti d0, d2",
+        "fcvtzs x20, d0",
+        "strh w20, [x4]"
+      ]
+    },
+    "fistp word [rax]": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf !11b /3"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "frinti d0, d2",
+        "fcvtzs x21, d0",
+        "strh w21, [x4]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fbld tword [rax]": {
+      "ExpectedInstructionCount": 102,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf !11b /4"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "sub w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "orr w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "strb w20, [x28, #747]",
+        "ldr q2, [x4]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v2.d[0]",
+        "umov w2, v2.h[4]",
+        "ldr x3, [x28, #1376]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v2.d[0]",
+        "umov w2, v2.h[4]",
+        "ldr x3, [x28, #1168]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "mov v2.8b, v0.8b",
+        "add x0, x28, x20, lsl #4",
+        "str d2, [x0, #752]"
+      ]
+    },
+    "fbstp tword [rax]": {
+      "ExpectedInstructionCount": 105,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf !11b /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d2, [x0, #752]",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "mov v0.8b, v2.8b",
+        "ldrh w0, [x28, #1008]",
+        "ldr x1, [x28, #1152]",
+        "blr x1",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "stp x4, x5, [x28, #8]",
+        "stp x6, x7, [x28, #24]",
+        "stp x8, x9, [x28, #40]",
+        "stp x10, x11, [x28, #56]",
+        "stp x12, x13, [x28, #72]",
+        "stp x14, x15, [x28, #88]",
+        "stp x16, x17, [x28, #104]",
+        "stp x19, x29, [x28, #120]",
+        "add x0, x28, #0xc0 (192)",
+        "st1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x0], #64",
+        "st1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x0], #64",
+        "st1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x0], #64",
+        "st1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x0], #64",
+        "sub sp, sp, #0xf0 (240)",
+        "mov x0, sp",
+        "st1 {v2.2d, v3.2d}, [x0], #32",
+        "st1 {v4.2d, v5.2d, v6.2d, v7.2d}, [x0], #64",
+        "st1 {v8.2d, v9.2d, v10.2d, v11.2d}, [x0], #64",
+        "st1 {v12.2d, v13.2d, v14.2d, v15.2d}, [x0], #64",
+        "str x30, [x0]",
+        "ldrh w0, [x28, #1008]",
+        "mov x1, v2.d[0]",
+        "umov w2, v2.h[4]",
+        "ldr x3, [x28, #1368]",
+        "blr x3",
+        "ld1 {v2.2d, v3.2d}, [sp], #32",
+        "ld1 {v4.2d, v5.2d, v6.2d, v7.2d}, [sp], #64",
+        "ld1 {v8.2d, v9.2d, v10.2d, v11.2d}, [sp], #64",
+        "ld1 {v12.2d, v13.2d, v14.2d, v15.2d}, [sp], #64",
+        "ldr x30, [sp], #16",
+        "add x5, x28, #0xc0 (192)",
+        "ld1 {v16.2d, v17.2d, v18.2d, v19.2d}, [x5], #64",
+        "ld1 {v20.2d, v21.2d, v22.2d, v23.2d}, [x5], #64",
+        "ld1 {v24.2d, v25.2d, v26.2d, v27.2d}, [x5], #64",
+        "ld1 {v28.2d, v29.2d, v30.2d, v31.2d}, [x5], #64",
+        "ldp x4, x5, [x28, #8]",
+        "ldp x6, x7, [x28, #24]",
+        "ldp x8, x9, [x28, #40]",
+        "ldp x10, x11, [x28, #56]",
+        "ldp x12, x13, [x28, #72]",
+        "ldp x14, x15, [x28, #88]",
+        "ldp x16, x17, [x28, #104]",
+        "ldp x19, x29, [x28, #120]",
+        "eor v2.16b, v2.16b, v2.16b",
+        "mov v2.d[0], x0",
+        "mov v2.h[4], w1",
+        "str d2, [x4]",
+        "mov x21, v2.d[1]",
+        "strh w21, [x4, #8]",
+        "ldrb w21, [x28, #1010]",
+        "mov w22, #0x1",
+        "lsl w22, w22, w20",
+        "bic w21, w21, w22",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "ffreep st0": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdf 11b 0xc0 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "ffreep st1": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdf 11b 0xc1 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "ffreep st2": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdf 11b 0xc2 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "ffreep st3": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdf 11b 0xc3 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "ffreep st4": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdf 11b 0xc4 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "ffreep st5": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdf 11b 0xc5 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "ffreep st6": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdf 11b 0xc6 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "ffreep st7": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0xdf 11b 0xc7 /0"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]"
+      ]
+    },
+    "fnstsw ax": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xe0 /4"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w20, #0x0",
+        "ldrb w21, [x28, #747]",
+        "bfi x20, x21, #11, #3",
+        "ldrb w21, [x28, #744]",
+        "ldrb w22, [x28, #745]",
+        "ldrb w23, [x28, #746]",
+        "ldrb w24, [x28, #750]",
+        "orr x20, x20, x21, lsl #8",
+        "orr x20, x20, x22, lsl #9",
+        "orr x20, x20, x23, lsl #10",
+        "orr x20, x20, x24, lsl #14",
+        "bfxil x4, x20, #0, #16"
+      ]
+    },
+    "fucomip st0": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xe8 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fucomip st1": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xe9 /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x22, eq",
+        "csinc x22, x22, xzr, vc",
+        "cset x1, lt",
+        "bfi x22, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x22, x1, #2, #1",
+        "ubfx x23, x22, #1, #1",
+        "ubfx x24, x22, #0, #1",
+        "ubfx x22, x22, #2, #1",
+        "orr w23, w23, w22",
+        "orr w24, w24, w22",
+        "lsl x23, x23, #29",
+        "orr w23, w23, w24, lsl #30",
+        "eor w22, w22, #0x1",
+        "strb w22, [x28, #706]",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w23, [x28, #728]"
+      ]
+    },
+    "fucomip st2": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xea /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fucomip st3": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xeb /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fucomip st4": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xec /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fucomip st5": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xed /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fucomip st6": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xee /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fucomip st7": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xef /5"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fcomip st0": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xf0 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x0 (0)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fcomip st1": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xf1 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "mov w21, #0x1",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x0, x28, x22, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x22, eq",
+        "csinc x22, x22, xzr, vc",
+        "cset x1, lt",
+        "bfi x22, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x22, x1, #2, #1",
+        "ubfx x23, x22, #1, #1",
+        "ubfx x24, x22, #0, #1",
+        "ubfx x22, x22, #2, #1",
+        "orr w23, w23, w22",
+        "orr w24, w24, w22",
+        "lsl x23, x23, #29",
+        "orr w23, w23, w24, lsl #30",
+        "eor w22, w22, #0x1",
+        "strb w22, [x28, #706]",
+        "ldrb w22, [x28, #1010]",
+        "lsl w21, w21, w20",
+        "bic w21, w22, w21",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w23, [x28, #728]"
+      ]
+    },
+    "fcomip st2": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xf2 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x2 (2)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fcomip st3": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xf3 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x3 (3)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fcomip st4": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xf4 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x4 (4)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fcomip st5": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xf5 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x5 (5)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fcomip st6": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xf6 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x6 (6)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    },
+    "fcomip st7": {
+      "ExpectedInstructionCount": 32,
+      "Optimal": "No",
+      "Comment": [
+        "0xdf 11b 0xf7 /6"
+      ],
+      "ExpectedArm64ASM": [
+        "ldrb w20, [x28, #747]",
+        "add w21, w20, #0x7 (7)",
+        "and w21, w21, #0x7",
+        "add x0, x28, x21, lsl #4",
+        "ldr d2, [x0, #752]",
+        "add x0, x28, x20, lsl #4",
+        "ldr d3, [x0, #752]",
+        "fcmp d3, d2",
+        "cset x21, eq",
+        "csinc x21, x21, xzr, vc",
+        "cset x1, lt",
+        "bfi x21, x1, #1, #1",
+        "cset x1, vs",
+        "bfi x21, x1, #2, #1",
+        "ubfx x22, x21, #1, #1",
+        "ubfx x23, x21, #0, #1",
+        "ubfx x21, x21, #2, #1",
+        "orr w22, w22, w21",
+        "orr w23, w23, w21",
+        "lsl x22, x22, #29",
+        "orr w22, w22, w23, lsl #30",
+        "mov w23, #0x1",
+        "eor w21, w21, #0x1",
+        "strb w21, [x28, #706]",
+        "ldrb w21, [x28, #1010]",
+        "lsl w23, w23, w20",
+        "bic w21, w21, w23",
+        "strb w21, [x28, #1010]",
+        "add w20, w20, #0x1 (1)",
+        "and w20, w20, #0x7",
+        "strb w20, [x28, #747]",
+        "str w22, [x28, #728]"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds support for the tests to set environment variables just like the asm tests.
This gets used to turn on the reduced precision mode.
Then adds all the x87 tests to be ran in this reduced precision mode.