### PR TITLE
AppConfig: Removes Steam config

### DIFF
--- a/Data/AppConfig/steam.json.in
+++ b/Data/AppConfig/steam.json.in
@@ -1,5 +1,0 @@
-{
-  "Config": {
-    "Env": "STEAM_GAME_LAUNCH_SHELL=@CMAKE_INSTALL_PREFIX@/bin/FEXBash"
-  }
-}


### PR DESCRIPTION
This was only required on x86 devices trying to escape the emulation. Since x86 is now remove, this is entirely unnecessary.

When Steam launches applications with `/bin/sh`, this will remain under the emulation and not escape these days.