### PR TITLE
X87F64: Use Bfe for rounding mode, FCHS use float instruction

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -72,11 +72,7 @@ void OpDispatchBuilder::X87LDENVF64(OpcodeArgs) {
   auto NewFCW = _LoadMem(GPRClass, 2, Mem, 2);
   //ignore the rounding precision, we're always 64-bit in F64.
   //extract rounding mode
-  OrderedNode *roundingMode = NewFCW;
-  auto roundShift = _Constant(10);
-  auto roundMask = _Constant(3);
-  roundingMode = _Lshr(OpSize::i32Bit, roundingMode, roundShift);
-  roundingMode = _And(OpSize::i32Bit, roundingMode, roundMask);
+  OrderedNode *roundingMode = _Bfe(OpSize::i32Bit, 3, 10, NewFCW);
   _SetRoundingMode(roundingMode);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 
@@ -96,11 +92,11 @@ void OpDispatchBuilder::X87FLDCWF64(OpcodeArgs) {
   OrderedNode *NewFCW = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
   //ignore the rounding precision, we're always 64-bit in F64.
   //extract rounding mode
-  OrderedNode *roundingMode = NewFCW;
-  auto shift = _Constant(10);
-  auto mask = _Constant(3);
-  roundingMode = _Lshr(OpSize::i32Bit, roundingMode, shift);
-  roundingMode = _And(OpSize::i32Bit, roundingMode, mask);
+  OrderedNode *roundingMode = _Bfe(OpSize::i32Bit, 3, 10, NewFCW);
+  //auto shift = _Constant(10);
+  //auto mask = _Constant(3);
+  //roundingMode = _Lshr(OpSize::i32Bit, roundingMode, shift);
+  //roundingMode = _And(OpSize::i32Bit, roundingMode, mask);
   _SetRoundingMode(roundingMode);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 }
@@ -589,9 +585,7 @@ void OpDispatchBuilder::FSUBF64<32, true, true, OpDispatchBuilder::OpResult::RES
 void OpDispatchBuilder::FCHSF64(OpcodeArgs) {
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 8, MMBaseOffset(), 16, FPRClass);
-  auto b = _VCastFromGPR(8, 8, _Constant(0x8000000000000000));
-
-  auto result = _VXor(8, 8, a, b);
+  auto result = _VFNeg(8, 8, a);
   // Write to ST[TOP]
   _StoreContextIndexed(result, top, 8, MMBaseOffset(), 16, FPRClass);
 }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -93,10 +93,6 @@ void OpDispatchBuilder::X87FLDCWF64(OpcodeArgs) {
   //ignore the rounding precision, we're always 64-bit in F64.
   //extract rounding mode
   OrderedNode *roundingMode = _Bfe(OpSize::i32Bit, 3, 10, NewFCW);
-  //auto shift = _Constant(10);
-  //auto mask = _Constant(3);
-  //roundingMode = _Lshr(OpSize::i32Bit, roundingMode, shift);
-  //roundingMode = _And(OpSize::i32Bit, roundingMode, mask);
   _SetRoundingMode(roundingMode);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 }

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -1746,15 +1746,14 @@
       ]
     },
     "fldenv [rax]": {
-      "ExpectedInstructionCount": 55,
+      "ExpectedInstructionCount": 54,
       "Optimal": "No",
       "Comment": [
         "0xd9 !11b /4"
       ],
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
-        "lsr w21, w20, #10",
-        "and w21, w21, #0x3",
+        "ubfx w21, w20, #10, #3",
         "rbit w1, w21",
         "lsr w1, w1, #30",
         "mrs x0, fpcr",
@@ -1810,15 +1809,14 @@
       ]
     },
     "fldcw [rax]": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "0xd9 !11b /5"
       ],
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
-        "lsr w21, w20, #10",
-        "and w21, w21, #0x3",
+        "ubfx w21, w20, #10, #3",
         "rbit w1, w21",
         "lsr w1, w1, #30",
         "mrs x0, fpcr",
@@ -2272,7 +2270,7 @@
       "ExpectedArm64ASM": []
     },
     "fchs": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe0 /4"
@@ -2281,9 +2279,7 @@
         "ldrb w20, [x28, #747]",
         "add x0, x28, x20, lsl #4",
         "ldr d2, [x0, #752]",
-        "mov x21, #0x8000000000000000",
-        "fmov d3, x21",
-        "eor v2.16b, v2.16b, v3.16b",
+        "fneg v2.2d, v2.2d",
         "add x0, x28, x20, lsl #4",
         "str d2, [x0, #752]"
       ]


### PR DESCRIPTION
Reduces the blowup for FLDCW and FCHS a bit.