### PR TITLE
Minor AVX optimizations

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -3551,7 +3551,7 @@ DEF_OP(VSRSHR) {
     if (Dst != Vector) {
       movprfx(Dst.Z(), Vector.Z());
     }
-    srshr(SubRegSize, Dst.Z(), Mask, Vector.Z(), BitShift);
+    srshr(SubRegSize, Dst.Z(), Mask, Dst.Z(), BitShift);
   } else {
     if (OpSize == 8) {
       srshr(SubRegSize, Dst.D(), Vector.D(), BitShift);
@@ -3587,7 +3587,7 @@ DEF_OP(VSQSHL) {
     if (Dst != Vector) {
       movprfx(Dst.Z(), Vector.Z());
     }
-    sqshl(SubRegSize, Dst.Z(), Mask, Vector.Z(), BitShift);
+    sqshl(SubRegSize, Dst.Z(), Mask, Dst.Z(), BitShift);
   } else {
     if (OpSize == 8) {
       sqshl(SubRegSize, Dst.D(), Vector.D(), BitShift);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -4803,8 +4803,9 @@ void OpDispatchBuilder::VZEROOp(OpcodeArgs) {
     // NOTE: Despite the name being VZEROALL, this will still only ever
     //       zero out up to the first 16 registers (even on AVX-512, where we have 32 registers)
 
-  OrderedNode* ZeroVector = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
-  for (uint32_t i = 0; i < NumRegs; i++) {
+    for (uint32_t i = 0; i < NumRegs; i++) {
+      // Explicitly not caching named vector zero. This ensures that every register gets movi #0.0 directly.
+      OrderedNode* ZeroVector = _LoadNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
       StoreXMMRegister(i, ZeroVector);
     }
   } else {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -9,33 +9,29 @@
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "SVE-256bit changes behaviour slightly",
         "0x66 0x0f 0xe4"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "umulh z2.h, p6/m, z2.h, z3.h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z2, z16",
+        "umulh z2.h, p6/m, z2.h, z17.h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "pmulhw xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "SVE-256bit changes behaviour slightly",
         "0x66 0x0f 0xe5"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "smulh z2.h, p6/m, z2.h, z3.h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z2, z16",
+        "smulh z2.h, p6/m, z2.h, z17.h",
+        "mov v16.16b, v2.16b"
       ]
     }
   }

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -11,29 +11,24 @@
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
-        "Spurious moves",
         "Map 1 0b00 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v16.16b"
       ]
     },
     "vmovups xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "SVE 128-bit load already zero's the upper bits",
-        "Spurious move afterwards",
         "Map 1 0b00 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q16, [x4]"
       ]
     },
     "vmovups ymm0, ymm0": {
@@ -49,41 +44,34 @@
       ]
     },
     "vmovups ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
-        "Doesn't load directly in to destination",
         "Map 1 0b00 0x10 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1b {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z16.b}, p7/z, [x4]"
       ]
     },
     "vmovupd xmm0, xmm0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
-        "Spurious moves",
         "Map 1 0b01 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v16.16b"
       ]
     },
     "vmovupd xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "SVE 128-bit load already zero's the upper bits",
-        "Spurious move afterwards",
         "Map 1 0b01 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q16, [x4]"
       ]
     },
     "vmovupd ymm0, ymm0": {
@@ -99,130 +87,115 @@
       ]
     },
     "vmovupd ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
-        "Doesn't load directly in to destination",
         "Map 1 0b01 0x10 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1b {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z16.b}, p7/z, [x4]"
       ]
     },
     "vmovss xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "32-bit vector load already zero's the upper bits",
-        "Spurious move afterwards",
         "Map 1 0b10 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr s2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr s16, [x4]"
       ]
     },
     "vmovss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b10 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.s[0], v18.s[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovsd xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "32-bit vector load already zero's the upper bits",
-        "Spurious move afterwards",
         "Map 1 0b11 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr d2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr d16, [x4]"
       ]
     },
     "vmovsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b11 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.d[0], v18.d[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovups [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x11 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str q2, [x4]"
+        "str q16, [x4]"
       ]
     },
     "vmovups [rax], ymm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x11 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1b {z2.b}, p7, [x4]"
+        "st1b {z16.b}, p7, [x4]"
       ]
     },
     "vmovupd [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x11 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str q2, [x4]"
+        "str q16, [x4]"
       ]
     },
     "vmovupd [rax], ymm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x11 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1b {z2.b}, p7, [x4]"
+        "st1b {z16.b}, p7, [x4]"
       ]
     },
     "vmovss [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x11 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str s2, [x4]"
+        "str s16, [x4]"
       ]
     },
     "db 0xc5, 0xf2, 0x11, 0xc2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "vmovss xmm2, xmm1, xmm0",
@@ -231,26 +204,23 @@
         "Map 1 0b10 0x11 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z16.d",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z18.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.s[0], v16.s[0]",
+        "mov v18.16b, v2.16b"
       ]
     },
     "vmovsd [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x11 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str d2, [x4]"
+        "str d16, [x4]"
       ]
     },
     "db 0xc5, 0xf3, 0x11, 0xc2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "vmovsd xmm2, xmm1, xmm0",
@@ -259,11 +229,9 @@
         "Map 1 0b11 0x11 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z16.d",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z18.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.d[0], v16.d[0]",
+        "mov v18.16b, v2.16b"
       ]
     },
     "vmovlps xmm0, xmm1, [rax]": {
@@ -274,11 +242,11 @@
         "Map 1 0b00 0x12 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ldr q3, [x4]",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x4]",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovlpd xmm0, xmm1, [rax]": {
@@ -289,15 +257,15 @@
         "Map 1 0b01 0x12 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ldr q3, [x4]",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x4]",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovsldup xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x12 128-bit"
@@ -305,24 +273,26 @@
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
         "trn1 v2.4s, v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovsldup ymm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
+        "Could potentially be considered optimal.",
+        "Ideally the load happens directly in the destination register",
+        "This would lower memory pressure of this instruction by 1 temporary",
+        "But the more optimal implementation is still the same number of instructions",
         "Map 1 0b10 0x12 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1b {z2.b}, p7/z, [x4]",
-        "trn1 z2.s, z2.s, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "trn1 z16.s, z2.s, z2.s"
       ]
     },
     "vmovddup xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x12 128-bit"
@@ -330,200 +300,182 @@
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
         "dup v2.2d, v2.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovddup ymm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
+        "Could potentially be considered optimal.",
+        "Ideally the load happens directly in the destination register",
+        "This would lower memory pressure of this instruction by 1 temporary",
+        "But the more optimal implementation is still the same number of instructions",
         "Map 1 0b11 0x12 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1b {z2.b}, p7/z, [x4]",
-        "trn1 z2.d, z2.d, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "trn1 z16.d, z2.d, z2.d"
       ]
     },
     "vmovlps [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x13 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str d2, [x4]"
+        "str d16, [x4]"
       ]
     },
     "vmovlpd [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x13 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str d2, [x4]"
+        "str d16, [x4]"
       ]
     },
     "vunpcklps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x14 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ldr q3, [x4]",
-        "zip1 v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x4]",
+        "zip1 v2.4s, v17.4s, v2.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vunpcklps ymm0, ymm1, [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x14 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ld1b {z3.b}, p7/z, [x4]",
-        "zip1 z4.s, z2.s, z3.s",
-        "zip2 z2.s, z2.s, z3.s",
+        "ld1b {z2.b}, p7/z, [x4]",
+        "zip1 z3.s, z17.s, z2.s",
+        "zip2 z2.s, z17.s, z2.s",
         "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vunpcklpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x14 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ldr q3, [x4]",
-        "zip1 v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x4]",
+        "zip1 v2.2d, v17.2d, v2.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vunpcklpd ymm0, ymm1, [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x14 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ld1b {z3.b}, p7/z, [x4]",
-        "zip1 z4.d, z2.d, z3.d",
-        "zip2 z2.d, z2.d, z3.d",
+        "ld1b {z2.b}, p7/z, [x4]",
+        "zip1 z3.d, z17.d, z2.d",
+        "zip2 z2.d, z17.d, z2.d",
         "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vunpckhps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x15 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ldr q3, [x4]",
-        "zip2 v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x4]",
+        "zip2 v2.4s, v17.4s, v2.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vunpckhps ymm0, ymm1, [rax]": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x15 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ld1b {z3.b}, p7/z, [x4]",
-        "zip1 z4.s, z2.s, z3.s",
-        "zip2 z2.s, z2.s, z3.s",
-        "mov z1.q, z4.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z2.b}, p7/z, [x4]",
+        "zip1 z3.s, z17.s, z2.s",
+        "zip2 z2.s, z17.s, z2.s",
+        "mov z1.q, z3.q[1]",
+        "mov z16.d, z2.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vunpckhpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x15 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ldr q3, [x4]",
-        "zip2 v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x4]",
+        "zip2 v2.2d, v17.2d, v2.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vunpckhpd ymm0, ymm1, [rax]": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x15 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ld1b {z3.b}, p7/z, [x4]",
-        "zip1 z4.d, z2.d, z3.d",
-        "zip2 z2.d, z2.d, z3.d",
-        "mov z1.q, z4.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z2.b}, p7/z, [x4]",
+        "zip1 z3.d, z17.d, z2.d",
+        "zip2 z2.d, z17.d, z2.d",
+        "mov z1.q, z3.q[1]",
+        "mov z16.d, z2.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vmovhps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.8b, v2.8b",
+        "mov v2.8b, v17.8b",
         "ldr d3, [x4]",
         "mov v2.d[1], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovhpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.8b, v2.8b",
+        "mov v2.8b, v17.8b",
         "ldr d3, [x4]",
         "mov v2.d[1], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovshdup xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x16 128-bit"
@@ -531,20 +483,18 @@
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
         "trn2 v2.4s, v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovshdup ymm0, [rax]": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x16 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1b {z2.b}, p7/z, [x4]",
-        "trn2 z2.s, z2.s, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "trn2 z16.s, z2.s, z2.s"
       ]
     },
     "vmovhps [rax], xmm0": {
@@ -554,8 +504,8 @@
         "Map 1 0b00 0x17 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov v2.d[0], v2.d[1]",
+        "mov v2.16b, v16.16b",
+        "mov v2.d[0], v16.d[1]",
         "str d2, [x4]"
       ]
     },
@@ -566,20 +516,19 @@
         "Map 1 0b01 0x17 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov v2.d[0], v2.d[1]",
+        "mov v2.16b, v16.16b",
+        "mov v2.d[0], v16.d[1]",
         "str d2, [x4]"
       ]
     },
     "vmovmskps rax, xmm0": {
-      "ExpectedInstructionCount": 6,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 5,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x50 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "ushr v2.4s, v2.4s, #31",
+        "ushr v2.4s, v16.4s, #31",
         "index z3.s, #0, #1",
         "ushl v2.4s, v2.4s, v3.4s",
         "addv s2, v2.4s",
@@ -587,50 +536,49 @@
       ]
     },
     "vmovmskps rax, ymm0": {
-      "ExpectedInstructionCount": 42,
+      "ExpectedInstructionCount": 41,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x50 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
         "mov w20, #0x0",
-        "mov w21, v2.s[0]",
+        "mov w21, v16.s[0]",
         "lsr w21, w21, #31",
         "orr x20, x20, x21",
-        "mov w21, v2.s[1]",
+        "mov w21, v16.s[1]",
         "lsr w21, w21, #31",
         "lsl w21, w21, #1",
         "orr x20, x20, x21",
-        "mov w21, v2.s[2]",
+        "mov w21, v16.s[2]",
         "lsr w21, w21, #31",
         "lsl w21, w21, #2",
         "orr x20, x20, x21",
-        "mov w21, v2.s[3]",
+        "mov w21, v16.s[3]",
         "lsr w21, w21, #31",
         "lsl w21, w21, #3",
         "orr x20, x20, x21",
         "not p0.b, p7/z, p6.b",
-        "compact z0.d, p0, z2.d",
-        "mov w21, v2.s[0]",
+        "compact z0.d, p0, z16.d",
+        "mov w21, v16.s[0]",
         "lsr w21, w21, #31",
         "lsl w21, w21, #4",
         "orr x20, x20, x21",
         "not p0.b, p7/z, p6.b",
-        "compact z0.d, p0, z2.d",
-        "mov w21, v2.s[1]",
+        "compact z0.d, p0, z16.d",
+        "mov w21, v16.s[1]",
         "lsr w21, w21, #31",
         "lsl w21, w21, #5",
         "orr x20, x20, x21",
         "not p0.b, p7/z, p6.b",
-        "compact z0.d, p0, z2.d",
-        "mov w21, v2.s[2]",
+        "compact z0.d, p0, z16.d",
+        "mov w21, v16.s[2]",
         "lsr w21, w21, #31",
         "lsl w21, w21, #6",
         "orr x20, x20, x21",
         "not p0.b, p7/z, p6.b",
-        "compact z0.d, p0, z2.d",
-        "mov w21, v2.s[3]",
+        "compact z0.d, p0, z16.d",
+        "mov w21, v16.s[3]",
         "lsr w21, w21, #31",
         "lsl w21, w21, #7",
         "orr x20, x20, x21",
@@ -638,44 +586,42 @@
       ]
     },
     "vmovmskpd rax, xmm0": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x50 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "uzp2 v2.4s, v2.4s, v2.4s",
+        "uzp2 v2.4s, v16.4s, v16.4s",
         "mov x20, v2.d[0]",
         "bfi x20, x20, #31, #32",
         "lsr x4, x20, #62"
       ]
     },
     "vmovmskpd rax, ymm0": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 21,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x50 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
         "mov w20, #0x0",
-        "mov x21, v2.d[0]",
+        "mov x21, v16.d[0]",
         "lsr x21, x21, #63",
         "orr x20, x20, x21",
-        "mov x21, v2.d[1]",
+        "mov x21, v16.d[1]",
         "lsr x21, x21, #63",
         "lsl x21, x21, #1",
         "orr x20, x20, x21",
         "not p0.b, p7/z, p6.b",
-        "compact z0.d, p0, z2.d",
-        "mov x21, v2.d[0]",
+        "compact z0.d, p0, z16.d",
+        "mov x21, v16.d[0]",
         "lsr x21, x21, #63",
         "lsl x21, x21, #2",
         "orr x20, x20, x21",
         "not p0.b, p7/z, p6.b",
-        "compact z0.d, p0, z2.d",
-        "mov x21, v2.d[1]",
+        "compact z0.d, p0, z16.d",
+        "mov x21, v16.d[1]",
         "lsr x21, x21, #63",
         "lsl x21, x21, #3",
         "orr x20, x20, x21",
@@ -683,530 +629,431 @@
       ]
     },
     "vsqrtps xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x51 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fsqrt v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fsqrt v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vsqrtps ymm0, ymm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x51 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fsqrt z2.s, p7/m, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "fsqrt z16.s, p7/m, z17.s"
       ]
     },
     "vsqrtpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x51 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fsqrt v2.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fsqrt v2.2d, v17.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vsqrtpd ymm0, ymm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x51 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fsqrt z2.d, p7/m, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "fsqrt z16.d, p7/m, z17.d"
       ]
     },
     "vsqrtss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b10 0x51 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "mov z3.d, p7/m, z17.d",
-        "fsqrt s2, s2",
-        "mov v0.16b, v3.16b",
+        "fsqrt s2, s18",
+        "mov v0.16b, v17.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vsqrtsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b11 0x51 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "mov z3.d, p7/m, z17.d",
-        "fsqrt d2, d2",
-        "mov v0.16b, v3.16b",
+        "fsqrt d2, d18",
+        "mov v0.16b, v17.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vrsqrtps xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "Map 1 0b00 0x52 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "fmov v0.4s, #0x70 (1.0000)",
-        "fsqrt v1.4s, v2.4s",
+        "fsqrt v1.4s, v17.4s",
         "fdiv v2.4s, v0.4s, v1.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vrsqrtps ymm0, ymm1": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "Map 1 0b00 0x52 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fsqrt z0.s, p7/m, z2.s",
-        "fmov z2.s, #0x70 (1.0000)",
-        "fdiv z2.s, p7/m, z2.s, z0.s",
-        "mov z16.d, p7/m, z2.d"
+        "fsqrt z0.s, p7/m, z17.s",
+        "fmov z16.s, #0x70 (1.0000)",
+        "fdiv z16.s, p7/m, z16.s, z0.s"
       ]
     },
     "vrsqrtss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "Map 1 0b10 0x52 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "mov z3.d, p7/m, z17.d",
         "fmov s0, #0x70 (1.0000)",
-        "fsqrt s1, s2",
+        "fsqrt s1, s18",
         "fdiv s2, s0, s1",
-        "mov v0.16b, v3.16b",
+        "mov v0.16b, v17.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vrcpps xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "Map 1 0b00 0x53 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "fmov v0.4s, #0x70 (1.0000)",
-        "fdiv v2.4s, v0.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fdiv v2.4s, v0.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vrcpps ymm0, ymm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "Map 1 0b00 0x53 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "fmov z0.s, #0x70 (1.0000)",
-        "fdiv z0.s, p7/m, z0.s, z2.s",
-        "mov z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "fdiv z0.s, p7/m, z0.s, z17.s",
+        "mov z16.d, z0.d"
       ]
     },
     "vrcpss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "Map 1 0b10 0x53 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "mov z3.d, p7/m, z17.d",
         "fmov s0, #0x70 (1.0000)",
-        "fdiv s2, s0, s2",
-        "mov v0.16b, v3.16b",
+        "fdiv s2, s0, s18",
+        "mov v0.16b, v17.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vandps xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x54 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "and v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "and v2.16b, v16.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vandps ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x54 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "and z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "and z16.d, z16.d, z17.d"
       ]
     },
     "vandpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x54 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "and v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "and v2.16b, v16.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vandpd ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x54 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "and z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "and z16.d, z16.d, z17.d"
       ]
     },
     "vandnps xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x55 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "bic v2.16b, v3.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "bic v2.16b, v17.16b, v16.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vandnps ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x55 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "bic z2.d, z3.d, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "bic z16.d, z17.d, z16.d"
       ]
     },
     "vandnpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x55 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "bic v2.16b, v3.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "bic v2.16b, v17.16b, v16.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vandnpd ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x55 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "bic z2.d, z3.d, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "bic z16.d, z17.d, z16.d"
       ]
     },
     "vorps xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x56 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "orr v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "orr v2.16b, v16.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vorps ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x56 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "orr z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "orr z16.d, z16.d, z17.d"
       ]
     },
     "vorpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x56 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "orr v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "orr v2.16b, v16.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vorpd ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x56 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "orr z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "orr z16.d, z16.d, z17.d"
       ]
     },
     "vxorps xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x57 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "eor v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "eor v2.16b, v16.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vxorps ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x57 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "eor z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "eor z16.d, z16.d, z17.d"
       ]
     },
     "vxorpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x57 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "eor v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "eor v2.16b, v16.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vxorpd ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x57 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "eor z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "eor z16.d, z16.d, z17.d"
       ]
     },
     "vpunpcklbw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x60 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpunpcklbw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x60 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 z4.b, z2.b, z3.b",
-        "zip2 z2.b, z2.b, z3.b",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "zip1 z2.b, z17.b, z18.b",
+        "zip2 z3.b, z17.b, z18.b",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpunpcklwd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x61 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpunpcklwd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x61 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 z4.h, z2.h, z3.h",
-        "zip2 z2.h, z2.h, z3.h",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "zip1 z2.h, z17.h, z18.h",
+        "zip2 z3.h, z17.h, z18.h",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpunpckldq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x62 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpunpckldq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x62 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 z4.s, z2.s, z3.s",
-        "zip2 z2.s, z2.s, z3.s",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "zip1 z2.s, z17.s, z18.s",
+        "zip2 z3.s, z17.s, z18.s",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpacksswb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x63 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqxtn v2.8b, v2.8h",
-        "sqxtn2 v2.16b, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqxtn v2.8b, v17.8h",
+        "sqxtn2 v2.16b, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpacksswb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x63 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqxtnb z1.b, z3.h",
+        "sqxtnb z1.b, z18.h",
         "uzp1 z1.b, z1.b, z1.b",
-        "sqxtnb z2.b, z2.h",
+        "sqxtnb z2.b, z17.h",
         "uzp1 z2.b, z2.b, z2.b",
         "splice z2.b, p6, z2.b, z1.b",
         "mov z1.d, z2.d[1]",
@@ -1215,130 +1062,106 @@
         "cmpeq p0.d, p7/z, z0.d, #0",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpcmpgtb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x64 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmgt v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "cmgt v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpcmpgtb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x64 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmpgt p0.b, p7/z, z2.b, z3.b",
-        "not z0.b, p0/m, z2.b",
-        "movprfx z2.b, p0/z, z2.b",
-        "orr z2.b, p0/m, z2.b, z0.b",
-        "mov z16.d, p7/m, z2.d"
+        "cmpgt p0.b, p7/z, z17.b, z18.b",
+        "not z0.b, p0/m, z17.b",
+        "movprfx z16.b, p0/z, z17.b",
+        "orr z16.b, p0/m, z16.b, z0.b"
       ]
     },
     "vpcmpgtw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x65 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmgt v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "cmgt v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpcmpgtw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x65 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmpgt p0.h, p7/z, z2.h, z3.h",
-        "not z0.h, p0/m, z2.h",
-        "movprfx z2.h, p0/z, z2.h",
-        "orr z2.h, p0/m, z2.h, z0.h",
-        "mov z16.d, p7/m, z2.d"
+        "cmpgt p0.h, p7/z, z17.h, z18.h",
+        "not z0.h, p0/m, z17.h",
+        "movprfx z16.h, p0/z, z17.h",
+        "orr z16.h, p0/m, z16.h, z0.h"
       ]
     },
     "vpcmpgtd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x66 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmgt v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "cmgt v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpcmpgtd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x66 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmpgt p0.s, p7/z, z2.s, z3.s",
-        "not z0.s, p0/m, z2.s",
-        "movprfx z2.s, p0/z, z2.s",
-        "orr z2.s, p0/m, z2.s, z0.s",
-        "mov z16.d, p7/m, z2.d"
+        "cmpgt p0.s, p7/z, z17.s, z18.s",
+        "not z0.s, p0/m, z17.s",
+        "movprfx z16.s, p0/z, z17.s",
+        "orr z16.s, p0/m, z16.s, z0.s"
       ]
     },
     "vpackuswb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x67 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqxtun v2.8b, v2.8h",
-        "sqxtun2 v2.16b, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqxtun v2.8b, v17.8h",
+        "sqxtun2 v2.16b, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpackuswb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x67 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqxtunb z1.b, z3.h",
+        "sqxtunb z1.b, z18.h",
         "uzp1 z1.b, z1.b, z1.b",
-        "sqxtunb z2.b, z2.h",
+        "sqxtunb z2.b, z17.h",
         "uzp1 z2.b, z2.b, z2.b",
         "splice z2.b, p6, z2.b, z1.b",
         "mov z1.d, z2.d[1]",
@@ -1347,2286 +1170,1991 @@
         "cmpeq p0.d, p7/z, z0.d, #0",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpshufd xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.s[0], v2.s[0]",
-        "mov v3.s[1], v2.s[0]",
-        "mov v3.s[2], v2.s[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.s[0], v17.s[0]",
+        "mov v2.s[1], v17.s[0]",
+        "mov v2.s[2], v17.s[0]",
+        "mov v2.s[3], v17.s[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshufd xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.s[0], v2.s[1]",
-        "mov v3.s[1], v2.s[0]",
-        "mov v3.s[2], v2.s[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.s[0], v17.s[1]",
+        "mov v2.s[1], v17.s[0]",
+        "mov v2.s[2], v17.s[0]",
+        "mov v2.s[3], v17.s[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshufd xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.s[0], v2.s[2]",
-        "mov v3.s[1], v2.s[0]",
-        "mov v3.s[2], v2.s[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.s[0], v17.s[2]",
+        "mov v2.s[1], v17.s[0]",
+        "mov v2.s[2], v17.s[0]",
+        "mov v2.s[3], v17.s[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshufd xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.s[0], v2.s[3]",
-        "mov v3.s[1], v2.s[0]",
-        "mov v3.s[2], v2.s[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.s[0], v17.s[3]",
+        "mov v2.s[1], v17.s[0]",
+        "mov v2.s[2], v17.s[0]",
+        "mov v2.s[3], v17.s[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshufd ymm0, ymm1, 00b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.s, s2",
-        "mov z3.d, z2.d",
+        "mov z1.s, s17",
+        "mov z2.d, z17.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
-        "mov z2.d, z3.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vpshufd ymm0, ymm1, 01b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.s, z2.s[1]",
-        "mov z3.d, z2.d",
+        "mov z1.s, z17.s[1]",
+        "mov z2.d, z17.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[5]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[5]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
-        "mov z2.d, z3.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vpshufd ymm0, ymm1, 10b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.s, z2.s[2]",
-        "mov z3.d, z2.d",
+        "mov z1.s, z17.s[2]",
+        "mov z2.d, z17.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[6]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[6]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
-        "mov z2.d, z3.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vpshufd ymm0, ymm1, 11b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.s, z2.s[3]",
-        "mov z3.d, z2.d",
+        "mov z1.s, z17.s[3]",
+        "mov z2.d, z17.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[7]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[7]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
-        "mov z2.d, z3.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vpshufhw xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[4], v2.h[4]",
-        "mov v3.h[5], v2.h[4]",
-        "mov v3.h[6], v2.h[4]",
-        "mov v0.16b, v3.16b",
-        "mov v0.h[7], v2.h[4]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.h[4], v17.h[4]",
+        "mov v2.h[5], v17.h[4]",
+        "mov v2.h[6], v17.h[4]",
+        "mov v2.h[7], v17.h[4]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshufhw xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[4], v2.h[5]",
-        "mov v3.h[5], v2.h[4]",
-        "mov v3.h[6], v2.h[4]",
-        "mov v0.16b, v3.16b",
-        "mov v0.h[7], v2.h[4]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.h[4], v17.h[5]",
+        "mov v2.h[5], v17.h[4]",
+        "mov v2.h[6], v17.h[4]",
+        "mov v2.h[7], v17.h[4]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshufhw xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[4], v2.h[6]",
-        "mov v3.h[5], v2.h[4]",
-        "mov v3.h[6], v2.h[4]",
-        "mov v0.16b, v3.16b",
-        "mov v0.h[7], v2.h[4]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.h[4], v17.h[6]",
+        "mov v2.h[5], v17.h[4]",
+        "mov v2.h[6], v17.h[4]",
+        "mov v2.h[7], v17.h[4]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshufhw xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[4], v2.h[7]",
-        "mov v3.h[5], v2.h[4]",
-        "mov v3.h[6], v2.h[4]",
-        "mov v0.16b, v3.16b",
-        "mov v0.h[7], v2.h[4]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.h[4], v17.h[7]",
+        "mov v2.h[5], v17.h[4]",
+        "mov v2.h[6], v17.h[4]",
+        "mov v2.h[7], v17.h[4]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshufhw ymm0, ymm1, 00b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.h, z2.h[4]",
-        "mov z3.d, z2.d",
+        "mov z1.h, z17.h[4]",
+        "mov z2.d, z17.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-4",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #4",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-3",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #5",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-2",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #6",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-1",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
-        "mov z2.d, z3.d",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
+        "mov z16.d, z2.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #7",
-        "mov z2.h, p0/m, z1.h",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.h, p0/m, z1.h"
       ]
     },
     "vpshufhw ymm0, ymm1, 01b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.h, z2.h[5]",
-        "mov z3.d, z2.d",
+        "mov z1.h, z17.h[5]",
+        "mov z2.d, z17.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-4",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[13]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[13]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #4",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-3",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #5",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-2",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #6",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-1",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
-        "mov z2.d, z3.d",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
+        "mov z16.d, z2.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #7",
-        "mov z2.h, p0/m, z1.h",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.h, p0/m, z1.h"
       ]
     },
     "vpshufhw ymm0, ymm1, 10b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.h, z2.h[6]",
-        "mov z3.d, z2.d",
+        "mov z1.h, z17.h[6]",
+        "mov z2.d, z17.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-4",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[14]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[14]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #4",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-3",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #5",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-2",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #6",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-1",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
-        "mov z2.d, z3.d",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
+        "mov z16.d, z2.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #7",
-        "mov z2.h, p0/m, z1.h",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.h, p0/m, z1.h"
       ]
     },
     "vpshufhw ymm0, ymm1, 11b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.h, z2.h[7]",
-        "mov z3.d, z2.d",
+        "mov z1.h, z17.h[7]",
+        "mov z2.d, z17.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-4",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[15]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[15]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #4",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-3",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #5",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-2",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #6",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-1",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
-        "mov z2.d, z3.d",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
+        "mov z16.d, z2.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #7",
-        "mov z2.h, p0/m, z1.h",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.h, p0/m, z1.h"
       ]
     },
     "vpshuflw xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[0], v2.h[0]",
-        "mov v3.h[1], v2.h[0]",
-        "mov v3.h[2], v2.h[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.h[3], v2.h[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.h[0], v17.h[0]",
+        "mov v2.h[1], v17.h[0]",
+        "mov v2.h[2], v17.h[0]",
+        "mov v2.h[3], v17.h[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshuflw xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[0], v2.h[1]",
-        "mov v3.h[1], v2.h[0]",
-        "mov v3.h[2], v2.h[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.h[3], v2.h[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.h[0], v17.h[1]",
+        "mov v2.h[1], v17.h[0]",
+        "mov v2.h[2], v17.h[0]",
+        "mov v2.h[3], v17.h[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshuflw xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[0], v2.h[2]",
-        "mov v3.h[1], v2.h[0]",
-        "mov v3.h[2], v2.h[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.h[3], v2.h[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.h[0], v17.h[2]",
+        "mov v2.h[1], v17.h[0]",
+        "mov v2.h[2], v17.h[0]",
+        "mov v2.h[3], v17.h[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshuflw xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[0], v2.h[3]",
-        "mov v3.h[1], v2.h[0]",
-        "mov v3.h[2], v2.h[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.h[3], v2.h[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.h[0], v17.h[3]",
+        "mov v2.h[1], v17.h[0]",
+        "mov v2.h[2], v17.h[0]",
+        "mov v2.h[3], v17.h[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshuflw ymm0, ymm1, 00b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.h, h2",
-        "mov z3.d, z2.d",
+        "mov z1.h, h17",
+        "mov z2.d, z17.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-8",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #0",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-7",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #1",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-6",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #2",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-5",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
-        "mov z2.d, z3.d",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
+        "mov z16.d, z2.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #3",
-        "mov z2.h, p0/m, z1.h",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.h, p0/m, z1.h"
       ]
     },
     "vpshuflw ymm0, ymm1, 01b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.h, z2.h[1]",
-        "mov z3.d, z2.d",
+        "mov z1.h, z17.h[1]",
+        "mov z2.d, z17.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-8",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[9]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[9]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #0",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-7",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #1",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-6",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #2",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-5",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
-        "mov z2.d, z3.d",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
+        "mov z16.d, z2.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #3",
-        "mov z2.h, p0/m, z1.h",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.h, p0/m, z1.h"
       ]
     },
     "vpshuflw ymm0, ymm1, 10b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.h, z2.h[2]",
-        "mov z3.d, z2.d",
+        "mov z1.h, z17.h[2]",
+        "mov z2.d, z17.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-8",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[10]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[10]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #0",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-7",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #1",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-6",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #2",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-5",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
-        "mov z2.d, z3.d",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
+        "mov z16.d, z2.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #3",
-        "mov z2.h, p0/m, z1.h",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.h, p0/m, z1.h"
       ]
     },
     "vpshuflw ymm0, ymm1, 11b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z1.h, z2.h[3]",
-        "mov z3.d, z2.d",
+        "mov z1.h, z17.h[3]",
+        "mov z2.d, z17.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-8",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[11]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[11]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #0",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-7",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #1",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-6",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #2",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, h2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, h17",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #-5",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[8]",
-        "mov z2.d, z3.d",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[8]",
+        "mov z16.d, z2.d",
         "index z0.h, #-8, #1",
         "cmpeq p0.h, p7/z, z0.h, #3",
-        "mov z2.h, p0/m, z1.h",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.h, p0/m, z1.h"
       ]
     },
     "vpcmpeqb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x74 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmeq v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "cmeq v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpcmpeqb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x74 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmpeq p0.b, p7/z, z2.b, z3.b",
-        "not z0.b, p0/m, z2.b",
-        "movprfx z2.b, p0/z, z2.b",
-        "orr z2.b, p0/m, z2.b, z0.b",
-        "mov z16.d, p7/m, z2.d"
+        "cmpeq p0.b, p7/z, z17.b, z18.b",
+        "not z0.b, p0/m, z17.b",
+        "movprfx z16.b, p0/z, z17.b",
+        "orr z16.b, p0/m, z16.b, z0.b"
       ]
     },
     "vpcmpeqw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x75 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmeq v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "cmeq v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpcmpeqw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x75 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmpeq p0.h, p7/z, z2.h, z3.h",
-        "not z0.h, p0/m, z2.h",
-        "movprfx z2.h, p0/z, z2.h",
-        "orr z2.h, p0/m, z2.h, z0.h",
-        "mov z16.d, p7/m, z2.d"
+        "cmpeq p0.h, p7/z, z17.h, z18.h",
+        "not z0.h, p0/m, z17.h",
+        "movprfx z16.h, p0/z, z17.h",
+        "orr z16.h, p0/m, z16.h, z0.h"
       ]
     },
     "vpcmpeqd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x76 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmeq v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "cmeq v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpcmpeqd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x76 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmpeq p0.s, p7/z, z2.s, z3.s",
-        "not z0.s, p0/m, z2.s",
-        "movprfx z2.s, p0/z, z2.s",
-        "orr z2.s, p0/m, z2.s, z0.s",
-        "mov z16.d, p7/m, z2.d"
+        "cmpeq p0.s, p7/z, z17.s, z18.s",
+        "not z0.s, p0/m, z17.s",
+        "movprfx z16.s, p0/z, z17.s",
+        "orr z16.s, p0/m, z16.s, z0.s"
       ]
     },
     "vzeroupper": {
-      "ExpectedInstructionCount": 48,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 16,
+      "Optimal": "Yes",
       "Comment": [
+        "Might need to revisit this if move renaming ends up slower than some other clearing",
         "Map 1 0b01 0x77 L=0"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z17.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z18.d",
-        "mov v2.16b, v2.16b",
-        "mov z18.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z19.d",
-        "mov v2.16b, v2.16b",
-        "mov z19.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z20.d",
-        "mov v2.16b, v2.16b",
-        "mov z20.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z21.d",
-        "mov v2.16b, v2.16b",
-        "mov z21.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z22.d",
-        "mov v2.16b, v2.16b",
-        "mov z22.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z23.d",
-        "mov v2.16b, v2.16b",
-        "mov z23.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z24.d",
-        "mov v2.16b, v2.16b",
-        "mov z24.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z25.d",
-        "mov v2.16b, v2.16b",
-        "mov z25.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z26.d",
-        "mov v2.16b, v2.16b",
-        "mov z26.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z27.d",
-        "mov v2.16b, v2.16b",
-        "mov z27.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z28.d",
-        "mov v2.16b, v2.16b",
-        "mov z28.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z29.d",
-        "mov v2.16b, v2.16b",
-        "mov z29.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z30.d",
-        "mov v2.16b, v2.16b",
-        "mov z30.d, p7/m, z2.d",
-        "mov z2.d, p7/m, z31.d",
-        "mov v2.16b, v2.16b",
-        "mov z31.d, p7/m, z2.d"
+        "mov v16.16b, v16.16b",
+        "mov v17.16b, v17.16b",
+        "mov v18.16b, v18.16b",
+        "mov v19.16b, v19.16b",
+        "mov v20.16b, v20.16b",
+        "mov v21.16b, v21.16b",
+        "mov v22.16b, v22.16b",
+        "mov v23.16b, v23.16b",
+        "mov v24.16b, v24.16b",
+        "mov v25.16b, v25.16b",
+        "mov v26.16b, v26.16b",
+        "mov v27.16b, v27.16b",
+        "mov v28.16b, v28.16b",
+        "mov v29.16b, v29.16b",
+        "mov v30.16b, v30.16b",
+        "mov v31.16b, v31.16b"
       ]
     },
     "vzeroall": {
-      "ExpectedInstructionCount": 17,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 16,
+      "Optimal": "Yes",
       "Comment": [
-        "Should use movi for all registers",
         "Map 1 0b01 0x77 L=1"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d",
-        "mov z17.d, p7/m, z2.d",
-        "mov z18.d, p7/m, z2.d",
-        "mov z19.d, p7/m, z2.d",
-        "mov z20.d, p7/m, z2.d",
-        "mov z21.d, p7/m, z2.d",
-        "mov z22.d, p7/m, z2.d",
-        "mov z23.d, p7/m, z2.d",
-        "mov z24.d, p7/m, z2.d",
-        "mov z25.d, p7/m, z2.d",
-        "mov z26.d, p7/m, z2.d",
-        "mov z27.d, p7/m, z2.d",
-        "mov z28.d, p7/m, z2.d",
-        "mov z29.d, p7/m, z2.d",
-        "mov z30.d, p7/m, z2.d",
-        "mov z31.d, p7/m, z2.d"
+        "movi v16.2d, #0x0",
+        "movi v17.2d, #0x0",
+        "movi v18.2d, #0x0",
+        "movi v19.2d, #0x0",
+        "movi v20.2d, #0x0",
+        "movi v21.2d, #0x0",
+        "movi v22.2d, #0x0",
+        "movi v23.2d, #0x0",
+        "movi v24.2d, #0x0",
+        "movi v25.2d, #0x0",
+        "movi v26.2d, #0x0",
+        "movi v27.2d, #0x0",
+        "movi v28.2d, #0x0",
+        "movi v29.2d, #0x0",
+        "movi v30.2d, #0x0",
+        "movi v31.2d, #0x0"
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmeq v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmeq v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x00": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmeq p0.s, p7/z, z2.s, z3.s",
-        "not z0.s, p0/m, z2.s",
-        "movprfx z2.s, p0/z, z2.s",
-        "orr z2.s, p0/m, z2.s, z0.s",
-        "mov z16.d, p7/m, z2.d"
+        "fcmeq p0.s, p7/z, z17.s, z18.s",
+        "not z0.s, p0/m, z17.s",
+        "movprfx z16.s, p0/z, z17.s",
+        "orr z16.s, p0/m, z16.s, z0.s"
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt v2.4s, v3.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt v2.4s, v18.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x01": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt p0.s, p7/z, z3.s, z2.s",
-        "not z0.s, p0/m, z3.s",
-        "movprfx z2.s, p0/z, z3.s",
-        "orr z2.s, p0/m, z2.s, z0.s",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt p0.s, p7/z, z18.s, z17.s",
+        "not z0.s, p0/m, z18.s",
+        "movprfx z16.s, p0/z, z18.s",
+        "orr z16.s, p0/m, z16.s, z0.s"
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge v2.4s, v3.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmge v2.4s, v18.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x02": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge p0.s, p7/z, z3.s, z2.s",
-        "not z0.s, p0/m, z3.s",
-        "movprfx z2.s, p0/z, z3.s",
-        "orr z2.s, p0/m, z2.s, z0.s",
-        "mov z16.d, p7/m, z2.d"
+        "fcmge p0.s, p7/z, z18.s, z17.s",
+        "not z0.s, p0/m, z18.s",
+        "movprfx z16.s, p0/z, z18.s",
+        "orr z16.s, p0/m, z16.s, z0.s"
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge v0.4s, v2.4s, v3.4s",
-        "fcmgt v1.4s, v3.4s, v2.4s",
+        "fcmge v0.4s, v17.4s, v18.4s",
+        "fcmgt v1.4s, v18.4s, v17.4s",
         "orr v2.16b, v0.16b, v1.16b",
         "mvn v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x03": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmuo p0.s, p7/z, z2.s, z3.s",
-        "not z0.s, p0/m, z2.s",
-        "movprfx z2.s, p0/z, z2.s",
-        "orr z2.s, p0/m, z2.s, z0.s",
-        "mov z16.d, p7/m, z2.d"
+        "fcmuo p0.s, p7/z, z17.s, z18.s",
+        "not z0.s, p0/m, z17.s",
+        "movprfx z16.s, p0/z, z17.s",
+        "orr z16.s, p0/m, z16.s, z0.s"
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmeq v2.4s, v2.4s, v3.4s",
+        "fcmeq v2.4s, v17.4s, v18.4s",
         "mvn v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x04": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmne p0.s, p7/z, z2.s, z3.s",
-        "not z0.s, p0/m, z2.s",
-        "movprfx z2.s, p0/z, z2.s",
-        "orr z2.s, p0/m, z2.s, z0.s",
-        "mov z16.d, p7/m, z2.d"
+        "fcmne p0.s, p7/z, z17.s, z18.s",
+        "not z0.s, p0/m, z17.s",
+        "movprfx z16.s, p0/z, z17.s",
+        "orr z16.s, p0/m, z16.s, z0.s"
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt v2.4s, v3.4s, v2.4s",
+        "fcmgt v2.4s, v18.4s, v17.4s",
         "mvn v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x05": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt p0.s, p7/z, z3.s, z2.s",
-        "not z0.s, p0/m, z3.s",
-        "movprfx z2.s, p0/z, z3.s",
+        "fcmgt p0.s, p7/z, z18.s, z17.s",
+        "not z0.s, p0/m, z18.s",
+        "movprfx z2.s, p0/z, z18.s",
         "orr z2.s, p0/m, z2.s, z0.s",
-        "not z2.b, p7/m, z2.b",
-        "mov z16.d, p7/m, z2.d"
+        "not z16.b, p7/m, z2.b"
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge v2.4s, v3.4s, v2.4s",
+        "fcmge v2.4s, v18.4s, v17.4s",
         "mvn v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x06": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge p0.s, p7/z, z3.s, z2.s",
-        "not z0.s, p0/m, z3.s",
-        "movprfx z2.s, p0/z, z3.s",
+        "fcmge p0.s, p7/z, z18.s, z17.s",
+        "not z0.s, p0/m, z18.s",
+        "movprfx z2.s, p0/z, z18.s",
         "orr z2.s, p0/m, z2.s, z0.s",
-        "not z2.b, p7/m, z2.b",
-        "mov z16.d, p7/m, z2.d"
+        "not z16.b, p7/m, z2.b"
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge v0.4s, v2.4s, v3.4s",
-        "fcmgt v1.4s, v3.4s, v2.4s",
+        "fcmge v0.4s, v17.4s, v18.4s",
+        "fcmgt v1.4s, v18.4s, v17.4s",
         "orr v2.16b, v0.16b, v1.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x07": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmuo p0.s, p7/z, z2.s, z3.s",
+        "fcmuo p0.s, p7/z, z17.s, z18.s",
         "not p0.b, p7/z, p0.b",
-        "not z0.s, p0/m, z2.s",
-        "movprfx z2.s, p0/z, z2.s",
-        "orr z2.s, p0/m, z2.s, z0.s",
-        "mov z16.d, p7/m, z2.d"
+        "not z0.s, p0/m, z17.s",
+        "movprfx z16.s, p0/z, z17.s",
+        "orr z16.s, p0/m, z16.s, z0.s"
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmeq v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmeq v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x00": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmeq p0.d, p7/z, z2.d, z3.d",
-        "not z0.d, p0/m, z2.d",
-        "movprfx z2.d, p0/z, z2.d",
-        "orr z2.d, p0/m, z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "fcmeq p0.d, p7/z, z17.d, z18.d",
+        "not z0.d, p0/m, z17.d",
+        "movprfx z16.d, p0/z, z17.d",
+        "orr z16.d, p0/m, z16.d, z0.d"
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt v2.2d, v3.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt v2.2d, v18.2d, v17.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x01": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt p0.d, p7/z, z3.d, z2.d",
-        "not z0.d, p0/m, z3.d",
-        "movprfx z2.d, p0/z, z3.d",
-        "orr z2.d, p0/m, z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt p0.d, p7/z, z18.d, z17.d",
+        "not z0.d, p0/m, z18.d",
+        "movprfx z16.d, p0/z, z18.d",
+        "orr z16.d, p0/m, z16.d, z0.d"
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge v2.2d, v3.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmge v2.2d, v18.2d, v17.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x02": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge p0.d, p7/z, z3.d, z2.d",
-        "not z0.d, p0/m, z3.d",
-        "movprfx z2.d, p0/z, z3.d",
-        "orr z2.d, p0/m, z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "fcmge p0.d, p7/z, z18.d, z17.d",
+        "not z0.d, p0/m, z18.d",
+        "movprfx z16.d, p0/z, z18.d",
+        "orr z16.d, p0/m, z16.d, z0.d"
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge v0.2d, v2.2d, v3.2d",
-        "fcmgt v1.2d, v3.2d, v2.2d",
+        "fcmge v0.2d, v17.2d, v18.2d",
+        "fcmgt v1.2d, v18.2d, v17.2d",
         "orr v2.16b, v0.16b, v1.16b",
         "mvn v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x03": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmuo p0.d, p7/z, z2.d, z3.d",
-        "not z0.d, p0/m, z2.d",
-        "movprfx z2.d, p0/z, z2.d",
-        "orr z2.d, p0/m, z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "fcmuo p0.d, p7/z, z17.d, z18.d",
+        "not z0.d, p0/m, z17.d",
+        "movprfx z16.d, p0/z, z17.d",
+        "orr z16.d, p0/m, z16.d, z0.d"
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmeq v2.2d, v2.2d, v3.2d",
+        "fcmeq v2.2d, v17.2d, v18.2d",
         "mvn v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x04": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmne p0.d, p7/z, z2.d, z3.d",
-        "not z0.d, p0/m, z2.d",
-        "movprfx z2.d, p0/z, z2.d",
-        "orr z2.d, p0/m, z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "fcmne p0.d, p7/z, z17.d, z18.d",
+        "not z0.d, p0/m, z17.d",
+        "movprfx z16.d, p0/z, z17.d",
+        "orr z16.d, p0/m, z16.d, z0.d"
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt v2.2d, v3.2d, v2.2d",
+        "fcmgt v2.2d, v18.2d, v17.2d",
         "mvn v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x05": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt p0.d, p7/z, z3.d, z2.d",
-        "not z0.d, p0/m, z3.d",
-        "movprfx z2.d, p0/z, z3.d",
+        "fcmgt p0.d, p7/z, z18.d, z17.d",
+        "not z0.d, p0/m, z18.d",
+        "movprfx z2.d, p0/z, z18.d",
         "orr z2.d, p0/m, z2.d, z0.d",
-        "not z2.b, p7/m, z2.b",
-        "mov z16.d, p7/m, z2.d"
+        "not z16.b, p7/m, z2.b"
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge v2.2d, v3.2d, v2.2d",
+        "fcmge v2.2d, v18.2d, v17.2d",
         "mvn v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x06": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge p0.d, p7/z, z3.d, z2.d",
-        "not z0.d, p0/m, z3.d",
-        "movprfx z2.d, p0/z, z3.d",
+        "fcmge p0.d, p7/z, z18.d, z17.d",
+        "not z0.d, p0/m, z18.d",
+        "movprfx z2.d, p0/z, z18.d",
         "orr z2.d, p0/m, z2.d, z0.d",
-        "not z2.b, p7/m, z2.b",
-        "mov z16.d, p7/m, z2.d"
+        "not z16.b, p7/m, z2.b"
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge v0.2d, v2.2d, v3.2d",
-        "fcmgt v1.2d, v3.2d, v2.2d",
+        "fcmge v0.2d, v17.2d, v18.2d",
+        "fcmgt v1.2d, v18.2d, v17.2d",
         "orr v2.16b, v0.16b, v1.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x07": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmuo p0.d, p7/z, z2.d, z3.d",
+        "fcmuo p0.d, p7/z, z17.d, z18.d",
         "not p0.b, p7/z, p0.b",
-        "not z0.d, p0/m, z2.d",
-        "movprfx z2.d, p0/z, z2.d",
-        "orr z2.d, p0/m, z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "not z0.d, p0/m, z17.d",
+        "movprfx z16.d, p0/z, z17.d",
+        "orr z16.d, p0/m, z16.d, z0.d"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmeq s3, s2, s3",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmeq s2, s17, s18",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt s3, s3, s2",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt s2, s18, s17",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge s3, s3, s2",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmge s2, s18, s17",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge s0, s2, s3",
-        "fcmgt s1, s3, s2",
-        "orr v3.8b, v0.8b, v1.8b",
-        "mvn v3.8b, v3.8b",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmge s0, s17, s18",
+        "fcmgt s1, s18, s17",
+        "orr v2.8b, v0.8b, v1.8b",
+        "mvn v2.8b, v2.8b",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmeq s3, s2, s3",
-        "mvn v3.8b, v3.8b",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmeq s2, s17, s18",
+        "mvn v2.8b, v2.8b",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt s3, s3, s2",
-        "mvn v3.16b, v3.16b",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt s2, s18, s17",
+        "mvn v2.16b, v2.16b",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge s3, s3, s2",
-        "mvn v3.16b, v3.16b",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmge s2, s18, s17",
+        "mvn v2.16b, v2.16b",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge s0, s2, s3",
-        "fcmgt s1, s3, s2",
-        "orr v3.8b, v0.8b, v1.8b",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmge s0, s17, s18",
+        "fcmgt s1, s18, s17",
+        "orr v2.8b, v0.8b, v1.8b",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmeq d3, d2, d3",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmeq d2, d17, d18",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt d3, d3, d2",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt d2, d18, d17",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge d3, d3, d2",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmge d2, d18, d17",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge d0, d2, d3",
-        "fcmgt d1, d3, d2",
-        "orr v3.8b, v0.8b, v1.8b",
-        "mvn v3.8b, v3.8b",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmeq d3, d2, d3",
-        "mvn v3.8b, v3.8b",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt d3, d3, d2",
-        "mvn v3.16b, v3.16b",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge d3, d3, d2",
-        "mvn v3.16b, v3.16b",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x07": {
       "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmge d0, d2, d3",
-        "fcmgt d1, d3, d2",
-        "orr v3.8b, v0.8b, v1.8b",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmge d0, d17, d18",
+        "fcmgt d1, d18, d17",
+        "orr v2.8b, v0.8b, v1.8b",
+        "mvn v2.8b, v2.8b",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x04": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcmeq d2, d17, d18",
+        "mvn v2.8b, v2.8b",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x05": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcmgt d2, d18, d17",
+        "mvn v2.16b, v2.16b",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x06": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcmge d2, d18, d17",
+        "mvn v2.16b, v2.16b",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x07": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcmge d0, d17, d18",
+        "fcmgt d1, d18, d17",
+        "orr v2.8b, v0.8b, v1.8b",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
+        "mov v2.16b, v17.16b",
         "mov v2.h[0], w4",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
+        "mov v2.16b, v17.16b",
         "mov v2.h[1], w4",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 111b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
+        "mov v2.16b, v17.16b",
         "mov v2.h[7], w4",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpextrw eax, xmm0, 000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "umov w4, v2.h[0]"
+        "umov w4, v16.h[0]"
       ]
     },
     "vpextrw eax, xmm0, 001b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "umov w4, v2.h[1]"
+        "umov w4, v16.h[1]"
       ]
     },
     "vpextrw eax, xmm0, 111b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "umov w4, v2.h[7]"
+        "umov w4, v16.h[7]"
       ]
     },
     "vpextrw [rax], xmm0, 000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1 {v2.h}[0], [x4]"
+        "st1 {v16.h}[0], [x4]"
       ]
     },
     "vpextrw [rax], xmm0, 001b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1 {v2.h}[1], [x4]"
+        "st1 {v16.h}[1], [x4]"
       ]
     },
     "vpextrw [rax], xmm0, 111b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1 {v2.h}[7], [x4]"
+        "st1 {v16.h}[7], [x4]"
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 00b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v2.4s, v2.s[0]",
-        "dup v3.4s, v3.s[0]",
+        "dup v2.4s, v17.s[0]",
+        "dup v3.4s, v18.s[0]",
         "zip1 v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 00b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z1.s, s2",
-        "mov z4.d, z2.d",
+        "mov z1.s, s17",
+        "mov z2.d, z17.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
-        "mov z2.d, z4.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s3",
+        "mov z1.s, s18",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, z3.s[4]",
+        "mov z1.s, z18.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s3",
+        "mov z1.s, s18",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, z3.s[4]",
+        "mov z1.s, z18.s[4]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 01b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "ldr x0, [x28, #1632]",
-        "ldr q4, [x0, #16]",
-        "tbl v2.16b, {v2.16b, v3.16b}, v4.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x0, #16]",
+        "tbl v2.16b, {v17.16b, v18.16b}, v2.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 01b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z1.s, z2.s[1]",
-        "mov z4.d, z2.d",
+        "mov z1.s, z17.s[1]",
+        "mov z2.d, z17.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[5]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[5]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
-        "mov z2.d, z4.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s3",
+        "mov z1.s, s18",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, z3.s[4]",
+        "mov z1.s, z18.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s3",
+        "mov z1.s, s18",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, z3.s[4]",
+        "mov z1.s, z18.s[4]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 10b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "ldr x0, [x28, #1632]",
-        "ldr q4, [x0, #32]",
-        "tbl v2.16b, {v2.16b, v3.16b}, v4.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x0, #32]",
+        "tbl v2.16b, {v17.16b, v18.16b}, v2.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 10b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z1.s, z2.s[2]",
-        "mov z4.d, z2.d",
+        "mov z1.s, z17.s[2]",
+        "mov z2.d, z17.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[6]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[6]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
-        "mov z2.d, z4.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s3",
+        "mov z1.s, s18",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, z3.s[4]",
+        "mov z1.s, z18.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s3",
+        "mov z1.s, s18",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, z3.s[4]",
+        "mov z1.s, z18.s[4]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 11b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "ldr x0, [x28, #1632]",
-        "ldr q4, [x0, #48]",
-        "tbl v2.16b, {v2.16b, v3.16b}, v4.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x0, #48]",
+        "tbl v2.16b, {v17.16b, v18.16b}, v2.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 11b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z1.s, z2.s[3]",
-        "mov z4.d, z2.d",
+        "mov z1.s, z17.s[3]",
+        "mov z2.d, z17.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[7]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[7]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
-        "mov z2.d, z4.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s3",
+        "mov z1.s, s18",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, z3.s[4]",
+        "mov z1.s, z18.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s3",
+        "mov z1.s, s18",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, z3.s[4]",
+        "mov z1.s, z18.s[4]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vshufpd xmm0, xmm1, xmm2, 0b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vshufpd ymm0, ymm1, ymm2, 0b": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z1.d, d2",
-        "mov z4.d, z2.d",
+        "mov z1.d, d17",
+        "mov z2.d, z17.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z4.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
         "mov z2.d, p0/m, z1.d",
-        "mov z1.d, d3",
+        "mov z1.d, d18",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[2]",
+        "mov z1.d, z18.d[2]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vshufpd xmm0, xmm1, xmm2, 1b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "ext v2.16b, v2.16b, v3.16b, #8",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ext v2.16b, v17.16b, v18.16b, #8",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vshufpd ymm0, ymm1, ymm2, 1b": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z1.d, z2.d[1]",
-        "mov z4.d, z2.d",
+        "mov z1.d, z17.d[1]",
+        "mov z2.d, z17.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z4.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
         "mov z2.d, p0/m, z1.d",
-        "mov z1.d, d3",
+        "mov z1.d, d18",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[2]",
+        "mov z1.d, z18.d[2]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vmovaps xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x28 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q16, [x4]"
       ]
     },
     "vmovaps ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x28 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1b {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z16.b}, p7/z, [x4]"
       ]
     },
     "vmovaps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x29 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vmovaps ymm0, ymm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x29 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vmovapd xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x28 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q16, [x4]"
       ]
     },
     "vmovapd ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x28 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1b {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z16.b}, p7/z, [x4]"
       ]
     },
     "vmovapd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x29 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vmovapd ymm0, ymm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x29 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vmovaps [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x29 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str q2, [x4]"
+        "str q16, [x4]"
       ]
     },
     "vmovaps [rax], ymm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x29 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1b {z2.b}, p7, [x4]"
+        "st1b {z16.b}, p7, [x4]"
       ]
     },
     "vmovapd [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x29 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str q2, [x4]"
+        "str q16, [x4]"
       ]
     },
     "vmovapd [rax], ymm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x29 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1b {z2.b}, p7, [x4]"
+        "st1b {z16.b}, p7, [x4]"
       ]
     },
     "vcvtsi2ss xmm0, xmm1, eax": {
@@ -3636,11 +3164,11 @@
         "Map 1 0b10 0x2A 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "scvtf s3, w4",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "scvtf s2, w4",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtsi2ss xmm0, xmm1, rax": {
@@ -3650,11 +3178,11 @@
         "Map 1 0b10 0x2A 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "scvtf s3, x4",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "scvtf s2, x4",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtsi2sd xmm0, xmm1, eax": {
@@ -3664,11 +3192,11 @@
         "Map 1 0b11 0x2A 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "scvtf d3, w4",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "scvtf d2, w4",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtsi2sd xmm0, xmm1, rax": {
@@ -3678,159 +3206,145 @@
         "Map 1 0b11 0x2A 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "scvtf d3, x4",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "scvtf d2, x4",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovntps [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x2B 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str q2, [x4]"
+        "str q16, [x4]"
       ]
     },
     "vmovntps [rax], ymm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x2B 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1b {z2.b}, p7, [x4]"
+        "st1b {z16.b}, p7, [x4]"
       ]
     },
     "vmovntpd [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x2B 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str q2, [x4]"
+        "str q16, [x4]"
       ]
     },
     "vmovntpd [rax], ymm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x2B 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1b {z2.b}, p7, [x4]"
+        "st1b {z16.b}, p7, [x4]"
       ]
     },
     "vcvttss2si eax, xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "fcvtzs w4, s2"
+        "fcvtzs w4, s16"
       ]
     },
     "vcvttss2si rax, xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "fcvtzs x4, s2"
+        "fcvtzs x4, s16"
       ]
     },
     "vcvttsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "fcvtzs w4, d2"
+        "fcvtzs w4, d16"
       ]
     },
     "vcvttsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "fcvtzs x4, d2"
+        "fcvtzs x4, d16"
       ]
     },
     "vcvtss2si eax, xmm0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "frinti s0, s2",
+        "frinti s0, s16",
         "fcvtzs w4, s0"
       ]
     },
     "vcvtss2si rax, xmm0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "frinti s0, s2",
+        "frinti s0, s16",
         "fcvtzs x4, s0"
       ]
     },
     "vcvtsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "frinti d0, d2",
+        "frinti d0, d16",
         "fcvtzs x4, d0"
       ]
     },
     "vcvtsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "frinti d0, d2",
+        "frinti d0, d16",
         "fcvtzs x4, d0"
       ]
     },
     "vucomiss xmm0, xmm1": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x2e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "fcmp s2, s3",
+        "fcmp s16, s17",
         "cset x20, eq",
         "csinc x20, x20, xzr, vc",
         "cset x1, lt",
@@ -3852,15 +3366,13 @@
       ]
     },
     "vucomisd xmm0, xmm1": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 22,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x2e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "fcmp d2, d3",
+        "fcmp d16, d17",
         "cset x20, eq",
         "csinc x20, x20, xzr, vc",
         "cset x1, lt",
@@ -3885,15 +3397,13 @@
       ]
     },
     "vcomiss xmm0, xmm1": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 22,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x2f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "fcmp s2, s3",
+        "fcmp s16, s17",
         "cset x20, eq",
         "csinc x20, x20, xzr, vc",
         "cset x1, lt",
@@ -3918,15 +3428,13 @@
       ]
     },
     "vcomisd xmm0, xmm1": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 22,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x2f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "fcmp d2, d3",
+        "fcmp d16, d17",
         "cset x20, eq",
         "csinc x20, x20, xzr, vc",
         "cset x1, lt",
@@ -3951,773 +3459,667 @@
       ]
     },
     "vaddps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fadd v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fadd v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaddps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x58 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fadd z2.s, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "fadd z16.s, z17.s, z18.s"
       ]
     },
     "vaddpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fadd v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fadd v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaddpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x58 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fadd z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "fadd z16.d, z17.d, z18.d"
       ]
     },
     "vaddss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fadd s3, s2, s3",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fadd s2, s17, s18",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaddsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fadd d3, d2, d3",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fadd d2, d17, d18",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmulps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fmul v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fmul v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmulps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x59 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fmul z2.s, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "fmul z16.s, z17.s, z18.s"
       ]
     },
     "vmulpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fmul v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fmul v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmulpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x59 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fmul z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "fmul z16.d, z17.d, z18.d"
       ]
     },
     "vmulss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fmul s3, s2, s3",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fmul s2, s17, s18",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmulsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fmul d3, d2, d3",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fmul d2, d17, d18",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtps2pd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fcvtl v2.2d, v2.2s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcvtl v2.2d, v17.2s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtpd2ps xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fcvtn v2.2s, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcvtn v2.2s, v17.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtss2sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x5a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcvt d3, s3",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcvt d2, s18",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtsd2ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x5a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcvt s3, d3",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcvt s2, d18",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtdq2ps xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "scvtf v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "scvtf v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtdq2ps ymm0, ymm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5b 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "scvtf z2.s, p7/m, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "scvtf z16.s, p7/m, z17.s"
       ]
     },
     "vcvtps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frinti v2.4s, v2.4s",
+        "frinti v2.4s, v17.4s",
         "fcvtzs v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtps2dq ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5b 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frinti z2.s, p7/m, z2.s",
-        "fcvtzs z2.s, p7/m, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "frinti z16.s, p7/m, z17.s",
+        "fcvtzs z16.s, p7/m, z16.s"
       ]
     },
     "vcvttps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fcvtzs v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcvtzs v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvttps2dq ymm0, ymm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5b 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fcvtzs z2.s, p7/m, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "fcvtzs z16.s, p7/m, z17.s"
       ]
     },
     "vsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fsub v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fsub v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vsubps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fsub z2.s, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "fsub z16.s, z17.s, z18.s"
       ]
     },
     "vsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fsub v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fsub v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vsubpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fsub z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "fsub z16.d, z17.d, z18.d"
       ]
     },
     "vsubss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x5c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fsub s3, s2, s3",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fsub s2, s17, s18",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vsubsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x5c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fsub d3, d2, d3",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fsub d2, d17, d18",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vminps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt v0.4s, v3.4s, v2.4s",
-        "bif v2.16b, v3.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt v0.4s, v18.4s, v17.4s",
+        "mov v2.16b, v17.16b",
+        "bif v2.16b, v18.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vminps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5d 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt p0.s, p7/z, z3.s, z2.s",
+        "fcmgt p0.s, p7/z, z18.s, z17.s",
         "not p0.b, p7/z, p0.b",
-        "mov z2.s, p0/m, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z0.d, z17.d",
+        "mov z0.s, p0/m, z18.s",
+        "mov z16.d, z0.d"
       ]
     },
     "vminpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt v0.2d, v3.2d, v2.2d",
-        "bif v2.16b, v3.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt v0.2d, v18.2d, v17.2d",
+        "mov v2.16b, v17.16b",
+        "bif v2.16b, v18.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vminpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5d 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt p0.d, p7/z, z3.d, z2.d",
+        "fcmgt p0.d, p7/z, z18.d, z17.d",
         "not p0.b, p7/z, p0.b",
-        "mov z2.d, p0/m, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z0.d, z17.d",
+        "mov z0.d, p0/m, z18.d",
+        "mov z16.d, z0.d"
       ]
     },
     "vminss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x5d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmp s2, s3",
-        "fcsel s3, s2, s3, mi",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmp s17, s18",
+        "fcsel s2, s17, s18, mi",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vminsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x5d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmp d2, d3",
-        "fcsel d3, d2, d3, mi",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmp d17, d18",
+        "fcsel d2, d17, d18, mi",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vdivps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fdiv v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fdiv v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vdivps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5e 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fdiv z2.s, p7/m, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "fdiv z0.s, p7/m, z0.s, z18.s",
+        "mov z16.d, z0.d"
       ]
     },
     "vdivpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fdiv v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fdiv v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vdivpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5e 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fdiv z2.d, p7/m, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "fdiv z0.d, p7/m, z0.d, z18.d",
+        "mov z16.d, z0.d"
       ]
     },
     "vdivss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x5e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fdiv s3, s2, s3",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fdiv s2, s17, s18",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vdivsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x5e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fdiv d3, d2, d3",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fdiv d2, d17, d18",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmaxps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt v0.4s, v3.4s, v2.4s",
-        "bit v2.16b, v3.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt v0.4s, v18.4s, v17.4s",
+        "mov v2.16b, v17.16b",
+        "bit v2.16b, v18.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmaxps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5f 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt p0.s, p7/z, z3.s, z2.s",
-        "mov z2.s, p0/m, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt p0.s, p7/z, z18.s, z17.s",
+        "mov z0.d, z17.d",
+        "mov z0.s, p0/m, z18.s",
+        "mov z16.d, z0.d"
       ]
     },
     "vmaxpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt v0.2d, v3.2d, v2.2d",
-        "bit v2.16b, v3.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt v0.2d, v18.2d, v17.2d",
+        "mov v2.16b, v17.16b",
+        "bit v2.16b, v18.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmaxpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5f 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmgt p0.d, p7/z, z3.d, z2.d",
-        "mov z2.d, p0/m, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "fcmgt p0.d, p7/z, z18.d, z17.d",
+        "mov z0.d, z17.d",
+        "mov z0.d, p0/m, z18.d",
+        "mov z16.d, z0.d"
       ]
     },
     "vmaxss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x5f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmp s2, s3",
-        "fcsel s3, s3, s2, mi",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmp s17, s18",
+        "fcsel s2, s18, s17, mi",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmaxsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x5f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "fcmp d2, d3",
-        "fcsel d3, d3, d2, mi",
-        "mov v2.d[0], v3.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fcmp d17, d18",
+        "fcsel d2, d18, d17, mi",
+        "mov v0.16b, v17.16b",
+        "mov v0.d[0], v2.d[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpunpckhbw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x68 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip2 v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "zip2 v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpunpckhbw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x68 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 z4.b, z2.b, z3.b",
-        "zip2 z2.b, z2.b, z3.b",
-        "mov z1.q, z4.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 z2.b, z17.b, z18.b",
+        "zip2 z3.b, z17.b, z18.b",
+        "mov z1.q, z2.q[1]",
+        "mov z16.d, z3.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vpunpckhwd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x69 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip2 v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "zip2 v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpunpckhwd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x69 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 z4.h, z2.h, z3.h",
-        "zip2 z2.h, z2.h, z3.h",
-        "mov z1.q, z4.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 z2.h, z17.h, z18.h",
+        "zip2 z3.h, z17.h, z18.h",
+        "mov z1.q, z2.q[1]",
+        "mov z16.d, z3.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vpunpckhdq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip2 v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "zip2 v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpunpckhdq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6a 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 z4.s, z2.s, z3.s",
-        "zip2 z2.s, z2.s, z3.s",
-        "mov z1.q, z4.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 z2.s, z17.s, z18.s",
+        "zip2 z3.s, z17.s, z18.s",
+        "mov z1.q, z2.q[1]",
+        "mov z16.d, z3.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vpackssdw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqxtn v2.4h, v2.4s",
-        "sqxtn2 v2.8h, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqxtn v2.4h, v17.4s",
+        "sqxtn2 v2.8h, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpackssdw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6b 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqxtnb z1.h, z3.s",
+        "sqxtnb z1.h, z18.s",
         "uzp1 z1.h, z1.h, z1.h",
-        "sqxtnb z2.h, z2.s",
+        "sqxtnb z2.h, z17.s",
         "uzp1 z2.h, z2.h, z2.h",
         "splice z2.h, p6, z2.h, z1.h",
         "mov z1.d, z2.d[1]",
@@ -4726,166 +4128,143 @@
         "cmpeq p0.d, p7/z, z0.d, #0",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpunpcklqdq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpunpcklqdq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 z4.d, z2.d, z3.d",
-        "zip2 z2.d, z2.d, z3.d",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "zip1 z2.d, z17.d, z18.d",
+        "zip2 z3.d, z17.d, z18.d",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpunpckhqdq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip2 v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "zip2 v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpunpckhqdq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6d 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "zip1 z4.d, z2.d, z3.d",
-        "zip2 z2.d, z2.d, z3.d",
-        "mov z1.q, z4.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 z2.d, z17.d, z18.d",
+        "zip2 z3.d, z17.d, z18.d",
+        "mov z1.q, z2.q[1]",
+        "mov z16.d, z3.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vmovd xmm0, dword [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr s2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr s16, [x4]"
       ]
     },
     "vmovq xmm0, qword [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr d2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr d16, [x4]"
       ]
     },
     "vmovdqa xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q16, [x4]"
       ]
     },
     "vmovdqa [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str q2, [x4]"
+        "str q16, [x4]"
       ]
     },
     "vmovdqu xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x6f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q16, [x4]"
       ]
     },
     "vmovdqu [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x6f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str q2, [x4]"
+        "str q16, [x4]"
       ]
     },
     "vhaddpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "faddp v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "faddp v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vhaddpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movprfx z0, z2",
-        "faddp z0.d, p7/m, z0.d, z3.d",
+        "movprfx z0, z17",
+        "faddp z0.d, p7/m, z0.d, z18.d",
         "uzp1 z2.d, z0.d, z0.d",
         "uzp2 z1.d, z0.d, z0.d",
         "splice z2.d, p6, z2.d, z1.d",
@@ -4895,38 +4274,32 @@
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[1]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vhaddps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x7c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "faddp v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "faddp v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vhaddps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x7c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movprfx z0, z2",
-        "faddp z0.s, p7/m, z0.s, z3.s",
+        "movprfx z0, z17",
+        "faddp z0.s, p7/m, z0.s, z18.s",
         "uzp1 z2.s, z0.s, z0.s",
         "uzp2 z1.s, z0.s, z0.s",
         "splice z2.d, p6, z2.d, z1.d",
@@ -4936,397 +4309,340 @@
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[1]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vhsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 v4.2d, v2.2d, v3.2d",
-        "uzp2 v2.2d, v2.2d, v3.2d",
-        "fsub v2.2d, v4.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uzp1 v2.2d, v17.2d, v18.2d",
+        "uzp2 v3.2d, v17.2d, v18.2d",
+        "fsub v2.2d, v2.2d, v3.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vhsubpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7d 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 z4.d, z2.d, z3.d",
-        "uzp2 z2.d, z2.d, z3.d",
-        "fsub z2.d, z4.d, z2.d",
+        "uzp1 z2.d, z17.d, z18.d",
+        "uzp2 z3.d, z17.d, z18.d",
+        "fsub z2.d, z2.d, z3.d",
         "mov z1.d, z2.d[2]",
         "mov z3.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[1]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vhsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x7d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 v4.4s, v2.4s, v3.4s",
-        "uzp2 v2.4s, v2.4s, v3.4s",
-        "fsub v2.4s, v4.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uzp1 v2.4s, v17.4s, v18.4s",
+        "uzp2 v3.4s, v17.4s, v18.4s",
+        "fsub v2.4s, v2.4s, v3.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vhsubps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x7d 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 z4.s, z2.s, z3.s",
-        "uzp2 z2.s, z2.s, z3.s",
-        "fsub z2.s, z4.s, z2.s",
+        "uzp1 z2.s, z17.s, z18.s",
+        "uzp2 z3.s, z17.s, z18.s",
+        "fsub z2.s, z2.s, z3.s",
         "mov z1.d, z2.d[2]",
         "mov z3.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[1]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vmovd dword [rax], xmm0": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
         "movi v0.2d, #0x0",
-        "mov v0.s[0], v2.s[0]",
+        "mov v0.s[0], v16.s[0]",
         "mov v2.16b, v0.16b",
         "str s2, [x4]"
       ]
     },
     "vmovq qword [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x7e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str d2, [x4]"
+        "str d16, [x4]"
       ]
     },
     "vmovdqa ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x7f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1b {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z16.b}, p7/z, [x4]"
       ]
     },
     "vmovdqa [rax], ymm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x7f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1b {z2.b}, p7, [x4]"
+        "st1b {z16.b}, p7, [x4]"
       ]
     },
     "vmovdqu ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x7f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1b {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z16.b}, p7/z, [x4]"
       ]
     },
     "vmovdqu [rax], ymm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x7f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1b {z2.b}, p7, [x4]"
+        "st1b {z16.b}, p7, [x4]"
       ]
     },
     "vaddsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd0 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "ldr x0, [x28, #1576]",
-        "ldr q4, [x0]",
-        "eor v3.16b, v3.16b, v4.16b",
-        "fadd v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x0]",
+        "eor v2.16b, v18.16b, v2.16b",
+        "fadd v2.2d, v17.2d, v2.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaddsubpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd0 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "ldr x0, [x28, #1576]",
-        "ld1b {z4.b}, p7/z, [x0]",
-        "eor z3.d, z3.d, z4.d",
-        "fadd z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z2.b}, p7/z, [x0]",
+        "eor z2.d, z18.d, z2.d",
+        "fadd z16.d, z17.d, z2.d"
       ]
     },
     "vaddsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xd0 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "ldr x0, [x28, #1560]",
-        "ldr q4, [x0]",
-        "eor v3.16b, v3.16b, v4.16b",
-        "fadd v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q2, [x0]",
+        "eor v2.16b, v18.16b, v2.16b",
+        "fadd v2.4s, v17.4s, v2.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaddsubps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xd0 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "ldr x0, [x28, #1560]",
-        "ld1b {z4.b}, p7/z, [x0]",
-        "eor z3.d, z3.d, z4.d",
-        "fadd z2.s, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z2.b}, p7/z, [x0]",
+        "eor z2.d, z18.d, z2.d",
+        "fadd z16.s, z17.s, z2.s"
       ]
     },
     "vpsrlw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd1 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
+        "mov z0.d, d18",
+        "movprfx z2, z17",
         "lsr z2.h, p6/m, z2.h, z0.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrlw ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd1 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
-        "lsr z2.h, p7/m, z2.h, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z0.d, d18",
+        "movprfx z16, z17",
+        "lsr z16.h, p7/m, z16.h, z0.d"
       ]
     },
     "vpsrld xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
+        "mov z0.d, d18",
+        "movprfx z2, z17",
         "lsr z2.s, p6/m, z2.s, z0.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrld ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
-        "lsr z2.s, p7/m, z2.s, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z0.d, d18",
+        "movprfx z16, z17",
+        "lsr z16.s, p7/m, z16.s, z0.d"
       ]
     },
     "vpsrlq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd3 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
+        "mov z0.d, d18",
+        "movprfx z2, z17",
         "lsr z2.d, p6/m, z2.d, z0.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrlq ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd3 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
-        "lsr z2.d, p7/m, z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z0.d, d18",
+        "movprfx z16, z17",
+        "lsr z16.d, p7/m, z16.d, z0.d"
       ]
     },
     "vpaddq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "add v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "add v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpaddq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd4 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "add z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "add z16.d, z17.d, z18.d"
       ]
     },
     "vpmullw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd5 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mul v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mul v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmullw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd4 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mul z2.h, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "mul z16.h, z17.h, z18.h"
       ]
     },
     "vmovq [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str d2, [x4]"
+        "str d16, [x4]"
       ]
     },
     "vpmovmskb rax, xmm0": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd7 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
         "mov x20, #0x201",
         "movk x20, #0x804, lsl #16",
         "movk x20, #0x2010, lsl #32",
         "movk x20, #0x8040, lsl #48",
-        "dup v3.2d, x20",
-        "cmlt v2.16b, v2.16b, #0",
-        "and v2.16b, v2.16b, v3.16b",
+        "dup v2.2d, x20",
+        "cmlt v3.16b, v16.16b, #0",
+        "and v2.16b, v3.16b, v2.16b",
         "addp v2.16b, v2.16b, v2.16b",
         "addp v2.8b, v2.8b, v2.8b",
         "addp v2.8b, v2.8b, v2.8b",
@@ -5334,24 +4650,23 @@
       ]
     },
     "vpmovmskb rax, ymm0": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd7 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
         "mov x20, #0x201",
         "movk x20, #0x804, lsl #16",
         "movk x20, #0x2010, lsl #32",
         "movk x20, #0x8040, lsl #48",
-        "mov z3.d, x20",
+        "mov z2.d, x20",
         "mov z0.d, #0",
-        "cmplt p0.b, p7/z, z2.b, #0",
-        "not z0.b, p0/m, z2.b",
-        "orr z0.b, p0/m, z0.b, z2.b",
-        "mov z2.d, z0.d",
-        "and z2.d, z2.d, z3.d",
+        "cmplt p0.b, p7/z, z16.b, #0",
+        "not z0.b, p0/m, z16.b",
+        "orr z0.b, p0/m, z0.b, z16.b",
+        "mov z3.d, z0.d",
+        "and z2.d, z3.d, z2.d",
         "movprfx z0, z2",
         "addp z0.b, p7/m, z0.b, z2.b",
         "uzp1 z2.b, z0.b, z0.b",
@@ -5363,942 +4678,782 @@
       ]
     },
     "vpsubusb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd8 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uqsub v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uqsub v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsubusb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd8 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uqsub z2.b, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "uqsub z16.b, z17.b, z18.b"
       ]
     },
     "vpsubusw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd9 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uqsub v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uqsub v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsubusw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd9 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uqsub z2.h, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "uqsub z16.h, z17.h, z18.h"
       ]
     },
     "vpminub xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xda 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umin v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "umin v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpminub ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xda 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umin z2.b, p7/m, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "umin z0.b, p7/m, z0.b, z18.b",
+        "mov z16.d, z0.d"
       ]
     },
     "vpand xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xdb 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "and v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "and v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpand ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdb 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "and z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "and z16.d, z17.d, z18.d"
       ]
     },
     "vpaddusb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xdc 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uqadd v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uqadd v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpaddusb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdc 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uqadd z2.b, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "uqadd z16.b, z17.b, z18.b"
       ]
     },
     "vpaddusw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xdd 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uqadd v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uqadd v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpaddusw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdd 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uqadd z2.h, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "uqadd z16.h, z17.h, z18.h"
       ]
     },
     "vpmaxub xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xdd 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umax v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "umax v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmaxub ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xde 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umax z2.b, p7/m, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "umax z0.b, p7/m, z0.b, z18.b",
+        "mov z16.d, z0.d"
       ]
     },
     "vpandn xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xdf 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "bic v2.16b, v3.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "bic v2.16b, v18.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpandn ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdf 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "bic z2.d, z3.d, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "bic z16.d, z18.d, z17.d"
       ]
     },
     "vpavgb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe0 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "urhadd v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "urhadd v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpavgb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe0 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "urhadd z2.b, p7/m, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "urhadd z0.b, p7/m, z0.b, z18.b",
+        "mov z16.d, z0.d"
       ]
     },
     "vpsraw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe1 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
+        "mov z0.d, d18",
+        "movprfx z2, z17",
         "asr z2.h, p6/m, z2.h, z0.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsraw ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe1 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
-        "asr z2.h, p7/m, z2.h, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z0.d, d18",
+        "movprfx z16, z17",
+        "asr z16.h, p7/m, z16.h, z0.d"
       ]
     },
     "vpsrad xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
+        "mov z0.d, d18",
+        "movprfx z2, z17",
         "asr z2.s, p6/m, z2.s, z0.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrad ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
-        "asr z2.s, p7/m, z2.s, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z0.d, d18",
+        "movprfx z16, z17",
+        "asr z16.s, p7/m, z16.s, z0.d"
       ]
     },
     "vpavgw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe3 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "urhadd v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "urhadd v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpavgw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe3 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "urhadd z2.h, p7/m, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "urhadd z0.h, p7/m, z0.h, z18.h",
+        "mov z16.d, z0.d"
       ]
     },
     "vpmulhuw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umulh z2.h, p6/m, z2.h, z3.h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z2, z17",
+        "umulh z2.h, p6/m, z2.h, z18.h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmulhuw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe4 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umulh z2.h, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "umulh z16.h, z17.h, z18.h"
       ]
     },
     "vpmulhw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe5 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smulh z2.h, p6/m, z2.h, z3.h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z2, z17",
+        "smulh z2.h, p6/m, z2.h, z18.h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmulhw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe5 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smulh z2.h, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "smulh z16.h, z17.h, z18.h"
       ]
     },
     "vcvttpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fcvtn v2.2s, v2.2d",
+        "fcvtn v2.2s, v17.2d",
         "fcvtzs v2.4s, v2.4s",
         "mov v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvttpd2dq xmm0, ymm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fcvtnt z2.s, p7/m, z2.d",
+        "fcvtnt z2.s, p7/m, z17.d",
         "uzp2 z2.s, z2.s, z2.s",
         "fcvtzs z2.s, p7/m, z2.s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtdq2pd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0xe6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sxtl v2.2d, v2.2s",
+        "sxtl v2.2d, v17.2s",
         "scvtf v2.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtdq2pd ymm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xe6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sunpklo z2.d, z2.s",
-        "scvtf z2.d, p7/m, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "sunpklo z2.d, z17.s",
+        "scvtf z16.d, p7/m, z2.d"
       ]
     },
     "vcvtpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xe6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fcvtn v2.2s, v2.2d",
+        "fcvtn v2.2s, v17.2d",
         "frinti v2.4s, v2.4s",
         "fcvtzs v2.4s, v2.4s",
         "mov v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtpd2dq xmm0, ymm1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xe6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "fcvtnt z2.s, p7/m, z2.d",
+        "fcvtnt z2.s, p7/m, z17.d",
         "uzp2 z2.s, z2.s, z2.s",
         "frinti z2.s, p7/m, z2.s",
         "fcvtzs z2.s, p7/m, z2.s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmovntdq [rax], xmm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe7 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "str q2, [x4]"
+        "str q16, [x4]"
       ]
     },
     "vmovntdq [rax], ymm0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe7 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1b {z2.b}, p7, [x4]"
+        "st1b {z16.b}, p7, [x4]"
       ]
     },
     "vpsubsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe8 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqsub v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqsub v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsubsb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe8 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqsub z2.b, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "sqsub z16.b, z17.b, z18.b"
       ]
     },
     "vpsubsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe9 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqsub v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqsub v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsubsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe9 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqsub z2.h, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "sqsub z16.h, z17.h, z18.h"
       ]
     },
     "vpminsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xea 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smin v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "smin v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpminsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xea 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smin z2.h, p7/m, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "smin z0.h, p7/m, z0.h, z18.h",
+        "mov z16.d, z0.d"
       ]
     },
     "vpor xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xeb 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "orr v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "orr v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpor ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xeb 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "orr z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "orr z16.d, z17.d, z18.d"
       ]
     },
     "vpaddsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xec 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqadd v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqadd v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpaddsb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xec 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqadd z2.b, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "sqadd z16.b, z17.b, z18.b"
       ]
     },
     "vpaddsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xed 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqadd v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqadd v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpaddsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xed 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqadd z2.h, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "sqadd z16.h, z17.h, z18.h"
       ]
     },
     "vpmaxsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xee 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smax v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "smax v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmaxsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xee 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smax z2.h, p7/m, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "smax z0.h, p7/m, z0.h, z18.h",
+        "mov z16.d, z0.d"
       ]
     },
     "vpxor xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xef 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "eor v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "eor v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpxor ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xef 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "eor z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "eor z16.d, z17.d, z18.d"
       ]
     },
     "vlddqu xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xf0 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q16, [x4]"
       ]
     },
     "vlddqu ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xf0 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1b {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z16.b}, p7/z, [x4]"
       ]
     },
     "vpsllw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf1 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
+        "mov z0.d, d18",
+        "movprfx z2, z17",
         "lsl z2.h, p6/m, z2.h, z0.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsllw ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf1 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
-        "lsl z2.h, p7/m, z2.h, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z0.d, d18",
+        "movprfx z16, z17",
+        "lsl z16.h, p7/m, z16.h, z0.d"
       ]
     },
     "vpslld xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
+        "mov z0.d, d18",
+        "movprfx z2, z17",
         "lsl z2.s, p6/m, z2.s, z0.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpslld ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf2 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
-        "lsl z2.s, p7/m, z2.s, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z0.d, d18",
+        "movprfx z16, z17",
+        "lsl z16.s, p7/m, z16.s, z0.d"
       ]
     },
     "vpsllq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf3 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
+        "mov z0.d, d18",
+        "movprfx z2, z17",
         "lsl z2.d, p6/m, z2.d, z0.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsllq ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf3 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z0.d, d3",
-        "lsl z2.d, p7/m, z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z0.d, d18",
+        "movprfx z16, z17",
+        "lsl z16.d, p7/m, z16.d, z0.d"
       ]
     },
     "vpmuludq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 v2.4s, v2.4s, v2.4s",
-        "uzp1 v3.4s, v3.4s, v3.4s",
+        "uzp1 v2.4s, v17.4s, v17.4s",
+        "uzp1 v3.4s, v18.4s, v18.4s",
         "umull v2.2d, v2.2s, v3.2s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmuludq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf4 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 z2.s, z2.s, z2.s",
-        "uzp1 z3.s, z3.s, z3.s",
+        "uzp1 z2.s, z17.s, z17.s",
+        "uzp1 z3.s, z18.s, z18.s",
         "umullb z0.d, z2.s, z3.s",
         "umullt z1.d, z2.s, z3.s",
-        "zip1 z2.d, z0.d, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 z16.d, z0.d, z1.d"
       ]
     },
     "vpmaddwd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf5 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smull v4.4s, v2.4h, v3.4h",
-        "smull2 v2.4s, v2.8h, v3.8h",
-        "addp v2.4s, v4.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "smull v2.4s, v17.4h, v18.4h",
+        "smull2 v3.4s, v17.8h, v18.8h",
+        "addp v2.4s, v2.4s, v3.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmaddwd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf5 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smullb z0.s, z2.h, z3.h",
-        "smullt z1.s, z2.h, z3.h",
-        "zip1 z4.s, z0.s, z1.s",
-        "smullb z0.s, z2.h, z3.h",
-        "smullt z1.s, z2.h, z3.h",
-        "zip2 z2.s, z0.s, z1.s",
-        "movprfx z0, z4",
-        "addp z0.s, p7/m, z0.s, z2.s",
-        "uzp1 z2.s, z0.s, z0.s",
+        "smullb z0.s, z17.h, z18.h",
+        "smullt z1.s, z17.h, z18.h",
+        "zip1 z2.s, z0.s, z1.s",
+        "smullb z0.s, z17.h, z18.h",
+        "smullt z1.s, z17.h, z18.h",
+        "zip2 z3.s, z0.s, z1.s",
+        "movprfx z0, z2",
+        "addp z0.s, p7/m, z0.s, z3.s",
+        "uzp1 z16.s, z0.s, z0.s",
         "uzp2 z1.s, z0.s, z0.s",
-        "splice z2.d, p6, z2.d, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "splice z16.d, p6, z16.d, z1.d"
       ]
     },
     "vpsadbw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uabdl v4.8h, v2.8b, v3.8b",
-        "uabdl2 v2.8h, v2.16b, v3.16b",
-        "addv h3, v4.8h",
+        "uabdl v2.8h, v17.8b, v18.8b",
+        "uabdl2 v3.8h, v17.16b, v18.16b",
         "addv h2, v2.8h",
-        "zip1 v2.2d, v3.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "addv h3, v3.8h",
+        "zip1 v2.2d, v2.2d, v3.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsadbw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 31,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf6 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uabdlb z0.h, z2.b, z3.b",
-        "uabdlt z1.h, z2.b, z3.b",
-        "zip1 z4.h, z0.h, z1.h",
-        "uabdlb z0.h, z2.b, z3.b",
-        "uabdlt z1.h, z2.b, z3.b",
-        "zip2 z2.h, z0.h, z1.h",
-        "addv h3, v4.8h",
-        "addv h5, v2.8h",
-        "zip1 z3.d, z3.d, z5.d",
-        "mov z4.q, z4.q[1]",
+        "uabdlb z0.h, z17.b, z18.b",
+        "uabdlt z1.h, z17.b, z18.b",
+        "zip1 z2.h, z0.h, z1.h",
+        "uabdlb z0.h, z17.b, z18.b",
+        "uabdlt z1.h, z17.b, z18.b",
+        "zip2 z3.h, z0.h, z1.h",
+        "addv h4, v2.8h",
+        "addv h5, v3.8h",
+        "zip1 z4.d, z4.d, z5.d",
         "mov z2.q, z2.q[1]",
-        "addv h4, v4.8h",
+        "mov z3.q, z3.q[1]",
         "addv h2, v2.8h",
-        "mov z1.d, d2",
-        "mov z2.d, z4.d",
+        "addv h3, v3.8h",
+        "mov z1.d, d3",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z2.d, p0/m, z1.d",
         "mov z1.q, q2",
-        "mov z2.d, z3.d",
+        "mov z2.d, z4.d",
         "not p0.b, p7/z, p6.b",
         "mov z2.b, p0/m, z1.b",
         "mov z1.d, z2.d[1]",
@@ -6307,215 +5462,170 @@
         "cmpeq p0.d, p7/z, z0.d, #0",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vmaskmovdqu xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf7 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "cmlt v2.16b, v2.16b, #0",
-        "mov z3.d, p7/m, z16.d",
-        "ldr q4, [x11]",
-        "bsl v2.16b, v3.16b, v4.16b",
+        "cmlt v2.16b, v17.16b, #0",
+        "ldr q3, [x11]",
+        "bsl v2.16b, v16.16b, v3.16b",
         "str q2, [x11]"
       ]
     },
     "vpsubb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf8 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sub v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sub v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsubb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf8 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sub z2.b, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "sub z16.b, z17.b, z18.b"
       ]
     },
     "vpsubw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf9 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sub v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sub v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsubw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf9 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sub z2.h, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "sub z16.h, z17.h, z18.h"
       ]
     },
     "vpsubd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xfa 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sub v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sub v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsubd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfa 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sub z2.s, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "sub z16.s, z17.s, z18.s"
       ]
     },
     "vpsubq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xfb 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sub v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sub v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsubq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfb 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sub z2.d, z2.d, z3.d",
-        "mov z16.d, p7/m, z2.d"
+        "sub z16.d, z17.d, z18.d"
       ]
     },
     "vpaddb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xfc 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "add v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "add v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpaddb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfc 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "add z2.b, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "add z16.b, z17.b, z18.b"
       ]
     },
     "vpaddw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xfd 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "add v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "add v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpaddw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfd 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "add z2.h, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "add z16.h, z17.h, z18.h"
       ]
     },
     "vpaddd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xfe 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "add v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "add v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpaddd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfe 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "add z2.s, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "add z16.s, z17.s, z18.s"
       ]
     }
   }

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -10,61 +10,55 @@
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd0 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "ext v3.16b, v3.16b, v3.16b, #8",
-        "fcadd v2.2d, v2.2d, v3.2d, #90",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ext v2.16b, v18.16b, v18.16b, #8",
+        "fcadd v2.2d, v17.2d, v2.2d, #90",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaddsubpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd0 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "ext z3.b, z3.b, z3.b, #8",
-        "fcadd z2.d, p7/m, z2.d, z3.d, #90",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z1, z18",
+        "ext z1.b, z1.b, z18.b, #8",
+        "mov z2.d, z1.d",
+        "movprfx z0, z17",
+        "fcadd z0.d, p7/m, z0.d, z2.d, #90",
+        "mov z16.d, z0.d"
       ]
     },
     "vaddsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xd0 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "rev64 v3.4s, v3.4s",
-        "fcadd v2.4s, v2.4s, v3.4s, #90",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "rev64 v2.4s, v18.4s",
+        "fcadd v2.4s, v17.4s, v2.4s, #90",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaddsubps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xd0 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "revw z3.d, p7/m, z3.d",
-        "fcadd z2.s, p7/m, z2.s, z3.s, #90",
-        "mov z16.d, p7/m, z2.d"
+        "revw z2.d, p7/m, z18.d",
+        "movprfx z0, z17",
+        "fcadd z0.s, p7/m, z0.s, z2.s, #90",
+        "mov z16.d, z0.d"
       ]
     }
   }

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -8,68 +8,58 @@
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x00 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.16b, #0x8f",
-        "and v3.16b, v3.16b, v4.16b",
-        "tbl v2.16b, {v2.16b}, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.16b, #0x8f",
+        "and v2.16b, v18.16b, v2.16b",
+        "tbl v2.16b, {v17.16b}, v2.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpshufb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z4.b, #-113",
-        "and z3.d, z3.d, z4.d",
-        "tbl v4.16b, {v2.16b}, v3.16b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "tbl v2.16b, {v2.16b}, v3.16b",
+        "mov z2.b, #-113",
+        "and z2.d, z18.d, z2.d",
+        "tbl v3.16b, {v17.16b}, v2.16b",
+        "mov z1.q, z17.q[1]",
+        "mov z4.d, z17.d",
+        "mov z4.b, p6/m, z1.b",
+        "tbl v2.16b, {v4.16b}, v2.16b",
         "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vphaddw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x01 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "addp v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "addp v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vphaddw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x01 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movprfx z0, z2",
-        "addp z0.h, p7/m, z0.h, z3.h",
+        "movprfx z0, z17",
+        "addp z0.h, p7/m, z0.h, z18.h",
         "uzp1 z2.h, z0.h, z0.h",
         "uzp2 z1.h, z0.h, z0.h",
         "splice z2.d, p6, z2.d, z1.d",
@@ -79,38 +69,32 @@
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[1]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vphaddd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "addp v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "addp v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vphaddd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x02 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movprfx z0, z2",
-        "addp z0.s, p7/m, z0.s, z3.s",
+        "movprfx z0, z17",
+        "addp z0.s, p7/m, z0.s, z18.s",
         "uzp1 z2.s, z0.s, z0.s",
         "uzp2 z1.s, z0.s, z0.s",
         "splice z2.d, p6, z2.d, z1.d",
@@ -120,493 +104,425 @@
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[1]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vphaddsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x03 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 v4.8h, v2.8h, v3.8h",
-        "uzp2 v2.8h, v2.8h, v3.8h",
-        "sqadd v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uzp1 v2.8h, v17.8h, v18.8h",
+        "uzp2 v3.8h, v17.8h, v18.8h",
+        "sqadd v2.8h, v2.8h, v3.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vphaddsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x03 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 z4.h, z2.h, z3.h",
-        "uzp2 z2.h, z2.h, z3.h",
-        "sqadd z2.h, z4.h, z2.h",
+        "uzp1 z2.h, z17.h, z18.h",
+        "uzp2 z3.h, z17.h, z18.h",
+        "sqadd z2.h, z2.h, z3.h",
         "mov z1.d, z2.d[2]",
         "mov z3.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[1]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpmaddubsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x04 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uxtl v4.8h, v2.8b",
-        "sxtl v5.8h, v3.8b",
-        "mul v4.8h, v4.8h, v5.8h",
-        "uxtl2 v2.8h, v2.16b",
-        "sxtl2 v3.8h, v3.16b",
+        "uxtl v2.8h, v17.8b",
+        "sxtl v3.8h, v18.8b",
         "mul v2.8h, v2.8h, v3.8h",
-        "uzp1 v3.8h, v4.8h, v2.8h",
-        "uzp2 v2.8h, v4.8h, v2.8h",
-        "sqadd v2.8h, v3.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uxtl2 v3.8h, v17.16b",
+        "sxtl2 v4.8h, v18.16b",
+        "mul v3.8h, v3.8h, v4.8h",
+        "uzp1 v4.8h, v2.8h, v3.8h",
+        "uzp2 v2.8h, v2.8h, v3.8h",
+        "sqadd v2.8h, v4.8h, v2.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmaddubsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x04 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uunpklo z4.h, z2.b",
-        "sunpklo z5.h, z3.b",
-        "mul z4.h, z4.h, z5.h",
-        "uunpkhi z2.h, z2.b",
-        "sunpkhi z3.h, z3.b",
+        "uunpklo z2.h, z17.b",
+        "sunpklo z3.h, z18.b",
         "mul z2.h, z2.h, z3.h",
-        "uzp1 z3.h, z4.h, z2.h",
-        "uzp2 z2.h, z4.h, z2.h",
-        "sqadd z2.h, z3.h, z2.h",
-        "mov z16.d, p7/m, z2.d"
+        "uunpkhi z3.h, z17.b",
+        "sunpkhi z4.h, z18.b",
+        "mul z3.h, z3.h, z4.h",
+        "uzp1 z4.h, z2.h, z3.h",
+        "uzp2 z2.h, z2.h, z3.h",
+        "sqadd z16.h, z4.h, z2.h"
       ]
     },
     "vphsubw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x05 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 v4.8h, v2.8h, v3.8h",
-        "uzp2 v2.8h, v2.8h, v3.8h",
-        "sub v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uzp1 v2.8h, v17.8h, v18.8h",
+        "uzp2 v3.8h, v17.8h, v18.8h",
+        "sub v2.8h, v2.8h, v3.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vphsubw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 z4.h, z2.h, z3.h",
-        "uzp2 z2.h, z2.h, z3.h",
-        "sub z2.h, z4.h, z2.h",
+        "uzp1 z2.h, z17.h, z18.h",
+        "uzp2 z3.h, z17.h, z18.h",
+        "sub z2.h, z2.h, z3.h",
         "mov z1.d, z2.d[2]",
         "mov z3.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[1]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vphsubd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x06 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 v4.4s, v2.4s, v3.4s",
-        "uzp2 v2.4s, v2.4s, v3.4s",
-        "sub v2.4s, v4.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uzp1 v2.4s, v17.4s, v18.4s",
+        "uzp2 v3.4s, v17.4s, v18.4s",
+        "sub v2.4s, v2.4s, v3.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vphsubd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 z4.s, z2.s, z3.s",
-        "uzp2 z2.s, z2.s, z3.s",
-        "sub z2.s, z4.s, z2.s",
+        "uzp1 z2.s, z17.s, z18.s",
+        "uzp2 z3.s, z17.s, z18.s",
+        "sub z2.s, z2.s, z3.s",
         "mov z1.d, z2.d[2]",
         "mov z3.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[1]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vphsubsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x07 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 v4.8h, v2.8h, v3.8h",
-        "uzp2 v2.8h, v2.8h, v3.8h",
-        "sqsub v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uzp1 v2.8h, v17.8h, v18.8h",
+        "uzp2 v3.8h, v17.8h, v18.8h",
+        "sqsub v2.8h, v2.8h, v3.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vphsubsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x07 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 z4.h, z2.h, z3.h",
-        "uzp2 z2.h, z2.h, z3.h",
-        "sqsub z2.h, z4.h, z2.h",
+        "uzp1 z2.h, z17.h, z18.h",
+        "uzp2 z3.h, z17.h, z18.h",
+        "sqsub z2.h, z2.h, z3.h",
         "mov z1.d, z2.d[2]",
         "mov z3.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[1]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpsignb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqshl v3.16b, v3.16b, #7",
-        "srshr v3.16b, v3.16b, #7",
-        "mul v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqshl v2.16b, v18.16b, #7",
+        "srshr v2.16b, v2.16b, #7",
+        "mul v2.16b, v17.16b, v2.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsignb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x08 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqshl z3.b, p7/m, z3.b, #7",
-        "srshr z3.b, p7/m, z3.b, #7",
-        "mul z2.b, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z2, z18",
+        "sqshl z2.b, p7/m, z2.b, #7",
+        "srshr z2.b, p7/m, z2.b, #7",
+        "mul z16.b, z17.b, z2.b"
       ]
     },
     "vpsignw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqshl v3.8h, v3.8h, #15",
-        "srshr v3.8h, v3.8h, #15",
-        "mul v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqshl v2.8h, v18.8h, #15",
+        "srshr v2.8h, v2.8h, #15",
+        "mul v2.8h, v17.8h, v2.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsignw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x09 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqshl z3.h, p7/m, z3.h, #15",
-        "srshr z3.h, p7/m, z3.h, #15",
-        "mul z2.h, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z2, z18",
+        "sqshl z2.h, p7/m, z2.h, #15",
+        "srshr z2.h, p7/m, z2.h, #15",
+        "mul z16.h, z17.h, z2.h"
       ]
     },
     "vpsignd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqshl v3.4s, v3.4s, #31",
-        "srshr v3.4s, v3.4s, #31",
-        "mul v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqshl v2.4s, v18.4s, #31",
+        "srshr v2.4s, v2.4s, #31",
+        "mul v2.4s, v17.4s, v2.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsignd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x0a 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqshl z3.s, p7/m, z3.s, #31",
-        "srshr z3.s, p7/m, z3.s, #31",
-        "mul z2.s, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z2, z18",
+        "sqshl z2.s, p7/m, z2.s, #31",
+        "srshr z2.s, p7/m, z2.s, #31",
+        "mul z16.s, z17.s, z2.s"
       ]
     },
     "vpmulhrsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smull v4.4s, v2.4h, v3.4h",
-        "smull2 v2.4s, v2.8h, v3.8h",
-        "sshr v3.4s, v4.4s, #14",
+        "smull v2.4s, v17.4h, v18.4h",
+        "smull2 v3.4s, v17.8h, v18.8h",
         "sshr v2.4s, v2.4s, #14",
+        "sshr v3.4s, v3.4s, #14",
         "movi v4.4s, #0x1, lsl #0",
-        "add v3.4s, v3.4s, v4.4s",
         "add v2.4s, v2.4s, v4.4s",
-        "shrn v3.4h, v3.4s, #1",
-        "mov v0.16b, v3.16b",
-        "shrn2 v0.8h, v2.4s, #1",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "add v3.4s, v3.4s, v4.4s",
+        "shrn v2.4h, v2.4s, #1",
+        "shrn2 v2.8h, v3.4s, #1",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmulhrsw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 17,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0b 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smullb z0.s, z2.h, z3.h",
-        "smullt z1.s, z2.h, z3.h",
-        "zip1 z4.s, z0.s, z1.s",
-        "smullb z0.s, z2.h, z3.h",
-        "smullt z1.s, z2.h, z3.h",
-        "zip2 z2.s, z0.s, z1.s",
-        "movprfx z3, z4",
-        "asr z3.s, p7/m, z3.s, #14",
+        "smullb z0.s, z17.h, z18.h",
+        "smullt z1.s, z17.h, z18.h",
+        "zip1 z2.s, z0.s, z1.s",
+        "smullb z0.s, z17.h, z18.h",
+        "smullt z1.s, z17.h, z18.h",
+        "zip2 z3.s, z0.s, z1.s",
         "asr z2.s, p7/m, z2.s, #14",
+        "asr z3.s, p7/m, z3.s, #14",
         "mov z4.s, #1",
-        "add z3.s, z3.s, z4.s",
         "add z2.s, z2.s, z4.s",
-        "shrnb z3.h, z3.s, #1",
-        "uzp1 z3.h, z3.h, z3.h",
-        "shrnb z1.h, z2.s, #1",
+        "add z3.s, z3.s, z4.s",
+        "shrnb z2.h, z2.s, #1",
+        "uzp1 z2.h, z2.h, z2.h",
+        "shrnb z1.h, z3.s, #1",
         "uzp1 z1.h, z1.h, z1.h",
-        "movprfx z2, z3",
-        "splice z2.h, p6, z2.h, z1.h",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z2",
+        "splice z16.h, p6, z16.h, z1.h"
       ]
     },
     "vpermilps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.4s, #0x3, lsl #0",
-        "and v3.16b, v3.16b, v4.16b",
-        "trn1 v3.16b, v3.16b, v3.16b",
-        "trn1 v3.8h, v3.8h, v3.8h",
-        "shl v3.16b, v3.16b, #2",
+        "movi v2.4s, #0x3, lsl #0",
+        "and v2.16b, v18.16b, v2.16b",
+        "trn1 v2.16b, v2.16b, v2.16b",
+        "trn1 v2.8h, v2.8h, v2.8h",
+        "shl v2.16b, v2.16b, #2",
         "mov w20, #0x100",
         "movk w20, #0x302, lsl #16",
-        "dup v4.4s, w20",
-        "add v3.16b, v4.16b, v3.16b",
-        "tbl v2.16b, {v2.16b}, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "dup v3.4s, w20",
+        "add v2.16b, v3.16b, v2.16b",
+        "tbl v2.16b, {v17.16b}, v2.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpermilps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 16,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z4.s, #3",
-        "and z3.d, z3.d, z4.d",
-        "trn1 z3.b, z3.b, z3.b",
-        "trn1 z3.h, z3.h, z3.h",
-        "lsl z3.b, p7/m, z3.b, #2",
+        "mov z2.s, #3",
+        "and z2.d, z18.d, z2.d",
+        "trn1 z2.b, z2.b, z2.b",
+        "trn1 z2.h, z2.h, z2.h",
+        "lsl z2.b, p7/m, z2.b, #2",
         "mov w20, #0x100",
         "movk w20, #0x302, lsl #16",
-        "mov z4.s, w20",
-        "movi v5.2d, #0x0",
-        "mov z6.b, #16",
-        "mov z1.q, q6",
+        "mov z3.s, w20",
+        "movi v4.2d, #0x0",
+        "mov z5.b, #16",
+        "mov z1.q, q5",
         "not p0.b, p7/z, p6.b",
-        "mov z5.b, p0/m, z1.b",
-        "add z4.b, z4.b, z5.b",
-        "add z3.b, z4.b, z3.b",
-        "tbl z2.b, {z2.b}, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z4.b, p0/m, z1.b",
+        "add z3.b, z3.b, z4.b",
+        "add z2.b, z3.b, z2.b",
+        "tbl z16.b, {z17.b}, z2.b"
       ]
     },
     "vpermilpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 16,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "ushr v3.2d, v3.2d, #1",
+        "ushr v2.2d, v18.2d, #1",
         "mov w0, #0x1",
-        "dup v4.2d, x0",
-        "and v3.16b, v3.16b, v4.16b",
-        "trn1 v3.16b, v3.16b, v3.16b",
-        "trn1 v3.8h, v3.8h, v3.8h",
-        "trn1 v3.4s, v3.4s, v3.4s",
-        "shl v3.16b, v3.16b, #3",
+        "dup v3.2d, x0",
+        "and v2.16b, v2.16b, v3.16b",
+        "trn1 v2.16b, v2.16b, v2.16b",
+        "trn1 v2.8h, v2.8h, v2.8h",
+        "trn1 v2.4s, v2.4s, v2.4s",
+        "shl v2.16b, v2.16b, #3",
         "mov x20, #0x100",
         "movk x20, #0x302, lsl #16",
         "movk x20, #0x504, lsl #32",
         "movk x20, #0x706, lsl #48",
-        "dup v4.2d, x20",
-        "add v3.16b, v4.16b, v3.16b",
-        "tbl v2.16b, {v2.16b}, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "dup v3.2d, x20",
+        "add v2.16b, v3.16b, v2.16b",
+        "tbl v2.16b, {v17.16b}, v2.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpermilpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 21,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0d 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "lsr z3.d, p7/m, z3.d, #1",
-        "mov z4.d, #1",
-        "and z3.d, z3.d, z4.d",
-        "trn1 z3.b, z3.b, z3.b",
-        "trn1 z3.h, z3.h, z3.h",
-        "trn1 z3.s, z3.s, z3.s",
-        "lsl z3.b, p7/m, z3.b, #3",
+        "movprfx z2, z18",
+        "lsr z2.d, p7/m, z2.d, #1",
+        "mov z3.d, #1",
+        "and z2.d, z2.d, z3.d",
+        "trn1 z2.b, z2.b, z2.b",
+        "trn1 z2.h, z2.h, z2.h",
+        "trn1 z2.s, z2.s, z2.s",
+        "lsl z2.b, p7/m, z2.b, #3",
         "mov x20, #0x100",
         "movk x20, #0x302, lsl #16",
         "movk x20, #0x504, lsl #32",
         "movk x20, #0x706, lsl #48",
-        "mov z4.d, x20",
-        "movi v5.2d, #0x0",
-        "mov z6.b, #16",
-        "mov z1.q, q6",
+        "mov z3.d, x20",
+        "movi v4.2d, #0x0",
+        "mov z5.b, #16",
+        "mov z1.q, q5",
         "not p0.b, p7/z, p6.b",
-        "mov z5.b, p0/m, z1.b",
-        "add z4.b, z4.b, z5.b",
-        "add z3.b, z4.b, z3.b",
-        "tbl z2.b, {z2.b}, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z4.b, p0/m, z1.b",
+        "add z3.b, z3.b, z4.b",
+        "add z2.b, z3.b, z2.b",
+        "tbl z16.b, {z17.b}, z2.b"
       ]
     },
     "vtestps xmm0, xmm1": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 25,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
         "mov w20, #0x80000000",
-        "dup v4.4s, w20",
-        "and v5.16b, v3.16b, v2.16b",
-        "bic v2.16b, v3.16b, v2.16b",
-        "and v3.16b, v5.16b, v4.16b",
-        "and v2.16b, v2.16b, v4.16b",
+        "dup v2.4s, w20",
+        "and v3.16b, v17.16b, v16.16b",
+        "bic v4.16b, v17.16b, v16.16b",
+        "and v3.16b, v3.16b, v2.16b",
+        "and v2.16b, v4.16b, v2.16b",
         "cnt v3.16b, v3.16b",
         "cnt v2.16b, v2.16b",
         "addv h3, v3.8h",
@@ -629,20 +545,18 @@
       ]
     },
     "vtestps ymm0, ymm1": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 33,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0e 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
         "mov w20, #0x80000000",
-        "mov z4.s, w20",
-        "and z5.d, z3.d, z2.d",
-        "bic z2.d, z3.d, z2.d",
-        "and z3.d, z5.d, z4.d",
-        "and z2.d, z2.d, z4.d",
+        "mov z2.s, w20",
+        "and z3.d, z17.d, z16.d",
+        "bic z4.d, z17.d, z16.d",
+        "and z3.d, z3.d, z2.d",
+        "and z2.d, z4.d, z2.d",
         "cnt z3.b, p7/m, z3.b",
         "cnt z2.b, p7/m, z2.b",
         "not p0.b, p7/z, p6.b",
@@ -673,20 +587,18 @@
       ]
     },
     "vtestpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 27,
+      "ExpectedInstructionCount": 25,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
         "mov x20, #0x8000000000000000",
-        "dup v4.2d, x20",
-        "and v5.16b, v3.16b, v2.16b",
-        "bic v2.16b, v3.16b, v2.16b",
-        "and v3.16b, v5.16b, v4.16b",
-        "and v2.16b, v2.16b, v4.16b",
+        "dup v2.2d, x20",
+        "and v3.16b, v17.16b, v16.16b",
+        "bic v4.16b, v17.16b, v16.16b",
+        "and v3.16b, v3.16b, v2.16b",
+        "and v2.16b, v4.16b, v2.16b",
         "cnt v3.16b, v3.16b",
         "cnt v2.16b, v2.16b",
         "addv h3, v3.8h",
@@ -709,20 +621,18 @@
       ]
     },
     "vtestpd ymm0, ymm1": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 33,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0f 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
         "mov x20, #0x8000000000000000",
-        "mov z4.d, x20",
-        "and z5.d, z3.d, z2.d",
-        "bic z2.d, z3.d, z2.d",
-        "and z3.d, z5.d, z4.d",
-        "and z2.d, z2.d, z4.d",
+        "mov z2.d, x20",
+        "and z3.d, z17.d, z16.d",
+        "bic z4.d, z17.d, z16.d",
+        "and z3.d, z3.d, z2.d",
+        "and z2.d, z4.d, z2.d",
         "cnt z3.b, p7/m, z3.b",
         "cnt z2.b, p7/m, z2.b",
         "not p0.b, p7/z, p6.b",
@@ -769,44 +679,39 @@
       ]
     },
     "vpermps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x16 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z4.s, #7",
-        "and z2.d, z2.d, z4.d",
+        "mov z2.s, #7",
+        "and z2.d, z17.d, z2.d",
         "trn1 z2.b, z2.b, z2.b",
         "trn1 z2.h, z2.h, z2.h",
         "lsl z2.b, p7/m, z2.b, #2",
         "mov w20, #0x100",
         "movk w20, #0x302, lsl #16",
-        "mov z4.s, w20",
-        "add z2.b, z2.b, z4.b",
-        "tbl z2.b, {z3.b}, z2.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z3.s, w20",
+        "add z2.b, z2.b, z3.b",
+        "tbl z16.b, {z18.b}, z2.b"
       ]
     },
     "vptest xmm0, xmm1": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 19,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "and v4.16b, v2.16b, v3.16b",
-        "bic v2.16b, v3.16b, v2.16b",
-        "cnt v3.16b, v4.16b",
+        "and v2.16b, v16.16b, v17.16b",
+        "bic v3.16b, v17.16b, v16.16b",
         "cnt v2.16b, v2.16b",
-        "addv h3, v3.8h",
+        "cnt v3.16b, v3.16b",
         "addv h2, v2.8h",
-        "umov w20, v3.h[0]",
-        "umov w21, v2.h[0]",
+        "addv h3, v3.8h",
+        "umov w20, v2.h[0]",
+        "umov w21, v3.h[0]",
         "mov w22, #0x0",
         "mov w23, #0x1",
         "cmp x20, #0x0 (0)",
@@ -821,30 +726,28 @@
       ]
     },
     "vptest ymm0, ymm1": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 27,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x16 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "and z4.d, z2.d, z3.d",
-        "bic z2.d, z3.d, z2.d",
-        "cnt z3.b, p7/m, z4.b",
+        "and z2.d, z16.d, z17.d",
+        "bic z3.d, z17.d, z16.d",
         "cnt z2.b, p7/m, z2.b",
-        "not p0.b, p7/z, p6.b",
-        "compact z0.d, p0, z3.d",
-        "addv h1, v3.8h",
-        "addv h0, v0.8h",
-        "add v3.8h, v0.8h, v1.8h",
+        "cnt z3.b, p7/m, z3.b",
         "not p0.b, p7/z, p6.b",
         "compact z0.d, p0, z2.d",
         "addv h1, v2.8h",
         "addv h0, v0.8h",
         "add v2.8h, v0.8h, v1.8h",
-        "umov w20, v3.h[0]",
-        "umov w21, v2.h[0]",
+        "not p0.b, p7/z, p6.b",
+        "compact z0.d, p0, z3.d",
+        "addv h1, v3.8h",
+        "addv h0, v0.8h",
+        "add v3.8h, v0.8h, v1.8h",
+        "umov w20, v2.h[0]",
+        "umov w21, v3.h[0]",
         "mov w22, #0x0",
         "mov w23, #0x1",
         "cmp x20, #0x0 (0)",
@@ -859,395 +762,336 @@
       ]
     },
     "vbroadcastss xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x18 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1rw {z2.s}, p6/z, [x4]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vbroadcastss ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x18 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1rw {z2.s}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1rw {z16.s}, p7/z, [x4]"
       ]
     },
     "vbroadcastsd ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x19 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1rd {z2.d}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1rd {z16.d}, p7/z, [x4]"
       ]
     },
     "vbroadcastf128 ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1a 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1rqb {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1rqb {z16.b}, p7/z, [x4]"
       ]
     },
     "vpabsb xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x1c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "abs v2.16b, v2.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "abs v2.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpabsb ymm0, ymm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x1c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "abs z2.b, p7/m, z2.b",
-        "mov z16.d, p7/m, z2.d"
+        "abs z16.b, p7/m, z17.b"
       ]
     },
     "vpabsw xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x1d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "abs v2.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "abs v2.8h, v17.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpabsw ymm0, ymm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x1d 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "abs z2.h, p7/m, z2.h",
-        "mov z16.d, p7/m, z2.d"
+        "abs z16.h, p7/m, z17.h"
       ]
     },
     "vpabsd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x1e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "abs v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "abs v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpabsd ymm0, ymm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x1e 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "abs z2.s, p7/m, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "abs z16.s, p7/m, z17.s"
       ]
     },
     "vpmovsxbw xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sxtl v2.8h, v2.8b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sxtl v2.8h, v17.8b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovsxbw ymm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x20 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sunpklo z2.h, z2.b",
-        "mov z16.d, p7/m, z2.d"
+        "sunpklo z16.h, z17.b"
       ]
     },
     "vpmovsxbd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sxtl v2.8h, v2.8b",
+        "sxtl v2.8h, v17.8b",
         "sxtl v2.4s, v2.4h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovsxbd ymm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x21 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sunpklo z2.h, z2.b",
-        "sunpklo z2.s, z2.h",
-        "mov z16.d, p7/m, z2.d"
+        "sunpklo z2.h, z17.b",
+        "sunpklo z16.s, z2.h"
       ]
     },
     "vpmovsxbq xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sxtl v2.8h, v2.8b",
+        "sxtl v2.8h, v17.8b",
         "sxtl v2.4s, v2.4h",
         "sxtl v2.2d, v2.2s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovsxbq ymm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x22 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sunpklo z2.h, z2.b",
+        "sunpklo z2.h, z17.b",
         "sunpklo z2.s, z2.h",
-        "sunpklo z2.d, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "sunpklo z16.d, z2.s"
       ]
     },
     "vpmovsxwd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x23 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sxtl v2.4s, v2.4h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sxtl v2.4s, v17.4h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovsxwd ymm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x23 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sunpklo z2.s, z2.h",
-        "mov z16.d, p7/m, z2.d"
+        "sunpklo z16.s, z17.h"
       ]
     },
     "vpmovsxwq xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x24 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sxtl v2.4s, v2.4h",
+        "sxtl v2.4s, v17.4h",
         "sxtl v2.2d, v2.2s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovsxwq ymm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x24 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sunpklo z2.s, z2.h",
-        "sunpklo z2.d, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "sunpklo z2.s, z17.h",
+        "sunpklo z16.d, z2.s"
       ]
     },
     "vpmovsxdq xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x25 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sxtl v2.2d, v2.2s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sxtl v2.2d, v17.2s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovsxdq ymm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x25 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sunpklo z2.d, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "sunpklo z16.d, z17.s"
       ]
     },
     "vpmuldq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x28 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 v2.4s, v2.4s, v2.4s",
-        "uzp1 v3.4s, v3.4s, v3.4s",
+        "uzp1 v2.4s, v17.4s, v17.4s",
+        "uzp1 v3.4s, v18.4s, v18.4s",
         "smull v2.2d, v2.2s, v3.2s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmuldq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x28 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "uzp1 z2.s, z2.s, z2.s",
-        "uzp1 z3.s, z3.s, z3.s",
+        "uzp1 z2.s, z17.s, z17.s",
+        "uzp1 z3.s, z18.s, z18.s",
         "smullb z0.d, z2.s, z3.s",
         "smullt z1.d, z2.s, z3.s",
-        "zip1 z2.d, z0.d, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "zip1 z16.d, z0.d, z1.d"
       ]
     },
     "vpcmpeqq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x29 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmeq v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "cmeq v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpcmpeqq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x29 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmpeq p0.d, p7/z, z2.d, z3.d",
-        "not z0.d, p0/m, z2.d",
-        "movprfx z2.d, p0/z, z2.d",
-        "orr z2.d, p0/m, z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "cmpeq p0.d, p7/z, z17.d, z18.d",
+        "not z0.d, p0/m, z17.d",
+        "movprfx z16.d, p0/z, z17.d",
+        "orr z16.d, p0/m, z16.d, z0.d"
       ]
     },
     "vmovntdqa xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x2a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ldr q16, [x4]"
       ]
     },
     "vmovntdqa ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x2a 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1b {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1b {z16.b}, p7/z, [x4]"
       ]
     },
     "vpackusdw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqxtun v2.4h, v2.4s",
-        "sqxtun2 v2.8h, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sqxtun v2.4h, v17.4s",
+        "sqxtun2 v2.8h, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpackusdw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2b 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "sqxtunb z1.h, z3.s",
+        "sqxtunb z1.h, z18.s",
         "uzp1 z1.h, z1.h, z1.h",
-        "sqxtunb z2.h, z2.s",
+        "sqxtunb z2.h, z17.s",
         "uzp1 z2.h, z2.h, z2.h",
         "splice z2.h, p6, z2.h, z1.h",
         "mov z1.d, z2.d[1]",
@@ -1256,1063 +1100,907 @@
         "cmpeq p0.d, p7/z, z0.d, #0",
         "mov z3.d, p0/m, z1.d",
         "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z16.d, z3.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vmaskmovps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "cmplt p0.s, p6/z, z2.s, #0",
+        "cmplt p0.s, p6/z, z17.s, #0",
         "ld1w {z2.s}, p0/z, [x4]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmaskmovps ymm0, ymm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "cmplt p0.s, p7/z, z2.s, #0",
-        "ld1w {z2.s}, p0/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "cmplt p0.s, p7/z, z17.s, #0",
+        "ld1w {z16.s}, p0/z, [x4]"
       ]
     },
     "vmaskmovpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "cmplt p0.d, p6/z, z2.d, #0",
+        "cmplt p0.d, p6/z, z17.d, #0",
         "ld1d {z2.d}, p0/z, [x4]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmaskmovpd ymm0, ymm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2d 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "cmplt p0.d, p7/z, z2.d, #0",
-        "ld1d {z2.d}, p0/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "cmplt p0.d, p7/z, z17.d, #0",
+        "ld1d {z16.d}, p0/z, [x4]"
       ]
     },
     "vmaskmovps [rax], xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "cmplt p0.s, p6/z, z2.s, #0",
-        "st1w {z3.s}, p0, [x4]"
+        "cmplt p0.s, p6/z, z16.s, #0",
+        "st1w {z17.s}, p0, [x4]"
       ]
     },
     "vmaskmovps [rax], ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2e 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "cmplt p0.s, p7/z, z2.s, #0",
-        "st1w {z3.s}, p0, [x4]"
+        "cmplt p0.s, p7/z, z16.s, #0",
+        "st1w {z17.s}, p0, [x4]"
       ]
     },
     "vmaskmovpd [rax], xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "cmplt p0.d, p6/z, z2.d, #0",
-        "st1d {z3.d}, p0, [x4]"
+        "cmplt p0.d, p6/z, z16.d, #0",
+        "st1d {z17.d}, p0, [x4]"
       ]
     },
     "vmaskmovpd [rax], ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2f 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "cmplt p0.d, p7/z, z2.d, #0",
-        "st1d {z3.d}, p0, [x4]"
+        "cmplt p0.d, p7/z, z16.d, #0",
+        "st1d {z17.d}, p0, [x4]"
       ]
     },
     "vpmovzxbw xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x30 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uxtl v2.8h, v2.8b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uxtl v2.8h, v17.8b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovzxbw ymm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x30 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uunpklo z2.h, z2.b",
-        "mov z16.d, p7/m, z2.d"
+        "uunpklo z16.h, z17.b"
       ]
     },
     "vpmovzxbd xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x31 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uxtl v2.8h, v2.8b",
+        "uxtl v2.8h, v17.8b",
         "uxtl v2.4s, v2.4h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovzxbd ymm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x31 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uunpklo z2.h, z2.b",
-        "uunpklo z2.s, z2.h",
-        "mov z16.d, p7/m, z2.d"
+        "uunpklo z2.h, z17.b",
+        "uunpklo z16.s, z2.h"
       ]
     },
     "vpmovzxbq xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x32 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uxtl v2.8h, v2.8b",
+        "uxtl v2.8h, v17.8b",
         "uxtl v2.4s, v2.4h",
         "uxtl v2.2d, v2.2s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovzxbq ymm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x32 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uunpklo z2.h, z2.b",
+        "uunpklo z2.h, z17.b",
         "uunpklo z2.s, z2.h",
-        "uunpklo z2.d, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "uunpklo z16.d, z2.s"
       ]
     },
     "vpmovzxwd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x33 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uxtl v2.4s, v2.4h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uxtl v2.4s, v17.4h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovzxwd ymm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x33 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uunpklo z2.s, z2.h",
-        "mov z16.d, p7/m, z2.d"
+        "uunpklo z16.s, z17.h"
       ]
     },
     "vpmovzxwq xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x34 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uxtl v2.4s, v2.4h",
+        "uxtl v2.4s, v17.4h",
         "uxtl v2.2d, v2.2s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovzxwq ymm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x34 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uunpklo z2.s, z2.h",
-        "uunpklo z2.d, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "uunpklo z2.s, z17.h",
+        "uunpklo z16.d, z2.s"
       ]
     },
     "vpmovzxdq xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x35 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uxtl v2.2d, v2.2s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "uxtl v2.2d, v17.2s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmovzxdq ymm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x35 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "uunpklo z2.d, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "uunpklo z16.d, z17.s"
       ]
     },
     "vpermd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x36 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z4.s, #7",
-        "and z2.d, z2.d, z4.d",
+        "mov z2.s, #7",
+        "and z2.d, z17.d, z2.d",
         "trn1 z2.b, z2.b, z2.b",
         "trn1 z2.h, z2.h, z2.h",
         "lsl z2.b, p7/m, z2.b, #2",
         "mov w20, #0x100",
         "movk w20, #0x302, lsl #16",
-        "mov z4.s, w20",
-        "add z2.b, z2.b, z4.b",
-        "tbl z2.b, {z3.b}, z2.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z3.s, w20",
+        "add z2.b, z2.b, z3.b",
+        "tbl z16.b, {z18.b}, z2.b"
       ]
     },
     "vpcmpgtq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x37 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmgt v2.2d, v2.2d, v3.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "cmgt v2.2d, v17.2d, v18.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpcmpgtq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x37 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "cmpgt p0.d, p7/z, z2.d, z3.d",
-        "not z0.d, p0/m, z2.d",
-        "movprfx z2.d, p0/z, z2.d",
-        "orr z2.d, p0/m, z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "cmpgt p0.d, p7/z, z17.d, z18.d",
+        "not z0.d, p0/m, z17.d",
+        "movprfx z16.d, p0/z, z17.d",
+        "orr z16.d, p0/m, z16.d, z0.d"
       ]
     },
     "vpminsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x38 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smin v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "smin v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpminsb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x38 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smin z2.b, p7/m, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "smin z0.b, p7/m, z0.b, z18.b",
+        "mov z16.d, z0.d"
       ]
     },
     "vpminsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x39 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smin v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "smin v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpminsd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x39 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smin z2.s, p7/m, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "smin z0.s, p7/m, z0.s, z18.s",
+        "mov z16.d, z0.d"
       ]
     },
     "vpminuw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umin v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "umin v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpminuw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3a 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umin z2.h, p7/m, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "umin z0.h, p7/m, z0.h, z18.h",
+        "mov z16.d, z0.d"
       ]
     },
     "vpminud xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umin v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "umin v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpminud ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3b 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umin z2.s, p7/m, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "umin z0.s, p7/m, z0.s, z18.s",
+        "mov z16.d, z0.d"
       ]
     },
     "vpmaxsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smax v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "smax v2.16b, v17.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmaxsb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smax z2.b, p7/m, z2.b, z3.b",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "smax z0.b, p7/m, z0.b, z18.b",
+        "mov z16.d, z0.d"
       ]
     },
     "vpmaxsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smax v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "smax v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmaxsd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3d 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "smax z2.s, p7/m, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "smax z0.s, p7/m, z0.s, z18.s",
+        "mov z16.d, z0.d"
       ]
     },
     "vpmaxuw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umax v2.8h, v2.8h, v3.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "umax v2.8h, v17.8h, v18.8h",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmaxuw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3e 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umax z2.h, p7/m, z2.h, z3.h",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "umax z0.h, p7/m, z0.h, z18.h",
+        "mov z16.d, z0.d"
       ]
     },
     "vpmaxud xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umax v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "umax v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmaxud ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3f 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "umax z2.s, p7/m, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z0, z17",
+        "umax z0.s, p7/m, z0.s, z18.s",
+        "mov z16.d, z0.d"
       ]
     },
     "vpmulld xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mul v2.4s, v2.4s, v3.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mul v2.4s, v17.4s, v18.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmulld ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x40 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mul z2.s, z2.s, z3.s",
-        "mov z16.d, p7/m, z2.d"
+        "mul z16.s, z17.s, z18.s"
       ]
     },
     "vphminposuw xmm0, xmm1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x41 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "ldr x0, [x28, #1544]",
-        "ldr q3, [x0]",
-        "zip1 v4.8h, v3.8h, v2.8h",
-        "zip2 v2.8h, v3.8h, v2.8h",
-        "umin v2.4s, v4.4s, v2.4s",
+        "ldr q2, [x0]",
+        "zip1 v3.8h, v2.8h, v17.8h",
+        "zip2 v2.8h, v2.8h, v17.8h",
+        "umin v2.4s, v3.4s, v2.4s",
         "uminv s2, v2.4s",
         "rev32 v2.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrlvd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "movi v0.4s, #0x20, lsl #0",
-        "umin v0.4s, v0.4s, v3.4s",
+        "umin v0.4s, v0.4s, v18.4s",
         "neg v0.4s, v0.4s",
-        "ushl v2.4s, v2.4s, v0.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ushl v2.4s, v17.4s, v0.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrlvd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "mov z1.s, #32",
-        "umin z1.s, p7/m, z1.s, z3.s",
-        "lsr z2.s, p7/m, z2.s, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "umin z1.s, p7/m, z1.s, z18.s",
+        "movprfx z16, z17",
+        "lsr z16.s, p7/m, z16.s, z1.s"
       ]
     },
     "vpsrlvq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "mov w0, #0x40",
         "dup v0.2d, x0",
-        "cmhi v1.2d, v3.2d, v0.2d",
-        "bif v0.16b, v3.16b, v1.16b",
+        "cmhi v1.2d, v18.2d, v0.2d",
+        "bif v0.16b, v18.16b, v1.16b",
         "neg v0.2d, v0.2d",
-        "ushl v2.2d, v2.2d, v0.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ushl v2.2d, v17.2d, v0.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrlvq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "mov z1.d, #64",
-        "umin z1.d, p7/m, z1.d, z3.d",
-        "lsr z2.d, p7/m, z2.d, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "umin z1.d, p7/m, z1.d, z18.d",
+        "movprfx z16, z17",
+        "lsr z16.d, p7/m, z16.d, z1.d"
       ]
     },
     "vpsravd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x46 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "movi v0.4s, #0x1f, lsl #0",
-        "umin v0.4s, v0.4s, v3.4s",
+        "umin v0.4s, v0.4s, v18.4s",
         "neg v0.4s, v0.4s",
-        "sshl v2.4s, v2.4s, v0.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sshl v2.4s, v17.4s, v0.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsravd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "mov z0.s, #31",
-        "umin z0.s, p7/m, z0.s, z3.s",
-        "asr z2.s, p7/m, z2.s, z0.s",
-        "mov z16.d, p7/m, z2.d"
+        "umin z0.s, p7/m, z0.s, z18.s",
+        "movprfx z16, z17",
+        "asr z16.s, p7/m, z16.s, z0.s"
       ]
     },
     "vpsllvd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "movi v0.4s, #0x20, lsl #0",
-        "umin v0.4s, v0.4s, v3.4s",
-        "ushl v2.4s, v2.4s, v0.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "umin v0.4s, v0.4s, v18.4s",
+        "ushl v2.4s, v17.4s, v0.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsllvd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "mov z1.s, #32",
-        "umin z1.s, p7/m, z1.s, z3.s",
-        "lsl z2.s, p7/m, z2.s, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "umin z1.s, p7/m, z1.s, z18.s",
+        "movprfx z16, z17",
+        "lsl z16.s, p7/m, z16.s, z1.s"
       ]
     },
     "vpsllvq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "mov w0, #0x40",
         "dup v0.2d, x0",
-        "cmhi v1.2d, v3.2d, v0.2d",
-        "bif v0.16b, v3.16b, v1.16b",
-        "ushl v2.2d, v2.2d, v0.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "cmhi v1.2d, v18.2d, v0.2d",
+        "bif v0.16b, v18.16b, v1.16b",
+        "ushl v2.2d, v17.2d, v0.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsllvq ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "mov z1.d, #64",
-        "umin z1.d, p7/m, z1.d, z3.d",
-        "lsl z2.d, p7/m, z2.d, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "umin z1.d, p7/m, z1.d, z18.d",
+        "movprfx z16, z17",
+        "lsl z16.d, p7/m, z16.d, z1.d"
       ]
     },
     "vpbroadcastd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "dup v2.4s, v2.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "dup v2.4s, v17.s[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpbroadcastd xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1rw {z2.s}, p6/z, [x4]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpbroadcastd ymm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x58 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.s, s2",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, s17"
       ]
     },
     "vpbroadcastd ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x58 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1rw {z2.s}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1rw {z16.s}, p7/z, [x4]"
       ]
     },
     "vpbroadcastq xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "dup v2.2d, v2.d[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "dup v2.2d, v17.d[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpbroadcastq xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1rd {z2.d}, p6/z, [x4]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpbroadcastq ymm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x59 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.d, d2",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, d17"
       ]
     },
     "vpbroadcastq ymm0, [rax]": {
       "ExpectedInstructiqonCount": -1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x59 256-bit"
       ],
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "ExpectedArm64ASM": [
-        "ld1rd {z2.d}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1rd {z16.d}, p7/z, [x4]"
       ]
     },
     "vbroadcasti128 ymm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x5a 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1rqb {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1rqb {z16.b}, p7/z, [x4]"
       ]
     },
     "vpbroadcastb xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "dup v2.16b, v2.b[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "dup v2.16b, v17.b[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpbroadcastb xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1rb {z2.b}, p6/z, [x4]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpbroadcastb ymm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x78 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.b, b2",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, b17"
       ]
     },
     "vpbroadcastb ymm0, [rax]": {
       "ExpectedInstructiqonCount": -1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x78 256-bit"
       ],
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "ExpectedArm64ASM": [
-        "ld1rb {z2.b}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1rb {z16.b}, p7/z, [x4]"
       ]
     },
     "vpbroadcastw xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "dup v2.8h, v2.h[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "dup v2.8h, v17.h[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpbroadcastw xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1rh {z2.h}, p6/z, [x4]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpbroadcastw ymm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x79 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.h, h2",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.h, h17"
       ]
     },
     "vpbroadcastw ymm0, [rax]": {
       "ExpectedInstructiqonCount": -1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x79 256-bit"
       ],
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "ExpectedArm64ASM": [
-        "ld1rh {z2.h}, p7/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "ld1rh {z16.h}, p7/z, [x4]"
       ]
     },
     "vpmaskmovd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "cmplt p0.s, p6/z, z2.s, #0",
+        "cmplt p0.s, p6/z, z17.s, #0",
         "ld1w {z2.s}, p0/z, [x4]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmaskmovd ymm0, ymm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "cmplt p0.s, p7/z, z2.s, #0",
-        "ld1w {z2.s}, p0/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "cmplt p0.s, p7/z, z17.s, #0",
+        "ld1w {z16.s}, p0/z, [x4]"
       ]
     },
     "vpmaskmovq xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "cmplt p0.d, p6/z, z2.d, #0",
+        "cmplt p0.d, p6/z, z17.d, #0",
         "ld1d {z2.d}, p0/z, [x4]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpmaskmovq ymm0, ymm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "cmplt p0.d, p7/z, z2.d, #0",
-        "ld1d {z2.d}, p0/z, [x4]",
-        "mov z16.d, p7/m, z2.d"
+        "cmplt p0.d, p7/z, z17.d, #0",
+        "ld1d {z16.d}, p0/z, [x4]"
       ]
     },
     "vpmaskmovd [rax], xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "cmplt p0.s, p6/z, z2.s, #0",
-        "st1w {z3.s}, p0, [x4]"
+        "cmplt p0.s, p6/z, z16.s, #0",
+        "st1w {z17.s}, p0, [x4]"
       ]
     },
     "vpmaskmovd [rax], ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "cmplt p0.s, p7/z, z2.s, #0",
-        "st1w {z3.s}, p0, [x4]"
+        "cmplt p0.s, p7/z, z16.s, #0",
+        "st1w {z17.s}, p0, [x4]"
       ]
     },
     "vpmaskmovq [rax], xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "cmplt p0.d, p6/z, z2.d, #0",
-        "st1d {z3.d}, p0, [x4]"
+        "cmplt p0.d, p6/z, z16.d, #0",
+        "st1d {z17.d}, p0, [x4]"
       ]
     },
     "vpmaskmovq [rax], ymm0, ymm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "cmplt p0.d, p7/z, z2.d, #0",
-        "st1d {z3.d}, p0, [x4]"
+        "cmplt p0.d, p7/z, z16.d, #0",
+        "st1d {z17.d}, p0, [x4]"
       ]
     },
     "vpgatherdd xmm0, [xmm1*1 + rax], xmm2": {
@@ -3596,33 +3284,29 @@
       ]
     },
     "vaesimc xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdb 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "unimplemented (Unimplemented)",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaesenc xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdc 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
+        "movi v2.2d, #0x0",
+        "mov v0.16b, v17.16b",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
-        "eor v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "eor v2.16b, v0.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaesenc ymm0, ymm1, ymm2": {
@@ -3634,19 +3318,17 @@
       ]
     },
     "vaesenclast xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdd 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
+        "movi v2.2d, #0x0",
+        "mov v0.16b, v17.16b",
         "unimplemented (Unimplemented)",
-        "eor v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "eor v2.16b, v0.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaesenclast ymm0, ymm1, ymm2": {
@@ -3658,20 +3340,18 @@
       ]
     },
     "vaesdec xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xde 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
+        "movi v2.2d, #0x0",
+        "mov v0.16b, v17.16b",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
-        "eor v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "eor v2.16b, v0.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaesdec ymm0, ymm1, ymm2": {
@@ -3683,19 +3363,17 @@
       ]
     },
     "vaesdeclast xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdf 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
+        "movi v2.2d, #0x0",
+        "mov v0.16b, v17.16b",
         "unimplemented (Unimplemented)",
-        "eor v2.16b, v2.16b, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "eor v2.16b, v0.16b, v18.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaesdeclast ymm0, ymm1, ymm2": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -8,417 +8,313 @@
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 00000000b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.d, d2",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, d17"
       ]
     },
     "vpermq ymm0, ymm1, 01010101b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.d, z2.d[1]",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, z17.d[1]"
       ]
     },
     "vpermq ymm0, ymm1, 10101010b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.d, z2.d[2]",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, z17.d[2]"
       ]
     },
     "vpermq ymm0, ymm1, 11111111b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.d, z2.d[3]",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, z17.d[3]"
       ]
     },
     "vpermpd ymm0, ymm1, 00000000b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x01 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.d, d2",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, d17"
       ]
     },
     "vpermpd ymm0, ymm1, 01010101b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x01 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.d, z2.d[1]",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, z17.d[1]"
       ]
     },
     "vpermpd ymm0, ymm1, 10101010b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x01 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.d, z2.d[2]",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, z17.d[2]"
       ]
     },
     "vpermpd ymm0, ymm1, 11111111b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x01 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.d, z2.d[3]",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, z17.d[3]"
       ]
     },
     "vpblendd xmm0, xmm1, 0000b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v16.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 0001b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[0], v3.s[0]",
-        "mov v3.16b, v0.16b",
-        "mov v3.s[1], v2.s[1]",
-        "mov v3.s[2], v2.s[2]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[3]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[0]",
+        "mov v2.s[1], v16.s[1]",
+        "mov v2.s[2], v16.s[2]",
+        "mov v2.s[3], v16.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 0010b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v2.s[0]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[1], v3.s[1]",
-        "mov v3.16b, v0.16b",
-        "mov v3.s[2], v2.s[2]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[3]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v16.s[0]",
+        "mov v2.s[1], v17.s[1]",
+        "mov v2.s[2], v16.s[2]",
+        "mov v2.s[3], v16.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 0011b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v3.s[0]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[1], v3.s[1]",
-        "mov v3.16b, v0.16b",
-        "mov v3.s[2], v2.s[2]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[3]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[0]",
+        "mov v2.s[1], v17.s[1]",
+        "mov v2.s[2], v16.s[2]",
+        "mov v2.s[3], v16.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 0100b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v2.s[0]",
-        "mov v4.s[1], v2.s[1]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[2], v3.s[2]",
-        "mov v3.16b, v0.16b",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[3]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v16.s[0]",
+        "mov v2.s[1], v16.s[1]",
+        "mov v2.s[2], v17.s[2]",
+        "mov v2.s[3], v16.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 0101b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v3.s[0]",
-        "mov v4.s[1], v2.s[1]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[2], v3.s[2]",
-        "mov v3.16b, v0.16b",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[3]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[0]",
+        "mov v2.s[1], v16.s[1]",
+        "mov v2.s[2], v17.s[2]",
+        "mov v2.s[3], v16.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 0110b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v2.s[0]",
-        "mov v4.s[1], v3.s[1]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[2], v3.s[2]",
-        "mov v3.16b, v0.16b",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[3]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v16.s[0]",
+        "mov v2.s[1], v17.s[1]",
+        "mov v2.s[2], v17.s[2]",
+        "mov v2.s[3], v16.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 0111b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v3.s[0]",
-        "mov v4.s[1], v3.s[1]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[2], v3.s[2]",
-        "mov v3.16b, v0.16b",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[3]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[0]",
+        "mov v2.s[1], v17.s[1]",
+        "mov v2.s[2], v17.s[2]",
+        "mov v2.s[3], v16.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 1000b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v2.s[0]",
-        "mov v4.s[1], v2.s[1]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[2], v2.s[2]",
-        "mov v2.16b, v0.16b",
-        "mov v2.s[3], v3.s[3]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v16.s[0]",
+        "mov v2.s[1], v16.s[1]",
+        "mov v2.s[2], v16.s[2]",
+        "mov v2.s[3], v17.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 1001b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v3.s[0]",
-        "mov v4.s[1], v2.s[1]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[2], v2.s[2]",
-        "mov v2.16b, v0.16b",
-        "mov v2.s[3], v3.s[3]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[0]",
+        "mov v2.s[1], v16.s[1]",
+        "mov v2.s[2], v16.s[2]",
+        "mov v2.s[3], v17.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 1010b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v2.s[0]",
-        "mov v4.s[1], v3.s[1]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[2], v2.s[2]",
-        "mov v2.16b, v0.16b",
-        "mov v2.s[3], v3.s[3]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v16.s[0]",
+        "mov v2.s[1], v17.s[1]",
+        "mov v2.s[2], v16.s[2]",
+        "mov v2.s[3], v17.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 1011b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v3.s[0]",
-        "mov v4.s[1], v3.s[1]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[2], v2.s[2]",
-        "mov v2.16b, v0.16b",
-        "mov v2.s[3], v3.s[3]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[0]",
+        "mov v2.s[1], v17.s[1]",
+        "mov v2.s[2], v16.s[2]",
+        "mov v2.s[3], v17.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 1100b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v2.s[0]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[1], v2.s[1]",
-        "mov v2.16b, v0.16b",
-        "mov v2.s[2], v3.s[2]",
-        "mov v2.s[3], v3.s[3]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v16.s[0]",
+        "mov v2.s[1], v16.s[1]",
+        "mov v2.s[2], v17.s[2]",
+        "mov v2.s[3], v17.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 1101b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v4.s[0], v3.s[0]",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[1], v2.s[1]",
-        "mov v2.16b, v0.16b",
-        "mov v2.s[2], v3.s[2]",
-        "mov v2.s[3], v3.s[3]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[0]",
+        "mov v2.s[1], v16.s[1]",
+        "mov v2.s[2], v17.s[2]",
+        "mov v2.s[3], v17.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 1110b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[0], v2.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.s[1], v3.s[1]",
-        "mov v2.s[2], v3.s[2]",
-        "mov v2.s[3], v3.s[3]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v16.s[0]",
+        "mov v2.s[1], v17.s[1]",
+        "mov v2.s[2], v17.s[2]",
+        "mov v2.s[3], v17.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendd xmm0, xmm1, 1111b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpblendd ymm0, ymm1, 00000000b": {
@@ -433,2911 +329,2562 @@
       ]
     },
     "vpblendd ymm0, ymm1, 01010101b": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov z1.s, s3",
+        "movi v2.2d, #0x0",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[1]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z16.s[1]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z3.s[2]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[2]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[3]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z16.s[3]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z3.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[5]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z16.s[5]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z3.s[6]",
-        "mov z3.d, z4.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[6]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[7]",
-        "mov z2.d, z3.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z16.s[7]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vpblendd ymm0, ymm1, 10101010b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov z3.d, p7/m, z17.d",
-        "movi v4.2d, #0x0",
-        "mov z1.s, s2",
+        "movi v2.2d, #0x0",
+        "mov z1.s, s16",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z3.s[1]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[1]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[2]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z16.s[2]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z3.s[3]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[3]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z16.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z3.s[5]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[5]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[6]",
-        "mov z2.d, z4.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z16.s[6]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, z3.s[7]",
+        "mov z1.s, z17.s[7]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vpblendd ymm0, ymm1, 11111111b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x02 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpermilps xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov v3.s[0], v2.s[0]",
-        "mov v3.s[1], v2.s[0]",
-        "mov v3.s[2], v2.s[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[0]",
+        "mov v2.s[1], v17.s[0]",
+        "mov v2.s[2], v17.s[0]",
+        "mov v2.s[3], v17.s[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpermilps xmm0, xmm1, 01010101b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov v3.s[0], v2.s[1]",
-        "mov v3.s[1], v2.s[1]",
-        "mov v3.s[2], v2.s[1]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[1]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[1]",
+        "mov v2.s[1], v17.s[1]",
+        "mov v2.s[2], v17.s[1]",
+        "mov v2.s[3], v17.s[1]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpermilps xmm0, xmm1, 10101010b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov v3.s[0], v2.s[2]",
-        "mov v3.s[1], v2.s[2]",
-        "mov v3.s[2], v2.s[2]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[2]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[2]",
+        "mov v2.s[1], v17.s[2]",
+        "mov v2.s[2], v17.s[2]",
+        "mov v2.s[3], v17.s[2]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpermilps xmm0, xmm1, 11111111b": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov v3.s[0], v2.s[3]",
-        "mov v3.s[1], v2.s[3]",
-        "mov v3.s[2], v2.s[3]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[3]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v17.s[3]",
+        "mov v2.s[1], v17.s[3]",
+        "mov v2.s[2], v17.s[3]",
+        "mov v2.s[3], v17.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpermilps ymm0, ymm1, 00000000b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.s, s2",
+        "movi v2.2d, #0x0",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s17",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
-        "mov z2.d, z3.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vpermilps ymm0, ymm1, 01010101b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.s, z2.s[1]",
+        "movi v2.2d, #0x0",
+        "mov z1.s, z17.s[1]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[1]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[1]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[1]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[1]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[1]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[1]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[5]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[5]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[5]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[5]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[5]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[5]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[5]",
-        "mov z2.d, z3.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[5]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vpermilps ymm0, ymm1, 10101010b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.s, z2.s[2]",
+        "movi v2.2d, #0x0",
+        "mov z1.s, z17.s[2]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[2]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[2]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[2]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[2]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[2]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[2]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[6]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[6]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[6]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[6]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[6]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[6]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[6]",
-        "mov z2.d, z3.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[6]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vpermilps ymm0, ymm1, 11111111b": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.s, z2.s[3]",
+        "movi v2.2d, #0x0",
+        "mov z1.s, z17.s[3]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[3]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[3]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[3]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[3]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[3]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[3]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[7]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[7]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[7]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[7]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[7]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[7]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, z2.s[7]",
-        "mov z2.d, z3.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[7]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vpermilpd xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov v3.d[0], v2.d[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.d[1], v2.d[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.d[0], v17.d[0]",
+        "mov v2.d[1], v17.d[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpermilpd xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov v3.d[0], v2.d[1]",
-        "mov v0.16b, v3.16b",
-        "mov v0.d[1], v2.d[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.d[0], v17.d[1]",
+        "mov v2.d[1], v17.d[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpermilpd xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov v3.d[0], v2.d[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.d[1], v2.d[1]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.d[0], v17.d[0]",
+        "mov v2.d[1], v17.d[1]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpermilpd xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov v3.d[0], v2.d[1]",
-        "mov v0.16b, v3.16b",
-        "mov v0.d[1], v2.d[1]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.d[0], v17.d[1]",
+        "mov v2.d[1], v17.d[1]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpermilpd ymm0, ymm1, 0000b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, d2",
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, d2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 0001b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, z2.d[1]",
+        "movi v2.2d, #0x0",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, d2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 0010b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, d2",
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 0011b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, z2.d[1]",
+        "movi v2.2d, #0x0",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 0100b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, d2",
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, d2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 0101b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, z2.d[1]",
+        "movi v2.2d, #0x0",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, d2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 0110b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, d2",
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 0111b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, z2.d[1]",
+        "movi v2.2d, #0x0",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 1000b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, d2",
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, d2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 1001b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, z2.d[1]",
+        "movi v2.2d, #0x0",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, d2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 1010b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, d2",
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 1011b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, z2.d[1]",
+        "movi v2.2d, #0x0",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 1100b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, d2",
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, d2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 1101b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, z2.d[1]",
+        "movi v2.2d, #0x0",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, d2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 1110b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, d2",
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vpermilpd ymm0, ymm1, 1111b": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.d, z2.d[1]",
+        "movi v2.2d, #0x0",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p0/m, z1.d"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00000000b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00000001b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00000010b": {
-      "ExpectedInstructionCount": 11,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, q3",
-        "mov z3.d, z4.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00000011b": {
-      "ExpectedInstructionCount": 11,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, z3.q[1]",
-        "mov z3.d, z4.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00010000b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00010001b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00010010b": {
-      "ExpectedInstructionCount": 11,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, q3",
-        "mov z3.d, z4.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00010011b": {
-      "ExpectedInstructionCount": 11,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, z3.q[1]",
-        "mov z3.d, z4.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00100000b": {
-      "ExpectedInstructionCount": 10,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, q3",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00100001b": {
-      "ExpectedInstructionCount": 10,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z4.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, q3",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00100010b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00100011b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00110000b": {
-      "ExpectedInstructionCount": 10,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z3.q[1]",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00110001b": {
-      "ExpectedInstructionCount": 10,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z4.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z3.q[1]",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00110010b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00110011b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00001000b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00011000b": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00101000b": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 00111000b": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x06 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2f128 ymm0, ymm1, ymm2, 10001000b": {
-      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "mov z1.q, q17",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00000001b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00000010b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00000011b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00010000b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q17",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00010001b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00010010b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00010011b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00100000b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q17",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00100001b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00100010b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00100011b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00110000b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q17",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00110001b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00110010b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00110011b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00001000b": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00011000b": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00101000b": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 00111000b": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2f128 ymm0, ymm1, ymm2, 10001000b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x06 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000000b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000001b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000010b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000011b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vroundps xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintn v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "frintn v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundps xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintm v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "frintm v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundps xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintp v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "frintp v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundps xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintz v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "frintz v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundps xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frinti v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "frinti v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundps ymm0, ymm1, 00000000b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x08 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintn z2.s, p7/m, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "frintn z16.s, p7/m, z17.s"
       ]
     },
     "vroundps ymm0, ymm1, 00000001b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x08 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintm z2.s, p7/m, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "frintm z16.s, p7/m, z17.s"
       ]
     },
     "vroundps ymm0, ymm1, 00000010b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x08 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintp z2.s, p7/m, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "frintp z16.s, p7/m, z17.s"
       ]
     },
     "vroundps ymm0, ymm1, 00000011b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x08 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintz z2.s, p7/m, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "frintz z16.s, p7/m, z17.s"
       ]
     },
     "vroundps ymm0, ymm1, 00000100b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x08 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frinti z2.s, p7/m, z2.s",
-        "mov z16.d, p7/m, z2.d"
+        "frinti z16.s, p7/m, z17.s"
       ]
     },
     "vroundpd xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintn v2.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "frintn v2.2d, v17.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundpd xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintm v2.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "frintm v2.2d, v17.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundpd xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintp v2.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "frintp v2.2d, v17.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundpd xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintz v2.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "frintz v2.2d, v17.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundpd xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frinti v2.2d, v2.2d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "frinti v2.2d, v17.2d",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundpd ymm0, ymm1, 00000000b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x09 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintn z2.d, p7/m, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "frintn z16.d, p7/m, z17.d"
       ]
     },
     "vroundpd ymm0, ymm1, 00000001b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x09 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintm z2.d, p7/m, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "frintm z16.d, p7/m, z17.d"
       ]
     },
     "vroundpd ymm0, ymm1, 00000010b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x09 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintp z2.d, p7/m, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "frintp z16.d, p7/m, z17.d"
       ]
     },
     "vroundpd ymm0, ymm1, 00000011b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x09 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintz z2.d, p7/m, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "frintz z16.d, p7/m, z17.d"
       ]
     },
     "vroundpd ymm0, ymm1, 00000100b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x09 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frinti z2.d, p7/m, z2.d",
-        "mov z16.d, p7/m, z2.d"
+        "frinti z16.d, p7/m, z17.d"
       ]
     },
     "vroundss xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x0a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintn s2, s2",
-        "mov z3.d, p7/m, z16.d",
-        "mov v0.16b, v3.16b",
+        "frintn s2, s17",
+        "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundss xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x0a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintm s2, s2",
-        "mov z3.d, p7/m, z16.d",
-        "mov v0.16b, v3.16b",
+        "frintm s2, s17",
+        "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundss xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x0a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintp s2, s2",
-        "mov z3.d, p7/m, z16.d",
-        "mov v0.16b, v3.16b",
+        "frintp s2, s17",
+        "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundss xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x0a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintz s2, s2",
-        "mov z3.d, p7/m, z16.d",
-        "mov v0.16b, v3.16b",
+        "frintz s2, s17",
+        "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundss xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x0a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frinti s2, s2",
-        "mov z3.d, p7/m, z16.d",
-        "mov v0.16b, v3.16b",
+        "frinti s2, s17",
+        "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundsd xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x0b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintn d2, d2",
-        "mov z3.d, p7/m, z16.d",
-        "mov v0.16b, v3.16b",
+        "frintn d2, d17",
+        "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundsd xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x0b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintm d2, d2",
-        "mov z3.d, p7/m, z16.d",
-        "mov v0.16b, v3.16b",
+        "frintm d2, d17",
+        "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundsd xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x0b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintp d2, d2",
-        "mov z3.d, p7/m, z16.d",
-        "mov v0.16b, v3.16b",
+        "frintp d2, d17",
+        "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundsd xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x0b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frintz d2, d2",
-        "mov z3.d, p7/m, z16.d",
-        "mov v0.16b, v3.16b",
+        "frintz d2, d17",
+        "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vroundsd xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x0b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "frinti d2, d2",
-        "mov z3.d, p7/m, z16.d",
-        "mov v0.16b, v3.16b",
+        "frinti d2, d17",
+        "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vblendps xmm0, xmm1, xmm2, 0000b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vblendps xmm0, xmm1, xmm2, 0001b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov v0.16b, v4.16b",
-        "mov v0.s[0], v3.s[0]",
-        "mov v3.16b, v0.16b",
-        "mov v3.s[1], v2.s[1]",
-        "mov v3.s[2], v2.s[2]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[3]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v2.s[0], v18.s[0]",
+        "mov v2.s[1], v17.s[1]",
+        "mov v2.s[2], v17.s[2]",
+        "mov v2.s[3], v17.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vblendps xmm0, xmm1, xmm2, 1111b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v18.16b"
       ]
     },
     "vblendps ymm0, ymm1, ymm2, 00000000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vblendps ymm0, ymm1, ymm2, 10000001b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.s, s3",
+        "movi v2.2d, #0x0",
+        "mov z1.s, s18",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[1]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[1]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[2]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[2]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[3]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[3]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[4]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[4]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[5]",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[5]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z4.s, p0/m, z1.s",
-        "mov z1.s, z2.s[6]",
-        "mov z2.d, z4.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, z17.s[6]",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
         "mov z2.s, p0/m, z1.s",
-        "mov z1.s, z3.s[7]",
+        "mov z1.s, z18.s[7]",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vblendps ymm0, ymm1, ymm2, 11111111b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z18.d"
       ]
     },
     "vblendpd xmm0, xmm1, xmm2, 00b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vblendpd xmm0, xmm1, xmm2, 01b": {
-      "ExpectedInstructionCount": 11,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov v0.16b, v4.16b",
-        "mov v0.d[0], v3.d[0]",
-        "mov v3.16b, v0.16b",
-        "mov v0.16b, v3.16b",
-        "mov v0.d[1], v2.d[1]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd xmm0, xmm1, xmm2, 10b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov v0.16b, v4.16b",
-        "mov v0.d[0], v2.d[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.d[1], v3.d[1]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd xmm0, xmm1, xmm2, 11b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 0000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 0001b": {
-      "ExpectedInstructionCount": 22,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d3",
-        "mov z3.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 0010b": {
-      "ExpectedInstructionCount": 22,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d2",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z3.d[1]",
-        "mov z3.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 0011b": {
-      "ExpectedInstructionCount": 22,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d3",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z3.d[1]",
-        "mov z3.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 0100b": {
-      "ExpectedInstructionCount": 22,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d2",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z3.d[2]",
-        "mov z3.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 0101b": {
-      "ExpectedInstructionCount": 22,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d3",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z3.d[2]",
-        "mov z3.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 0110b": {
-      "ExpectedInstructionCount": 22,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d2",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z3.d[1]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z3.d[2]",
-        "mov z3.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 0111b": {
-      "ExpectedInstructionCount": 22,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d3",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z3.d[1]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z3.d[2]",
-        "mov z3.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
-        "mov z1.d, z2.d[3]",
-        "mov z2.d, z3.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 1000b": {
-      "ExpectedInstructionCount": 21,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d2",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[3]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 1001b": {
-      "ExpectedInstructionCount": 21,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d3",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[3]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 1010b": {
-      "ExpectedInstructionCount": 21,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d2",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z3.d[1]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[3]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 1011b": {
-      "ExpectedInstructionCount": 21,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d3",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z3.d[1]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[2]",
-        "mov z2.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[3]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 1100b": {
-      "ExpectedInstructionCount": 21,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d2",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
-        "mov z2.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[2]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[3]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 1101b": {
-      "ExpectedInstructionCount": 21,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d3",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z4.d, p0/m, z1.d",
-        "mov z1.d, z2.d[1]",
-        "mov z2.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[2]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[3]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 1110b": {
-      "ExpectedInstructionCount": 21,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.d, d2",
-        "mov z2.d, z4.d",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[1]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[2]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "mov z1.d, z3.d[3]",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z2.d, p0/m, z1.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vblendpd ymm0, ymm1, ymm2, 1111b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0d 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpblendw xmm0, xmm1, xmm2, 00000000b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0e 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpblendw xmm0, xmm1, xmm2, 00000001b": {
-      "ExpectedInstructionCount": 17,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0e 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov v0.16b, v4.16b",
-        "mov v0.h[0], v3.h[0]",
-        "mov v3.16b, v0.16b",
-        "mov v3.h[1], v2.h[1]",
-        "mov v3.h[2], v2.h[2]",
-        "mov v3.h[3], v2.h[3]",
-        "mov v3.h[4], v2.h[4]",
-        "mov v3.h[5], v2.h[5]",
-        "mov v3.h[6], v2.h[6]",
-        "mov v0.16b, v3.16b",
-        "mov v0.h[7], v2.h[7]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpblendw xmm0, xmm1, xmm2, 11111111b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0e 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpblendw ymm0, ymm1, ymm2, 00000000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0e 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpblendw ymm0, ymm1, ymm2, 00000001b": {
-      "ExpectedInstructionCount": 70,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0e 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.h, h3",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #-8",
-        "mov z4.h, p0/m, z1.h",
-        "mov z1.h, z2.h[1]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #-7",
-        "mov z4.h, p0/m, z1.h",
-        "mov z1.h, z2.h[2]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #-6",
-        "mov z4.h, p0/m, z1.h",
-        "mov z1.h, z2.h[3]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #-5",
-        "mov z4.h, p0/m, z1.h",
-        "mov z1.h, z2.h[4]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #-4",
-        "mov z4.h, p0/m, z1.h",
-        "mov z1.h, z2.h[5]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #-3",
-        "mov z4.h, p0/m, z1.h",
-        "mov z1.h, z2.h[6]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #-2",
-        "mov z4.h, p0/m, z1.h",
-        "mov z1.h, z2.h[7]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #-1",
-        "mov z4.h, p0/m, z1.h",
-        "mov z1.h, z3.h[8]",
-        "mov z3.d, z4.d",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #0",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[9]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #1",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[10]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #2",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[11]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #3",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[12]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #4",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[13]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #5",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[14]",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #6",
-        "mov z3.h, p0/m, z1.h",
-        "mov z1.h, z2.h[15]",
-        "mov z2.d, z3.d",
-        "index z0.h, #-8, #1",
-        "cmpeq p0.h, p7/z, z0.h, #7",
-        "mov z2.h, p0/m, z1.h",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpblendw ymm0, ymm1, ymm2, 11111111b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0e 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpalignr xmm0, xmm1, xmm2, 0": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0f 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "ext v2.16b, v3.16b, v2.16b, #0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpalignr xmm0, xmm1, xmm2, 1": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0f 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "ext v2.16b, v3.16b, v2.16b, #1",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpalignr xmm0, xmm1, xmm2, 15": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0f 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "ext v2.16b, v3.16b, v2.16b, #15",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpalignr xmm0, xmm1, xmm2, 16": {
-      "ExpectedInstructionCount": 6,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0f 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v0.2d, #0x0",
-        "ext v2.16b, v2.16b, v0.16b, #0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpalignr ymm0, ymm1, ymm2, 0": {
-      "ExpectedInstructionCount": 13,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0f 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "ext v4.16b, v3.16b, v2.16b, #0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z3.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "ext v2.16b, v3.16b, v2.16b, #0",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpalignr ymm0, ymm1, ymm2, 1": {
-      "ExpectedInstructionCount": 13,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0f 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "ext v4.16b, v3.16b, v2.16b, #1",
-        "mov z1.q, z2.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z3.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "ext v2.16b, v3.16b, v2.16b, #1",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpalignr ymm0, ymm1, ymm2, 15": {
-      "ExpectedInstructionCount": 13,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0f 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "ext v4.16b, v3.16b, v2.16b, #15",
-        "mov z1.q, z2.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z3.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "ext v2.16b, v3.16b, v2.16b, #15",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpalignr ymm0, ymm1, ymm2, 16": {
-      "ExpectedInstructionCount": 15,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x0f 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v0.2d, #0x0",
-        "ext v4.16b, v2.16b, v0.16b, #0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z3.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "movi v0.2d, #0x0",
-        "ext v2.16b, v2.16b, v0.16b, #0",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpextrb rax, xmm0, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x14 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "umov w4, v2.b[0]"
-      ]
-    },
-    "vpextrb rax, xmm0, 15": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x14 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "umov w4, v2.b[15]"
-      ]
-    },
-    "vpextrw rax, xmm0, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x15 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "umov w4, v2.h[0]"
-      ]
-    },
-    "vpextrw rax, xmm0, 7": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x15 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "umov w4, v2.h[7]"
-      ]
-    },
-    "vpextrd rax, xmm0, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x16 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov w4, v2.s[0]"
-      ]
-    },
-    "vpextrd rax, xmm0, 3": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x16 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov w4, v2.s[3]"
-      ]
-    },
-    "vpextrb [rax], xmm0, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x14 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1 {v2.b}[0], [x4]"
-      ]
-    },
-    "vpextrb [rax], xmm0, 15": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x14 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1 {v2.b}[15], [x4]"
-      ]
-    },
-    "vpextrw [rax], xmm0, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x15 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1 {v2.h}[0], [x4]"
-      ]
-    },
-    "vpextrw [rax], xmm0, 7": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x15 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1 {v2.h}[7], [x4]"
-      ]
-    },
-    "vpextrd [rax], xmm0, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x16 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1 {v2.s}[0], [x4]"
-      ]
-    },
-    "vpextrd [rax], xmm0, 3": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x16 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "st1 {v2.s}[3], [x4]"
-      ]
-    },
-    "vextractps eax, xmm0, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x17 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov w4, v2.s[0]"
-      ]
-    },
-    "vextractps eax, xmm0, 3": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x17 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z16.d",
-        "mov w4, v2.s[3]"
-      ]
-    },
-    "vinsertf128 ymm0, ymm1, xmm2, 0": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x18 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z1.q, q3",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vinsertf128 ymm0, ymm1, xmm2, 1": {
-      "ExpectedInstructionCount": 6,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x18 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z1.q, q3",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vextractf128 xmm0, ymm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x19 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vextractf128 xmm0, ymm1, 1": {
       "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
+        "Map 3 0b01 0x0d 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov v2.d[0], v18.d[0]",
+        "mov v2.d[1], v17.d[1]",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vblendpd xmm0, xmm1, xmm2, 10b": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov v2.d[0], v17.d[0]",
+        "mov v2.d[1], v18.d[1]",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vblendpd xmm0, xmm1, xmm2, 11b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x0d 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov v16.16b, v18.16b"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 0000b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z16.d, p7/m, z17.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 0001b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d18",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 0010b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 0011b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d18",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 0100b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 0101b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d18",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 0110b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 0111b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d18",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 1000b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 1001b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d18",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 1010b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 1011b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d18",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 1100b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 1101b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d18",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z17.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 1110b": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.d, d17",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[1]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[2]",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #0",
+        "mov z2.d, p0/m, z1.d",
+        "mov z1.d, z18.d[3]",
+        "mov z16.d, z2.d",
+        "index z0.d, #-2, #1",
+        "cmpeq p0.d, p7/z, z0.d, #1",
+        "mov z16.d, p0/m, z1.d"
+      ]
+    },
+    "vblendpd ymm0, ymm1, ymm2, 1111b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x0d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z16.d, p7/m, z18.d"
+      ]
+    },
+    "vpblendw xmm0, xmm1, xmm2, 00000000b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x0e 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov v16.16b, v17.16b"
+      ]
+    },
+    "vpblendw xmm0, xmm1, xmm2, 00000001b": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0e 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov v2.h[0], v18.h[0]",
+        "mov v2.h[1], v17.h[1]",
+        "mov v2.h[2], v17.h[2]",
+        "mov v2.h[3], v17.h[3]",
+        "mov v2.h[4], v17.h[4]",
+        "mov v2.h[5], v17.h[5]",
+        "mov v2.h[6], v17.h[6]",
+        "mov v2.h[7], v17.h[7]",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vpblendw xmm0, xmm1, xmm2, 11111111b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x0e 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov v16.16b, v18.16b"
+      ]
+    },
+    "vpblendw ymm0, ymm1, ymm2, 00000000b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x0e 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z16.d, p7/m, z17.d"
+      ]
+    },
+    "vpblendw ymm0, ymm1, ymm2, 00000001b": {
+      "ExpectedInstructionCount": 66,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0e 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.h, h18",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #-8",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[1]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #-7",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[2]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #-6",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[3]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #-5",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[4]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #-4",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[5]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #-3",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[6]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #-2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[7]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #-1",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z18.h[8]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #0",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[9]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #1",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[10]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #2",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[11]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #3",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[12]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #4",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[13]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #5",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[14]",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #6",
+        "mov z2.h, p0/m, z1.h",
+        "mov z1.h, z17.h[15]",
+        "mov z16.d, z2.d",
+        "index z0.h, #-8, #1",
+        "cmpeq p0.h, p7/z, z0.h, #7",
+        "mov z16.h, p0/m, z1.h"
+      ]
+    },
+    "vpblendw ymm0, ymm1, ymm2, 11111111b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x0e 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z16.d, p7/m, z18.d"
+      ]
+    },
+    "vpalignr xmm0, xmm1, xmm2, 0": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0f 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ext v2.16b, v18.16b, v17.16b, #0",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vpalignr xmm0, xmm1, xmm2, 1": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0f 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ext v2.16b, v18.16b, v17.16b, #1",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vpalignr xmm0, xmm1, xmm2, 15": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0f 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ext v2.16b, v18.16b, v17.16b, #15",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vpalignr xmm0, xmm1, xmm2, 16": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0f 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v0.2d, #0x0",
+        "ext v2.16b, v17.16b, v0.16b, #0",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vpalignr ymm0, ymm1, ymm2, 0": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0f 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ext v2.16b, v18.16b, v17.16b, #0",
+        "mov z1.q, z17.q[1]",
+        "mov z3.d, z17.d",
+        "mov z3.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z4.d, z18.d",
+        "mov z4.b, p6/m, z1.b",
+        "ext v3.16b, v4.16b, v3.16b, #0",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vpalignr ymm0, ymm1, ymm2, 1": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0f 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ext v2.16b, v18.16b, v17.16b, #1",
+        "mov z1.q, z17.q[1]",
+        "mov z3.d, z17.d",
+        "mov z3.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z4.d, z18.d",
+        "mov z4.b, p6/m, z1.b",
+        "ext v3.16b, v4.16b, v3.16b, #1",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vpalignr ymm0, ymm1, ymm2, 15": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0f 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ext v2.16b, v18.16b, v17.16b, #15",
+        "mov z1.q, z17.q[1]",
+        "mov z3.d, z17.d",
+        "mov z3.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z4.d, z18.d",
+        "mov z4.b, p6/m, z1.b",
+        "ext v3.16b, v4.16b, v3.16b, #15",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vpalignr ymm0, ymm1, ymm2, 16": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x0f 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v0.2d, #0x0",
+        "ext v2.16b, v17.16b, v0.16b, #0",
+        "mov z1.q, z17.q[1]",
+        "mov z3.d, z17.d",
+        "mov z3.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z4.d, z18.d",
+        "mov z4.b, p6/m, z1.b",
+        "movi v0.2d, #0x0",
+        "ext v3.16b, v3.16b, v0.16b, #0",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vpextrb rax, xmm0, 0": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x14 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "umov w4, v16.b[0]"
+      ]
+    },
+    "vpextrb rax, xmm0, 15": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x14 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "umov w4, v16.b[15]"
+      ]
+    },
+    "vpextrw rax, xmm0, 0": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x15 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "umov w4, v16.h[0]"
+      ]
+    },
+    "vpextrw rax, xmm0, 7": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x15 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "umov w4, v16.h[7]"
+      ]
+    },
+    "vpextrd rax, xmm0, 0": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x16 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w4, v16.s[0]"
+      ]
+    },
+    "vpextrd rax, xmm0, 3": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x16 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w4, v16.s[3]"
+      ]
+    },
+    "vpextrb [rax], xmm0, 0": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x14 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "st1 {v16.b}[0], [x4]"
+      ]
+    },
+    "vpextrb [rax], xmm0, 15": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x14 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "st1 {v16.b}[15], [x4]"
+      ]
+    },
+    "vpextrw [rax], xmm0, 0": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x15 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "st1 {v16.h}[0], [x4]"
+      ]
+    },
+    "vpextrw [rax], xmm0, 7": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x15 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "st1 {v16.h}[7], [x4]"
+      ]
+    },
+    "vpextrd [rax], xmm0, 0": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x16 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "st1 {v16.s}[0], [x4]"
+      ]
+    },
+    "vpextrd [rax], xmm0, 3": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x16 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "st1 {v16.s}[3], [x4]"
+      ]
+    },
+    "vextractps eax, xmm0, 0": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x17 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w4, v16.s[0]"
+      ]
+    },
+    "vextractps eax, xmm0, 3": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x17 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w4, v16.s[3]"
+      ]
+    },
+    "vinsertf128 ymm0, ymm1, xmm2, 0": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x18 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z1.q, q18",
+        "mov z16.d, z17.d",
+        "mov z16.b, p6/m, z1.b"
+      ]
+    },
+    "vinsertf128 ymm0, ymm1, xmm2, 1": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x18 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z1.q, q18",
+        "mov z16.d, z17.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vextractf128 xmm0, ymm1, 0": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
         "Map 3 0b01 0x19 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.q, z2.q[1]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
+      ]
+    },
+    "vextractf128 xmm0, ymm1, 1": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x19 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z2.q, z17.q[1]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vcvtps2ph xmm0, xmm1, 00000000b": {
@@ -3431,328 +2978,240 @@
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "nearest rounding",
         "Map 3 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
+        "mov v2.16b, v17.16b",
         "mov v2.b[0], w4",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 15": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "nearest rounding",
         "Map 3 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
+        "mov v2.16b, v17.16b",
         "mov v2.b[15], w4",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b00 << 6) | (0b00 << 4) | (0b0000))": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "nearest rounding",
         "Map 3 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov v2.s[0], v3.s[0]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.s[0], v18.s[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b00 << 6) | (0b00 << 4) | (0b1111))": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
-        "nearest rounding",
         "Map 3 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b11 << 6) | (0b11 << 4) | (0b0000))": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "nearest rounding",
         "Map 3 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov v2.s[3], v3.s[3]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v2.16b, v17.16b",
+        "mov v2.s[3], v18.s[3]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "nearest rounding",
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
+        "mov v2.16b, v17.16b",
         "mov v2.s[0], w4",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 3": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "nearest rounding",
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
+        "mov v2.16b, v17.16b",
         "mov v2.s[3], w4",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpinsrq xmm0, xmm1, rax, 0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "nearest rounding",
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
+        "mov v2.16b, v17.16b",
         "mov v2.d[0], x4",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpinsrq xmm0, xmm1, rax, 1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "nearest rounding",
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
+        "mov v2.16b, v17.16b",
         "mov v2.d[1], x4",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vinserti128 ymm0, ymm1, xmm2, 0": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x38 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z1.q, q3",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z1.q, q18",
+        "mov z16.d, z17.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vinserti128 ymm0, ymm1, xmm2, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x38 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z1.q, q3",
+        "mov z1.q, q18",
+        "mov z16.d, z17.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vextracti128 xmm0, ymm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x39 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vextracti128 xmm0, ymm1, 1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x39 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z2.q, z2.q[1]",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z2.q, z17.q[1]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 00000000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 00001111b": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 13,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "fmul v2.4s, v2.4s, v3.4s",
-        "mov v2.s[0], v4.s[0]",
-        "mov v2.s[1], v4.s[0]",
-        "mov v2.s[2], v4.s[0]",
-        "mov v2.s[3], v4.s[0]",
-        "faddp v2.4s, v2.4s, v4.4s",
-        "faddp v2.4s, v2.4s, v4.4s",
-        "mov v3.16b, v4.16b",
+        "movi v2.2d, #0x0",
+        "fmul v3.4s, v17.4s, v18.4s",
         "mov v3.s[0], v2.s[0]",
         "mov v3.s[1], v2.s[0]",
         "mov v3.s[2], v2.s[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v3.s[3], v2.s[0]",
+        "faddp v3.4s, v3.4s, v2.4s",
+        "faddp v3.4s, v3.4s, v2.4s",
+        "mov v2.s[0], v3.s[0]",
+        "mov v2.s[1], v3.s[0]",
+        "mov v2.s[2], v3.s[0]",
+        "mov v2.s[3], v3.s[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 11110000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 11111111b": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "fmul v2.4s, v2.4s, v3.4s",
-        "faddp v2.4s, v2.4s, v4.4s",
-        "faddp v2.4s, v2.4s, v4.4s",
-        "mov v3.16b, v4.16b",
-        "mov v3.s[0], v2.s[0]",
-        "mov v3.s[1], v2.s[0]",
-        "mov v3.s[2], v2.s[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.s[3], v2.s[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "fmul v3.4s, v17.4s, v18.4s",
+        "faddp v3.4s, v3.4s, v2.4s",
+        "faddp v3.4s, v3.4s, v2.4s",
+        "mov v2.s[0], v3.s[0]",
+        "mov v2.s[1], v3.s[0]",
+        "mov v2.s[2], v3.s[0]",
+        "mov v2.s[3], v3.s[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vdpps ymm0, ymm1, ymm2, 00000000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "movi v16.2d, #0x0"
       ]
     },
     "vdpps ymm0, ymm1, ymm2, 00001111b": {
-      "ExpectedInstructionCount": 81,
+      "ExpectedInstructionCount": 77,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "fmul z2.s, z2.s, z3.s",
-        "mov z1.s, s4",
-        "index z0.s, #-4, #1",
-        "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s4",
-        "index z0.s, #-4, #1",
-        "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s4",
-        "index z0.s, #-4, #1",
-        "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s4",
-        "index z0.s, #-4, #1",
-        "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s4",
-        "index z0.s, #-4, #1",
-        "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s4",
-        "index z0.s, #-4, #1",
-        "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s4",
-        "index z0.s, #-4, #1",
-        "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z2.s, p0/m, z1.s",
-        "mov z1.s, s4",
-        "index z0.s, #-4, #1",
-        "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "movprfx z0, z2",
-        "faddp z0.s, p7/m, z0.s, z4.s",
-        "uzp1 z2.s, z0.s, z0.s",
-        "uzp2 z1.s, z0.s, z0.s",
-        "splice z2.d, p6, z2.d, z1.d",
-        "movprfx z0, z2",
-        "faddp z0.s, p7/m, z0.s, z4.s",
-        "uzp1 z2.s, z0.s, z0.s",
-        "uzp2 z1.s, z0.s, z0.s",
-        "splice z2.d, p6, z2.d, z1.d",
+        "movi v2.2d, #0x0",
+        "fmul z3.s, z17.s, z18.s",
         "mov z1.s, s2",
-        "mov z3.d, z4.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
         "mov z3.s, p0/m, z1.s",
@@ -3781,790 +3240,752 @@
         "cmpeq p0.s, p7/z, z0.s, #2",
         "mov z3.s, p0/m, z1.s",
         "mov z1.s, s2",
-        "mov z2.d, z3.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
+        "mov z3.s, p0/m, z1.s",
+        "movprfx z0, z3",
+        "faddp z0.s, p7/m, z0.s, z2.s",
+        "uzp1 z3.s, z0.s, z0.s",
+        "uzp2 z1.s, z0.s, z0.s",
+        "splice z3.d, p6, z3.d, z1.d",
+        "movprfx z0, z3",
+        "faddp z0.s, p7/m, z0.s, z2.s",
+        "uzp1 z3.s, z0.s, z0.s",
+        "uzp2 z1.s, z0.s, z0.s",
+        "splice z3.d, p6, z3.d, z1.d",
+        "mov z1.s, s3",
+        "index z0.s, #-4, #1",
+        "cmpeq p0.s, p7/z, z0.s, #-4",
         "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z1.s, s3",
+        "index z0.s, #-4, #1",
+        "cmpeq p0.s, p7/z, z0.s, #-3",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
+        "index z0.s, #-4, #1",
+        "cmpeq p0.s, p7/z, z0.s, #-2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
+        "index z0.s, #-4, #1",
+        "cmpeq p0.s, p7/z, z0.s, #-1",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
+        "index z0.s, #-4, #1",
+        "cmpeq p0.s, p7/z, z0.s, #0",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
+        "index z0.s, #-4, #1",
+        "cmpeq p0.s, p7/z, z0.s, #1",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
+        "index z0.s, #-4, #1",
+        "cmpeq p0.s, p7/z, z0.s, #2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
+        "mov z16.d, z2.d",
+        "index z0.s, #-4, #1",
+        "cmpeq p0.s, p7/z, z0.s, #3",
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vdpps ymm0, ymm1, ymm2, 11110000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "movi v16.2d, #0x0"
       ]
     },
     "vdpps ymm0, ymm1, ymm2, 11111111b": {
-      "ExpectedInstructionCount": 49,
+      "ExpectedInstructionCount": 45,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "fmul z2.s, z2.s, z3.s",
-        "movprfx z0, z2",
-        "faddp z0.s, p7/m, z0.s, z4.s",
-        "uzp1 z2.s, z0.s, z0.s",
+        "movi v2.2d, #0x0",
+        "fmul z3.s, z17.s, z18.s",
+        "movprfx z0, z3",
+        "faddp z0.s, p7/m, z0.s, z2.s",
+        "uzp1 z3.s, z0.s, z0.s",
         "uzp2 z1.s, z0.s, z0.s",
-        "splice z2.d, p6, z2.d, z1.d",
-        "movprfx z0, z2",
-        "faddp z0.s, p7/m, z0.s, z4.s",
-        "uzp1 z2.s, z0.s, z0.s",
+        "splice z3.d, p6, z3.d, z1.d",
+        "movprfx z0, z3",
+        "faddp z0.s, p7/m, z0.s, z2.s",
+        "uzp1 z3.s, z0.s, z0.s",
         "uzp2 z1.s, z0.s, z0.s",
-        "splice z2.d, p6, z2.d, z1.d",
-        "mov z1.s, s2",
-        "mov z3.d, z4.d",
+        "splice z3.d, p6, z3.d, z1.d",
+        "mov z1.s, s3",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-4",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-3",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #-1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #0",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #1",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #2",
-        "mov z3.s, p0/m, z1.s",
-        "mov z1.s, s2",
-        "mov z2.d, z3.d",
+        "mov z2.s, p0/m, z1.s",
+        "mov z1.s, s3",
+        "mov z16.d, z2.d",
         "index z0.s, #-4, #1",
         "cmpeq p0.s, p7/z, z0.s, #3",
-        "mov z2.s, p0/m, z1.s",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.s, p0/m, z1.s"
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 00000000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 00001111b": {
-      "ExpectedInstructionCount": 14,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x41 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "fmul v2.2d, v2.2d, v3.2d",
-        "mov v2.d[0], v4.d[0]",
-        "mov v2.d[1], v4.d[0]",
-        "faddp v2.2d, v2.2d, v4.2d",
-        "mov v3.16b, v4.16b",
-        "mov v3.d[0], v2.d[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.d[1], v2.d[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vdppd xmm0, xmm1, xmm2, 11110000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "fmul v3.2d, v17.2d, v18.2d",
+        "mov v3.d[0], v2.d[0]",
+        "mov v3.d[1], v2.d[0]",
+        "faddp v3.2d, v3.2d, v2.2d",
+        "mov v2.d[0], v3.d[0]",
+        "mov v2.d[1], v3.d[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
-    "vdppd xmm0, xmm1, xmm2, 11111111b": {
-      "ExpectedInstructionCount": 12,
+    "vdppd xmm0, xmm1, xmm2, 11110000b": {
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "fmul v2.2d, v2.2d, v3.2d",
-        "faddp v2.2d, v2.2d, v4.2d",
-        "mov v3.16b, v4.16b",
-        "mov v3.d[0], v2.d[0]",
-        "mov v0.16b, v3.16b",
-        "mov v0.d[1], v2.d[0]",
-        "mov v2.16b, v0.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vdppd xmm0, xmm1, xmm2, 11111111b": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x41 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "fmul v3.2d, v17.2d, v18.2d",
+        "faddp v3.2d, v3.2d, v2.2d",
+        "mov v2.d[0], v3.d[0]",
+        "mov v2.d[1], v3.d[0]",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 000b": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v3.4s, v3.s[0]",
-        "ext v4.16b, v2.16b, v2.16b, #0",
-        "ext v5.16b, v2.16b, v2.16b, #1",
-        "ext v6.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v4.8h, v6.8h",
-        "addp v2.8h, v5.8h, v2.8h",
+        "dup v2.4s, v18.s[0]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
         "addp v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 001b": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v3.4s, v3.s[1]",
-        "ext v4.16b, v2.16b, v2.16b, #0",
-        "ext v5.16b, v2.16b, v2.16b, #1",
-        "ext v6.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v4.8h, v6.8h",
-        "addp v2.8h, v5.8h, v2.8h",
+        "dup v2.4s, v18.s[1]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
         "addp v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 010b": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v3.4s, v3.s[2]",
-        "ext v4.16b, v2.16b, v2.16b, #0",
-        "ext v5.16b, v2.16b, v2.16b, #1",
-        "ext v6.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v4.8h, v6.8h",
-        "addp v2.8h, v5.8h, v2.8h",
+        "dup v2.4s, v18.s[2]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
         "addp v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 011b": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v3.4s, v3.s[3]",
-        "ext v4.16b, v2.16b, v2.16b, #0",
-        "ext v5.16b, v2.16b, v2.16b, #1",
-        "ext v6.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v4.8h, v6.8h",
-        "addp v2.8h, v5.8h, v2.8h",
+        "dup v2.4s, v18.s[3]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
         "addp v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 100b": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v3.4s, v3.s[0]",
-        "ext v4.16b, v2.16b, v2.16b, #4",
-        "ext v5.16b, v2.16b, v2.16b, #5",
-        "ext v6.16b, v2.16b, v2.16b, #6",
-        "ext v2.16b, v2.16b, v2.16b, #7",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v4.8h, v6.8h",
-        "addp v2.8h, v5.8h, v2.8h",
+        "dup v2.4s, v18.s[0]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
         "addp v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 101b": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v3.4s, v3.s[1]",
-        "ext v4.16b, v2.16b, v2.16b, #4",
-        "ext v5.16b, v2.16b, v2.16b, #5",
-        "ext v6.16b, v2.16b, v2.16b, #6",
-        "ext v2.16b, v2.16b, v2.16b, #7",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v4.8h, v6.8h",
-        "addp v2.8h, v5.8h, v2.8h",
+        "dup v2.4s, v18.s[1]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
         "addp v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 110b": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v3.4s, v3.s[2]",
-        "ext v4.16b, v2.16b, v2.16b, #4",
-        "ext v5.16b, v2.16b, v2.16b, #5",
-        "ext v6.16b, v2.16b, v2.16b, #6",
-        "ext v2.16b, v2.16b, v2.16b, #7",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v4.8h, v6.8h",
-        "addp v2.8h, v5.8h, v2.8h",
+        "dup v2.4s, v18.s[2]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
         "addp v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 111b": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v3.4s, v3.s[3]",
-        "ext v4.16b, v2.16b, v2.16b, #4",
-        "ext v5.16b, v2.16b, v2.16b, #5",
-        "ext v6.16b, v2.16b, v2.16b, #6",
-        "ext v2.16b, v2.16b, v2.16b, #7",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v4.8h, v6.8h",
-        "addp v2.8h, v5.8h, v2.8h",
+        "dup v2.4s, v18.s[3]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
         "addp v2.8h, v4.8h, v2.8h",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vmpsadbw ymm0, ymm1, ymm2, 000b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v4.4s, v3.s[0]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v8.16b, v2.16b, v2.16b, #3",
+        "dup v2.4s, v18.s[0]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v2.8h, v4.8h, v2.8h",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
+        "dup v4.4s, v4.s[0]",
+        "ext v5.16b, v3.16b, v3.16b, #0",
+        "ext v6.16b, v3.16b, v3.16b, #1",
+        "ext v7.16b, v3.16b, v3.16b, #2",
+        "ext v3.16b, v3.16b, v3.16b, #3",
         "uabdl v5.8h, v5.8b, v4.8b",
         "uabdl v6.8h, v6.8b, v4.8b",
         "uabdl v7.8h, v7.8b, v4.8b",
-        "uabdl v4.8h, v8.8b, v4.8b",
-        "addp v5.8h, v5.8h, v7.8h",
-        "addp v4.8h, v6.8h, v4.8h",
-        "trn1 v6.4s, v5.4s, v4.4s",
-        "trn2 v4.4s, v5.4s, v4.4s",
-        "addp v4.8h, v6.8h, v4.8h",
-        "mov z2.q, z2.q[1]",
-        "mov z3.q, z3.q[1]",
-        "dup v3.4s, v3.s[0]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v7.8h, v7.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v5.8h, v7.8h",
-        "addp v2.8h, v6.8h, v2.8h",
-        "trn1 v5.4s, v3.4s, v2.4s",
-        "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v5.8h, v2.8h",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "uabdl v3.8h, v3.8b, v4.8b",
+        "addp v4.8h, v5.8h, v7.8h",
+        "addp v3.8h, v6.8h, v3.8h",
+        "trn1 v5.4s, v4.4s, v3.4s",
+        "trn2 v3.4s, v4.4s, v3.4s",
+        "addp v3.8h, v5.8h, v3.8h",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vmpsadbw ymm0, ymm1, ymm2, 001b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v4.4s, v3.s[1]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v8.16b, v2.16b, v2.16b, #3",
+        "dup v2.4s, v18.s[1]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v2.8h, v4.8h, v2.8h",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
+        "dup v4.4s, v4.s[0]",
+        "ext v5.16b, v3.16b, v3.16b, #0",
+        "ext v6.16b, v3.16b, v3.16b, #1",
+        "ext v7.16b, v3.16b, v3.16b, #2",
+        "ext v3.16b, v3.16b, v3.16b, #3",
         "uabdl v5.8h, v5.8b, v4.8b",
         "uabdl v6.8h, v6.8b, v4.8b",
         "uabdl v7.8h, v7.8b, v4.8b",
-        "uabdl v4.8h, v8.8b, v4.8b",
-        "addp v5.8h, v5.8h, v7.8h",
-        "addp v4.8h, v6.8h, v4.8h",
-        "trn1 v6.4s, v5.4s, v4.4s",
-        "trn2 v4.4s, v5.4s, v4.4s",
-        "addp v4.8h, v6.8h, v4.8h",
-        "mov z2.q, z2.q[1]",
-        "mov z3.q, z3.q[1]",
-        "dup v3.4s, v3.s[0]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v7.8h, v7.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v5.8h, v7.8h",
-        "addp v2.8h, v6.8h, v2.8h",
-        "trn1 v5.4s, v3.4s, v2.4s",
-        "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v5.8h, v2.8h",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "uabdl v3.8h, v3.8b, v4.8b",
+        "addp v4.8h, v5.8h, v7.8h",
+        "addp v3.8h, v6.8h, v3.8h",
+        "trn1 v5.4s, v4.4s, v3.4s",
+        "trn2 v3.4s, v4.4s, v3.4s",
+        "addp v3.8h, v5.8h, v3.8h",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vmpsadbw ymm0, ymm1, ymm2, 010b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v4.4s, v3.s[2]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v8.16b, v2.16b, v2.16b, #3",
+        "dup v2.4s, v18.s[2]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v2.8h, v4.8h, v2.8h",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
+        "dup v4.4s, v4.s[0]",
+        "ext v5.16b, v3.16b, v3.16b, #0",
+        "ext v6.16b, v3.16b, v3.16b, #1",
+        "ext v7.16b, v3.16b, v3.16b, #2",
+        "ext v3.16b, v3.16b, v3.16b, #3",
         "uabdl v5.8h, v5.8b, v4.8b",
         "uabdl v6.8h, v6.8b, v4.8b",
         "uabdl v7.8h, v7.8b, v4.8b",
-        "uabdl v4.8h, v8.8b, v4.8b",
-        "addp v5.8h, v5.8h, v7.8h",
-        "addp v4.8h, v6.8h, v4.8h",
-        "trn1 v6.4s, v5.4s, v4.4s",
-        "trn2 v4.4s, v5.4s, v4.4s",
-        "addp v4.8h, v6.8h, v4.8h",
-        "mov z2.q, z2.q[1]",
-        "mov z3.q, z3.q[1]",
-        "dup v3.4s, v3.s[0]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v7.8h, v7.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v5.8h, v7.8h",
-        "addp v2.8h, v6.8h, v2.8h",
-        "trn1 v5.4s, v3.4s, v2.4s",
-        "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v5.8h, v2.8h",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "uabdl v3.8h, v3.8b, v4.8b",
+        "addp v4.8h, v5.8h, v7.8h",
+        "addp v3.8h, v6.8h, v3.8h",
+        "trn1 v5.4s, v4.4s, v3.4s",
+        "trn2 v3.4s, v4.4s, v3.4s",
+        "addp v3.8h, v5.8h, v3.8h",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vmpsadbw ymm0, ymm1, ymm2, 011b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v4.4s, v3.s[3]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v8.16b, v2.16b, v2.16b, #3",
+        "dup v2.4s, v18.s[3]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v2.8h, v4.8h, v2.8h",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
+        "dup v4.4s, v4.s[0]",
+        "ext v5.16b, v3.16b, v3.16b, #0",
+        "ext v6.16b, v3.16b, v3.16b, #1",
+        "ext v7.16b, v3.16b, v3.16b, #2",
+        "ext v3.16b, v3.16b, v3.16b, #3",
         "uabdl v5.8h, v5.8b, v4.8b",
         "uabdl v6.8h, v6.8b, v4.8b",
         "uabdl v7.8h, v7.8b, v4.8b",
-        "uabdl v4.8h, v8.8b, v4.8b",
-        "addp v5.8h, v5.8h, v7.8h",
-        "addp v4.8h, v6.8h, v4.8h",
-        "trn1 v6.4s, v5.4s, v4.4s",
-        "trn2 v4.4s, v5.4s, v4.4s",
-        "addp v4.8h, v6.8h, v4.8h",
-        "mov z2.q, z2.q[1]",
-        "mov z3.q, z3.q[1]",
-        "dup v3.4s, v3.s[0]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v7.8h, v7.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v5.8h, v7.8h",
-        "addp v2.8h, v6.8h, v2.8h",
-        "trn1 v5.4s, v3.4s, v2.4s",
-        "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v5.8h, v2.8h",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "uabdl v3.8h, v3.8b, v4.8b",
+        "addp v4.8h, v5.8h, v7.8h",
+        "addp v3.8h, v6.8h, v3.8h",
+        "trn1 v5.4s, v4.4s, v3.4s",
+        "trn2 v3.4s, v4.4s, v3.4s",
+        "addp v3.8h, v5.8h, v3.8h",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vmpsadbw ymm0, ymm1, ymm2, 100b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v4.4s, v3.s[0]",
-        "ext v5.16b, v2.16b, v2.16b, #4",
-        "ext v6.16b, v2.16b, v2.16b, #5",
-        "ext v7.16b, v2.16b, v2.16b, #6",
-        "ext v8.16b, v2.16b, v2.16b, #7",
+        "dup v2.4s, v18.s[0]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v2.8h, v4.8h, v2.8h",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
+        "dup v4.4s, v4.s[0]",
+        "ext v5.16b, v3.16b, v3.16b, #0",
+        "ext v6.16b, v3.16b, v3.16b, #1",
+        "ext v7.16b, v3.16b, v3.16b, #2",
+        "ext v3.16b, v3.16b, v3.16b, #3",
         "uabdl v5.8h, v5.8b, v4.8b",
         "uabdl v6.8h, v6.8b, v4.8b",
         "uabdl v7.8h, v7.8b, v4.8b",
-        "uabdl v4.8h, v8.8b, v4.8b",
-        "addp v5.8h, v5.8h, v7.8h",
-        "addp v4.8h, v6.8h, v4.8h",
-        "trn1 v6.4s, v5.4s, v4.4s",
-        "trn2 v4.4s, v5.4s, v4.4s",
-        "addp v4.8h, v6.8h, v4.8h",
-        "mov z2.q, z2.q[1]",
-        "mov z3.q, z3.q[1]",
-        "dup v3.4s, v3.s[0]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v7.8h, v7.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v5.8h, v7.8h",
-        "addp v2.8h, v6.8h, v2.8h",
-        "trn1 v5.4s, v3.4s, v2.4s",
-        "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v5.8h, v2.8h",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "uabdl v3.8h, v3.8b, v4.8b",
+        "addp v4.8h, v5.8h, v7.8h",
+        "addp v3.8h, v6.8h, v3.8h",
+        "trn1 v5.4s, v4.4s, v3.4s",
+        "trn2 v3.4s, v4.4s, v3.4s",
+        "addp v3.8h, v5.8h, v3.8h",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vmpsadbw ymm0, ymm1, ymm2, 101b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v4.4s, v3.s[1]",
-        "ext v5.16b, v2.16b, v2.16b, #4",
-        "ext v6.16b, v2.16b, v2.16b, #5",
-        "ext v7.16b, v2.16b, v2.16b, #6",
-        "ext v8.16b, v2.16b, v2.16b, #7",
+        "dup v2.4s, v18.s[1]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v2.8h, v4.8h, v2.8h",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
+        "dup v4.4s, v4.s[0]",
+        "ext v5.16b, v3.16b, v3.16b, #0",
+        "ext v6.16b, v3.16b, v3.16b, #1",
+        "ext v7.16b, v3.16b, v3.16b, #2",
+        "ext v3.16b, v3.16b, v3.16b, #3",
         "uabdl v5.8h, v5.8b, v4.8b",
         "uabdl v6.8h, v6.8b, v4.8b",
         "uabdl v7.8h, v7.8b, v4.8b",
-        "uabdl v4.8h, v8.8b, v4.8b",
-        "addp v5.8h, v5.8h, v7.8h",
-        "addp v4.8h, v6.8h, v4.8h",
-        "trn1 v6.4s, v5.4s, v4.4s",
-        "trn2 v4.4s, v5.4s, v4.4s",
-        "addp v4.8h, v6.8h, v4.8h",
-        "mov z2.q, z2.q[1]",
-        "mov z3.q, z3.q[1]",
-        "dup v3.4s, v3.s[0]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v7.8h, v7.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v5.8h, v7.8h",
-        "addp v2.8h, v6.8h, v2.8h",
-        "trn1 v5.4s, v3.4s, v2.4s",
-        "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v5.8h, v2.8h",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "uabdl v3.8h, v3.8b, v4.8b",
+        "addp v4.8h, v5.8h, v7.8h",
+        "addp v3.8h, v6.8h, v3.8h",
+        "trn1 v5.4s, v4.4s, v3.4s",
+        "trn2 v3.4s, v4.4s, v3.4s",
+        "addp v3.8h, v5.8h, v3.8h",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vmpsadbw ymm0, ymm1, ymm2, 110b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v4.4s, v3.s[2]",
-        "ext v5.16b, v2.16b, v2.16b, #4",
-        "ext v6.16b, v2.16b, v2.16b, #5",
-        "ext v7.16b, v2.16b, v2.16b, #6",
-        "ext v8.16b, v2.16b, v2.16b, #7",
+        "dup v2.4s, v18.s[2]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v2.8h, v4.8h, v2.8h",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
+        "dup v4.4s, v4.s[0]",
+        "ext v5.16b, v3.16b, v3.16b, #0",
+        "ext v6.16b, v3.16b, v3.16b, #1",
+        "ext v7.16b, v3.16b, v3.16b, #2",
+        "ext v3.16b, v3.16b, v3.16b, #3",
         "uabdl v5.8h, v5.8b, v4.8b",
         "uabdl v6.8h, v6.8b, v4.8b",
         "uabdl v7.8h, v7.8b, v4.8b",
-        "uabdl v4.8h, v8.8b, v4.8b",
-        "addp v5.8h, v5.8h, v7.8h",
-        "addp v4.8h, v6.8h, v4.8h",
-        "trn1 v6.4s, v5.4s, v4.4s",
-        "trn2 v4.4s, v5.4s, v4.4s",
-        "addp v4.8h, v6.8h, v4.8h",
-        "mov z2.q, z2.q[1]",
-        "mov z3.q, z3.q[1]",
-        "dup v3.4s, v3.s[0]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v7.8h, v7.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v5.8h, v7.8h",
-        "addp v2.8h, v6.8h, v2.8h",
-        "trn1 v5.4s, v3.4s, v2.4s",
-        "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v5.8h, v2.8h",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "uabdl v3.8h, v3.8b, v4.8b",
+        "addp v4.8h, v5.8h, v7.8h",
+        "addp v3.8h, v6.8h, v3.8h",
+        "trn1 v5.4s, v4.4s, v3.4s",
+        "trn2 v3.4s, v4.4s, v3.4s",
+        "addp v3.8h, v5.8h, v3.8h",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vmpsadbw ymm0, ymm1, ymm2, 111b": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 34,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v4.4s, v3.s[3]",
-        "ext v5.16b, v2.16b, v2.16b, #4",
-        "ext v6.16b, v2.16b, v2.16b, #5",
-        "ext v7.16b, v2.16b, v2.16b, #6",
-        "ext v8.16b, v2.16b, v2.16b, #7",
+        "dup v2.4s, v18.s[3]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v2.8h, v4.8h, v2.8h",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
+        "dup v4.4s, v4.s[0]",
+        "ext v5.16b, v3.16b, v3.16b, #0",
+        "ext v6.16b, v3.16b, v3.16b, #1",
+        "ext v7.16b, v3.16b, v3.16b, #2",
+        "ext v3.16b, v3.16b, v3.16b, #3",
         "uabdl v5.8h, v5.8b, v4.8b",
         "uabdl v6.8h, v6.8b, v4.8b",
         "uabdl v7.8h, v7.8b, v4.8b",
-        "uabdl v4.8h, v8.8b, v4.8b",
-        "addp v5.8h, v5.8h, v7.8h",
-        "addp v4.8h, v6.8h, v4.8h",
-        "trn1 v6.4s, v5.4s, v4.4s",
-        "trn2 v4.4s, v5.4s, v4.4s",
-        "addp v4.8h, v6.8h, v4.8h",
-        "mov z2.q, z2.q[1]",
-        "mov z3.q, z3.q[1]",
-        "dup v3.4s, v3.s[0]",
-        "ext v5.16b, v2.16b, v2.16b, #0",
-        "ext v6.16b, v2.16b, v2.16b, #1",
-        "ext v7.16b, v2.16b, v2.16b, #2",
-        "ext v2.16b, v2.16b, v2.16b, #3",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v7.8h, v7.8b, v3.8b",
-        "uabdl v2.8h, v2.8b, v3.8b",
-        "addp v3.8h, v5.8h, v7.8h",
-        "addp v2.8h, v6.8h, v2.8h",
-        "trn1 v5.4s, v3.4s, v2.4s",
-        "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v5.8h, v2.8h",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "uabdl v3.8h, v3.8b, v4.8b",
+        "addp v4.8h, v5.8h, v7.8h",
+        "addp v3.8h, v6.8h, v3.8h",
+        "trn1 v5.4s, v4.4s, v3.4s",
+        "trn2 v3.4s, v4.4s, v3.4s",
+        "addp v3.8h, v5.8h, v3.8h",
+        "mov z1.q, q3",
+        "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 00000b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "unallocated (Unallocated)",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 00001b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v0.2d, v2.d[1]",
+        "dup v0.2d, v17.d[1]",
         "unallocated (Unallocated)",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 10000b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "dup v0.2d, v3.d[1]",
+        "dup v0.2d, v18.d[1]",
         "unallocated (Unallocated)",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 10001b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
         "unallocated (Unallocated)",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpclmulqdq ymm0, ymm1, ymm2, 00000b": {
@@ -4600,537 +4021,455 @@
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00000000b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00000001b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00000010b": {
-      "ExpectedInstructionCount": 11,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, q3",
-        "mov z3.d, z4.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00000011b": {
-      "ExpectedInstructionCount": 11,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, z3.q[1]",
-        "mov z3.d, z4.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00010000b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00010001b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00010010b": {
-      "ExpectedInstructionCount": 11,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, q3",
-        "mov z3.d, z4.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00010011b": {
-      "ExpectedInstructionCount": 11,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, z3.q[1]",
-        "mov z3.d, z4.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00100000b": {
-      "ExpectedInstructionCount": 10,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, q3",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00100001b": {
-      "ExpectedInstructionCount": 10,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z4.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, q3",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00100010b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00100011b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00110000b": {
-      "ExpectedInstructionCount": 10,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z3.q[1]",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00110001b": {
-      "ExpectedInstructionCount": 10,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "movi v4.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z4.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z3.q[1]",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00110010b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00110011b": {
-      "ExpectedInstructionCount": 9,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00001000b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00011000b": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00101000b": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 00111000b": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x46 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vperm2i128 ymm0, ymm1, ymm2, 10001000b": {
-      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "mov z1.q, q17",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00000001b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00000010b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00000011b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00010000b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q17",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00010001b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00010010b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00010011b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00100000b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q17",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00100001b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00100010b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00100011b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00110000b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q17",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00110001b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00110010b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00110011b": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z1.b",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00001000b": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00011000b": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00101000b": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 00111000b": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vperm2i128 ymm0, ymm1, ymm2, 10001000b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x46 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000000b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov z1.q, q17",
+        "mov z16.d, z2.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000001b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov z1.q, z17.q[1]",
+        "mov z16.d, z2.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000010b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, q2",
-        "mov z2.d, z3.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov z1.q, q18",
+        "mov z16.d, z2.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000011b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z18.d",
-        "movi v3.2d, #0x0",
-        "mov z1.q, z2.q[1]",
-        "mov z2.d, z3.d",
-        "mov z2.b, p6/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "movi v2.2d, #0x0",
+        "mov z1.q, z18.q[1]",
+        "mov z16.d, z2.d",
+        "mov z16.b, p6/m, z1.b"
       ]
     },
     "vblendvps xmm0, xmm1, xmm2, xmm3": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z4.d, p7/m, z19.d",
-        "sshr v4.4s, v4.4s, #31",
-        "bit v2.16b, v3.16b, v4.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sshr v2.4s, v19.4s, #31",
+        "bsl v2.16b, v18.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vblendvps ymm0, ymm1, ymm2, ymm3": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4a 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z4.d, p7/m, z19.d",
-        "asr z4.s, p7/m, z4.s, #31",
-        "movprfx z0, z3",
-        "bsl z0.d, z0.d, z2.d, z4.d",
-        "mov z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z2, z19",
+        "asr z2.s, p7/m, z2.s, #31",
+        "movprfx z0, z18",
+        "bsl z0.d, z0.d, z17.d, z2.d",
+        "mov z16.d, z0.d"
       ]
     },
     "vblendvpd xmm0, xmm1, xmm2, xmm3": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z4.d, p7/m, z19.d",
-        "sshr v4.2d, v4.2d, #63",
-        "bit v2.16b, v3.16b, v4.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sshr v2.2d, v19.2d, #63",
+        "bsl v2.16b, v18.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vblendvpd ymm0, ymm1, ymm2, ymm3": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4b 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z4.d, p7/m, z19.d",
-        "asr z4.d, p7/m, z4.d, #63",
-        "movprfx z0, z3",
-        "bsl z0.d, z0.d, z2.d, z4.d",
-        "mov z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z2, z19",
+        "asr z2.d, p7/m, z2.d, #63",
+        "movprfx z0, z18",
+        "bsl z0.d, z0.d, z17.d, z2.d",
+        "mov z16.d, z0.d"
       ]
     },
     "vpblendvb xmm0, xmm1, xmm2, xmm3": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z4.d, p7/m, z19.d",
-        "sshr v4.16b, v4.16b, #7",
-        "bit v2.16b, v3.16b, v4.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sshr v2.16b, v19.16b, #7",
+        "bsl v2.16b, v18.16b, v17.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpblendvb ymm0, ymm1, ymm2, ymm3": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z3.d, p7/m, z18.d",
-        "mov z4.d, p7/m, z19.d",
-        "asr z4.b, p7/m, z4.b, #7",
-        "movprfx z0, z3",
-        "bsl z0.d, z0.d, z2.d, z4.d",
-        "mov z2.d, z0.d",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z2, z19",
+        "asr z2.b, p7/m, z2.b, #7",
+        "movprfx z0, z18",
+        "bsl z0.d, z0.d, z17.d, z2.d",
+        "mov z16.d, z0.d"
       ]
     },
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {
@@ -5374,40 +4713,38 @@
       ]
     },
     "vaeskeygenassist xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0xdf 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "ldr x0, [x28, #1600]",
-        "ldr q3, [x0]",
-        "movi v4.2d, #0x0",
+        "ldr q2, [x0]",
+        "movi v3.2d, #0x0",
+        "mov v2.16b, v17.16b",
         "unimplemented (Unimplemented)",
-        "tbl v2.16b, {v2.16b}, v3.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "tbl v2.16b, {v2.16b}, v2.16b",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vaeskeygenassist xmm0, xmm1, 0xFF": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0xdf 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "ldr x0, [x28, #1600]",
-        "ldr q3, [x0]",
-        "movi v4.2d, #0x0",
+        "ldr q2, [x0]",
+        "movi v3.2d, #0x0",
+        "mov v2.16b, v17.16b",
         "unimplemented (Unimplemented)",
-        "tbl v2.16b, {v2.16b}, v3.16b",
+        "tbl v2.16b, {v2.16b}, v2.16b",
         "mov x0, #0xff00000000",
         "dup v1.2d, x0",
         "eor v2.16b, v2.16b, v1.16b",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "rorx eax, ebx, 0": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -8,543 +8,459 @@
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpsrlw xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ushr v2.8h, v2.8h, #15",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ushr v2.8h, v17.8h, #15",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrlw xmm0, xmm1, 16": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrlw ymm0, ymm1, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpsrlw ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "lsr z2.h, p7/m, z2.h, #15",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z17",
+        "lsr z16.h, p7/m, z16.h, #15"
       ]
     },
     "vpsrlw ymm0, ymm1, 16": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsraw xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpsraw xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sshr v2.8h, v2.8h, #15",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sshr v2.8h, v17.8h, #15",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsraw xmm0, xmm1, 16": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sshr v2.8h, v2.8h, #15",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sshr v2.8h, v17.8h, #15",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsraw ymm0, ymm1, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpsraw ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "asr z2.h, p7/m, z2.h, #15",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z17",
+        "asr z16.h, p7/m, z16.h, #15"
       ]
     },
     "vpsraw ymm0, ymm1, 16": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "asr z2.h, p7/m, z2.h, #15",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z17",
+        "asr z16.h, p7/m, z16.h, #15"
       ]
     },
     "vpsllw xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpsllw xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "shl v2.8h, v2.8h, #15",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "shl v2.8h, v17.8h, #15",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsllw xmm0, xmm1, 16": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsllw ymm0, ymm1, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpsllw ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "lsl z2.h, p7/m, z2.h, #15",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z17",
+        "lsl z16.h, p7/m, z16.h, #15"
       ]
     },
     "vpsllw ymm0, ymm1, 16": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsrld xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpsrld xmm0, xmm1, 31": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ushr v2.4s, v2.4s, #31",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ushr v2.4s, v17.4s, #31",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrld xmm0, xmm1, 32": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrld ymm0, ymm1, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpsrld ymm0, ymm1, 31": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "lsr z2.s, p7/m, z2.s, #31",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z17",
+        "lsr z16.s, p7/m, z16.s, #31"
       ]
     },
     "vpsrld ymm0, ymm1, 32": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsrad xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpsrad xmm0, xmm1, 31": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sshr v2.4s, v2.4s, #31",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sshr v2.4s, v17.4s, #31",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrad xmm0, xmm1, 32": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "sshr v2.4s, v2.4s, #31",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "sshr v2.4s, v17.4s, #31",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrad ymm0, ymm1, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpsrad ymm0, ymm1, 31": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "asr z2.s, p7/m, z2.s, #31",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z17",
+        "asr z16.s, p7/m, z16.s, #31"
       ]
     },
     "vpsrad ymm0, ymm1, 32": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "asr z2.s, p7/m, z2.s, #31",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z17",
+        "asr z16.s, p7/m, z16.s, #31"
       ]
     },
     "vpslld xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpslld xmm0, xmm1, 31": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "shl v2.4s, v2.4s, #31",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "shl v2.4s, v17.4s, #31",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpslld xmm0, xmm1, 32": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpslld ymm0, ymm1, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpslld ymm0, ymm1, 31": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "lsl z2.s, p7/m, z2.s, #31",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z17",
+        "lsl z16.s, p7/m, z16.s, #31"
       ]
     },
     "vpslld ymm0, ymm1, 32": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsrlq xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpsrlq xmm0, xmm1, 63": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "ushr v2.2d, v2.2d, #63",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ushr v2.2d, v17.2d, #63",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrlq xmm0, xmm1, 64": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrlq ymm0, ymm1, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpsrlq ymm0, ymm1, 63": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "lsr z2.d, p7/m, z2.d, #63",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z17",
+        "lsr z16.d, p7/m, z16.d, #63"
       ]
     },
     "vpsrlq ymm0, ymm1, 64": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsrldq xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b011 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpsrldq xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
-      "Comment": [
-        "Map group 14 0b011 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "ext v2.16b, v2.16b, v3.16b, #15",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpsrldq xmm0, xmm1, 16": {
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
@@ -552,19 +468,29 @@
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ext v2.16b, v17.16b, v2.16b, #15",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vpsrldq xmm0, xmm1, 16": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Map group 14 0b011 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsrldq ymm0, ymm1, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b011 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpsrldq ymm0, ymm1, 15": {
@@ -574,128 +500,101 @@
         "Map group 14 0b011 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "ext v4.16b, v2.16b, v3.16b, #15",
-        "ext z2.b, z2.b, z3.b, #31",
+        "movi v2.2d, #0x0",
+        "ext v3.16b, v17.16b, v2.16b, #15",
+        "movprfx z1, z17",
+        "ext z1.b, z1.b, z2.b, #31",
+        "mov z2.d, z1.d",
         "mov z1.q, q2",
-        "mov z2.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpsrldq ymm0, ymm1, 16": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b011 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsllq xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpsllq xmm0, xmm1, 63": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "shl v2.2d, v2.2d, #63",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "shl v2.2d, v17.2d, #63",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsllq xmm0, xmm1, 64": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpsllq ymm0, ymm1, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpsllq ymm0, ymm1, 63": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "lsl z2.d, p7/m, z2.d, #63",
-        "mov z16.d, p7/m, z2.d"
+        "movprfx z16, z17",
+        "lsl z16.d, p7/m, z16.d, #63"
       ]
     },
     "vpsllq ymm0, ymm1, 64": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpslldq xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b111 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "mov v16.16b, v17.16b"
       ]
     },
     "vpslldq xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
-      "Comment": [
-        "Map group 14 0b111 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "ext v2.16b, v3.16b, v2.16b, #1",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpslldq xmm0, xmm1, 16": {
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
@@ -703,50 +602,55 @@
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov v2.16b, v2.16b",
-        "mov z16.d, p7/m, z2.d"
+        "ext v2.16b, v2.16b, v17.16b, #1",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vpslldq xmm0, xmm1, 16": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Map group 14 0b111 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "mov v16.16b, v2.16b"
       ]
     },
     "vpslldq ymm0, ymm1, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b111 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "mov z16.d, p7/m, z2.d"
+        "mov z16.d, p7/m, z17.d"
       ]
     },
     "vpslldq ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 11,
-      "Optimal": "No",
-      "Comment": [
-        "Map group 14 0b111 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.d, p7/m, z17.d",
-        "movi v3.2d, #0x0",
-        "ext v4.16b, v3.16b, v2.16b, #1",
-        "movprfx z1, z3",
-        "ext z1.b, z1.b, z2.b, #17",
-        "mov z2.d, z1.d",
-        "mov z1.q, q2",
-        "mov z2.d, z4.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z16.d, p7/m, z2.d"
-      ]
-    },
-    "vpslldq ymm0, ymm1, 16": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
         "Map group 14 0b111 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z16.d, p7/m, z2.d"
+        "ext v3.16b, v2.16b, v17.16b, #1",
+        "ext z2.b, z2.b, z17.b, #17",
+        "mov z1.q, q2",
+        "mov z16.d, z3.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vpslldq ymm0, ymm1, 16": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map group 14 0b111 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
       ]
     },
     "vldmxcsr [rax]": {


### PR DESCRIPTION
Some very minor optimizations that I saw we were missing

- Minor optimization in vzeroall to take advantage of `movi` directly to the destination register instead of using a temporary.
- Allow RA to pre-alias and pre-colour AVX registers, which removes a TON of redundant moves in AVX operations.
   - 218 instructions went from non-optimal to optimal 