### PR TITLE
Linux: Fixes warning in 32-bit clock_settime

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/x32/Time.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/x32/Time.cpp
@@ -160,13 +160,14 @@ namespace FEX::HLE::x32 {
     });
 
     REGISTER_SYSCALL_IMPL_X32(clock_settime, [](FEXCore::Core::CpuStateFrame *Frame, clockid_t clockid, const timespec32 *tp) -> uint64_t {
-      uint64_t Result = 0;
-      if (tp) {
-        const struct timespec tp64 = *tp;
-        Result = ::clock_settime(clockid, &tp64);
-      } else {
-        Result = ::clock_settime(clockid, nullptr);
+      if (!tp) {
+        // clock_settime is required to pass a timespec.
+        return -EFAULT;
       }
+
+      uint64_t Result = 0;
+      const struct timespec tp64 = *tp;
+      Result = ::clock_settime(clockid, &tp64);
       SYSCALL_ERRNO();
     });
 


### PR DESCRIPTION
This syscall requires a valid pointer otherwise it returns EFAULT. When going through the glibc helper it can crash before reaching the raw syscall even.