### PR TITLE
InstCountCI: Support multiple instructions in the tests

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -48,6 +48,10 @@ namespace FEXCore::Context {
     CompileBlock(Thread->CurrentFrame, GuestRIP);
   }
 
+  void FEXCore::Context::ContextImpl::CompileRIPCount(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst) {
+    CompileBlock(Thread->CurrentFrame, GuestRIP, MaxInst);
+  }
+
   FEXCore::Context::ExitReason FEXCore::Context::ContextImpl::GetExitReason() {
     return ParentThread->ExitReason;
   }

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -90,6 +90,7 @@ namespace FEXCore::Context {
       void ExecuteThread(FEXCore::Core::InternalThreadState *Thread) override;
 
       void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) override;
+      void CompileRIPCount(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst) override;
 
       int GetProgramStatus() const override;
 
@@ -322,7 +323,7 @@ namespace FEXCore::Context {
       uint64_t StartAddr;
       uint64_t Length;
     };
-    [[nodiscard]] GenerateIRResult GenerateIR(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, bool ExtendedDebugInfo);
+    [[nodiscard]] GenerateIRResult GenerateIR(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, bool ExtendedDebugInfo, uint64_t MaxInst);
 
     struct CompileCodeResult {
       void* CompiledCode;
@@ -333,8 +334,8 @@ namespace FEXCore::Context {
       uint64_t StartAddr;
       uint64_t Length;
     };
-    [[nodiscard]] CompileCodeResult CompileCode(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
-    uintptr_t CompileBlock(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP);
+    [[nodiscard]] CompileCodeResult CompileCode(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst = 0);
+    uintptr_t CompileBlock(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP, uint64_t MaxInst = 0);
 
     // same as CompileBlock, but aborts on failure
     void CompileBlockJit(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP);

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -34,7 +34,7 @@ public:
 
   Decoder(FEXCore::Context::ContextImpl *ctx);
   ~Decoder();
-  void DecodeInstructionsAtEntry(uint8_t const* InstStream, uint64_t PC, std::function<void(uint64_t BlockEntry, uint64_t Start, uint64_t Length)> AddContainedCodePage);
+  void DecodeInstructionsAtEntry(uint8_t const* InstStream, uint64_t PC, uint64_t MaxInst, std::function<void(uint64_t BlockEntry, uint64_t Start, uint64_t Length)> AddContainedCodePage);
 
   DecodedBlockInformation const *GetDecodedBlockInfo() const {
     return &BlockInfo;

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -182,6 +182,7 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual void ExecuteThread(FEXCore::Core::InternalThreadState *Thread) = 0;
 
       FEX_DEFAULT_VISIBILITY virtual void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) = 0;
+      FEX_DEFAULT_VISIBILITY virtual void CompileRIPCount(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst) = 0;
 
       /**
        * @brief Gets the program exit status

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -230,6 +230,7 @@ struct TestInfo {
   uint64_t Optimal;
   int64_t ExpectedInstructionCount;
   uint64_t CodeSize;
+  uint64_t x86InstCount;
   uint32_t Cookie;
   uint8_t Code[];
 };
@@ -258,7 +259,7 @@ static bool TestInstructions(FEXCore::Context::Context *CTX, FEXCore::Core::Inte
     LogMan::Msg::IFmt("Compiling instruction '{}'", CurrentTest->TestInst);
 
     // Compile the INST.
-    CTX->CompileRIP(Thread, CodeRIP);
+    CTX->CompileRIPCount(Thread, CodeRIP, CurrentTest->x86InstCount);
 
     // Go to the next test.
     CurrentTest = reinterpret_cast<TestInfo const*>(&CurrentTest->Code[CurrentTest->CodeSize]);


### PR DESCRIPTION
There are some cases where we want to test multiple instructions where we can do optimizations that would overwise be hard to see.

eg:
```asm
; Can be optimized to a single stp
push eax
push ebx

; Can remove half of the copy since we know the direction
cld
rep movsb

; Can remove a redundant insert
addss xmm0, xmm1
addss xmm0, xmm2
```

This lets us have arbitrary sized code in instruction count CI, with the original json key becoming only a label if the instruction array is provided.

There are still some major limitations to this, instructions that generate side-effects might have "garbage" after the end of the block that isn't correctly accounted for. So care must be taken.

Example in the json
```json
"push ax, bx": {
  "ExpectedInstructionCount": 4,
  "Optimal": "No",
  "Comment": "0x50",
  "x86Insts": [
    "push ax",
    "push bx"
  ],
  "ExpectedArm64ASM": [
    "uxth w20, w4",
    "strh w20, [x8, #-2]!",
    "uxth w20, w7",
    "strh w20, [x8, #-2]!"
  ]
}
```