### PR TITLE
Thunks: Avoid recompiling thunk interfaces on FEXLoader changes

### DIFF
--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -20,7 +20,6 @@ function(generate NAME SOURCE_FILE GUEST_BITNESS)
   # Interface target for the user to add include directories
   add_library(${NAME}-${GUEST_BITNESS}-deps INTERFACE)
   target_include_directories(${NAME}-${GUEST_BITNESS}-deps INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
-  target_link_libraries(${NAME}-${GUEST_BITNESS}-deps INTERFACE FEXLoader)
   # Shorthand for the include directories added after calling this function.
   # This is not evaluated directly, hence directories added after return are still picked up
   set(prop "$<TARGET_PROPERTY:${NAME}-${GUEST_BITNESS}-deps,INTERFACE_INCLUDE_DIRECTORIES>")
@@ -75,6 +74,7 @@ function(add_host_lib NAME GUEST_BITNESS)
   target_include_directories(${NAME}-host-${GUEST_BITNESS} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/gen_${GUEST_BITNESS}/")
   target_link_libraries(${NAME}-host-${GUEST_BITNESS} PRIVATE dl)
   target_link_libraries(${NAME}-host-${GUEST_BITNESS} PRIVATE lib${NAME}-${GUEST_BITNESS}-deps)
+  target_link_libraries(${NAME}-host-${GUEST_BITNESS} PRIVATE FEXLoader)
   ## Make signed overflow well defined 2's complement overflow
   target_compile_options(${NAME}-host-${GUEST_BITNESS} PRIVATE -fwrapv)
 


### PR DESCRIPTION
The interface files themselves don't use FEXLoader. Only the final library does.

Speeds up build times of some of the thunk targets, allowing for quicker development iteration cycles (e.g. while rebasing branches).