### PR TITLE
FEXCore: Support crypto extensions in HostFeatures override

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -82,7 +82,9 @@
           "ENABLEFLAGM": "enableflagm",
           "DISABLEFLAGM": "disableflagm",
           "ENABLEFLAGM2": "enableflagm2",
-          "DISABLEFLAGM2": "disableflagm2"
+          "DISABLEFLAGM2": "disableflagm2",
+          "ENABLECRYPTO": "enablecrypto",
+          "DISABLECRYPTO": "disablecrypto"
         },
         "Desc": [
           "Allows controlling of the CPU features in the JIT.",
@@ -100,7 +102,8 @@
           "\t{enable,disable}atomics: Will force enable or disable ARMv8.1 LSE atomics even if the host doesn't support it",
           "\t{enable,disable}fcma: Will force enable or disable fcma even if the host doesn't support it",
           "\t{enable,disable}flagm: Will force enable or disable flagm even if the host doesn't support it",
-          "\t{enable,disable}flagm2: Will force enable or disable flagm2 even if the host doesn't support it"
+          "\t{enable,disable}flagm2: Will force enable or disable flagm2 even if the host doesn't support it",
+          "\t{enable,disable}crypto: Will force enable or disable crypto extensions even if the host doesn't support it"
         ]
       }
     },

--- a/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -125,6 +125,10 @@ static void OverrideFeatures(HostFeatures *Features) {
   const bool EnableFlagM2 = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEFLAGM2;
   LogMan::Throw::AFmt(!(DisableFlagM2 && EnableFlagM2), "Disabling and Enabling CPU features are mutually exclusive");
 
+  const bool DisableCrypto = HostFeatures() & FEXCore::Config::HostFeatures::DISABLECRYPTO;
+  const bool EnableCrypto = HostFeatures() & FEXCore::Config::HostFeatures::ENABLECRYPTO;
+  LogMan::Throw::AFmt(!(DisableCrypto && EnableCrypto), "Disabling and Enabling CPU features are mutually exclusive");
+
   if (EnableAVX) {
     Features->SupportsAVX = true;
   }
@@ -208,6 +212,16 @@ static void OverrideFeatures(HostFeatures *Features) {
   }
   else if (DisableFlagM2) {
     Features->SupportsFlagM2 = false;
+  }
+  if (EnableCrypto) {
+    Features->SupportsAES = true;
+    Features->SupportsCRC = true;
+    Features->SupportsPMULL_128Bit = true;
+  }
+  else if (DisableCrypto) {
+    Features->SupportsAES = false;
+    Features->SupportsCRC = false;
+    Features->SupportsPMULL_128Bit = false;
   }
 }
 

--- a/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -69,65 +69,28 @@ static void OverrideFeatures(HostFeatures *Features) {
     return;
   }
 
-  const bool DisableAVX = HostFeatures() & FEXCore::Config::HostFeatures::DISABLEAVX;
-  const bool EnableAVX = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEAVX;
-  LogMan::Throw::AFmt(!(DisableAVX && EnableAVX), "Disabling and Enabling CPU features are mutually exclusive");
+#define ENABLE_DISABLE_OPTION(name, enum_name) \
+    const bool Disable##name = (HostFeatures() & FEXCore::Config::HostFeatures::DISABLE##enum_name) != 0; \
+    const bool Enable##name = (HostFeatures() & FEXCore::Config::HostFeatures::ENABLE##enum_name) != 0;   \
+    LogMan::Throw::AFmt(!(Disable##name && Enable##name), "Disabling and Enabling CPU feature (" #name ") is mutually exclusive");
 
-  const bool DisableAVX2 = HostFeatures() & FEXCore::Config::HostFeatures::DISABLEAVX2;
-  const bool EnableAVX2 = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEAVX2;
-  LogMan::Throw::AFmt(!(DisableAVX2 && EnableAVX2), "Disabling and Enabling CPU features are mutually exclusive");
+  ENABLE_DISABLE_OPTION(AVX, AVX);
+  ENABLE_DISABLE_OPTION(AVX2, AVX2);
+  ENABLE_DISABLE_OPTION(SVE, SVE);
+  ENABLE_DISABLE_OPTION(AFP, AFP);
+  ENABLE_DISABLE_OPTION(LRCPC, LRCPC);
+  ENABLE_DISABLE_OPTION(LRCPC2, LRCPC2);
+  ENABLE_DISABLE_OPTION(CSSC, CSSC);
+  ENABLE_DISABLE_OPTION(PMULL128, PMULL128);
+  ENABLE_DISABLE_OPTION(RNG, RNG);
+  ENABLE_DISABLE_OPTION(CLZERO, CLZERO);
+  ENABLE_DISABLE_OPTION(Atomics, ATOMICS);
+  ENABLE_DISABLE_OPTION(FCMA, FCMA);
+  ENABLE_DISABLE_OPTION(FlagM, FLAGM);
+  ENABLE_DISABLE_OPTION(FlagM2, FLAGM2);
+  ENABLE_DISABLE_OPTION(Crypto, CRYPTO);
 
-  const bool DisableSVE = HostFeatures() & FEXCore::Config::HostFeatures::DISABLESVE;
-  const bool EnableSVE = HostFeatures() & FEXCore::Config::HostFeatures::ENABLESVE;
-  LogMan::Throw::AFmt(!(DisableSVE && EnableSVE), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableAFP = HostFeatures() & FEXCore::Config::HostFeatures::DISABLEAFP;
-  const bool EnableAFP = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEAFP;
-  LogMan::Throw::AFmt(!(DisableAFP && EnableAFP), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableLRCPC = HostFeatures() & FEXCore::Config::HostFeatures::DISABLELRCPC;
-  const bool EnableLRCPC = HostFeatures() & FEXCore::Config::HostFeatures::ENABLELRCPC;
-  LogMan::Throw::AFmt(!(DisableLRCPC && EnableLRCPC), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableLRCPC2 = HostFeatures() & FEXCore::Config::HostFeatures::DISABLELRCPC2;
-  const bool EnableLRCPC2 = HostFeatures() & FEXCore::Config::HostFeatures::ENABLELRCPC2;
-  LogMan::Throw::AFmt(!(DisableLRCPC2 && EnableLRCPC2), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableCSSC = HostFeatures() & FEXCore::Config::HostFeatures::DISABLECSSC;
-  const bool EnableCSSC = HostFeatures() & FEXCore::Config::HostFeatures::ENABLECSSC;
-  LogMan::Throw::AFmt(!(DisableCSSC && EnableCSSC), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisablePMULL128 = HostFeatures() & FEXCore::Config::HostFeatures::DISABLEPMULL128;
-  const bool EnablePMULL128 = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEPMULL128;
-  LogMan::Throw::AFmt(!(DisablePMULL128 && EnablePMULL128), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableRNG = HostFeatures() & FEXCore::Config::HostFeatures::DISABLERNG;
-  const bool EnableRNG = HostFeatures() & FEXCore::Config::HostFeatures::ENABLERNG;
-  LogMan::Throw::AFmt(!(DisableRNG && EnableRNG), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableCLZERO = HostFeatures() & FEXCore::Config::HostFeatures::DISABLECLZERO;
-  const bool EnableCLZERO = HostFeatures() & FEXCore::Config::HostFeatures::ENABLECLZERO;
-  LogMan::Throw::AFmt(!(DisableCLZERO && EnableCLZERO), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableAtomics = HostFeatures() & FEXCore::Config::HostFeatures::DISABLEATOMICS;
-  const bool EnableAtomics = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEATOMICS;
-  LogMan::Throw::AFmt(!(DisableAtomics && EnableAtomics), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableFCMA = HostFeatures() & FEXCore::Config::HostFeatures::DISABLEFCMA;
-  const bool EnableFCMA = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEFCMA;
-  LogMan::Throw::AFmt(!(DisableFCMA && EnableFCMA), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableFlagM = HostFeatures() & FEXCore::Config::HostFeatures::DISABLEFLAGM;
-  const bool EnableFlagM = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEFLAGM;
-  LogMan::Throw::AFmt(!(DisableFlagM && EnableFlagM), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableFlagM2 = HostFeatures() & FEXCore::Config::HostFeatures::DISABLEFLAGM2;
-  const bool EnableFlagM2 = HostFeatures() & FEXCore::Config::HostFeatures::ENABLEFLAGM2;
-  LogMan::Throw::AFmt(!(DisableFlagM2 && EnableFlagM2), "Disabling and Enabling CPU features are mutually exclusive");
-
-  const bool DisableCrypto = HostFeatures() & FEXCore::Config::HostFeatures::DISABLECRYPTO;
-  const bool EnableCrypto = HostFeatures() & FEXCore::Config::HostFeatures::ENABLECRYPTO;
-  LogMan::Throw::AFmt(!(DisableCrypto && EnableCrypto), "Disabling and Enabling CPU features are mutually exclusive");
+#undef ENABLE_DISABLE_OPTION
 
   if (EnableAVX) {
     Features->SupportsAVX = true;

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -489,6 +489,8 @@ int main(int argc, char **argv, char **const envp) {
 
   // Always enable ARMv8.1 LSE atomics.
   HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEATOMICS);
+  // Always enable crypto extensions.
+  HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLECRYPTO);
 
   if (TestHeaderData->DisabledHostFeatures & FEATURE_SVE128) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLESVE);


### PR DESCRIPTION
Enables in InstCountCI so Pi users can run InstCountCI can run the tests without breaking on crypto operations.

When crypto is enabled or disabled just wholesale change AES, CRC32, and PMULL 128-bit in one step. We don't really care about partial support here.