### PR TITLE
OpcodeDispatcher: Remove redundant moves from rorx

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2451,7 +2451,8 @@ void OpDispatchBuilder::RORX(OpcodeArgs) {
     return;
   }
 
-  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, true, false,
+                         MemoryAccessType::ACCESS_DEFAULT, true);
   auto* Result = Src;
   if (DoRotation) [[likely]] {
     Result = _Ror(OpSizeFromSrc(Op), Src, _Constant(Amount));

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -4748,14 +4748,13 @@
       ]
     },
     "rorx eax, ebx, 31": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 32-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov w20, w7",
-        "ror w4, w20, #31"
+        "ror w4, w7, #31"
       ]
     },
     "rorx eax, ebx, 32": {


### PR DESCRIPTION
By allowing junk in the upper bits, we can avoid an unnecessary move, since we'll be ignoring them in the following ROR instruction anyway.