### PR TITLE
unittests: Instruct CTest to print output from tests on failure

### DIFF
--- a/FEXCore/unittests/APITests/CMakeLists.txt
+++ b/FEXCore/unittests/APITests/CMakeLists.txt
@@ -17,5 +17,5 @@ add_custom_target(
   fexcore_apitests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.FEXCore_Tests$$")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "\.*.FEXCore_Tests$$")
 

--- a/FEXCore/unittests/Emitter/CMakeLists.txt
+++ b/FEXCore/unittests/Emitter/CMakeLists.txt
@@ -18,7 +18,7 @@ if (COMPILE_VIXL_DISASSEMBLER)
     emitter_tests
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/"
     USES_TERMINAL
-    COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.Emitter$$")
+    COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "\.*.Emitter$$")
 else()
   message(AUTHOR_WARNING "Tests are enabled but vixl disassembler is not. Emitter tests won't be built.")
 endif()

--- a/Source/Tools/FEXLoader/LinuxSyscalls/CMakeLists.txt
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/CMakeLists.txt
@@ -164,4 +164,4 @@ add_custom_target(
   struct_verifier
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "Test_verify*")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "Test_verify*")

--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -117,4 +117,4 @@ add_custom_target(
   32bit_asm_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*32Bit\.*.asm$$")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "\.*32Bit\.*.asm$$")

--- a/unittests/APITests/CMakeLists.txt
+++ b/unittests/APITests/CMakeLists.txt
@@ -20,7 +20,7 @@ add_custom_target(
   api_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.APITest")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "\.*.APITest")
 
 foreach(API_TEST ${TESTS})
   add_dependencies(api_tests ${API_TEST})

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -124,4 +124,4 @@ add_custom_target(
   asm_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.asm$$")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "\.*.asm$$")

--- a/unittests/FEXLinuxTests/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/CMakeLists.txt
@@ -105,7 +105,7 @@ add_custom_target(
   fex_linux_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "30" "-j${CORES}" "-R" "\.*\.jit\.flt$$" "--output-on-failure"
+  COMMAND "ctest" "--output-on-failure" "--timeout" "30" "-j${CORES}" "-R" "\.*\.jit\.flt$$"
   DEPENDS FEXLinuxTests FEXLinuxTests_32 FEXLoader
   )
 
@@ -114,7 +114,7 @@ add_custom_target(
   fex_linux_tests_host
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "30" "-j${CORES}" "-R" "\.*\.host\.flt$$" "--output-on-failure"
+  COMMAND "ctest" "--output-on-failure" "--timeout" "30" "-j${CORES}" "-R" "\.*\.host\.flt$$"
   DEPENDS FEXLinuxTests FEXLinuxTests_32
   )
 
@@ -123,6 +123,6 @@ add_custom_target(
   fex_linux_tests_all
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "30" "-j${CORES}" "-R" "\.*\.flt$$" "--output-on-failure"
+  COMMAND "ctest" "--output-on-failure" "--timeout" "30" "-j${CORES}" "-R" "\.*\.flt$$"
   DEPENDS FEXLinuxTests FEXLinuxTests_32 FEXLoader
   )

--- a/unittests/IR/CMakeLists.txt
+++ b/unittests/IR/CMakeLists.txt
@@ -75,4 +75,4 @@ add_custom_target(
   ir_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.ir$$")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "\.*.ir$$")

--- a/unittests/InstructionCountCI/CMakeLists.txt
+++ b/unittests/InstructionCountCI/CMakeLists.txt
@@ -56,10 +56,10 @@ add_custom_target(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   DEPENDS instcountci_test_files
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "InstCountCI/\.*.instcountci$$")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "InstCountCI/\.*.instcountci$$")
 
 add_custom_target(
   instcountci_update_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "InstCountCI/\.*new_numbers$$")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "InstCountCI/\.*new_numbers$$")

--- a/unittests/POSIX/CMakeLists.txt
+++ b/unittests/POSIX/CMakeLists.txt
@@ -30,4 +30,4 @@ add_custom_target(
   posix_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.posix")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "\.*.posix")

--- a/unittests/ThunkFunctionalTests/CMakeLists.txt
+++ b/unittests/ThunkFunctionalTests/CMakeLists.txt
@@ -39,19 +39,19 @@ add_custom_target(
   thunk_functional_tests_nothunks
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "ThunkFunctionalTest-NoThunks-\.*"
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "ThunkFunctionalTest-NoThunks-\.*"
   DEPENDS "${FUNCTIONAL_DEPENDS}")
 
 add_custom_target(
   thunk_functional_tests_thunks
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "ThunkFunctionalTest-Thunks-\.*"
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "ThunkFunctionalTest-Thunks-\.*"
   DEPENDS "${FUNCTIONAL_DEPENDS}")
 
 add_custom_target(
   thunk_functional_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "ThunkFunctionalTest\.*"
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "ThunkFunctionalTest\.*"
   DEPENDS "${FUNCTIONAL_DEPENDS}")

--- a/unittests/ThunkLibs/CMakeLists.txt
+++ b/unittests/ThunkLibs/CMakeLists.txt
@@ -10,5 +10,5 @@ add_custom_target(
   thunkgen_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.ThunkGen")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "\.*.ThunkGen")
 add_dependencies(thunkgen_tests thunkgentest)

--- a/unittests/gcc-target-tests-32/CMakeLists.txt
+++ b/unittests/gcc-target-tests-32/CMakeLists.txt
@@ -30,4 +30,4 @@ add_custom_target(
   gcc_target_tests_32
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "20" "-j${CORES}" "-R" "\.*.gcc-target-32$$")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "20" "-j${CORES}" "-R" "\.*.gcc-target-32$$")

--- a/unittests/gcc-target-tests-64/CMakeLists.txt
+++ b/unittests/gcc-target-tests-64/CMakeLists.txt
@@ -30,4 +30,4 @@ add_custom_target(
   gcc_target_tests_64
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
-  COMMAND "ctest" "--timeout" "20" "-j${CORES}" "-R" "\.*.gcc-target-64$$")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "20" "-j${CORES}" "-R" "\.*.gcc-target-64$$")

--- a/unittests/gvisor-tests/CMakeLists.txt
+++ b/unittests/gvisor-tests/CMakeLists.txt
@@ -33,4 +33,4 @@ add_custom_target(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "sh" "-c" "${RM_DIR_COMMAND}"
-  COMMAND "ctest" "--timeout" "302" "-j${CORES}" "-R" "\.*.gvisor$$")
+  COMMAND "ctest" "--output-on-failure" "--timeout" "302" "-j${CORES}" "-R" "\.*.gvisor$$")


### PR DESCRIPTION
Yet another layer of indirection that was swallowing test output in CI runs.