### PR TITLE
X87F64: Implement FABS with vector instruction

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -969,6 +969,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry,
         REGISTER_OP(VUMINV,            VUMinV);
         REGISTER_OP(VURAVG,            VURAvg);
         REGISTER_OP(VABS,              VAbs);
+        REGISTER_OP(VFABS,             VFAbs);
         REGISTER_OP(VPOPCOUNT,         VPopcount);
         REGISTER_OP(VFADD,             VFAdd);
         REGISTER_OP(VFADDP,            VFAddP);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -399,6 +399,7 @@ private:
   DEF_OP(VUMinV);
   DEF_OP(VURAvg);
   DEF_OP(VAbs);
+  DEF_OP(VFAbs);
   DEF_OP(VPopcount);
   DEF_OP(VFAdd);
   DEF_OP(VFAddP);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -643,7 +643,6 @@ DEF_OP(VFAbs) {
           break;
         }
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -720,7 +719,6 @@ DEF_OP(VFAdd) {
           break;
         }
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -803,7 +801,6 @@ DEF_OP(VFSub) {
           break;
         }
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -848,7 +845,6 @@ DEF_OP(VFMul) {
           break;
         }
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -905,7 +901,6 @@ DEF_OP(VFDiv) {
           break;
         }
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -984,7 +979,6 @@ DEF_OP(VFMin) {
           break;
         }
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -1064,7 +1058,6 @@ DEF_OP(VFMax) {
           break;
         }
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -1128,7 +1121,6 @@ DEF_OP(VFRecp) {
           break;
         }
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -1175,7 +1167,6 @@ DEF_OP(VFSqrt) {
           break;
         }
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -1226,7 +1217,6 @@ DEF_OP(VFRSqrt) {
           break;
         }
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -1348,7 +1338,6 @@ DEF_OP(VUMin) {
         break;
       }
       default:
-        LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
         break;
     }
   }
@@ -1400,7 +1389,6 @@ DEF_OP(VSMin) {
         break;
       }
       default:
-        LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
         break;
     }
   }
@@ -1452,7 +1440,6 @@ DEF_OP(VUMax) {
         break;
       }
       default:
-        LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
         break;
     }
   }
@@ -1504,7 +1491,6 @@ DEF_OP(VSMax) {
         break;
       }
       default:
-        LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
         break;
     }
   }
@@ -1982,7 +1968,6 @@ DEF_OP(VFCMPEQ) {
           fcmeq(SubRegSize.Scalar, Dst, Vector1, Vector2);
           break;
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -2029,7 +2014,6 @@ DEF_OP(VFCMPNEQ) {
           fcmeq(SubRegSize.Scalar, Dst, Vector1, Vector2);
           break;
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
       mvn(ARMEmitter::SubRegSize::i8Bit, Dst.D(), Dst.D());
@@ -2078,7 +2062,6 @@ DEF_OP(VFCMPLT) {
           fcmgt(SubRegSize.Scalar, Dst, Vector2, Vector1);
           break;
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -2125,7 +2108,6 @@ DEF_OP(VFCMPGT) {
           fcmgt(SubRegSize.Scalar, Dst, Vector1, Vector2);
           break;
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -2172,7 +2154,6 @@ DEF_OP(VFCMPLE) {
           fcmge(SubRegSize.Scalar, Dst, Vector2, Vector1);
           break;
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -2228,7 +2209,6 @@ DEF_OP(VFCMPORD) {
           orr(Dst.D(), VTMP1.D(), VTMP2.D());
           break;
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {
@@ -2284,7 +2264,6 @@ DEF_OP(VFCMPUNO) {
           mvn(ARMEmitter::SubRegSize::i8Bit, Dst.D(), Dst.D());
           break;
         default:
-          LOGMAN_MSG_A_FMT("Unknown Element Size: {}", ElementSize);
           break;
       }
     } else {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -589,9 +589,7 @@ void OpDispatchBuilder::FCHSF64(OpcodeArgs) {
 void OpDispatchBuilder::FABSF64(OpcodeArgs) {
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 8, MMBaseOffset(), 16, FPRClass);
-  auto b = _VCastFromGPR(8, 8, _Constant(0x7fffffffffffffff));
-  auto result = _VAnd(8, 8, a, b);
-
+  auto result = _VFAbs(8, 8, a);
   // Write to ST[TOP]
   _StoreContextIndexed(result, top, 8, MMBaseOffset(), 16, FPRClass);
 }

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1331,6 +1331,11 @@
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
+      
+      "FPR = VFAbs u8:#RegisterSize, u8:#ElementSize, FPR:$Vector": {
+        "DestSize": "RegisterSize",
+        "NumElements": "RegisterSize / ElementSize"
+      },
 
       "FPR = VFNeg u8:#RegisterSize, u8:#ElementSize, FPR:$Vector": {
         "DestSize": "RegisterSize",

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -2285,7 +2285,7 @@
       ]
     },
     "fabs": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe1 /4"
@@ -2294,9 +2294,7 @@
         "ldrb w20, [x28, #747]",
         "add x0, x28, x20, lsl #4",
         "ldr d2, [x0, #752]",
-        "orr x21, xzr, #0x7fffffffffffffff",
-        "fmov d3, x21",
-        "and v2.16b, v2.16b, v3.16b",
+        "fabs d2, d2",
         "add x0, x28, x20, lsl #4",
         "str d2, [x0, #752]"
       ]


### PR DESCRIPTION
- `_VFAbs` added to IR, implemented with fabs arm instruction.
- X87F64 FABS implementation updated to use it.

Reduces fabs instruction count by two :tada: 
