### PR TITLE
FEXCore: Implements support for RPRES 

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -84,7 +84,9 @@
           "ENABLEFLAGM2": "enableflagm2",
           "DISABLEFLAGM2": "disableflagm2",
           "ENABLECRYPTO": "enablecrypto",
-          "DISABLECRYPTO": "disablecrypto"
+          "DISABLECRYPTO": "disablecrypto",
+          "ENABLERPRES": "enablerpres",
+          "DISABLERPRES": "disablerpres"
         },
         "Desc": [
           "Allows controlling of the CPU features in the JIT.",
@@ -103,7 +105,8 @@
           "\t{enable,disable}fcma: Will force enable or disable fcma even if the host doesn't support it",
           "\t{enable,disable}flagm: Will force enable or disable flagm even if the host doesn't support it",
           "\t{enable,disable}flagm2: Will force enable or disable flagm2 even if the host doesn't support it",
-          "\t{enable,disable}crypto: Will force enable or disable crypto extensions even if the host doesn't support it"
+          "\t{enable,disable}crypto: Will force enable or disable crypto extensions even if the host doesn't support it",
+          "\t{enable,disable}rpres: Will force enable or disable rpres even if the host doesn't support it"
         ]
       }
     },

--- a/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -89,6 +89,7 @@ static void OverrideFeatures(HostFeatures *Features) {
   ENABLE_DISABLE_OPTION(FlagM, FLAGM);
   ENABLE_DISABLE_OPTION(FlagM2, FLAGM2);
   ENABLE_DISABLE_OPTION(Crypto, CRYPTO);
+  ENABLE_DISABLE_OPTION(RPRES, RPRES);
 
 #undef ENABLE_DISABLE_OPTION
 
@@ -186,6 +187,12 @@ static void OverrideFeatures(HostFeatures *Features) {
     Features->SupportsCRC = false;
     Features->SupportsPMULL_128Bit = false;
   }
+  if (EnableRPRES) {
+    Features->SupportsRPRES = true;
+  }
+  else if (DisableRPRES) {
+    Features->SupportsRPRES = false;
+  }
 }
 
 HostFeatures::HostFeatures() {
@@ -193,6 +200,8 @@ HostFeatures::HostFeatures() {
   auto Features = vixl::CPUFeatures::All();
   // Vixl simulator doesn't support AFP.
   Features.Remove(vixl::CPUFeatures::Feature::kAFP);
+  // Vixl simulator doesn't support RPRES.
+  Features.Remove(vixl::CPUFeatures::Feature::kRPRES);
 #elif !defined(_WIN32)
   auto Features = vixl::CPUFeatures::InferFromOS();
 #else
@@ -214,6 +223,7 @@ HostFeatures::HostFeatures() {
   SupportsFCMA = Features.Has(vixl::CPUFeatures::Feature::kFcma);
   SupportsFlagM = Features.Has(vixl::CPUFeatures::Feature::kFlagM);
   SupportsFlagM2 = Features.Has(vixl::CPUFeatures::Feature::kAXFlag);
+  SupportsRPRES = Features.Has(vixl::CPUFeatures::Feature::kRPRES);
 
   Supports3DNow = true;
   SupportsSSE4A = true;

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -533,6 +533,7 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::In
   , Arm64Emitter(ctx, 0)
   , HostSupportsSVE128{ctx->HostFeatures.SupportsSVE}
   , HostSupportsSVE256{ctx->HostFeatures.SupportsAVX}
+  , HostSupportsRPRES{ctx->HostFeatures.SupportsRPRES}
   , CTX {ctx} {
 
   RAPass = Thread->PassManager->GetPass<IR::RegisterAllocationPass>("RA");

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -58,6 +58,7 @@ private:
 
   const bool HostSupportsSVE128{};
   const bool HostSupportsSVE256{};
+  const bool HostSupportsRPRES{};
 
   ARMEmitter::BiDirectionalLabel *PendingTargetLabel;
   FEXCore::Context::ContextImpl *CTX;

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1115,11 +1115,23 @@ DEF_OP(VFRecp) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
+    if (ElementSize == 4 && HostSupportsRPRES) {
+      // RPRES gives enough precision for this.
+      frecpe(SubRegSize.Vector, Dst.Z(), Vector.Z());
+      return;
+    }
+
     fmov(SubRegSize.Vector, VTMP1.Z(), 1.0);
     fdiv(SubRegSize.Vector, VTMP1.Z(), Pred, VTMP1.Z(), Vector.Z());
     mov(Dst.Z(), VTMP1.Z());
   } else {
     if (IsScalar) {
+      if (ElementSize == 4 && HostSupportsRPRES) {
+        // RPRES gives enough precision for this.
+        frecpe(SubRegSize.Scalar, Dst.S(), Vector.S());
+        return;
+      }
+
       fmov(SubRegSize.Scalar, VTMP1.Q(), 1.0f);
       switch (ElementSize) {
         case 2: {
@@ -1138,6 +1150,17 @@ DEF_OP(VFRecp) {
           break;
       }
     } else {
+      if (ElementSize == 4 && HostSupportsRPRES) {
+        // RPRES gives enough precision for this.
+        if (OpSize == 8) {
+          frecpe(SubRegSize.Vector, Dst.D(), Vector.D());
+        }
+        else {
+          frecpe(SubRegSize.Vector, Dst.Q(), Vector.Q());
+        }
+        return;
+      }
+
       fmov(SubRegSize.Vector, VTMP1.Q(), 1.0f);
       fdiv(SubRegSize.Vector, Dst.Q(), VTMP1.Q(), Vector.Q());
     }
@@ -1208,11 +1231,23 @@ DEF_OP(VFRSqrt) {
 
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
+    if (ElementSize == 4 && HostSupportsRPRES) {
+      // RPRES gives enough precision for this.
+      frsqrte(SubRegSize.Vector, Dst.Z(), Vector.Z());
+      return;
+    }
+
     fsqrt(SubRegSize.Vector, VTMP1.Z(), Pred, Vector.Z());
     fmov(SubRegSize.Vector, Dst.Z(), 1.0);
     fdiv(SubRegSize.Vector, Dst.Z(), Pred, Dst.Z(), VTMP1.Z());
   } else {
     if (IsScalar) {
+      if (ElementSize == 4 && HostSupportsRPRES) {
+        // RPRES gives enough precision for this.
+        frsqrte(SubRegSize.Scalar, Dst.S(), Vector.S());
+        return;
+      }
+
       fmov(SubRegSize.Scalar, VTMP1.Q(), 1.0);
       switch (ElementSize) {
         case 2: {
@@ -1234,6 +1269,17 @@ DEF_OP(VFRSqrt) {
           break;
       }
     } else {
+      if (ElementSize == 4 && HostSupportsRPRES) {
+        // RPRES gives enough precision for this.
+        if (OpSize == 8) {
+          frsqrte(SubRegSize.Vector, Dst.D(), Vector.D());
+        }
+        else {
+          frsqrte(SubRegSize.Vector, Dst.Q(), Vector.Q());
+        }
+        return;
+      }
+
       fmov(SubRegSize.Vector, VTMP1.Q(), 1.0);
       fsqrt(SubRegSize.Vector, VTMP2.Q(), Vector.Q());
       fdiv(SubRegSize.Vector, Dst.Q(), VTMP1.Q(), VTMP2.Q());

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -36,6 +36,7 @@ class HostFeatures final {
     bool SupportsFCMA{};
     bool SupportsFlagM{};
     bool SupportsFlagM2{};
+    bool SupportsRPRES{};
 
     // Float exception behaviour
     bool SupportsAFP{};

--- a/Scripts/InstructionCountParser.py
+++ b/Scripts/InstructionCountParser.py
@@ -49,6 +49,8 @@ class HostFeatures(Flag) :
     FEATURE_FCMA   = (1 << 4)
     FEATURE_CSSC   = (1 << 5)
     FEATURE_AFP    = (1 << 6)
+    FEATURE_RPRES  = (1 << 7)
+
 
 HostFeaturesLookup = {
     "SVE128"  : HostFeatures.FEATURE_SVE128,
@@ -58,6 +60,7 @@ HostFeaturesLookup = {
     "FCMA"    : HostFeatures.FEATURE_FCMA,
     "CSSC"    : HostFeatures.FEATURE_CSSC,
     "AFP"     : HostFeatures.FEATURE_AFP,
+    "RPRES"   : HostFeatures.FEATURE_RPRES,
 }
 
 def GetHostFeatures(data):

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -463,6 +463,7 @@ int main(int argc, char **argv, char **const envp) {
     FEATURE_FCMA   = (1U << 4),
     FEATURE_CSSC   = (1U << 5),
     FEATURE_AFP    = (1U << 6),
+    FEATURE_RPRES  = (1U << 7),
   };
 
   uint64_t SVEWidth = 0;
@@ -490,6 +491,9 @@ int main(int argc, char **argv, char **const envp) {
   if (TestHeaderData->EnabledHostFeatures & FEATURE_AFP) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEAFP);
   }
+  if (TestHeaderData->EnabledHostFeatures & FEATURE_RPRES) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLERPRES);
+  }
 
   // Always enable ARMv8.1 LSE atomics.
   HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEATOMICS);
@@ -516,6 +520,9 @@ int main(int argc, char **argv, char **const envp) {
   }
   if (TestHeaderData->DisabledHostFeatures & FEATURE_AFP) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLEAFP);
+  }
+  if (TestHeaderData->DisabledHostFeatures & FEATURE_RPRES) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLERPRES);
   }
 
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_HOSTFEATURES, fextl::fmt::format("{}", HostFeatureControl));

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -4,7 +4,8 @@
     "EnabledHostFeatures": [],
     "DisabledHostFeatures": [
       "SVE128",
-      "SVE256"
+      "SVE256",
+      "RPRES"
     ]
   },
   "Comment": [
@@ -79,7 +80,6 @@
       "ExpectedInstructionCount": 4,
       "Optimal": "Yes",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "0x0f 0x0f 0x86"
       ],
       "ExpectedArm64ASM": [
@@ -93,7 +93,6 @@
       "ExpectedInstructionCount": 5,
       "Optimal": "Yes",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "0x0f 0x0f 0x87"
       ],
       "ExpectedArm64ASM": [
@@ -158,7 +157,6 @@
       "ExpectedInstructionCount": 5,
       "Optimal": "Yes",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "0x0f 0x0f 0x96"
       ],
       "ExpectedArm64ASM": [
@@ -173,7 +171,6 @@
       "ExpectedInstructionCount": 6,
       "Optimal": "Yes",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "0x0f 0x0f 0x97"
       ],
       "ExpectedArm64ASM": [

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -1,0 +1,64 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "RPRES"
+    ],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256"
+    ]
+  },
+  "Instructions": {
+    "pfrcpv mm0, mm1": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x0f 0x0f 0x86"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr d2, [x28, #768]",
+        "frecpe v2.2s, v2.2s",
+        "str d2, [x28, #752]"
+      ]
+    },
+    "pfrsqrtv mm0, mm1": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x0f 0x0f 0x87"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr d2, [x28, #768]",
+        "frsqrte v2.2s, v2.2s",
+        "str d2, [x28, #752]"
+      ]
+    },
+    "pfrcp mm0, mm1": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x0f 0x0f 0x96"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr d2, [x28, #768]",
+        "frecpe s2, s2",
+        "dup v2.4s, v2.s[0]",
+        "str d2, [x28, #752]"
+      ]
+    },
+    "pfrsqrt mm0, mm1": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x0f 0x0f 0x97"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr d2, [x28, #768]",
+        "frsqrte s2, s2",
+        "dup v2.4s, v2.s[0]",
+        "str d2, [x28, #752]"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -1,0 +1,34 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "RPRES"
+    ],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256"
+    ]
+  },
+  "Instructions": {
+    "rsqrtps xmm0, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x0f 0x52"
+      ],
+      "ExpectedArm64ASM": [
+        "frsqrte v16.4s, v17.4s"
+      ]
+    },
+    "rcpps xmm0, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "0x0f 0x53"
+      ],
+      "ExpectedArm64ASM": [
+        "frecpe v16.4s, v17.4s"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP.json
@@ -1,0 +1,38 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "RPRES"
+    ],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256"
+    ]
+  },
+  "Instructions": {
+    "rsqrtss xmm0, xmm1": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "AFP can make this more optimal",
+        "0xf3 0x0f 0x52"
+      ],
+      "ExpectedArm64ASM": [
+        "frsqrte s2, s17",
+        "mov v16.s[0], v2.s[0]"
+      ]
+    },
+    "rcpss xmm0, xmm1": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "AFP can make this more optimal",
+        "0xf3 0x0f 0x53"
+      ],
+      "ExpectedArm64ASM": [
+        "frecpe s2, s17",
+        "mov v16.s[0], v2.s[0]"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/RPRES/VEX_map1.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1.json
@@ -1,0 +1,84 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "SVE128",
+      "SVE256",
+      "RPRES"
+    ],
+    "DisabledHostFeatures": []
+  },
+  "Instructions": {
+    "vrsqrtps xmm0, xmm1": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b00 0x52 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frsqrte v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vrsqrtps ymm0, ymm1": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 1 0b00 0x52 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frsqrte z16.s, z17.s"
+      ]
+    },
+    "vrsqrtss xmm0, xmm1, xmm2": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "AFP can make this more optimal",
+        "Map 1 0b10 0x52 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frsqrte s2, s18",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vrcpps xmm0, xmm1": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b00 0x53 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frecpe v2.4s, v17.4s",
+        "mov v16.16b, v2.16b"
+      ]
+    },
+    "vrcpps ymm0, ymm1": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 1 0b00 0x53 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frecpe z16.s, z17.s"
+      ]
+    },
+    "vrcpss xmm0, xmm1, xmm2": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b10 0x53 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frecpe s2, s18",
+        "mov v0.16b, v17.16b",
+        "mov v0.s[0], v2.s[0]",
+        "mov v2.16b, v0.16b",
+        "mov v16.16b, v2.16b"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -4,7 +4,8 @@
     "EnabledHostFeatures": [],
     "DisabledHostFeatures": [
       "SVE128",
-      "SVE256"
+      "SVE256",
+      "RPRES"
     ]
   },
   "Comment": [
@@ -868,7 +869,6 @@
       "ExpectedInstructionCount": 3,
       "Optimal": "Yes",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "0x0f 0x52"
       ],
       "ExpectedArm64ASM": [
@@ -881,7 +881,6 @@
       "ExpectedInstructionCount": 2,
       "Optimal": "Yes",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "0x0f 0x53"
       ],
       "ExpectedArm64ASM": [

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -4,7 +4,8 @@
     "EnabledHostFeatures": [],
     "DisabledHostFeatures": [
       "SVE128",
-      "SVE256"
+      "SVE256",
+      "RPRES"
     ]
   },
   "Instructions": {
@@ -206,7 +207,6 @@
       "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "0xf3 0x0f 0x52"
       ],
       "ExpectedArm64ASM": [
@@ -220,7 +220,6 @@
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "0xf3 0x0f 0x53"
       ],
       "ExpectedArm64ASM": [

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -6,7 +6,8 @@
       "SVE256"
     ],
     "DisabledHostFeatures": [
-      "FCMA"
+      "FCMA",
+      "RPRES"
     ]
   },
   "Instructions": {
@@ -704,7 +705,6 @@
       "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "Map 1 0b00 0x52 128-bit"
       ],
       "ExpectedArm64ASM": [
@@ -718,7 +718,6 @@
       "ExpectedInstructionCount": 3,
       "Optimal": "Yes",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "Map 1 0b00 0x52 256-bit"
       ],
       "ExpectedArm64ASM": [
@@ -731,7 +730,6 @@
       "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "Map 1 0b10 0x52 128-bit"
       ],
       "ExpectedArm64ASM": [
@@ -748,7 +746,6 @@
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "Map 1 0b00 0x53 128-bit"
       ],
       "ExpectedArm64ASM": [
@@ -761,7 +758,6 @@
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "Map 1 0b00 0x53 256-bit"
       ],
       "ExpectedArm64ASM": [
@@ -774,7 +770,6 @@
       "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
-        "FEAT_FPRES could make this more optimal",
         "Map 1 0b10 0x53 128-bit"
       ],
       "ExpectedArm64ASM": [


### PR DESCRIPTION
This allows us to use reciprocal instructions which matches precision of
what x86 expects rather than converting everything to float divides.

Currently no hardware supports this, and even the upcoming X4/A720/A520
won't support it, but it was trivial to implement so wire it up.