### PR TITLE
InstCountCI: Support overriding AFP features

### DIFF
--- a/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -111,10 +111,10 @@ static void OverrideFeatures(HostFeatures *Features) {
     Features->SupportsSVE = false;
   }
   if (EnableAFP) {
-    Features->SupportsFlushInputsToZero = true;
+    Features->SupportsAFP = true;
   }
   else if (DisableAFP) {
-    Features->SupportsFlushInputsToZero = false;
+    Features->SupportsAFP = false;
   }
   if (EnableLRCPC) {
     Features->SupportsRCPC = true;
@@ -191,6 +191,8 @@ static void OverrideFeatures(HostFeatures *Features) {
 HostFeatures::HostFeatures() {
 #ifdef VIXL_SIMULATOR
   auto Features = vixl::CPUFeatures::All();
+  // Vixl simulator doesn't support AFP.
+  Features.Remove(vixl::CPUFeatures::Feature::kAFP);
 #elif !defined(_WIN32)
   auto Features = vixl::CPUFeatures::InferFromOS();
 #else
@@ -204,7 +206,7 @@ HostFeatures::HostFeatures() {
   SupportsRAND = Features.Has(vixl::CPUFeatures::Feature::kRNG);
 
   // Only supported when FEAT_AFP is supported
-  SupportsFlushInputsToZero = Features.Has(vixl::CPUFeatures::Feature::kAFP);
+  SupportsAFP = Features.Has(vixl::CPUFeatures::Feature::kAFP);
   SupportsRCPC = Features.Has(vixl::CPUFeatures::Feature::kRCpc);
   SupportsTSOImm9 = Features.Has(vixl::CPUFeatures::Feature::kRCpcImm);
   SupportsPMULL_128Bit = Features.Has(vixl::CPUFeatures::Feature::kPmull1Q);
@@ -313,7 +315,7 @@ HostFeatures::HostFeatures() {
     SupportsCLZERO = data[1] & 1;
   }
 
-  SupportsFlushInputsToZero = true;
+  SupportsAFP = true;
   SupportsFloatExceptions = true;
 #endif
 #endif

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -38,7 +38,7 @@ class HostFeatures final {
     bool SupportsFlagM2{};
 
     // Float exception behaviour
-    bool SupportsFlushInputsToZero{};
+    bool SupportsAFP{};
     bool SupportsFloatExceptions{};
 };
 }

--- a/Scripts/InstructionCountParser.py
+++ b/Scripts/InstructionCountParser.py
@@ -48,7 +48,7 @@ class HostFeatures(Flag) :
     FEATURE_RNG    = (1 << 3)
     FEATURE_FCMA   = (1 << 4)
     FEATURE_CSSC   = (1 << 5)
-
+    FEATURE_AFP    = (1 << 6)
 
 HostFeaturesLookup = {
     "SVE128"  : HostFeatures.FEATURE_SVE128,
@@ -57,6 +57,7 @@ HostFeaturesLookup = {
     "RNG"     : HostFeatures.FEATURE_RNG,
     "FCMA"    : HostFeatures.FEATURE_FCMA,
     "CSSC"    : HostFeatures.FEATURE_CSSC,
+    "AFP"     : HostFeatures.FEATURE_AFP,
 }
 
 def GetHostFeatures(data):

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -462,6 +462,7 @@ int main(int argc, char **argv, char **const envp) {
     FEATURE_RNG    = (1U << 3),
     FEATURE_FCMA   = (1U << 4),
     FEATURE_CSSC   = (1U << 5),
+    FEATURE_AFP    = (1U << 6),
   };
 
   uint64_t SVEWidth = 0;
@@ -485,6 +486,9 @@ int main(int argc, char **argv, char **const envp) {
   }
   if (TestHeaderData->EnabledHostFeatures & FEATURE_CSSC) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLECSSC);
+  }
+  if (TestHeaderData->EnabledHostFeatures & FEATURE_AFP) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEAFP);
   }
 
   // Always enable ARMv8.1 LSE atomics.
@@ -510,6 +514,10 @@ int main(int argc, char **argv, char **const envp) {
   if (TestHeaderData->DisabledHostFeatures & FEATURE_CSSC) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLECSSC);
   }
+  if (TestHeaderData->DisabledHostFeatures & FEATURE_AFP) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLEAFP);
+  }
+
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_HOSTFEATURES, fextl::fmt::format("{}", HostFeatureControl));
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_FORCESVEWIDTH, fextl::fmt::format("{}", SVEWidth));
 


### PR DESCRIPTION
Also disable AFP under the vixl simulator by default since it doesn't support it.