### PR TITLE
InstCountCI: Adds missing atomic tests

### DIFF
--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -1,0 +1,2337 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256"
+    ]
+  },
+  "Instructions": {
+    "lock add byte [rax], cl": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": "0x00",
+      "ExpectedArm64ASM": [
+        "uxtb w20, w5",
+        "ldaddalb w20, w21, [x4]",
+        "add w22, w21, w20",
+        "eor w23, w21, w20",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w23, w22, #24",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "ubfx w24, w22, #8, #1",
+        "orr w23, w23, w24, lsl #29",
+        "eor w20, w21, w20",
+        "eor w21, w22, w21",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w23, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add word [rax], cx": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": "0x01",
+      "ExpectedArm64ASM": [
+        "uxth w20, w5",
+        "ldaddalh w20, w21, [x4]",
+        "add w22, w21, w20",
+        "eor w23, w21, w20",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w23, w22, #16",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "ubfx w24, w22, #16, #1",
+        "orr w23, w23, w24, lsl #29",
+        "eor w20, w21, w20",
+        "eor w21, w22, w21",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w23, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add dword [rax], ecx": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": "0x01",
+      "ExpectedArm64ASM": [
+        "mov w20, w5",
+        "ldaddal w20, w21, [x4]",
+        "add w22, w21, w20",
+        "eor w23, w21, w20",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "cmn w21, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or byte [rax], cl": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "0x08",
+      "ExpectedArm64ASM": [
+        "ldsetalb w5, w20, [x4]",
+        "orr w20, w20, w5",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #24",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or word [rax], cx": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "0x09",
+      "ExpectedArm64ASM": [
+        "ldsetalh w5, w20, [x4]",
+        "orr w20, w20, w5",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or dword [rax], ecx": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": "0x09",
+      "ExpectedArm64ASM": [
+        "ldsetal w5, w20, [x4]",
+        "orr w20, w20, w5",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc byte [rax], cl": {
+      "ExpectedInstructionCount": 26,
+      "Optimal": "No",
+      "Comment": "0x10",
+      "ExpectedArm64ASM": [
+        "uxtb w20, w5",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w22, w20, w21",
+        "ldaddalb w22, w23, [x4]",
+        "add w22, w23, w22",
+        "uxtb w22, w22",
+        "eor w24, w23, w20",
+        "strb w24, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w24, w22, #24",
+        "tst w24, w24",
+        "mrs x24, nzcv",
+        "cmp w22, w20",
+        "cset x25, lo",
+        "cmp w22, w20",
+        "cset x26, ls",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x26, x25, eq",
+        "orr w21, w24, w21, lsl #29",
+        "eor w20, w23, w20",
+        "eor w22, w22, w23",
+        "bic w20, w22, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc word [rax], cx": {
+      "ExpectedInstructionCount": 26,
+      "Optimal": "No",
+      "Comment": "0x11",
+      "ExpectedArm64ASM": [
+        "uxth w20, w5",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w22, w20, w21",
+        "ldaddalh w22, w23, [x4]",
+        "add w22, w23, w22",
+        "uxth w22, w22",
+        "eor w24, w23, w20",
+        "strb w24, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w24, w22, #16",
+        "tst w24, w24",
+        "mrs x24, nzcv",
+        "cmp w22, w20",
+        "cset x25, lo",
+        "cmp w22, w20",
+        "cset x26, ls",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x26, x25, eq",
+        "orr w21, w24, w21, lsl #29",
+        "eor w20, w23, w20",
+        "eor w22, w22, w23",
+        "bic w20, w22, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc dword [rax], ecx": {
+      "ExpectedInstructionCount": 13,
+      "Optimal": "No",
+      "Comment": "0x11",
+      "ExpectedArm64ASM": [
+        "mov w20, w5",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add w22, w20, w22",
+        "ldaddal w22, w23, [x4]",
+        "add w22, w23, w22",
+        "eor w24, w23, w20",
+        "strb w24, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "msr nzcv, x21",
+        "adcs wzr, w23, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb byte [rax], cl": {
+      "ExpectedInstructionCount": 27,
+      "Optimal": "No",
+      "Comment": "0x18",
+      "ExpectedArm64ASM": [
+        "uxtb w20, w5",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w22, w20, w21",
+        "neg w1, w22",
+        "ldaddalb w1, w23, [x4]",
+        "sub w22, w23, w22",
+        "uxtb w22, w22",
+        "eor w24, w23, w20",
+        "strb w24, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w24, w22, #24",
+        "tst w24, w24",
+        "mrs x24, nzcv",
+        "cmp w22, w23",
+        "cset x25, hi",
+        "cmp w22, w23",
+        "cset x26, hs",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x26, x25, eq",
+        "orr w21, w24, w21, lsl #29",
+        "eor w20, w23, w20",
+        "eor w22, w22, w23",
+        "and w20, w22, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb word [rax], cx": {
+      "ExpectedInstructionCount": 27,
+      "Optimal": "No",
+      "Comment": "0x19",
+      "ExpectedArm64ASM": [
+        "uxth w20, w5",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w22, w20, w21",
+        "neg w1, w22",
+        "ldaddalh w1, w23, [x4]",
+        "sub w22, w23, w22",
+        "uxth w22, w22",
+        "eor w24, w23, w20",
+        "strb w24, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w24, w22, #16",
+        "tst w24, w24",
+        "mrs x24, nzcv",
+        "cmp w22, w23",
+        "cset x25, hi",
+        "cmp w22, w23",
+        "cset x26, hs",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x26, x25, eq",
+        "orr w21, w24, w21, lsl #29",
+        "eor w20, w23, w20",
+        "eor w22, w22, w23",
+        "and w20, w22, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb dword [rax], ecx": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": "0x19",
+      "ExpectedArm64ASM": [
+        "mov w20, w5",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add w22, w20, w22",
+        "neg w1, w22",
+        "ldaddal w1, w23, [x4]",
+        "sub w22, w23, w22",
+        "eor w24, w23, w20",
+        "strb w24, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "eor w0, w21, #0x20000000",
+        "msr nzcv, x0",
+        "sbcs wzr, w23, w20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and byte [rax], cl": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "0x20",
+      "ExpectedArm64ASM": [
+        "mvn w1, w5",
+        "ldclralb w1, w20, [x4]",
+        "and w20, w20, w5",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #24",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and word [rax], cx": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "0x21",
+      "ExpectedArm64ASM": [
+        "mvn w1, w5",
+        "ldclralh w1, w20, [x4]",
+        "and w20, w20, w5",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and dword [rax], ecx": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "0x21",
+      "ExpectedArm64ASM": [
+        "mvn w1, w5",
+        "ldclral w1, w20, [x4]",
+        "and w20, w20, w5",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub byte [rax], cl": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": "0x28",
+      "ExpectedArm64ASM": [
+        "uxtb w20, w5",
+        "neg w1, w20",
+        "ldaddalb w1, w21, [x4]",
+        "sub w22, w21, w20",
+        "eor w23, w21, w20",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w23, w22, #24",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "ubfx w24, w22, #8, #1",
+        "orr w23, w23, w24, lsl #29",
+        "eor w20, w21, w20",
+        "eor w21, w22, w21",
+        "and w20, w21, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w23, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub word [rax], cx": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": "0x28",
+      "ExpectedArm64ASM": [
+        "uxth w20, w5",
+        "neg w1, w20",
+        "ldaddalh w1, w21, [x4]",
+        "sub w22, w21, w20",
+        "eor w23, w21, w20",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w23, w22, #16",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "ubfx w24, w22, #16, #1",
+        "orr w23, w23, w24, lsl #29",
+        "eor w20, w21, w20",
+        "eor w21, w22, w21",
+        "and w20, w21, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w23, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub dword [rax], ecx": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "No",
+      "Comment": "0x29",
+      "ExpectedArm64ASM": [
+        "mov w20, w5",
+        "neg w1, w20",
+        "ldaddal w1, w21, [x4]",
+        "sub w22, w21, w20",
+        "eor w23, w21, w20",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "cmp w21, w20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor byte [rax], cl": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "0x30",
+      "ExpectedArm64ASM": [
+        "ldeoralb w5, w20, [x4]",
+        "eor w20, w20, w5",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #24",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor word [rax], cx": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "0x31",
+      "ExpectedArm64ASM": [
+        "ldeoralh w5, w20, [x4]",
+        "eor w20, w20, w5",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor dword [rax], ecx": {
+      "ExpectedInstructionCount": 6,
+      "Optimal": "No",
+      "Comment": "0x31",
+      "ExpectedArm64ASM": [
+        "ldeoral w5, w20, [x4]",
+        "eor w20, w20, w5",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add qword [rax], rcx": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "0x01",
+      "ExpectedArm64ASM": [
+        "ldaddal x5, x20, [x4]",
+        "add x21, x20, x5",
+        "eor x22, x20, x5",
+        "strb w22, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmn x20, x5",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "xchg byte [rax], cl": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "No",
+      "Comment": "0x86",
+      "ExpectedArm64ASM": [
+        "uxtb w20, w5",
+        "mov w1, w20",
+        "swpalb w1, w20, [x4]",
+        "bfxil x5, x20, #0, #8"
+      ]
+    },
+    "xchg word [rax], cx": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "No",
+      "Comment": "0x87",
+      "ExpectedArm64ASM": [
+        "uxth w20, w5",
+        "mov w1, w20",
+        "swpalh w1, w20, [x4]",
+        "bfxil x5, x20, #0, #16"
+      ]
+    },
+    "xchg dword [rax], ecx": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "No",
+      "Comment": "0x87",
+      "ExpectedArm64ASM": [
+        "mov w20, w5",
+        "mov w1, w20",
+        "swpal w1, w5, [x4]"
+      ]
+    },
+    "xchg qword [rax], rcx": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": "0x87",
+      "ExpectedArm64ASM": [
+        "mov x1, x5",
+        "swpal x1, x5, [x4]"
+      ]
+    },
+    "xadd byte [rax], bl": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": "0x0f 0xc0",
+      "ExpectedArm64ASM": [
+        "uxtb w20, w7",
+        "ldaddalb w20, w21, [x4]",
+        "bfxil x7, x21, #0, #8",
+        "add w22, w21, w20",
+        "eor w23, w21, w20",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w23, w22, #24",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "ubfx w24, w22, #8, #1",
+        "orr w23, w23, w24, lsl #29",
+        "eor w20, w21, w20",
+        "eor w21, w22, w21",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w23, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "xadd word [rax], bx": {
+      "ExpectedInstructionCount": 18,
+      "Optimal": "No",
+      "Comment": "0x0f 0xc1",
+      "ExpectedArm64ASM": [
+        "uxth w20, w7",
+        "ldaddalh w20, w21, [x4]",
+        "bfxil x7, x21, #0, #16",
+        "add w22, w21, w20",
+        "eor w23, w21, w20",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w23, w22, #16",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "ubfx w24, w22, #16, #1",
+        "orr w23, w23, w24, lsl #29",
+        "eor w20, w21, w20",
+        "eor w21, w22, w21",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w23, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "xadd dword [rax], ebx": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": "0x0f 0xc1",
+      "ExpectedArm64ASM": [
+        "mov w20, w7",
+        "ldaddal w20, w7, [x4]",
+        "add w21, w7, w20",
+        "eor w22, w7, w20",
+        "strb w22, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmn w7, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "xadd qword [rax], rbx": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": "0x0f 0xc1",
+      "ExpectedArm64ASM": [
+        "mov x20, x7",
+        "ldaddal x20, x7, [x4]",
+        "add x21, x7, x20",
+        "eor x22, x7, x20",
+        "strb w22, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmn x7, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add byte [rax], 1": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldaddalb w20, w20, [x4]",
+        "add w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "lsl w22, w21, #24",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w21, #8, #1",
+        "orr w22, w22, w23, lsl #29",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add byte [rax], 0xFF": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xff",
+        "ldaddalb w20, w20, [x4]",
+        "add w21, w20, #0xff (255)",
+        "eor w22, w20, #0xff",
+        "strb w22, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "lsl w22, w21, #24",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w21, #8, #1",
+        "orr w22, w22, w23, lsl #29",
+        "bic w20, w20, w21",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add word [rax], 0x100": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldaddalh w20, w20, [x4]",
+        "add w21, w20, #0x100 (256)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "lsl w22, w21, #16",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w21, #16, #1",
+        "orr w22, w22, w23, lsl #29",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add word [rax], 0xFFFF": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "ldaddalh w20, w21, [x4]",
+        "add w20, w21, w20",
+        "eor w22, w21, #0xffff",
+        "strb w22, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w22, w20, #16",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w20, #16, #1",
+        "orr w22, w22, w23, lsl #29",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add dword [rax], 0x100": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldaddal w20, w20, [x4]",
+        "add w21, w20, #0x100 (256)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmn w20, #0x100 (256)",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add dword [rax], 0xFFFFFFFF": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "movk w20, #0xffff, lsl #16",
+        "ldaddal w20, w21, [x4]",
+        "add w22, w21, w20",
+        "eor w23, w21, w20",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "cmn w21, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add qword [rax], 0x100": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldaddal x20, x20, [x4]",
+        "add x21, x20, #0x100 (256)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmn x20, #0x100 (256)",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add qword [rax], -2147483647": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /0",
+      "ExpectedArm64ASM": [
+        "mov x20, #0xffffffff80000001",
+        "ldaddal x20, x21, [x4]",
+        "add x22, x21, x20",
+        "strb w21, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "cmn x21, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add word [rax], 1": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldaddalh w20, w20, [x4]",
+        "add w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "lsl w22, w21, #16",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w21, #16, #1",
+        "orr w22, w22, w23, lsl #29",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add dword [rax], 1": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldaddal w20, w20, [x4]",
+        "add w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmn w20, #0x1 (1)",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock add qword [rax], 1": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "Yes",
+      "Comment": "GROUP1 0x83 /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldaddal x20, x20, [x4]",
+        "add x21, x20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmn x20, #0x1 (1)",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or byte [rax], 1": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldsetalb w20, w20, [x4]",
+        "orr w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #24",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or byte [rax], 0xFF": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xff",
+        "ldsetalb w20, w20, [x4]",
+        "orr w20, w20, #0xff",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #24",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or word [rax], 0x100": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldsetalh w20, w20, [x4]",
+        "orr w20, w20, #0x100",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or word [rax], 0xFFFF": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "ldsetalh w20, w20, [x4]",
+        "orr w20, w20, #0xffff",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or dword [rax], 0x100": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldsetal w20, w20, [x4]",
+        "orr w20, w20, #0x100",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or dword [rax], 0xFFFFFFFF": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "movk w20, #0xffff, lsl #16",
+        "ldsetal w20, w21, [x4]",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or qword [rax], 0x100": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldsetal x20, x20, [x4]",
+        "orr x20, x20, #0x100",
+        "strb w20, [x28, #706]",
+        "tst x20, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or qword [rax], -2147483647": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /1",
+      "ExpectedArm64ASM": [
+        "mov x20, #0xffffffff80000001",
+        "ldsetal x20, x20, [x4]",
+        "orr x20, x20, #0xffffffff80000001",
+        "strb w20, [x28, #706]",
+        "tst x20, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or word [rax], 1": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldsetalh w20, w20, [x4]",
+        "orr w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or dword [rax], 1": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldsetal w20, w20, [x4]",
+        "orr w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock or qword [rax], 1": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "Yes",
+      "Comment": "GROUP1 0x83 /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldsetal x20, x20, [x4]",
+        "orr x20, x20, #0x1",
+        "strb w20, [x28, #706]",
+        "tst x20, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc byte [rax], 1": {
+      "ExpectedInstructionCount": 23,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w20, w20, w21",
+        "ldaddalb w20, w22, [x4]",
+        "add w20, w22, w20",
+        "uxtb w20, w20",
+        "strb w22, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w23, w20, #24",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "cmp w20, #0x1 (1)",
+        "cset x24, lo",
+        "cmp w20, #0x1 (1)",
+        "cset x25, ls",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x25, x24, eq",
+        "orr w21, w23, w21, lsl #29",
+        "bic w20, w20, w22",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc byte [rax], 0xFF": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xff",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w20, w20, w21",
+        "ldaddalb w20, w22, [x4]",
+        "add w20, w22, w20",
+        "uxtb w20, w20",
+        "eor w23, w22, #0xff",
+        "strb w23, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w23, w20, #24",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "cmp w20, #0xff (255)",
+        "cset x24, lo",
+        "cmp w20, #0xff (255)",
+        "cset x25, ls",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x25, x24, eq",
+        "orr w21, w23, w21, lsl #29",
+        "bic w20, w22, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc word [rax], 0x100": {
+      "ExpectedInstructionCount": 23,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w20, w20, w21",
+        "ldaddalh w20, w22, [x4]",
+        "add w20, w22, w20",
+        "uxth w20, w20",
+        "strb w22, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w23, w20, #16",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "cmp w20, #0x100 (256)",
+        "cset x24, lo",
+        "cmp w20, #0x100 (256)",
+        "cset x25, ls",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x25, x24, eq",
+        "orr w21, w23, w21, lsl #29",
+        "bic w20, w20, w22",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc word [rax], 0xFFFF": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w22, w20, w21",
+        "ldaddalh w22, w23, [x4]",
+        "add w22, w23, w22",
+        "uxth w22, w22",
+        "eor w24, w23, #0xffff",
+        "strb w24, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "lsl w24, w22, #16",
+        "tst w24, w24",
+        "mrs x24, nzcv",
+        "cmp w22, w20",
+        "cset x25, lo",
+        "cmp w22, w20",
+        "cset x20, ls",
+        "cmp x21, #0x1 (1)",
+        "csel x20, x20, x25, eq",
+        "orr w20, w24, w20, lsl #29",
+        "bic w21, w23, w22",
+        "ubfx w21, w21, #15, #1",
+        "orr w20, w20, w21, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc dword [rax], 0x100": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add w22, w20, w22",
+        "ldaddal w22, w23, [x4]",
+        "add w22, w23, w22",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "msr nzcv, x21",
+        "adcs wzr, w23, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc dword [rax], 0xFFFFFFFF": {
+      "ExpectedInstructionCount": 14,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "movk w20, #0xffff, lsl #16",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add w22, w20, w22",
+        "ldaddal w22, w23, [x4]",
+        "add w22, w23, w22",
+        "eor w24, w23, w20",
+        "strb w24, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "msr nzcv, x21",
+        "adcs wzr, w23, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc qword [rax], 0x100": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add x22, x20, x22",
+        "ldaddal x22, x23, [x4]",
+        "add x22, x23, x22",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "msr nzcv, x21",
+        "adcs xzr, x23, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc qword [rax], -2147483647": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /2",
+      "ExpectedArm64ASM": [
+        "mov x20, #0xffffffff80000001",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add x22, x20, x22",
+        "ldaddal x22, x23, [x4]",
+        "add x22, x23, x22",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "msr nzcv, x21",
+        "adcs xzr, x23, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc word [rax], 1": {
+      "ExpectedInstructionCount": 23,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w20, w20, w21",
+        "ldaddalh w20, w22, [x4]",
+        "add w20, w22, w20",
+        "uxth w20, w20",
+        "strb w22, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w23, w20, #16",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "cmp w20, #0x1 (1)",
+        "cset x24, lo",
+        "cmp w20, #0x1 (1)",
+        "cset x25, ls",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x25, x24, eq",
+        "orr w21, w23, w21, lsl #29",
+        "bic w20, w20, w22",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc dword [rax], 1": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add w22, w20, w22",
+        "ldaddal w22, w23, [x4]",
+        "add w22, w23, w22",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "msr nzcv, x21",
+        "adcs wzr, w23, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock adc qword [rax], 1": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "Yes",
+      "Comment": "GROUP1 0x83 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add x22, x20, x22",
+        "ldaddal x22, x23, [x4]",
+        "add x22, x23, x22",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "msr nzcv, x21",
+        "adcs xzr, x23, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb byte [rax], 1": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /3",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w20, w20, w21",
+        "neg w1, w20",
+        "ldaddalb w1, w22, [x4]",
+        "sub w20, w22, w20",
+        "uxtb w20, w20",
+        "strb w22, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w23, w20, #24",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "cmp w20, w22",
+        "cset x24, hi",
+        "cmp w20, w22",
+        "cset x25, hs",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x25, x24, eq",
+        "orr w21, w23, w21, lsl #29",
+        "bic w20, w22, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb byte [rax], 0xFF": {
+      "ExpectedInstructionCount": 25,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /3",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xff",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w20, w20, w21",
+        "neg w1, w20",
+        "ldaddalb w1, w22, [x4]",
+        "sub w20, w22, w20",
+        "uxtb w20, w20",
+        "eor w23, w22, #0xff",
+        "strb w23, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w23, w20, #24",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "cmp w20, w22",
+        "cset x24, hi",
+        "cmp w20, w22",
+        "cset x25, hs",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x25, x24, eq",
+        "orr w21, w23, w21, lsl #29",
+        "bic w20, w20, w22",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb word [rax], 0x100": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /3",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w20, w20, w21",
+        "neg w1, w20",
+        "ldaddalh w1, w22, [x4]",
+        "sub w20, w22, w20",
+        "uxth w20, w20",
+        "strb w22, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w23, w20, #16",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "cmp w20, w22",
+        "cset x24, hi",
+        "cmp w20, w22",
+        "cset x25, hs",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x25, x24, eq",
+        "orr w21, w23, w21, lsl #29",
+        "bic w20, w22, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb word [rax], 0xFFFF": {
+      "ExpectedInstructionCount": 25,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /3",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w20, w20, w21",
+        "neg w1, w20",
+        "ldaddalh w1, w22, [x4]",
+        "sub w20, w22, w20",
+        "uxth w20, w20",
+        "eor w23, w22, #0xffff",
+        "strb w23, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w23, w20, #16",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "cmp w20, w22",
+        "cset x24, hi",
+        "cmp w20, w22",
+        "cset x25, hs",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x25, x24, eq",
+        "orr w21, w23, w21, lsl #29",
+        "bic w20, w20, w22",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb dword [rax], 0x100": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /3",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add w22, w20, w22",
+        "neg w1, w22",
+        "ldaddal w1, w23, [x4]",
+        "sub w22, w23, w22",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "eor w0, w21, #0x20000000",
+        "msr nzcv, x0",
+        "sbcs wzr, w23, w20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb dword [rax], 0xFFFFFFFF": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /3",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "movk w20, #0xffff, lsl #16",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add w22, w20, w22",
+        "neg w1, w22",
+        "ldaddal w1, w23, [x4]",
+        "sub w22, w23, w22",
+        "eor w24, w23, w20",
+        "strb w24, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "eor w0, w21, #0x20000000",
+        "msr nzcv, x0",
+        "sbcs wzr, w23, w20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb qword [rax], 0x100": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /3",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add x22, x20, x22",
+        "neg x1, x22",
+        "ldaddal x1, x23, [x4]",
+        "sub x22, x23, x22",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "eor w0, w21, #0x20000000",
+        "msr nzcv, x0",
+        "sbcs xzr, x23, x20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb qword [rax], -2147483647": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /3",
+      "ExpectedArm64ASM": [
+        "mov x20, #0xffffffff80000001",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add x22, x20, x22",
+        "neg x1, x22",
+        "ldaddal x1, x23, [x4]",
+        "sub x22, x23, x22",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "eor w0, w21, #0x20000000",
+        "msr nzcv, x0",
+        "sbcs xzr, x23, x20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb word [rax], 1": {
+      "ExpectedInstructionCount": 24,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /3",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "add w20, w20, w21",
+        "neg w1, w20",
+        "ldaddalh w1, w22, [x4]",
+        "sub w20, w22, w20",
+        "uxth w20, w20",
+        "strb w22, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w23, w20, #16",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "cmp w20, w22",
+        "cset x24, hi",
+        "cmp w20, w22",
+        "cset x25, hs",
+        "cmp x21, #0x1 (1)",
+        "csel x21, x25, x24, eq",
+        "orr w21, w23, w21, lsl #29",
+        "bic w20, w22, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w21, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb dword [rax], 1": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /3",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add w22, w20, w22",
+        "neg w1, w22",
+        "ldaddal w1, w23, [x4]",
+        "sub w22, w23, w22",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "eor w0, w21, #0x20000000",
+        "msr nzcv, x0",
+        "sbcs wzr, w23, w20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sbb qword [rax], 1": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "Yes",
+      "Comment": "GROUP1 0x83 /3",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldr w21, [x28, #728]",
+        "ubfx w22, w21, #29, #1",
+        "add x22, x20, x22",
+        "neg x1, x22",
+        "ldaddal x1, x23, [x4]",
+        "sub x22, x23, x22",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "eor w0, w21, #0x20000000",
+        "msr nzcv, x0",
+        "sbcs xzr, x23, x20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and byte [rax], 1": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /4",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "mvn w1, w20",
+        "ldclralb w1, w20, [x4]",
+        "and w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #24",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and byte [rax], 0xFF": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /4",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xff",
+        "mvn w1, w20",
+        "ldclralb w1, w20, [x4]",
+        "and w20, w20, #0xff",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #24",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and word [rax], 0x100": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /4",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "mvn w1, w20",
+        "ldclralh w1, w20, [x4]",
+        "and w20, w20, #0x100",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and word [rax], 0xFFFF": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /4",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "mvn w1, w20",
+        "ldclralh w1, w20, [x4]",
+        "and w20, w20, #0xffff",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and dword [rax], 0x100": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /4",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "mvn w1, w20",
+        "ldclral w1, w20, [x4]",
+        "and w20, w20, #0x100",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and dword [rax], 0xFFFFFFFF": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /4",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "movk w20, #0xffff, lsl #16",
+        "mvn w1, w20",
+        "ldclral w1, w21, [x4]",
+        "and w20, w21, w20",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and qword [rax], 0x100": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /4",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "mvn x1, x20",
+        "ldclral x1, x20, [x4]",
+        "and x20, x20, #0x100",
+        "strb w20, [x28, #706]",
+        "tst x20, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and qword [rax], -2147483647": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /4",
+      "ExpectedArm64ASM": [
+        "mov x20, #0xffffffff80000001",
+        "mvn x1, x20",
+        "ldclral x1, x20, [x4]",
+        "and x20, x20, #0xffffffff80000001",
+        "strb w20, [x28, #706]",
+        "tst x20, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and word [rax], 1": {
+      "ExpectedInstructionCount": 9,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /4",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "mvn w1, w20",
+        "ldclralh w1, w20, [x4]",
+        "and w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and dword [rax], 1": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /4",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "mvn w1, w20",
+        "ldclral w1, w20, [x4]",
+        "and w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock and qword [rax], 1": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "Yes",
+      "Comment": "GROUP1 0x83 /4",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "mvn x1, x20",
+        "ldclral x1, x20, [x4]",
+        "and x20, x20, #0x1",
+        "strb w20, [x28, #706]",
+        "tst x20, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub byte [rax], 1": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /5",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "neg w1, w20",
+        "ldaddalb w1, w20, [x4]",
+        "sub w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "lsl w22, w21, #24",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w21, #8, #1",
+        "orr w22, w22, w23, lsl #29",
+        "bic w20, w20, w21",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub byte [rax], 0xFF": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /5",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xff",
+        "neg w1, w20",
+        "ldaddalb w1, w20, [x4]",
+        "sub w21, w20, #0xff (255)",
+        "eor w22, w20, #0xff",
+        "strb w22, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "lsl w22, w21, #24",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w21, #8, #1",
+        "orr w22, w22, w23, lsl #29",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub word [rax], 0x100": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /5",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "neg w1, w20",
+        "ldaddalh w1, w20, [x4]",
+        "sub w21, w20, #0x100 (256)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "lsl w22, w21, #16",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w21, #16, #1",
+        "orr w22, w22, w23, lsl #29",
+        "bic w20, w20, w21",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub word [rax], 0xFFFF": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /5",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "neg w1, w20",
+        "ldaddalh w1, w21, [x4]",
+        "sub w20, w21, w20",
+        "eor w22, w21, #0xffff",
+        "strb w22, [x28, #708]",
+        "strb w20, [x28, #706]",
+        "lsl w22, w20, #16",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w20, #16, #1",
+        "orr w22, w22, w23, lsl #29",
+        "bic w20, w20, w21",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub dword [rax], 0x100": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /5",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "neg w1, w20",
+        "ldaddal w1, w20, [x4]",
+        "sub w21, w20, #0x100 (256)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmp w20, #0x100 (256)",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub dword [rax], 0xFFFFFFFF": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /5",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "movk w20, #0xffff, lsl #16",
+        "neg w1, w20",
+        "ldaddal w1, w21, [x4]",
+        "sub w22, w21, w20",
+        "eor w23, w21, w20",
+        "strb w23, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "cmp w21, w20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub qword [rax], 0x100": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /5",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "neg x1, x20",
+        "ldaddal x1, x20, [x4]",
+        "sub x21, x20, #0x100 (256)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmp x20, #0x100 (256)",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub qword [rax], -2147483647": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /5",
+      "ExpectedArm64ASM": [
+        "mov x20, #0xffffffff80000001",
+        "neg x1, x20",
+        "ldaddal x1, x21, [x4]",
+        "sub x22, x21, x20",
+        "strb w21, [x28, #708]",
+        "strb w22, [x28, #706]",
+        "cmp x21, x20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub word [rax], 1": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /5",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "neg w1, w20",
+        "ldaddalh w1, w20, [x4]",
+        "sub w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "lsl w22, w21, #16",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w21, #16, #1",
+        "orr w22, w22, w23, lsl #29",
+        "bic w20, w20, w21",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub dword [rax], 1": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /5",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "neg w1, w20",
+        "ldaddal w1, w20, [x4]",
+        "sub w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmp w20, #0x1 (1)",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock sub qword [rax], 1": {
+      "ExpectedInstructionCount": 10,
+      "Optimal": "Yes",
+      "Comment": "GROUP1 0x83 /5",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "neg x1, x20",
+        "ldaddal x1, x20, [x4]",
+        "sub x21, x20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmp x20, #0x1 (1)",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor byte [rax], 1": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /6",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldeoralb w20, w20, [x4]",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #24",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor byte [rax], 0xFF": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x80 /6",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xff",
+        "ldeoralb w20, w20, [x4]",
+        "eor w20, w20, #0xff",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #24",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor word [rax], 0x100": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /6",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldeoralh w20, w20, [x4]",
+        "eor w20, w20, #0x100",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor word [rax], 0xFFFF": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /6",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "ldeoralh w20, w20, [x4]",
+        "eor w20, w20, #0xffff",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor dword [rax], 0x100": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /6",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldeoral w20, w20, [x4]",
+        "eor w20, w20, #0x100",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor dword [rax], 0xFFFFFFFF": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /6",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "movk w20, #0xffff, lsl #16",
+        "ldeoral w20, w21, [x4]",
+        "eor w20, w21, w20",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor qword [rax], 0x100": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /6",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x100",
+        "ldeoral x20, x20, [x4]",
+        "eor x20, x20, #0x100",
+        "strb w20, [x28, #706]",
+        "tst x20, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor qword [rax], -2147483647": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x81 /6",
+      "ExpectedArm64ASM": [
+        "mov x20, #0xffffffff80000001",
+        "ldeoral x20, x20, [x4]",
+        "eor x20, x20, #0xffffffff80000001",
+        "strb w20, [x28, #706]",
+        "tst x20, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor word [rax], 1": {
+      "ExpectedInstructionCount": 8,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /6",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldeoralh w20, w20, [x4]",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "lsl w20, w20, #16",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor dword [rax], 1": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "No",
+      "Comment": "GROUP1 0x83 /6",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldeoral w20, w20, [x4]",
+        "eor w20, w20, #0x1",
+        "strb w20, [x28, #706]",
+        "tst w20, w20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock xor qword [rax], 1": {
+      "ExpectedInstructionCount": 7,
+      "Optimal": "Yes",
+      "Comment": "GROUP1 0x83 /6",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldeoral x20, x20, [x4]",
+        "eor x20, x20, #0x1",
+        "strb w20, [x28, #706]",
+        "tst x20, x20",
+        "mrs x20, nzcv",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock dec byte [rax]": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": "GROUP3 0xfe /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "neg w1, w20",
+        "ldaddalb w1, w20, [x4]",
+        "sub w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "ldr w22, [x28, #728]",
+        "ubfx w22, w22, #29, #1",
+        "lsl w23, w21, #24",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "bic w20, w20, w21",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w23, w20, lsl #28",
+        "orr w20, w20, w22, lsl #29",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock not byte [rax]": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": "GROUP2 0xf6 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xff",
+        "steorlb w20, [x4]"
+      ]
+    },
+    "lock not word [rax]": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": "GROUP2 0xf7 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "steorlh w20, [x4]"
+      ]
+    },
+    "lock not dword [rax]": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "No",
+      "Comment": "GROUP2 0xf7 /2",
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffff",
+        "movk w20, #0xffff, lsl #16",
+        "steorl w20, [x4]"
+      ]
+    },
+    "lock not qword [rax]": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "No",
+      "Comment": "GROUP2 0xf7 /2",
+      "ExpectedArm64ASM": [
+        "mov x20, #0xffffffffffffffff",
+        "steorl x20, [x4]"
+      ]
+    },
+    "lock neg byte [rax]": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": "GROUP2 0xf6 /3",
+      "ExpectedArm64ASM": [
+        "ldaxrb w1, [x4]",
+        "neg w2, w1",
+        "stlxrb w3, w2, [x4]",
+        "cbnz w3, #-0xc",
+        "mov w20, w1",
+        "neg w21, w20",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "lsl w22, w21, #24",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w21, #8, #1",
+        "orr w22, w22, w23, lsl #29",
+        "and w20, w21, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock neg word [rax]": {
+      "ExpectedInstructionCount": 17,
+      "Optimal": "No",
+      "Comment": "GROUP2 0xf7 /3",
+      "ExpectedArm64ASM": [
+        "ldaxrh w1, [x4]",
+        "neg w2, w1",
+        "stlxrh w3, w2, [x4]",
+        "cbnz w3, #-0xc",
+        "mov w20, w1",
+        "neg w21, w20",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "lsl w22, w21, #16",
+        "tst w22, w22",
+        "mrs x22, nzcv",
+        "ubfx w23, w21, #16, #1",
+        "orr w22, w22, w23, lsl #29",
+        "and w20, w21, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w22, w20, lsl #28",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock neg dword [rax]": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": "GROUP2 0xf7 /3",
+      "ExpectedArm64ASM": [
+        "ldaxr w1, [x4]",
+        "neg w2, w1",
+        "stlxr w3, w2, [x4]",
+        "cbnz w3, #-0xc",
+        "mov w20, w1",
+        "neg w21, w20",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmp wzr, w20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock neg qword [rax]": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": "GROUP2 0xf7 /3",
+      "ExpectedArm64ASM": [
+        "ldaxr x1, [x4]",
+        "neg x2, x1",
+        "stlxr w3, x2, [x4]",
+        "cbnz x3, #-0xc",
+        "mov x20, x1",
+        "neg x21, x20",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmp xzr, x20",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock dec word [rax]": {
+      "ExpectedInstructionCount": 16,
+      "Optimal": "No",
+      "Comment": "GROUP4 0xfe /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "neg w1, w20",
+        "ldaddalh w1, w20, [x4]",
+        "sub w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "ldr w22, [x28, #728]",
+        "ubfx w22, w22, #29, #1",
+        "lsl w23, w21, #16",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "bic w20, w20, w21",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w23, w20, lsl #28",
+        "orr w20, w20, w22, lsl #29",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock dec dword [rax]": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "No",
+      "Comment": "GROUP4 0xfe /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "neg w1, w20",
+        "ldaddal w1, w20, [x4]",
+        "sub w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "cmp w20, #0x1 (1)",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock dec qword [rax]": {
+      "ExpectedInstructionCount": 12,
+      "Optimal": "Yes",
+      "Comment": "GROUP4 0xfe /1",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "neg x1, x20",
+        "ldaddal x1, x20, [x4]",
+        "sub x21, x20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "cmp x20, #0x1 (1)",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock inc byte [rax]": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP4 0xfe /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldaddalb w20, w20, [x4]",
+        "add w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "ldr w22, [x28, #728]",
+        "ubfx w22, w22, #29, #1",
+        "lsl w23, w21, #24",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #7, #1",
+        "orr w20, w23, w20, lsl #28",
+        "orr w20, w20, w22, lsl #29",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock inc word [rax]": {
+      "ExpectedInstructionCount": 15,
+      "Optimal": "No",
+      "Comment": "GROUP4 0xfe /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldaddalh w20, w20, [x4]",
+        "add w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "ldr w22, [x28, #728]",
+        "ubfx w22, w22, #29, #1",
+        "lsl w23, w21, #16",
+        "tst w23, w23",
+        "mrs x23, nzcv",
+        "bic w20, w21, w20",
+        "ubfx w20, w20, #15, #1",
+        "orr w20, w23, w20, lsl #28",
+        "orr w20, w20, w22, lsl #29",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock inc dword [rax]": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "Yes",
+      "Comment": "GROUP4 0xfe /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldaddal w20, w20, [x4]",
+        "add w21, w20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "cmn w20, #0x1 (1)",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
+        "str w20, [x28, #728]"
+      ]
+    },
+    "lock inc qword [rax]": {
+      "ExpectedInstructionCount": 11,
+      "Optimal": "Yes",
+      "Comment": "GROUP4 0xfe /0",
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1",
+        "ldaddal x20, x20, [x4]",
+        "add x21, x20, #0x1 (1)",
+        "strb w20, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "ldr w21, [x28, #728]",
+        "ubfx w21, w21, #29, #1",
+        "cmn x20, #0x1 (1)",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
+        "str w20, [x28, #728]"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds all the missing atomic tests in to their own tests files. This includes all of them except a few choice ones that are in their original files.

- BTC, BTR, BTS  are in their Secondary/SecondaryGroup files
- CMPXCHG, CMPXCHG8B, CMPXCHG16B are in their Secondary/SecondaryGroup files
   - These always imply lock semantics even without the prefix.