### PR TITLE
OpcodeDispatcher: Put extra LoadSource options in a struct

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5048,8 +5048,8 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(RegisterClassType Class, X
     Src = LoadGPRRegister(Operand.Data.GPR.GPR, GPRSize);
 
     LoadableType = true;
-    if (Operand.Data.GPR.GPR == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::ACCESS_DEFAULT) {
-      AccessType = MemoryAccessType::ACCESS_NONTSO;
+    if (Operand.Data.GPR.GPR == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::DEFAULT) {
+      AccessType = MemoryAccessType::NONTSO;
     }
   }
   else if (Operand.IsGPRIndirect()) {
@@ -5060,8 +5060,8 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(RegisterClassType Class, X
     Src = _Add(IR::SizeToOpSize(GPRSize), GPR, Constant);
 
     LoadableType = true;
-    if (Operand.Data.GPRIndirect.GPR == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::ACCESS_DEFAULT) {
-      AccessType = MemoryAccessType::ACCESS_NONTSO;
+    if (Operand.Data.GPRIndirect.GPR == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::DEFAULT) {
+      AccessType = MemoryAccessType::NONTSO;
     }
   }
   else if (Operand.IsRIPRelative()) {
@@ -5095,8 +5095,8 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(RegisterClassType Class, X
         auto Constant = _Constant(GPRSize * 8, Operand.Data.SIB.Scale);
         Tmp = _Mul(IR::SizeToOpSize(GPRSize), Tmp, Constant);
       }
-      if (Operand.Data.SIB.Index == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::ACCESS_DEFAULT) {
-        AccessType = MemoryAccessType::ACCESS_NONTSO;
+      if (Operand.Data.SIB.Index == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::DEFAULT) {
+        AccessType = MemoryAccessType::NONTSO;
       }
     }
 
@@ -5110,8 +5110,8 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(RegisterClassType Class, X
         Tmp = GPR;
       }
 
-      if (Operand.Data.SIB.Base == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::ACCESS_DEFAULT) {
-        AccessType = MemoryAccessType::ACCESS_NONTSO;
+      if (Operand.Data.SIB.Base == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::DEFAULT) {
+        AccessType = MemoryAccessType::NONTSO;
       }
     }
 
@@ -5149,7 +5149,7 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(RegisterClassType Class, X
   if ((LoadableType && LoadData) || ForceLoad) {
     Src = AppendSegmentOffset(Src, Flags);
 
-    if (AccessType == MemoryAccessType::ACCESS_NONTSO || AccessType == MemoryAccessType::ACCESS_STREAM) {
+    if (AccessType == MemoryAccessType::NONTSO || AccessType == MemoryAccessType::STREAM) {
       Src = _LoadMem(Class, OpSize, Src, Align == -1 ? OpSize : Align);
     }
     else {
@@ -5302,8 +5302,8 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
     MemStoreDst = LoadGPRRegister(Operand.Data.GPR.GPR, GPRSize);
 
     MemStore = true;
-    if (Operand.Data.GPR.GPR == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::ACCESS_DEFAULT) {
-      AccessType = MemoryAccessType::ACCESS_NONTSO;
+    if (Operand.Data.GPR.GPR == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::DEFAULT) {
+      AccessType = MemoryAccessType::NONTSO;
     }
   }
   else if (Operand.IsGPRIndirect()) {
@@ -5312,8 +5312,8 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
 
     MemStoreDst = _Add(IR::SizeToOpSize(GPRSize), GPR, Constant);
     MemStore = true;
-    if (Operand.Data.GPRIndirect.GPR == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::ACCESS_DEFAULT) {
-      AccessType = MemoryAccessType::ACCESS_NONTSO;
+    if (Operand.Data.GPRIndirect.GPR == FEXCore::X86State::REG_RSP && AccessType == MemoryAccessType::DEFAULT) {
+      AccessType = MemoryAccessType::NONTSO;
     }
   }
   else if (Operand.IsRIPRelative()) {
@@ -5384,7 +5384,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
       auto DestAddr = _Add(OpSize::i64Bit, MemStoreDst, _Constant(8));
       _StoreMem(GPRClass, 2, DestAddr, Upper, std::min<uint8_t>(Align, 8));
     } else {
-      if (AccessType == MemoryAccessType::ACCESS_NONTSO || AccessType == MemoryAccessType::ACCESS_STREAM) {
+      if (AccessType == MemoryAccessType::NONTSO || AccessType == MemoryAccessType::STREAM) {
         _StoreMem(Class, OpSize, MemStoreDst, Src, Align == -1 ? OpSize : Align);
       }
       else {
@@ -5434,7 +5434,7 @@ void OpDispatchBuilder::MOVGPROp(OpcodeArgs) {
 
 void OpDispatchBuilder::MOVGPRNTOp(OpcodeArgs) {
   OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.Align = 1});
-  StoreResult(GPRClass, Op, Src, 1, MemoryAccessType::ACCESS_STREAM);
+  StoreResult(GPRClass, Op, Src, 1, MemoryAccessType::STREAM);
 }
 
 void OpDispatchBuilder::ALUOpImpl(OpcodeArgs, FEXCore::IR::IROps ALUIROp, FEXCore::IR::IROps AtomicFetchOp) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -192,7 +192,7 @@ void OpDispatchBuilder::LEAOp(OpcodeArgs) {
     const uint32_t DstSize = X86Tables::DecodeFlags::GetOpAddr(Op->Flags, 0) == X86Tables::DecodeFlags::FLAG_OPERAND_SIZE_LAST ? 2 :
       X86Tables::DecodeFlags::GetOpAddr(Op->Flags, 0) == X86Tables::DecodeFlags::FLAG_WIDENING_SIZE_LAST ? 8 : 4;
 
-    auto Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1, false);
+    auto Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], SrcSize, Op->Flags, {.LoadData = false});
     if (DstSize != SrcSize) {
       // If the SrcSize isn't the DstSize then we need to zero extend.
       const uint8_t GPRSize = CTX->GetGPRSize();
@@ -203,7 +203,7 @@ void OpDispatchBuilder::LEAOp(OpcodeArgs) {
   else {
     uint32_t DstSize = X86Tables::DecodeFlags::GetOpAddr(Op->Flags, 0) == X86Tables::DecodeFlags::FLAG_OPERAND_SIZE_LAST ? 2 : 4;
 
-    auto Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1, false);
+    auto Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], SrcSize, Op->Flags, {.LoadData = false});
     StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Src, DstSize, -1);
   }
 }
@@ -231,7 +231,7 @@ void OpDispatchBuilder::RETOp(OpcodeArgs) {
 
   OrderedNode *NewSP;
   if (Op->OP == 0xC2) {
-    auto Offset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+    auto Offset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
     NewSP = _Add(IR::SizeToOpSize(GPRSize), _Add(IR::SizeToOpSize(GPRSize), OldSP, Constant), Offset);
   }
   else {
@@ -357,14 +357,14 @@ void OpDispatchBuilder::SecondaryALUOp(OpcodeArgs) {
   };
 #undef OPD
   // X86 basic ALU ops just do the operation between the destination and a single source
-  auto Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+  auto Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
   uint8_t Size = GetDstSize(Op);
   OrderedNode *Result{};
   OrderedNode *Dest{};
 
   if (DestIsLockedMem(Op)) {
     HandledLock = true;
-    auto DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    auto DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     DestMem = AppendSegmentOffset(DestMem, Op->Flags);
     switch (IROp) {
       case FEXCore::IR::IROps::OP_ADD: {
@@ -398,7 +398,7 @@ void OpDispatchBuilder::SecondaryALUOp(OpcodeArgs) {
     }
   }
   else {
-    Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+    Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
     auto ALUOp = _Add(IR::SizeToOpSize(std::max<uint8_t>(4u, Size)), Dest, Src);
     // Overwrite our IR's op type
     ALUOp.first->Header.Op = IROp;
@@ -433,7 +433,7 @@ void OpDispatchBuilder::ADCOp(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags);
   uint8_t Size = GetDstSize(Op);
   const auto OpSize = IR::SizeToOpSize(std::max<uint8_t>(4u, Size));
 
@@ -444,13 +444,13 @@ void OpDispatchBuilder::ADCOp(OpcodeArgs) {
   OrderedNode *Before{};
   if (DestIsLockedMem(Op)) {
     HandledLock = true;
-    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     DestMem = AppendSegmentOffset(DestMem, Op->Flags);
     Before = _AtomicFetchAdd(IR::SizeToOpSize(Size), ALUOp, DestMem);
     Result = _Add(OpSize, Before, ALUOp);
   }
   else {
-    Before = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+    Before = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
     Result = _Add(OpSize, Before, ALUOp);
     StoreResult(GPRClass, Op, Result, -1);
   }
@@ -465,7 +465,7 @@ void OpDispatchBuilder::SBBOp(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags);
   auto Size = GetDstSize(Op);
   const auto OpSize = IR::SizeToOpSize(std::max<uint8_t>(4u, Size));
 
@@ -476,13 +476,13 @@ void OpDispatchBuilder::SBBOp(OpcodeArgs) {
   OrderedNode *Before{};
   if (DestIsLockedMem(Op)) {
     HandledLock = true;
-    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     DestMem = AppendSegmentOffset(DestMem, Op->Flags);
     Before = _AtomicFetchSub(IR::SizeToOpSize(Size), ALUOp, DestMem);
     Result = _Sub(Size == 8 ? OpSize::i64Bit : OpSize::i32Bit, Before, ALUOp);
   }
   else {
-    Before = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+    Before = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
     Result = _Sub(Size == 8 ? OpSize::i64Bit : OpSize::i32Bit, Before, ALUOp);
     StoreResult(GPRClass, Op, Result, -1);
   }
@@ -498,7 +498,7 @@ void OpDispatchBuilder::SBBOp(OpcodeArgs) {
 void OpDispatchBuilder::PUSHOp(OpcodeArgs) {
   const uint8_t Size = GetSrcSize(Op);
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
 
   auto OldSP = LoadGPRRegister(X86State::REG_RSP);
 
@@ -512,7 +512,8 @@ void OpDispatchBuilder::PUSHOp(OpcodeArgs) {
 void OpDispatchBuilder::PUSHREGOp(OpcodeArgs) {
   const uint8_t Size = GetSrcSize(Op);
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Dest , Op->Flags, -1, true, false, MemoryAccessType::ACCESS_DEFAULT, true);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Dest , Op->Flags,
+                                {.AllowUpperGarbage = true});
 
   auto OldSP = LoadGPRRegister(X86State::REG_RSP);
   const uint8_t GPRSize = CTX->GetGPRSize();
@@ -775,7 +776,7 @@ void OpDispatchBuilder::CALLOp(OpcodeArgs) {
 
   auto ConstantPC = GetRelocatedPC(Op);
 
-  OrderedNode *JMPPCOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *JMPPCOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
 
   OrderedNode *NewRIP = _Add(IR::SizeToOpSize(GPRSize), ConstantPC, JMPPCOffset);
 
@@ -807,7 +808,7 @@ void OpDispatchBuilder::CALLAbsoluteOp(OpcodeArgs) {
   BlockSetRIP = true;
 
   const uint8_t Size = GetSrcSize(Op);
-  OrderedNode *JMPPCOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *JMPPCOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
 
   auto ConstantPCReturn = GetRelocatedPC(Op);
 
@@ -1057,13 +1058,13 @@ void OpDispatchBuilder::CMOVOp(OpcodeArgs) {
   CalculateDeferredFlags();
 
   // Destination is always a GPR.
-  OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, GPRSize, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, GPRSize, Op->Flags);
   OrderedNode *Src{};
   if (Op->Src[0].IsGPR()) {
-    Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], GPRSize, Op->Flags, -1);
+    Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], GPRSize, Op->Flags);
   }
   else {
-    Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   }
 
   auto SrcCond = SelectCC(Op->OP & 0xF, IR::SizeToOpSize(std::max<uint8_t>(4u, GetSrcSize(Op))), Src, Dest);
@@ -1234,7 +1235,7 @@ void OpDispatchBuilder::LoopOp(OpcodeArgs) {
 
   uint64_t Target = Op->PC + Op->InstSize + Op->Src[1].Data.Literal.Value;
 
-  OrderedNode *CondReg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *CondReg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   CondReg = _Sub(SrcSize == 8 ? OpSize::i64Bit : OpSize::i32Bit, CondReg, _Constant(SrcSize * 8, 1));
   StoreResult(GPRClass, Op, Op->Src[0], CondReg, -1);
 
@@ -1361,7 +1362,7 @@ void OpDispatchBuilder::JUMPAbsoluteOp(OpcodeArgs) {
   // This is just an unconditional jump
   // This uses ModRM to determine its location
   // No way to use this effectively in multiblock
-  auto RIPOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  auto RIPOffset = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   CalculateDeferredFlags();
 
   // Store the new RIP
@@ -1372,8 +1373,10 @@ template<uint32_t SrcIndex>
 void OpDispatchBuilder::TESTOp(OpcodeArgs) {
   // TEST is an instruction that does an AND between the sources
   // Result isn't stored in result, only writes to flags
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1, true, false, MemoryAccessType::ACCESS_DEFAULT, true);
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, true, false, MemoryAccessType::ACCESS_DEFAULT, true);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, 
+                                {.AllowUpperGarbage = true});
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags,
+                                 {.AllowUpperGarbage = true});
 
   auto Size = GetDstSize(Op);
 
@@ -1401,7 +1404,7 @@ void OpDispatchBuilder::MOVSXDOp(OpcodeArgs) {
   //
   uint8_t Size = std::min(static_cast<uint8_t>(4), GetSrcSize(Op));
 
-  OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], Size, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], Size, Op->Flags);
   if (Size == 2) {
     // This'll make sure to insert in to the lower 16bits without modifying upper bits
     StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Src, Size, -1);
@@ -1421,13 +1424,13 @@ void OpDispatchBuilder::MOVSXOp(OpcodeArgs) {
   // This will ZExt the loaded size
   // We want to Sext it
   uint8_t Size = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   Src = _Sbfe(OpSize::i64Bit, Size * 8, 0, Src);
   StoreResult(GPRClass, Op, Op->Dest, Src, -1);
 }
 
 void OpDispatchBuilder::MOVZXOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   // Store result implicitly zero extends
   StoreResult(GPRClass, Op, Src, -1);
 }
@@ -1436,8 +1439,8 @@ template<uint32_t SrcIndex>
 void OpDispatchBuilder::CMPOp(OpcodeArgs) {
   // CMP is an instruction that does a SUB between the sources
   // Result isn't stored in result, only writes to flags
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   auto Size = GetDstSize(Op);
 
@@ -1459,7 +1462,7 @@ void OpDispatchBuilder::CMPOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::CQOOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   auto Size = GetSrcSize(Op);
   OrderedNode *Upper = _Sbfe(OpSize::i64Bit, 1, Size * 8 - 1, Src);
 
@@ -1489,10 +1492,10 @@ void OpDispatchBuilder::XCHGOp(OpcodeArgs) {
     return;
   }
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   if (DestIsMem(Op)) {
     HandledLock = Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_LOCK;
-    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
 
     Dest = AppendSegmentOffset(Dest, Op->Flags);
 
@@ -1500,7 +1503,7 @@ void OpDispatchBuilder::XCHGOp(OpcodeArgs) {
     StoreResult(GPRClass, Op, Op->Src[0], Result, -1);
   }
   else {
-    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
     // Swap the contents
     // Order matters here since we don't want to swap context contents for one that effects the other
@@ -1510,7 +1513,7 @@ void OpDispatchBuilder::XCHGOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::CDQOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   uint8_t DstSize = GetDstSize(Op);
   uint8_t SrcSize = DstSize >> 1;
 
@@ -1614,7 +1617,7 @@ void OpDispatchBuilder::MOVSegOp(OpcodeArgs) {
   // The loads here also load the selector, NOT the base
 
   if constexpr (ToSeg) {
-    OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], 2, Op->Flags, -1);
+    OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], 2, Op->Flags);
 
     switch (Op->Dest.Data.GPR.GPR) {
       case FEXCore::X86State::REG_RAX: // ES
@@ -1730,14 +1733,14 @@ void OpDispatchBuilder::MOVOffsetOp(OpcodeArgs) {
   case 0xA1:
     // Source is memory(literal)
     // Dest is GPR
-    Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, true, true);
+    Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.ForceLoad = true});
     StoreResult(GPRClass, Op, Op->Dest, Src, -1);
     break;
   case 0xA2:
   case 0xA3:
     // Source is GPR
     // Dest is memory(literal)
-    Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
     // This one is a bit special since the destination is a literal
     // So the destination gets stored in Src[1]
     StoreResult(GPRClass, Op, Op->Src[1], Src, -1);
@@ -1748,7 +1751,7 @@ void OpDispatchBuilder::MOVOffsetOp(OpcodeArgs) {
 void OpDispatchBuilder::CPUIDOp(OpcodeArgs) {
   const auto GPRSize = CTX->GetGPRSize();
 
-  OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], GPRSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], GPRSize, Op->Flags);
   OrderedNode *Leaf = LoadGPRRegister(X86State::REG_RCX);
 
   auto Res = _CPUID(Src, Leaf);
@@ -1777,13 +1780,13 @@ void OpDispatchBuilder::XGetBVOp(OpcodeArgs) {
 template<bool SHL1Bit>
 void OpDispatchBuilder::SHLOp(OpcodeArgs) {
   OrderedNode *Src{};
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   if constexpr (SHL1Bit) {
     Src = _Constant(1);
   }
   else {
-    Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
   }
   const auto Size = GetSrcBitSize(Op);
 
@@ -1803,7 +1806,7 @@ void OpDispatchBuilder::SHLOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::SHLImmediateOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
 
@@ -1832,13 +1835,13 @@ void OpDispatchBuilder::SHLImmediateOp(OpcodeArgs) {
 template<bool SHR1Bit>
 void OpDispatchBuilder::SHROp(OpcodeArgs) {
   OrderedNode *Src;
-  auto Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  auto Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   if constexpr (SHR1Bit) {
     Src = _Constant(1);
   }
   else {
-    Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
   }
 
   auto ALUOp = _Lshr(IR::SizeToOpSize(std::max<uint8_t>(4, GetSrcSize(Op))), Dest, Src);
@@ -1853,7 +1856,7 @@ void OpDispatchBuilder::SHROp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::SHRImmediateOp(OpcodeArgs) {
-  auto Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  auto Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
 
@@ -1878,10 +1881,10 @@ void OpDispatchBuilder::SHLDOp(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
-  OrderedNode *Shift = LoadSource_WithOpSize(GPRClass, Op, Op->Src[1], 1, Op->Flags, -1);
+  OrderedNode *Shift = LoadSource_WithOpSize(GPRClass, Op, Op->Src[1], 1, Op->Flags);
 
   const auto Size = GetSrcBitSize(Op);
 
@@ -1935,8 +1938,8 @@ void OpDispatchBuilder::SHLDOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::SHLDImmediateOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
 
@@ -1980,8 +1983,8 @@ void OpDispatchBuilder::SHRDOp(OpcodeArgs) {
   // This instruction conditionally generates flags so we need to insure sane state going in.
   CalculateDeferredFlags();
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   OrderedNode *Shift = LoadGPRRegister(X86State::REG_RCX);
 
@@ -2035,8 +2038,8 @@ void OpDispatchBuilder::SHRDOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::SHRDImmediateOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
 
@@ -2079,14 +2082,14 @@ void OpDispatchBuilder::SHRDImmediateOp(OpcodeArgs) {
 template<bool SHR1Bit>
 void OpDispatchBuilder::ASHROp(OpcodeArgs) {
   OrderedNode *Src;
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   const auto Size = GetSrcBitSize(Op);
 
   if constexpr (SHR1Bit) {
     Src = _Constant(Size, 1);
   } else {
-    Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
   }
 
   if (Size < 32) {
@@ -2104,7 +2107,7 @@ void OpDispatchBuilder::ASHROp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::ASHRImmediateOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
 
@@ -2133,13 +2136,13 @@ void OpDispatchBuilder::ASHRImmediateOp(OpcodeArgs) {
 template<bool Is1Bit>
 void OpDispatchBuilder::ROROp(OpcodeArgs) {
   OrderedNode *Src;
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   const uint32_t Size = GetSrcBitSize(Op);
   if constexpr (Is1Bit) {
     Src = _Constant(std::max(32U, Size), 1);
   } else {
-    Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
   }
 
   // x86 masks the shift by 0x3F or 0x1F depending on size of op
@@ -2172,7 +2175,7 @@ void OpDispatchBuilder::ROROp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::RORImmediateOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
 
@@ -2209,7 +2212,7 @@ void OpDispatchBuilder::RORImmediateOp(OpcodeArgs) {
 template<bool Is1Bit>
 void OpDispatchBuilder::ROLOp(OpcodeArgs) {
   OrderedNode *Src;
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   const uint32_t Size = GetSrcBitSize(Op);
 
@@ -2217,7 +2220,7 @@ void OpDispatchBuilder::ROLOp(OpcodeArgs) {
   if constexpr (Is1Bit) {
     Src = _Constant(Size, 1);
   } else {
-    Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
   }
 
   // x86 masks the shift by 0x3F or 0x1F depending on size of op
@@ -2252,7 +2255,7 @@ void OpDispatchBuilder::ROLOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::ROLImmediateOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
 
@@ -2289,8 +2292,8 @@ void OpDispatchBuilder::ROLImmediateOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::ANDNBMIOp(OpcodeArgs) {
-  auto* Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  auto* Src2 = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+  auto* Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  auto* Src2 = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
 
   auto Dest = _Andn(OpSizeFromSrc(Op), Src2, Src1);
 
@@ -2302,8 +2305,8 @@ void OpDispatchBuilder::BEXTRBMIOp(OpcodeArgs) {
   // Essentially (Src1 >> Start) & ((1 << Length) - 1)
   // along with some edge-case handling and flag setting.
 
-  auto* Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  auto* Src2 = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+  auto* Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  auto* Src2 = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
 
   const auto Size = GetSrcSize(Op);
   const auto SrcSize = Size * 8;
@@ -2342,7 +2345,7 @@ void OpDispatchBuilder::BEXTRBMIOp(OpcodeArgs) {
 void OpDispatchBuilder::BLSIBMIOp(OpcodeArgs) {
   // Equivalent to performing: SRC & -SRC
 
-  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   auto NegatedSrc = _Neg(OpSizeFromSrc(Op), Src);
   auto Result = _And(OpSizeFromSrc(Op), Src, NegatedSrc);
 
@@ -2356,7 +2359,7 @@ void OpDispatchBuilder::BLSMSKBMIOp(OpcodeArgs) {
   // Equivalent to: (Src - 1) ^ Src
   auto One = _Constant(1);
 
-  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   auto Result = _Xor(OpSize::i64Bit, _Sub(OpSize::i64Bit, Src, One), Src);
 
   StoreResult(GPRClass, Op, Result, -1);
@@ -2367,7 +2370,7 @@ void OpDispatchBuilder::BLSRBMIOp(OpcodeArgs) {
   // Equivalent to: (Src - 1) & Src
   auto One = _Constant(1);
 
-  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   auto Result = _And(OpSize::i64Bit, _Sub(OpSize::i64Bit, Src, One), Src);
 
   StoreResult(GPRClass, Op, Result, -1);
@@ -2383,8 +2386,8 @@ void OpDispatchBuilder::BMI2Shift(OpcodeArgs) {
   const auto Size = GetSrcSize(Op);
   const auto SrcSize = Op->Src[0].IsGPR() ? GPRSize : Size;
 
-  auto* Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
-  auto* Shift = LoadSource_WithOpSize(GPRClass, Op, Op->Src[1], GPRSize, Op->Flags, -1);
+  auto* Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
+  auto* Shift = LoadSource_WithOpSize(GPRClass, Op, Op->Src[1], GPRSize, Op->Flags);
 
   auto* Result = [&]() -> OrderedNode* {
     // SARX
@@ -2407,8 +2410,8 @@ void OpDispatchBuilder::BZHI(OpcodeArgs) {
   const auto Size = GetSrcSize(Op);
   const auto OperandSize = Size * 8;
 
-  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  auto* Index = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  auto* Index = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
 
   // Mask off the index so we only consider the lower byte.
   auto MaskedIndex = _And(OpSize::i64Bit, Index, _Constant(0xFF));
@@ -2451,8 +2454,7 @@ void OpDispatchBuilder::RORX(OpcodeArgs) {
     return;
   }
 
-  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, true, false,
-                         MemoryAccessType::ACCESS_DEFAULT, true);
+  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.AllowUpperGarbage = true});
   auto* Result = Src;
   if (DoRotation) [[likely]] {
     Result = _Ror(OpSizeFromSrc(Op), Src, _Constant(Amount));
@@ -2471,7 +2473,7 @@ void OpDispatchBuilder::MULX(OpcodeArgs) {
   const auto GPRSize = CTX->GetGPRSize();
   const auto Src1Size = Op->Src[1].IsGPR() ? GPRSize : OperandSize;
 
-  OrderedNode* Src1 = LoadSource_WithOpSize(GPRClass, Op, Op->Src[1], Src1Size, Op->Flags, -1);
+  OrderedNode* Src1 = LoadSource_WithOpSize(GPRClass, Op, Op->Src[1], Src1Size, Op->Flags);
   OrderedNode* Src2 = LoadGPRRegister(X86State::REG_RDX, GPRSize);
 
   // As per the Intel Software Development Manual, if the destination and
@@ -2490,16 +2492,16 @@ void OpDispatchBuilder::MULX(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::PDEP(OpcodeArgs) {
-  auto* Input = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  auto* Mask = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+  auto* Input = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  auto* Mask = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
   auto Result = _PDep(OpSizeFromSrc(Op), Input, Mask);
 
   StoreResult(GPRClass, Op, Op->Dest, Result, -1);
 }
 
 void OpDispatchBuilder::PEXT(OpcodeArgs) {
-  auto* Input = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  auto* Mask = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+  auto* Input = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  auto* Mask = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
   auto Result = _PExt(OpSizeFromSrc(Op), Input, Mask);
 
   StoreResult(GPRClass, Op, Op->Dest, Result, -1);
@@ -2523,8 +2525,8 @@ void OpDispatchBuilder::ADXOp(OpcodeArgs) {
     }
   }();
 
-  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  auto* Before = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  auto* Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  auto* Before = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   auto ALUOp = _Add(OpSize, Src, Flag);
   auto Result = _Add(OpSize, Before, ALUOp);
@@ -2548,7 +2550,7 @@ void OpDispatchBuilder::RCROp1Bit(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
 
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   const auto Size = GetSrcBitSize(Op);
   auto CF = GetRFLAG(FEXCore::X86State::RFLAG_CF_RAW_LOC);
 
@@ -2594,7 +2596,7 @@ void OpDispatchBuilder::RCROp8x1Bit(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
 
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   const auto SizeBit = GetSrcBitSize(Op);
   auto CF = GetRFLAG(FEXCore::X86State::RFLAG_CF_RAW_LOC);
 
@@ -2629,8 +2631,8 @@ void OpDispatchBuilder::RCROp(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   auto CF = GetRFLAG(FEXCore::X86State::RFLAG_CF_RAW_LOC);
 
   // Res = Src >> Shift
@@ -2686,8 +2688,8 @@ void OpDispatchBuilder::RCRSmallerOp(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   auto CF = GetRFLAG(FEXCore::X86State::RFLAG_CF_RAW_LOC);
 
   const auto Size = GetSrcBitSize(Op);
@@ -2780,7 +2782,7 @@ void OpDispatchBuilder::RCLOp1Bit(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
 
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   const auto Size = GetSrcBitSize(Op);
   const auto OpSize = Size == 64 ? OpSize::i64Bit : OpSize::i32Bit;
   auto CF = GetRFLAG(FEXCore::X86State::RFLAG_CF_RAW_LOC);
@@ -2817,8 +2819,8 @@ void OpDispatchBuilder::RCLOp(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   auto CF = GetRFLAG(FEXCore::X86State::RFLAG_CF_RAW_LOC);
 
   // Res = Src << Shift
@@ -2876,8 +2878,8 @@ void OpDispatchBuilder::RCLSmallerOp(OpcodeArgs) {
   // Calculate flags early.
   CalculateDeferredFlags();
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   auto CF = GetRFLAG(FEXCore::X86State::RFLAG_CF_RAW_LOC);
 
   const auto Size = GetSrcBitSize(Op);
@@ -2945,7 +2947,7 @@ void OpDispatchBuilder::BTOp(OpcodeArgs) {
   InvalidateDeferredFlags();
 
   if (Op->Src[SrcIndex].IsGPR()) {
-    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags);
   } else {
     // Can only be an immediate
     // Masked by operand size
@@ -2956,7 +2958,7 @@ void OpDispatchBuilder::BTOp(OpcodeArgs) {
   if (Op->Dest.IsGPR()) {
     // When the destination is a GPR, we don't care about garbage in the upper bits.
     // Load the full register.
-    auto Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, CTX->GetGPRSize(), Op->Flags, -1);
+    auto Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, CTX->GetGPRSize(), Op->Flags);
 
     OrderedNode *BitSelect{};
     if (AlreadyMasked) {
@@ -2971,7 +2973,7 @@ void OpDispatchBuilder::BTOp(OpcodeArgs) {
     Result = _Lshr(IR::SizeToOpSize(std::max<uint8_t>(4u, GetOpSize(Dest))), Dest, BitSelect);
   } else {
     // Load the address to the memory location
-    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     Dest = AppendSegmentOffset(Dest, Op->Flags);
     // Get the bit selection from the src
     OrderedNode *BitSelect = _Bfe(IR::SizeToOpSize(std::max<uint8_t>(4u, GetOpSize(Src))), 3, 0, Src);
@@ -3008,7 +3010,7 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
   InvalidateDeferredFlags();
 
   if (Op->Src[SrcIndex].IsGPR()) {
-    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags);
   } else {
     // Can only be an immediate
     // Masked by operand size
@@ -3019,7 +3021,7 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
   if (Op->Dest.IsGPR()) {
     // When the destination is a GPR, we don't care about garbage in the upper bits.
     // Load the full register.
-    auto Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, CTX->GetGPRSize(), Op->Flags, -1);
+    auto Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, CTX->GetGPRSize(), Op->Flags);
 
     OrderedNode *BitSelect{};
     if (AlreadyMasked) {
@@ -3038,7 +3040,7 @@ void OpDispatchBuilder::BTROp(OpcodeArgs) {
     StoreResult(GPRClass, Op, Dest, -1);
   } else {
     // Load the address to the memory location
-    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     Dest = AppendSegmentOffset(Dest, Op->Flags);
 
     // Get the bit selection from the src
@@ -3088,7 +3090,7 @@ void OpDispatchBuilder::BTSOp(OpcodeArgs) {
   InvalidateDeferredFlags();
 
   if (Op->Src[SrcIndex].IsGPR()) {
-    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags);
   } else {
     // Can only be an immediate
     // Masked by operand size
@@ -3099,7 +3101,7 @@ void OpDispatchBuilder::BTSOp(OpcodeArgs) {
   if (Op->Dest.IsGPR()) {
     // When the destination is a GPR, we don't care about garbage in the upper bits.
     // Load the full register.
-    auto Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, CTX->GetGPRSize(), Op->Flags, -1);
+    auto Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, CTX->GetGPRSize(), Op->Flags);
 
     OrderedNode *BitSelect{};
     if (AlreadyMasked) {
@@ -3118,7 +3120,7 @@ void OpDispatchBuilder::BTSOp(OpcodeArgs) {
     StoreResult(GPRClass, Op, Dest, -1);
   } else {
     // Load the address to the memory location
-    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     Dest = AppendSegmentOffset(Dest, Op->Flags);
     // Get the bit selection from the src
     OrderedNode *BitSelect = _Bfe(IR::SizeToOpSize(std::max<uint8_t>(4u, GetOpSize(Src))), 3, 0, Src);
@@ -3166,7 +3168,7 @@ void OpDispatchBuilder::BTCOp(OpcodeArgs) {
   InvalidateDeferredFlags();
 
   if (Op->Src[SrcIndex].IsGPR()) {
-    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, -1);
+    Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags);
   } else {
     // Can only be an immediate
     // Masked by operand size
@@ -3177,7 +3179,7 @@ void OpDispatchBuilder::BTCOp(OpcodeArgs) {
   if (Op->Dest.IsGPR()) {
     // When the destination is a GPR, we don't care about garbage in the upper bits.
     // Load the full register.
-    auto Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, CTX->GetGPRSize(), Op->Flags, -1);
+    auto Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, CTX->GetGPRSize(), Op->Flags);
 
     OrderedNode *BitSelect{};
     if (AlreadyMasked) {
@@ -3196,7 +3198,7 @@ void OpDispatchBuilder::BTCOp(OpcodeArgs) {
     StoreResult(GPRClass, Op, Dest, -1);
   } else {
     // Load the address to the memory location
-    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     Dest = AppendSegmentOffset(Dest, Op->Flags);
     // Get the bit selection from the src
     OrderedNode *BitSelect = _Bfe(IR::SizeToOpSize(std::max<uint8_t>(4u, GetOpSize(Src))), 3, 0, Src);
@@ -3230,8 +3232,8 @@ void OpDispatchBuilder::BTCOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::IMUL1SrcOp(OpcodeArgs) {
-  OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src2 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
 
   uint8_t Size = GetSrcSize(Op);
   if (Size != 8) {
@@ -3252,8 +3254,8 @@ void OpDispatchBuilder::IMUL1SrcOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::IMUL2SrcOp(OpcodeArgs) {
-  OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(GPRClass, Op, Op->Src[1], Op->Flags);
 
   uint8_t Size = GetSrcSize(Op);
   if (Size != 8) {
@@ -3277,7 +3279,7 @@ void OpDispatchBuilder::IMUL2SrcOp(OpcodeArgs) {
 void OpDispatchBuilder::IMULOp(OpcodeArgs) {
   const uint8_t Size = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   OrderedNode* Src2 = LoadGPRRegister(X86State::REG_RAX);
 
   if (Size != 8) {
@@ -3329,7 +3331,7 @@ void OpDispatchBuilder::IMULOp(OpcodeArgs) {
 void OpDispatchBuilder::MULOp(OpcodeArgs) {
   const uint8_t Size = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   OrderedNode* Src2 = LoadGPRRegister(X86State::REG_RAX);
 
   if (Size != 8) {
@@ -3387,20 +3389,20 @@ void OpDispatchBuilder::NOTOp(OpcodeArgs) {
 
   if (DestIsLockedMem(Op)) {
     HandledLock = true;
-    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     DestMem = AppendSegmentOffset(DestMem, Op->Flags);
     _AtomicXor(IR::SizeToOpSize(Size), MaskConst, DestMem);
   }
   else {
-    OrderedNode *Src = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+    OrderedNode *Src = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
     Src = _Xor(OpSize::i64Bit, Src, MaskConst);
     StoreResult(GPRClass, Op, Src, -1);
   }
 }
 
 void OpDispatchBuilder::XADDOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result;
 
   const auto Size = GetSrcBitSize(Op);
@@ -3430,7 +3432,7 @@ void OpDispatchBuilder::XADDOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::PopcountOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   Src = _Popcount(OpSizeFromSrc(Op), Src);
   StoreResult(GPRClass, Op, Src, -1);
 
@@ -3733,7 +3735,7 @@ void OpDispatchBuilder::WriteSegmentReg(OpcodeArgs) {
   // Documentation claims that the 32-bit version of this instruction inserts in to the lower 32-bits of the segment
   // This is incorrect and it instead zero extends the 32-bit value to 64-bit
   auto Size = GetDstSize(Op);
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   if constexpr (Seg == Segment::FS) {
     _StoreContext(Size, GPRClass, Src, offsetof(FEXCore::Core::CPUState, fs_cached));
   }
@@ -3781,7 +3783,7 @@ void OpDispatchBuilder::EnterOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::SGDTOp(OpcodeArgs) {
-  auto DestAddress = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+  auto DestAddress = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
 
   // Store an emulated value in the format of:
   // uint16_t Limit;
@@ -3827,12 +3829,12 @@ void OpDispatchBuilder::INCOp(OpcodeArgs) {
 
   if (IsLocked) {
     HandledLock = true;
-    auto DestAddress = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    auto DestAddress = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     DestAddress = AppendSegmentOffset(DestAddress, Op->Flags);
     Dest = _AtomicFetchAdd(OpSizeFromSrc(Op), OneConst, DestAddress);
 
   } else {
-    Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+    Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   }
 
   Result = _Add(Size == 64 ? OpSize::i64Bit : OpSize::i32Bit, Dest, OneConst);
@@ -3859,11 +3861,11 @@ void OpDispatchBuilder::DECOp(OpcodeArgs) {
 
   if (IsLocked) {
     HandledLock = true;
-    auto DestAddress = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    auto DestAddress = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     DestAddress = AppendSegmentOffset(DestAddress, Op->Flags);
     Dest = _AtomicFetchSub(OpSizeFromSrc(Op), OneConst, DestAddress);
   } else {
-    Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+    Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   }
 
   Result = _Sub(Size == 64 ? OpSize::i64Bit : OpSize::i32Bit, Dest, OneConst);
@@ -3885,7 +3887,7 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
   const bool Repeat = (Op->Flags & (FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX | FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX)) != 0;
 
   if (!Repeat) {
-    OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+    OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
     OrderedNode *Dest = LoadGPRRegister(X86State::REG_RDI);
 
     // Only ES prefix
@@ -3913,7 +3915,7 @@ void OpDispatchBuilder::STOSOp(OpcodeArgs) {
     // FEX doesn't support partial faulting REP instructions.
     // Converting this to a `MemSet` IR op optimizes this quite significantly in our codegen.
     // If FEX is to gain support for faulting REP instructions, then this implementation needs to change significantly.
-    OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+    OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
     OrderedNode *Dest = LoadGPRRegister(X86State::REG_RDI);
 
     // Only ES prefix
@@ -4224,7 +4226,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
     OrderedNode *Dest_RDI = LoadGPRRegister(X86State::REG_RDI);
     Dest_RDI = AppendSegmentOffset(Dest_RDI, 0, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX, true);
 
-    auto Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+    auto Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
     auto Src2 = _LoadMemAutoTSO(GPRClass, Size, Dest_RDI, Size);
 
     OrderedNode* Result = _Sub(Size == 8 ? OpSize::i64Bit : OpSize::i32Bit, Src1, Src2);
@@ -4285,7 +4287,7 @@ void OpDispatchBuilder::SCASOp(OpcodeArgs) {
 
       Dest_RDI = AppendSegmentOffset(Dest_RDI, 0, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX, true);
 
-      auto Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+      auto Src1 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       auto Src2 = _LoadMemAutoTSO(GPRClass, Size, Dest_RDI, Size);
 
       OrderedNode* Result = _Sub(Size == 8 ? OpSize::i64Bit : OpSize::i32Bit, Src1, Src2);
@@ -4333,7 +4335,7 @@ void OpDispatchBuilder::BSWAPOp(OpcodeArgs) {
     Dest = _Constant(0);
   }
   else {
-    Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, CTX->GetGPRSize(), Op->Flags, -1);
+    Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, CTX->GetGPRSize(), Op->Flags);
     Dest = _Rev(IR::SizeToOpSize(Size), Dest);
   }
   StoreResult(GPRClass, Op, Dest, -1);
@@ -4386,14 +4388,14 @@ void OpDispatchBuilder::NEGOp(OpcodeArgs) {
   OrderedNode *Result{};
 
   if (DestIsLockedMem(Op)) {
-    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     DestMem = AppendSegmentOffset(DestMem, Op->Flags);
 
     Dest = _AtomicFetchNeg(IR::SizeToOpSize(Size), DestMem);
     Result = _Neg(Size == 8 ? OpSize::i64Bit : OpSize::i32Bit, Dest);
   }
   else {
-    Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+    Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
     Result = _Neg(Size == 8 ? OpSize::i64Bit : OpSize::i32Bit, Dest);
 
     StoreResult(GPRClass, Op, Result, -1);
@@ -4404,7 +4406,7 @@ void OpDispatchBuilder::NEGOp(OpcodeArgs) {
 
 void OpDispatchBuilder::DIVOp(OpcodeArgs) {
   // This loads the divisor
-  OrderedNode *Divisor = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Divisor = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   const auto GPRSize = CTX->GetGPRSize();
   const auto Size = GetSrcSize(Op);
@@ -4457,7 +4459,7 @@ void OpDispatchBuilder::DIVOp(OpcodeArgs) {
 
 void OpDispatchBuilder::IDIVOp(OpcodeArgs) {
   // This loads the divisor
-  OrderedNode *Divisor = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Divisor = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   const auto GPRSize = CTX->GetGPRSize();
   const auto Size = GetSrcSize(Op);
@@ -4513,8 +4515,8 @@ void OpDispatchBuilder::IDIVOp(OpcodeArgs) {
 void OpDispatchBuilder::BSFOp(OpcodeArgs) {
   const uint8_t GPRSize = CTX->GetGPRSize();
   const uint8_t DstSize = GetDstSize(Op) == 2 ? 2 : GPRSize;
-  OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, DstSize, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, DstSize, Op->Flags);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
 
   // Find the LSB of this source
   auto Result = _FindLSB(OpSizeFromSrc(Op), Src);
@@ -4534,8 +4536,8 @@ void OpDispatchBuilder::BSFOp(OpcodeArgs) {
 void OpDispatchBuilder::BSROp(OpcodeArgs) {
   const uint8_t GPRSize = CTX->GetGPRSize();
   const uint8_t DstSize = GetDstSize(Op) == 2 ? 2 : GPRSize;
-  OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, DstSize, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, DstSize, Op->Flags);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
 
   // Find the MSB of this source
   auto Result = _FindMSB(OpSizeFromSrc(Op), Src);
@@ -4572,7 +4574,7 @@ void OpDispatchBuilder::CMPXCHGOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
 
   // This is our source register
-  OrderedNode *Src2 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src2 = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   // 0x80014000
   // 0x80064000
   // 0x80064000
@@ -4584,11 +4586,11 @@ void OpDispatchBuilder::CMPXCHGOp(OpcodeArgs) {
     OrderedNode *Src3{};
     OrderedNode *Src3Lower{};
     if (GPRSize == 8 && Size == 4) {
-      Src1 = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, GPRSize, Op->Flags, -1);
+      Src1 = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, GPRSize, Op->Flags);
       Src3 = LoadGPRRegister(X86State::REG_RAX);
     }
     else {
-      Src1 = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, Size, Op->Flags, -1);
+      Src1 = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, Size, Op->Flags);
       Src3 = LoadGPRRegister(X86State::REG_RAX);
     }
 
@@ -4650,7 +4652,7 @@ void OpDispatchBuilder::CMPXCHGOp(OpcodeArgs) {
       Src3Lower = Src3;
     }
     // If this is a memory location then we want the pointer to it
-    OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
 
     Src1 = AppendSegmentOffset(Src1, Op->Flags);
 
@@ -4690,7 +4692,7 @@ void OpDispatchBuilder::CMPXCHGPairOp(OpcodeArgs) {
 
   HandledLock = (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_LOCK) != 0;
   // If this is a memory location then we want the pointer to it
-  OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+  OrderedNode *Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
 
   Src1 = AppendSegmentOffset(Src1, Op->Flags);
 
@@ -4991,7 +4993,8 @@ void OpDispatchBuilder::UpdatePrefixFromSegment(OrderedNode *Segment, uint32_t S
   }
 }
 
-OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp const& Op, FEXCore::X86Tables::DecodedOperand const& Operand, uint8_t OpSize, uint32_t Flags, int8_t Align, bool LoadData, bool ForceLoad, MemoryAccessType AccessType, bool AllowUpperGarbage) {
+OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(RegisterClassType Class, X86Tables::DecodedOp const& Op, X86Tables::DecodedOperand const& Operand,
+                                                      uint8_t OpSize, uint32_t Flags, const LoadSourceOptions& Options) {
   LOGMAN_THROW_A_FMT(Operand.IsGPR() ||
                      Operand.IsLiteral() ||
                      Operand.IsGPRDirect() ||
@@ -4999,6 +5002,8 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(FEXCore::IR::RegisterClass
                      Operand.IsRIPRelative() ||
                      Operand.IsSIB(),
                      "Unsupported Src type");
+
+  auto [Align, LoadData, ForceLoad, AccessType, AllowUpperGarbage] = Options;
 
   OrderedNode *Src {nullptr};
   bool LoadableType = false;
@@ -5212,9 +5217,10 @@ void OpDispatchBuilder::StoreXMMRegister(uint32_t XMM, OrderedNode *const Src) {
   _StoreRegister(Src, false, VectorOffset, FPRClass, FPRFixedClass, VectorSize);
 }
 
-OrderedNode *OpDispatchBuilder::LoadSource(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp const& Op, FEXCore::X86Tables::DecodedOperand const& Operand, uint32_t Flags, int8_t Align, bool LoadData, bool ForceLoad, MemoryAccessType AccessType, bool AllowUpperGarbage) {
+OrderedNode *OpDispatchBuilder::LoadSource(RegisterClassType Class, X86Tables::DecodedOp const& Op, X86Tables::DecodedOperand const& Operand,
+                                           uint32_t Flags, const LoadSourceOptions& Options) {
   const uint8_t OpSize = GetSrcSize(Op);
-  return LoadSource_WithOpSize(Class, Op, Operand, OpSize, Flags, Align, LoadData, ForceLoad, AccessType, AllowUpperGarbage);
+  return LoadSource_WithOpSize(Class, Op, Operand, OpSize, Flags, Options);
 }
 
 void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, uint8_t OpSize, int8_t Align, MemoryAccessType AccessType) {
@@ -5422,12 +5428,12 @@ void OpDispatchBuilder::UnhandledOp(OpcodeArgs) {
 
 template<uint32_t SrcIndex>
 void OpDispatchBuilder::MOVGPROp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, 1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[SrcIndex], Op->Flags, {.Align = 1});
   StoreResult(GPRClass, Op, Src, 1);
 }
 
 void OpDispatchBuilder::MOVGPRNTOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, 1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.Align = 1});
   StoreResult(GPRClass, Op, Src, 1, MemoryAccessType::ACCESS_STREAM);
 }
 
@@ -5441,14 +5447,15 @@ void OpDispatchBuilder::ALUOpImpl(OpcodeArgs, FEXCore::IR::IROps ALUIROp, FEXCor
                            ALUIROp == FEXCore::IR::IROps::OP_OR;
 
   // X86 basic ALU ops just do the operation between the destination and a single source
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, true, false, MemoryAccessType::ACCESS_DEFAULT, AllowUpperGarbage);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags,
+                                {.AllowUpperGarbage = AllowUpperGarbage});
 
   OrderedNode *Result{};
   OrderedNode *Dest{};
 
   if (DestIsLockedMem(Op)) {
     HandledLock = true;
-    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     DestMem = AppendSegmentOffset(DestMem, Op->Flags);
 
     auto FetchOp = _AtomicFetchAdd(IR::SizeToOpSize(Size), Src, DestMem);
@@ -5463,7 +5470,8 @@ void OpDispatchBuilder::ALUOpImpl(OpcodeArgs, FEXCore::IR::IROps ALUIROp, FEXCor
     Result = ALUOp;
   }
   else {
-    Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, true, false, MemoryAccessType::ACCESS_DEFAULT, AllowUpperGarbage);
+    Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags,
+                      {.AllowUpperGarbage = AllowUpperGarbage});
 
     /* On x86, the canonical way to zero a register is XOR with itself...
      * because modern x86 detects this pattern in hardware. arm64 does not
@@ -5618,7 +5626,7 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::TZCNT(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
 
   Src = _FindTrailingZeroes(OpSizeFromSrc(Op), Src);
   StoreResult(GPRClass, Op, Src, -1);
@@ -5627,7 +5635,7 @@ void OpDispatchBuilder::TZCNT(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::LZCNT(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
 
   auto Res = _CountLeadingZeroes(OpSizeFromSrc(Op), Src);
   StoreResult(GPRClass, Op, Res, -1);
@@ -5638,14 +5646,14 @@ void OpDispatchBuilder::MOVBEOp(OpcodeArgs) {
   const uint8_t GPRSize = CTX->GetGPRSize();
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, 1);
+  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.Align = 1});
   Src = _Rev(IR::SizeToOpSize(std::max<uint8_t>(4u, SrcSize)), Src);
 
   if (SrcSize == 2) {
     // 16-bit does an insert.
     // Rev of 16-bit value as 32-bit replaces the result in the upper 16-bits of the result.
     // bfxil the 16-bit result in to the GPR.
-    OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, GPRSize, Op->Flags, -1);
+    OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, GPRSize, Op->Flags);
     auto Result = _Bfxil(IR::SizeToOpSize(GPRSize), 16, 16, Dest, Src);
     StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Result, GPRSize, -1);
   }
@@ -5656,13 +5664,13 @@ void OpDispatchBuilder::MOVBEOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::CLWB(OpcodeArgs) {
-  OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+  OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
   DestMem = AppendSegmentOffset(DestMem, Op->Flags);
   _CacheLineClean(DestMem);
 }
 
 void OpDispatchBuilder::CLFLUSHOPT(OpcodeArgs) {
-  OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+  OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
   DestMem = AppendSegmentOffset(DestMem, Op->Flags);
   _CacheLineClear(DestMem, false);
 }
@@ -5694,14 +5702,14 @@ void OpDispatchBuilder::StoreFenceOrCLFlush(OpcodeArgs) {
   }
   else {
     // This is a CLFlush
-    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     DestMem = AppendSegmentOffset(DestMem, Op->Flags);
     _CacheLineClear(DestMem, true);
   }
 }
 
 void OpDispatchBuilder::CLZeroOp(OpcodeArgs) {
-  OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
+  OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.LoadData = false});
   _CacheLineZero(DestMem);
 }
 
@@ -5729,15 +5737,15 @@ void OpDispatchBuilder::CRC32(OpcodeArgs) {
 
   // Destination GPR size is always 4 or 8 bytes depending on widening
   uint8_t DstSize = Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REX_WIDENING ? 8 : 4;
-  OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, GPRSize, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, GPRSize, Op->Flags);
 
   // Incoming memory is 8, 16, 32, or 64
   OrderedNode *Src{};
   if (Op->Src[0].IsGPR()) {
-    Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], GPRSize, Op->Flags, -1);
+    Src = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], GPRSize, Op->Flags);
   }
   else {
-    Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, 1);
+    Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.Align = 1});
   }
   auto Result = _CRC32(Dest, Src, GetSrcSize(Op));
   StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Result, DstSize, -1);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -29,13 +29,13 @@ class PassManager;
 
 enum class MemoryAccessType {
   // Choose TSO or Non-TSO depending on access type
-  ACCESS_DEFAULT,
+  DEFAULT,
   // TSO access behaviour
-  ACCESS_TSO,
+  TSO,
   // Non-TSO access behaviour
-  ACCESS_NONTSO,
+  NONTSO,
   // Non-temporal streaming
-  ACCESS_STREAM,
+  STREAM,
 };
 
 struct LoadSourceOptions {
@@ -55,7 +55,7 @@ struct LoadSourceOptions {
   bool ForceLoad = false;
 
   // Specifies the access type of the load.
-  MemoryAccessType AccessType = MemoryAccessType::ACCESS_DEFAULT;
+  MemoryAccessType AccessType = MemoryAccessType::DEFAULT;
 
   // Whether or not a zero extend should clear the upper bits
   // in the register (e.g. an 8-bit load would clear the upper 24 bits
@@ -1160,9 +1160,9 @@ private:
 
   OrderedNode *LoadSource(RegisterClassType Class, X86Tables::DecodedOp const& Op, X86Tables::DecodedOperand const& Operand, uint32_t Flags, const LoadSourceOptions& Options = {});
   OrderedNode *LoadSource_WithOpSize(RegisterClassType Class, X86Tables::DecodedOp const& Op, X86Tables::DecodedOperand const& Operand, uint8_t OpSize, uint32_t Flags, const LoadSourceOptions& Options = {});
-  void StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, uint8_t OpSize, int8_t Align, MemoryAccessType AccessType = MemoryAccessType::ACCESS_DEFAULT);
-  void StoreResult(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, int8_t Align, MemoryAccessType AccessType = MemoryAccessType::ACCESS_DEFAULT);
-  void StoreResult(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, OrderedNode *const Src, int8_t Align, MemoryAccessType AccessType = MemoryAccessType::ACCESS_DEFAULT);
+  void StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, uint8_t OpSize, int8_t Align, MemoryAccessType AccessType = MemoryAccessType::DEFAULT);
+  void StoreResult(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, FEXCore::X86Tables::DecodedOperand const& Operand, OrderedNode *const Src, int8_t Align, MemoryAccessType AccessType = MemoryAccessType::DEFAULT);
+  void StoreResult(FEXCore::IR::RegisterClassType Class, FEXCore::X86Tables::DecodedOp Op, OrderedNode *const Src, int8_t Align, MemoryAccessType AccessType = MemoryAccessType::DEFAULT);
 
   constexpr OpSize GetGuestVectorLength() const {
     return CTX->HostFeatures.SupportsAVX ? OpSize::i256Bit : OpSize::i128Bit;

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
@@ -23,8 +23,8 @@ class OrderedNode;
 #define OpcodeArgs [[maybe_unused]] FEXCore::X86Tables::DecodedOp Op
 
 void OpDispatchBuilder::SHA1NEXTEOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   auto Tmp = _Ror(OpSize::i32Bit, _VExtractToGPR(16, 4, Dest, 3), _Constant(32, 2));
   auto Top = _Add(OpSize::i32Bit, _VExtractToGPR(16, 4, Src, 3), Tmp);
@@ -34,8 +34,8 @@ void OpDispatchBuilder::SHA1NEXTEOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::SHA1MSG1Op(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   OrderedNode *NewVec = _VExtr(16, 8, Dest, Src, 1);
 
@@ -46,8 +46,8 @@ void OpDispatchBuilder::SHA1MSG1Op(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::SHA1MSG2Op(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   // ROR by 31 is equivalent to a ROL by 1
   auto ThirtyOne = _Constant(32, 31);
@@ -102,8 +102,8 @@ void OpDispatchBuilder::SHA1RNDS4Op(OpcodeArgs) {
   const FnType Fn = fn_array[Imm8];
   auto K = _Constant(32, k_array[Imm8]);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   auto W0E = _VExtractToGPR(16, 4, Src, 3);
   auto W1  = _VExtractToGPR(16, 4, Src, 2);
@@ -155,8 +155,8 @@ void OpDispatchBuilder::SHA256MSG1Op(OpcodeArgs) {
     return _Xor(OpSize::i32Bit, _Xor(OpSize::i32Bit, _Ror(OpSize::i32Bit, W, _Constant(32, 7)), _Ror(OpSize::i32Bit, W, _Constant(32, 18))), _Lshr(OpSize::i32Bit, W, _Constant(32, 3)));
   };
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   auto W4 = _VExtractToGPR(16, 4, Src, 0);
   auto W3 = _VExtractToGPR(16, 4, Dest, 3);
@@ -182,8 +182,8 @@ void OpDispatchBuilder::SHA256MSG2Op(OpcodeArgs) {
     return _Xor(OpSize::i32Bit, _Xor(OpSize::i32Bit, _Ror(OpSize::i32Bit, W, _Constant(32, 17)), _Ror(OpSize::i32Bit, W, _Constant(32, 19))), _Lshr(OpSize::i32Bit, W, _Constant(32, 10)));
   };
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   auto W14 = _VExtractToGPR(16, 4, Src, 2);
   auto W15 = _VExtractToGPR(16, 4, Src, 3);
@@ -214,8 +214,8 @@ void OpDispatchBuilder::SHA256RNDS2Op(OpcodeArgs) {
     return _Xor(OpSize::i32Bit, _Xor(OpSize::i32Bit, _Ror(OpSize::i32Bit, E, _Constant(32, 6)), _Ror(OpSize::i32Bit, E, _Constant(32, 11))), _Ror(OpSize::i32Bit, E, _Constant(32, 25)));
   };
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   // Hardcoded to XMM0
   auto XMM0 = LoadXMMRegister(0);
 
@@ -260,14 +260,14 @@ void OpDispatchBuilder::SHA256RNDS2Op(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::AESImcOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = _VAESImc(Src);
   StoreResult(FPRClass, Op, Result, -1);
 }
 
 void OpDispatchBuilder::AESEncOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   const auto ZeroRegister = LoadAndCacheNamedVectorConstant(16, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
   OrderedNode *Result = _VAESEnc(16, Dest, Src, ZeroRegister);
   StoreResult(FPRClass, Op, Result, -1);
@@ -280,8 +280,8 @@ void OpDispatchBuilder::VAESEncOp(OpcodeArgs) {
   // TODO: Handle 256-bit VAESENC.
   LOGMAN_THROW_A_FMT(Is128Bit, "256-bit VAESENC unimplemented");
 
-  OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   const auto ZeroRegister = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
   OrderedNode *Result = _VAESEnc(DstSize, State, Key, ZeroRegister);
 
@@ -289,8 +289,8 @@ void OpDispatchBuilder::VAESEncOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::AESEncLastOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   const auto ZeroRegister = LoadAndCacheNamedVectorConstant(16, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
   OrderedNode *Result = _VAESEncLast(16, Dest, Src, ZeroRegister);
   StoreResult(FPRClass, Op, Result, -1);
@@ -303,8 +303,8 @@ void OpDispatchBuilder::VAESEncLastOp(OpcodeArgs) {
   // TODO: Handle 256-bit VAESENCLAST.
   LOGMAN_THROW_A_FMT(Is128Bit, "256-bit VAESENCLAST unimplemented");
 
-  OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   const auto ZeroRegister = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
   OrderedNode *Result = _VAESEncLast(DstSize, State, Key, ZeroRegister);
 
@@ -312,8 +312,8 @@ void OpDispatchBuilder::VAESEncLastOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::AESDecOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   const auto ZeroRegister = LoadAndCacheNamedVectorConstant(16, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
   OrderedNode *Result = _VAESDec(16, Dest, Src, ZeroRegister);
   StoreResult(FPRClass, Op, Result, -1);
@@ -326,8 +326,8 @@ void OpDispatchBuilder::VAESDecOp(OpcodeArgs) {
   // TODO: Handle 256-bit VAESDEC.
   LOGMAN_THROW_A_FMT(Is128Bit, "256-bit VAESDEC unimplemented");
 
-  OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   const auto ZeroRegister = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
   OrderedNode *Result = _VAESDec(DstSize, State, Key, ZeroRegister);
 
@@ -335,8 +335,8 @@ void OpDispatchBuilder::VAESDecOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::AESDecLastOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   const auto ZeroRegister = LoadAndCacheNamedVectorConstant(16, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
   OrderedNode *Result = _VAESDecLast(16, Dest, Src, ZeroRegister);
   StoreResult(FPRClass, Op, Result, -1);
@@ -349,8 +349,8 @@ void OpDispatchBuilder::VAESDecLastOp(OpcodeArgs) {
   // TODO: Handle 256-bit VAESDECLAST.
   LOGMAN_THROW_A_FMT(Is128Bit, "256-bit VAESDECLAST unimplemented");
 
-  OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *State = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Key = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   const auto ZeroRegister = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
   OrderedNode *Result = _VAESDecLast(DstSize, State, Key, ZeroRegister);
 
@@ -358,7 +358,7 @@ void OpDispatchBuilder::VAESDecLastOp(OpcodeArgs) {
 }
 
 OrderedNode* OpDispatchBuilder::AESKeyGenAssistImpl(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   const uint64_t RCON = Op->Src[1].Data.Literal.Value;
 
@@ -375,8 +375,8 @@ void OpDispatchBuilder::AESKeyGenAssist(OpcodeArgs) {
 void OpDispatchBuilder::PCLMULQDQOp(OpcodeArgs) {
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Selector needs to be literal here");
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   const auto Selector = static_cast<uint8_t>(Op->Src[1].Data.Literal.Value);
 
   auto Res = _PCLMUL(16, Dest, Src, Selector);
@@ -388,8 +388,8 @@ void OpDispatchBuilder::VPCLMULQDQOp(OpcodeArgs) {
 
   const auto DstSize = GetDstSize(Op);
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   const auto Selector = static_cast<uint8_t>(Op->Src[2].Data.Literal.Value);
 
   OrderedNode *Res = _PCLMUL(DstSize, Src1, Src2, Selector);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -36,8 +36,8 @@ void OpDispatchBuilder::MOVVectorOp(OpcodeArgs) {
 
 void OpDispatchBuilder::MOVVectorNTOp(OpcodeArgs) {
   OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags,
-                                {.Align = 1, .AccessType = MemoryAccessType::ACCESS_STREAM});
-  StoreResult(FPRClass, Op, Src, 1, MemoryAccessType::ACCESS_STREAM);
+                                {.Align = 1, .AccessType = MemoryAccessType::STREAM});
+  StoreResult(FPRClass, Op, Src, 1, MemoryAccessType::STREAM);
 }
 
 void OpDispatchBuilder::MOVAPS_MOVAPDOp(OpcodeArgs) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -30,22 +30,23 @@ void OpDispatchBuilder::MOVVectorOp(OpcodeArgs) {
     // Nop
     return;
   }
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, {.Align = 1});
   StoreResult(FPRClass, Op, Src, 1);
 }
 
 void OpDispatchBuilder::MOVVectorNTOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 1, true, false, MemoryAccessType::ACCESS_STREAM);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags,
+                                {.Align = 1, .AccessType = MemoryAccessType::ACCESS_STREAM});
   StoreResult(FPRClass, Op, Src, 1, MemoryAccessType::ACCESS_STREAM);
 }
 
 void OpDispatchBuilder::MOVAPS_MOVAPDOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   StoreResult(FPRClass, Op, Src, -1);
 }
 
 void OpDispatchBuilder::MOVUPS_MOVUPDOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, {.Align = 1});
   StoreResult(FPRClass, Op, Src, 1);
 }
 
@@ -53,16 +54,16 @@ void OpDispatchBuilder::MOVHPDOp(OpcodeArgs) {
   if (Op->Dest.IsGPR()) {
     if (Op->Src[0].IsGPR()) {
       // MOVLHPS between two vector registers.
-      OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
-      OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, 16, Op->Flags, -1);
+      OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+      OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, 16, Op->Flags);
       auto Result = _VInsElement(16, 8, 1, 0, Dest, Src);
       StoreResult(FPRClass, Op, Result, -1);
     }
     else {
       // If the destination is a GPR then the source is memory
       // xmm1[127:64] = src
-      OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
-      OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, 16, Op->Flags, -1);
+      OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.LoadData = false});
+      OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, 16, Op->Flags);
       auto Result = _VLoadVectorElement(16, 8, Dest, 1, Src);
       StoreResult(FPRClass, Op, Result, -1);
     }
@@ -70,21 +71,21 @@ void OpDispatchBuilder::MOVHPDOp(OpcodeArgs) {
   else {
     // In this case memory is the destination and the high bits of the XMM are source
     // Mem64 = xmm1[127:64]
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-    OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, 8, Op->Flags, -1, false);
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+    OrderedNode *Dest = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, 8, Op->Flags, {.LoadData = false});
     _VStoreVectorElement(16, 8, Src, 1, Dest);
   }
 }
 
 void OpDispatchBuilder::VMOVHPOp(OpcodeArgs) {
   if (Op->Dest.IsGPR()) {
-    OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 16);
-    OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, 8);
+    OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, {.Align = 16});
+    OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, {.Align = 8});
     OrderedNode *Result = _VInsElement(16, 8, 1, 0, Src1, Src2);
 
     StoreResult(FPRClass, Op, Result, -1);
   } else {
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 16);
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, {.Align = 16});
     OrderedNode *Result = _VInsElement(16, 8, 0, 1, Src, Src);
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Result, 8, 8);
   }
@@ -94,48 +95,48 @@ void OpDispatchBuilder::MOVLPOp(OpcodeArgs) {
   if (Op->Dest.IsGPR()) {
     // xmm, xmm is movhlps special case
     if (Op->Src[0].IsGPR()) {
-      OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 8);
-      OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, 8, 16);
+      OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, {.Align = 16});
+      OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, {.Align = 16});
       auto Result = _VInsElement(16, 8, 0, 1, Dest, Src);
       StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Result, 16, 16);
     }
     else {
       auto DstSize = GetDstSize(Op);
-      OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, 8, false);
-      OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, DstSize, Op->Flags, -1);
+      OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.Align = 8, .LoadData = false});
+      OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, DstSize, Op->Flags);
       auto Result = _VLoadVectorElement(16, 8, Dest, 0, Src);
       StoreResult(FPRClass, Op, Result, -1);
     }
   }
   else {
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 8);
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, {.Align = 8});
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Src, 8, 8);
   }
 }
 
 void OpDispatchBuilder::VMOVLPOp(OpcodeArgs) {
   if (Op->Dest.IsGPR()) {
-    OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 16);
-    OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, 8);
+    OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, {.Align = 16});
+    OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, {.Align = 8});
     OrderedNode *Result = _VInsElement(16, 8, 0, 0, Src1, Src2);
 
     StoreResult(FPRClass, Op, Result, -1);
   } else {
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, 8);
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, {.Align = 8});
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Src, 8, 8);
   }
 }
 
 void OpDispatchBuilder::VMOVSHDUPOp(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = _VTrn2(SrcSize, 4, Src, Src);
   StoreResult(FPRClass, Op, Result, -1);
 }
 
 void OpDispatchBuilder::VMOVSLDUPOp(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = _VTrn(SrcSize, 4, Src, Src);
   StoreResult(FPRClass, Op, Result, -1);
 }
@@ -143,20 +144,20 @@ void OpDispatchBuilder::VMOVSLDUPOp(OpcodeArgs) {
 void OpDispatchBuilder::MOVScalarOpImpl(OpcodeArgs, size_t ElementSize) {
   if (Op->Dest.IsGPR() && Op->Src[0].IsGPR()) {
     // MOVSS/SD xmm1, xmm2
-    OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+    OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     auto Result = _VInsElement(16, ElementSize, 0, 0, Dest, Src);
     StoreResult(FPRClass, Op, Result, -1);
   }
   else if (Op->Dest.IsGPR()) {
     // MOVSS/SD xmm1, mem32/mem64
     // xmm1[127:0] <- zext(mem32/mem64)
-    OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], ElementSize, Op->Flags, -1);
+    OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], ElementSize, Op->Flags);
     StoreResult(FPRClass, Op, Src, -1);
   }
   else {
     // MOVSS/SD mem32/mem64, xmm1
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Src, ElementSize, -1);
   }
 }
@@ -172,17 +173,17 @@ void OpDispatchBuilder::MOVSDOp(OpcodeArgs) {
 void OpDispatchBuilder::VMOVScalarOpImpl(OpcodeArgs, size_t ElementSize) {
   if (Op->Dest.IsGPR() && Op->Src[0].IsGPR() && Op->Src[1].IsGPR()) {
     // VMOVSS/SD xmm1, xmm2, xmm3
-    OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-    OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+    OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+    OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
     OrderedNode *Result = _VInsElement(16, ElementSize, 0, 0, Src1, Src2);
     StoreResult(FPRClass, Op, Result, -1);
   } else if (Op->Dest.IsGPR()) {
     // VMOVSS/SD xmm1, mem32/mem64
-    OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], ElementSize, Op->Flags, -1);
+    OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], ElementSize, Op->Flags);
     StoreResult(FPRClass, Op, Src, -1);
   } else {
     // VMOVSS/SD mem32/mem64, xmm1
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, Src, ElementSize, -1);
   }
 }
@@ -197,8 +198,8 @@ void OpDispatchBuilder::VMOVSSOp(OpcodeArgs) {
 
 void OpDispatchBuilder::VectorALUOpImpl(OpcodeArgs, IROps IROp, size_t ElementSize) {
   const auto Size = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
 
   auto ALUOp = _VAdd(Size, ElementSize, Dest, Src);
   // Overwrite our IR's op type
@@ -343,8 +344,8 @@ void OpDispatchBuilder::VectorALUOp<IR::OP_VUQSUB, 2>(OpcodeArgs);
 void OpDispatchBuilder::AVXVectorALUOpImpl(OpcodeArgs, IROps IROp, size_t ElementSize) {
   const auto Size = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
 
   auto ALUOp = _VAdd(Size, ElementSize, Src1, Src2);
   // Overwrite our IR's op type
@@ -478,8 +479,8 @@ void OpDispatchBuilder::AVXVectorALUOp<IR::OP_VMUL, 4>(OpcodeArgs);
 
 void OpDispatchBuilder::VectorALUROpImpl(OpcodeArgs, IROps IROp, size_t ElementSize) {
   const auto Size = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
 
   auto ALUOp = _VAdd(Size, ElementSize, Src, Dest);
   // Overwrite our IR's op type
@@ -510,8 +511,9 @@ OrderedNode* OpDispatchBuilder::VectorScalarInsertALUOpImpl(OpcodeArgs, IROps IR
   // element that we're going to operate on.
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags, -1, true, false, MemoryAccessType::ACCESS_DEFAULT, true);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags,
+                                            {.AllowUpperGarbage = true});
 
   // If OpSize == ElementSize then it only does the lower scalar op
   auto ALUOp = _VFAddScalarInsert(IR::SizeToOpSize(DstSize), ElementSize, Src1, Src2, ZeroUpperBits);
@@ -595,8 +597,9 @@ OrderedNode* OpDispatchBuilder::VectorScalarUnaryInsertALUOpImpl(OpcodeArgs, IRO
   // element that we're going to operate on.
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags, -1, true, false, MemoryAccessType::ACCESS_DEFAULT, true);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags,
+                                            {.AllowUpperGarbage = true});
 
   // If OpSize == ElementSize then it only does the lower scalar op
   auto ALUOp = _VFSqrtScalarInsert(IR::SizeToOpSize(DstSize), ElementSize, Src1, Src2, ZeroUpperBits);
@@ -657,8 +660,8 @@ void OpDispatchBuilder::InsertMMX_To_XMM_Vector_CVT_Int_To_Float(OpcodeArgs) {
   const auto DstSize = GetGuestVectorLength();
   const auto SrcSize = Op->Src[0].IsGPR() ? 8 : GetSrcSize(Op);
 
-  OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, DstSize, Op->Flags, -1);
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, DstSize, Op->Flags);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
 
   // Always 32-bit.
   const size_t ElementSize = 4;
@@ -678,24 +681,24 @@ OrderedNode* OpDispatchBuilder::InsertCVTGPR_To_FPRImpl(OpcodeArgs,
   // element that we're going to operate on.
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags);
 
   if (Src2Op.IsGPR()) {
     // If the source is a GPR then convert directly from the GPR.
-    auto Src2 = LoadSource_WithOpSize(GPRClass, Op, Src2Op, CTX->GetGPRSize(), Op->Flags, -1);
+    auto Src2 = LoadSource_WithOpSize(GPRClass, Op, Src2Op, CTX->GetGPRSize(), Op->Flags);
     return _VSToFGPRInsert(IR::SizeToOpSize(DstSize), DstElementSize, SrcSize, Src1, Src2, ZeroUpperBits);
   }
   else if (SrcSize != DstElementSize) {
     // If the source is from memory but the Source size and destination size aren't the same,
     // then it is more optimal to load in to a GPR and convert between GPR->FPR.
     // ARM GPR->FPR conversion supports different size source and destinations while FPR->FPR doesn't.
-    auto Src2 = LoadSource(GPRClass, Op, Src2Op, Op->Flags, -1);
+    auto Src2 = LoadSource(GPRClass, Op, Src2Op, Op->Flags);
     return _VSToFGPRInsert(IR::SizeToOpSize(DstSize), DstElementSize, SrcSize, Src1, Src2, ZeroUpperBits);
   }
 
   // In the case of cvtsi2s{s,d} where the source and destination are the same size,
   // then it is more optimal to load in to the FPR register directly and convert there.
-  auto Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags, -1);
+  auto Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags);
   // Always signed
   return _VSToFVectorInsert(IR::SizeToOpSize(DstSize), DstElementSize, DstElementSize, Src1, Src2, false, ZeroUpperBits);
 }
@@ -734,8 +737,9 @@ OrderedNode* OpDispatchBuilder::InsertScalar_CVT_Float_To_FloatImpl(OpcodeArgs,
   // element that we're going to operate on.
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags, -1, true, false, MemoryAccessType::ACCESS_DEFAULT, true);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags,
+                                            {.AllowUpperGarbage = true});
 
   return _VFToFScalarInsert(IR::SizeToOpSize(DstSize), DstElementSize, SrcElementSize, Src1, Src2, ZeroUpperBits);
 }
@@ -774,8 +778,9 @@ OrderedNode* OpDispatchBuilder::InsertScalarRoundImpl(OpcodeArgs,
   // element that we're going to operate on.
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags, -1, true, false, MemoryAccessType::ACCESS_DEFAULT, true);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags,
+                                            {.AllowUpperGarbage = true});
 
   const uint64_t RoundControlSource = (Mode >> 2) & 1;
   uint64_t RoundControl = Mode & 0b11;
@@ -835,8 +840,9 @@ OrderedNode* OpDispatchBuilder::InsertScalarFCMPOpImpl(OpcodeArgs,
   // element that we're going to operate on.
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags, -1, true, false, MemoryAccessType::ACCESS_DEFAULT, true);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags,
+                                            {.AllowUpperGarbage = true});
 
   switch (CompType) {
     case 0x00: case 0x08: case 0x10: case 0x18: // EQ
@@ -908,7 +914,7 @@ void OpDispatchBuilder::VectorUnaryOpImpl(OpcodeArgs, IROps IROp, size_t Element
   const auto SrcSize = GetSrcSize(Op);
   const auto OpSize = GetSrcSize(Op);
 
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
 
   auto ALUOp = _VFSqrt(OpSize, ElementSize, Src);
   // Overwrite our IR's op type
@@ -947,7 +953,7 @@ void OpDispatchBuilder::AVXVectorUnaryOpImpl(OpcodeArgs, IROps IROp, size_t Elem
   const auto SrcSize = GetSrcSize(Op);
   const auto OpSize = GetSrcSize(Op);
 
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
 
   auto ALUOp = _VFSqrt(OpSize, ElementSize, Src);
   // Overwrite our IR's op type
@@ -985,7 +991,7 @@ void OpDispatchBuilder::AVXVectorUnaryOp<IR::OP_VFRSQRT, 4>(OpcodeArgs);
 void OpDispatchBuilder::VectorUnaryDuplicateOpImpl(OpcodeArgs, IROps IROp, size_t ElementSize) {
   const auto Size = GetSrcSize(Op);
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   auto ALUOp = _VFSqrt(ElementSize, ElementSize, Src);
   // Overwrite our IR's op type
@@ -1008,7 +1014,7 @@ void OpDispatchBuilder::VectorUnaryDuplicateOp<IR::OP_VFRECP, 4>(OpcodeArgs);
 
 void OpDispatchBuilder::MOVQOp(OpcodeArgs) {
   const auto SrcSize = Op->Src[0].IsGPR() ? 16U : GetSrcSize(Op);
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
   // This instruction is a bit special that if the destination is a register then it'll ZEXT the 64bit source to 128bit
   if (Op->Dest.IsGPR()) {
     const auto gpr = Op->Dest.Data.GPR.GPR;
@@ -1028,7 +1034,7 @@ void OpDispatchBuilder::MOVMSKOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
   uint8_t NumElements = Size / ElementSize;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   if (Size == 16 && ElementSize == 8) {
     // UnZip2 the 64-bit elements as 32-bit to get the sign bits closer.
@@ -1085,7 +1091,7 @@ void OpDispatchBuilder::MOVMSKOpOne(OpcodeArgs) {
   const auto Is256Bit = SrcSize == Core::CPUState::XMM_AVX_REG_SIZE;
   const auto ExtractSize = Is256Bit ? 4 : 2;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *VMask = _VDupFromGPR(SrcSize, 8, _Constant(0x80'40'20'10'08'04'02'01ULL));
 
   auto VCMP = _VCMPLTZ(SrcSize, 1, Src);
@@ -1109,8 +1115,8 @@ template<size_t ElementSize>
 void OpDispatchBuilder::PUNPCKLOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   auto ALUOp = _VZip(Size, ElementSize, Dest, Src);
   StoreResult(FPRClass, Op, ALUOp, -1);
@@ -1130,8 +1136,8 @@ void OpDispatchBuilder::VPUNPCKLOp(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
   const auto Is128Bit = SrcSize == Core::CPUState::XMM_SSE_REG_SIZE;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
 
   OrderedNode *Result{};
   if (Is128Bit) {
@@ -1158,8 +1164,8 @@ void OpDispatchBuilder::VPUNPCKLOp<8>(OpcodeArgs);
 template<size_t ElementSize>
 void OpDispatchBuilder::PUNPCKHOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   auto ALUOp = _VZip2(Size, ElementSize, Dest, Src);
   StoreResult(FPRClass, Op, ALUOp, -1);
@@ -1179,8 +1185,8 @@ void OpDispatchBuilder::VPUNPCKHOp(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
   const auto Is128Bit = SrcSize == Core::CPUState::XMM_SSE_REG_SIZE;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
 
   OrderedNode *Result{};
   if (Is128Bit) {
@@ -1206,8 +1212,8 @@ void OpDispatchBuilder::VPUNPCKHOp<8>(OpcodeArgs);
 
 OrderedNode* OpDispatchBuilder::PSHUFBOpImpl(OpcodeArgs, const X86Tables::DecodedOperand& Src1,
                                              const X86Tables::DecodedOperand& Src2) {
-  OrderedNode *Src1Node = LoadSource(FPRClass, Op, Src1, Op->Flags, -1);
-  OrderedNode *Src2Node = LoadSource(FPRClass, Op, Src2, Op->Flags, -1);
+  OrderedNode *Src1Node = LoadSource(FPRClass, Op, Src1, Op->Flags);
+  OrderedNode *Src2Node = LoadSource(FPRClass, Op, Src2, Op->Flags);
 
   const auto SrcSize = GetSrcSize(Op);
   const auto Is256Bit = SrcSize == Core::CPUState::XMM_AVX_REG_SIZE;
@@ -1255,7 +1261,7 @@ void OpDispatchBuilder::PSHUFW8ByteOp(OpcodeArgs) {
 
   uint16_t Shuffle = Op->Src[1].Data.Literal.Value;
   const auto Size = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Dest{};
 
   // TODO: There can be more optimized copies here.
@@ -1299,7 +1305,7 @@ void OpDispatchBuilder::PSHUFWOp(OpcodeArgs) {
 
   uint16_t Shuffle = Op->Src[1].Data.Literal.Value;
   const auto Size = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Dest{};
 
   const uint8_t NumElements = Size / 2;
@@ -1371,7 +1377,7 @@ void OpDispatchBuilder::PSHUFDOp(OpcodeArgs) {
 
   uint16_t Shuffle = Op->Src[1].Data.Literal.Value;
   const auto Size = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Dest{};
 
   // TODO: There can be more optimized copies here.
@@ -1417,7 +1423,7 @@ void OpDispatchBuilder::VPSHUFWOp(OpcodeArgs) {
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src[1] needs to be a literal");
   auto Shuffle = Op->Src[1].Data.Literal.Value;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   // Note/TODO: With better immediate facilities or vector loading in our IR
   //            much of this can be reduced to setting up a table index register
@@ -1471,8 +1477,8 @@ OrderedNode* OpDispatchBuilder::SHUFOpImpl(OpcodeArgs, size_t ElementSize,
                                            const X86Tables::DecodedOperand& Src1,
                                            const X86Tables::DecodedOperand& Src2,
                                            const X86Tables::DecodedOperand& Imm) {
-  OrderedNode *Src1Node = LoadSource(FPRClass, Op, Src1, Op->Flags, -1);
-  OrderedNode *Src2Node = LoadSource(FPRClass, Op, Src2, Op->Flags, -1);
+  OrderedNode *Src1Node = LoadSource(FPRClass, Op, Src1, Op->Flags);
+  OrderedNode *Src2Node = LoadSource(FPRClass, Op, Src2, Op->Flags);
 
   LOGMAN_THROW_A_FMT(Imm.IsLiteral(), "Imm needs to be a literal");
   uint8_t Shuffle = Imm.Data.Literal.Value;
@@ -1696,8 +1702,8 @@ void OpDispatchBuilder::VSHUFOp<8>(OpcodeArgs);
 void OpDispatchBuilder::VANDNOp(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   OrderedNode *Dest = _VBic(SrcSize, SrcSize, Src2, Src1);
 
   StoreResult(FPRClass, Op, Dest, -1);
@@ -1708,8 +1714,8 @@ void OpDispatchBuilder::VHADDPOp(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
   const auto Is256Bit = SrcSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
 
   auto Res = _VFAddP(SrcSize, ElementSize, Src1, Src2);
   Res.first->Header.Op = IROp;
@@ -1738,11 +1744,12 @@ void OpDispatchBuilder::VBROADCASTOp(OpcodeArgs) {
   OrderedNode *Result{};
 
   if (Op->Src[0].IsGPR()) {
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     Result = _VDupElement(DstSize, ElementSize, Src, 0);
   } else {
     // Get the address to broadcast from into a GPR.
-    OrderedNode *Address = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], CTX->GetGPRSize(), Op->Flags, -1, false);
+    OrderedNode *Address = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], CTX->GetGPRSize(), Op->Flags,
+                                                 {.LoadData = false});
     Address = AppendSegmentOffset(Address, Op->Flags);
 
     Result = _VBroadcastFromMem(DstSize, ElementSize, Address);
@@ -1773,16 +1780,16 @@ OrderedNode* OpDispatchBuilder::PINSROpImpl(OpcodeArgs, size_t ElementSize,
   const auto NumElements = Size / ElementSize;
   LOGMAN_THROW_A_FMT(Imm.IsLiteral(), "Imm needs to be literal here");
   const uint64_t Index = Imm.Data.Literal.Value & (NumElements - 1);
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, Size, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, Size, Op->Flags);
 
   if (Src2Op.IsGPR()) {
     // If the source is a GPR then convert directly from the GPR.
-    auto Src2 = LoadSource_WithOpSize(GPRClass, Op, Src2Op, CTX->GetGPRSize(), Op->Flags, -1);
+    auto Src2 = LoadSource_WithOpSize(GPRClass, Op, Src2Op, CTX->GetGPRSize(), Op->Flags);
     return _VInsGPR(Size, ElementSize, Index, Src1, Src2);
   }
 
   // If loading from memory then we only load the element size
-  auto Src2 = LoadSource_WithOpSize(GPRClass, Op, Src2Op, ElementSize, Op->Flags, -1, false);
+  auto Src2 = LoadSource_WithOpSize(GPRClass, Op, Src2Op, ElementSize, Op->Flags, {.LoadData = false});
   return _VLoadVectorElement(Size, ElementSize, Src1, Index, Src2);
 }
 
@@ -1832,18 +1839,18 @@ OrderedNode* OpDispatchBuilder::InsertPSOpImpl(OpcodeArgs, const X86Tables::Deco
   OrderedNode *Dest{};
   if (ZMask != 0xF) {
     // Only need to load destination if it isn't a full zero
-    Dest = LoadSource_WithOpSize(FPRClass, Op, Src1, DstSize, Op->Flags, -1);
+    Dest = LoadSource_WithOpSize(FPRClass, Op, Src1, DstSize, Op->Flags);
   }
 
   if ((ZMask & (1 << CountD)) == 0) {
     // In the case that ZMask overwrites the destination element, then don't even insert
     OrderedNode *Src{};
     if (Src2.IsGPR()) {
-      Src = LoadSource(FPRClass, Op, Src2, Op->Flags, -1);
+      Src = LoadSource(FPRClass, Op, Src2, Op->Flags);
     } else {
       // If loading from memory then CountS is forced to zero
       CountS = 0;
-      Src = LoadSource_WithOpSize(FPRClass, Op, Src2, 4, Op->Flags, -1);
+      Src = LoadSource_WithOpSize(FPRClass, Op, Src2, 4, Op->Flags);
     }
 
     Dest = _VInsElement(DstSize, 4, CountD, CountS, Dest, Src);
@@ -1880,7 +1887,7 @@ template<size_t ElementSize>
 void OpDispatchBuilder::PExtrOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint64_t Index = Op->Src[1].Data.Literal.Value;
 
@@ -1906,7 +1913,7 @@ void OpDispatchBuilder::PExtrOp(OpcodeArgs) {
   }
 
   // If we are storing to memory then we store the size of the element extracted
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
   _VStoreVectorElement(16, OverridenElementSize, Src, Index, Dest);
 }
 
@@ -1923,7 +1930,7 @@ void OpDispatchBuilder::VEXTRACT128Op(OpcodeArgs) {
   const auto DstIsXMM = Op->Dest.IsGPR();
   const auto StoreSize = DstIsXMM ? 32 : 16;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src[1] needs to be literal here");
   const auto Selector = Op->Src[1].Data.Literal.Value & 0b1;
@@ -1963,8 +1970,8 @@ OrderedNode* OpDispatchBuilder::PSIGNImpl(OpcodeArgs, size_t ElementSize,
 
 template <size_t ElementSize>
 void OpDispatchBuilder::PSIGN(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
   OrderedNode* Res = PSIGNImpl(Op, ElementSize, Dest, Src);
 
   StoreResult(FPRClass, Op, Res, -1);
@@ -1979,8 +1986,8 @@ void OpDispatchBuilder::PSIGN<4>(OpcodeArgs);
 
 template <size_t ElementSize>
 void OpDispatchBuilder::VPSIGN(OpcodeArgs) {
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   OrderedNode* Res = PSIGNImpl(Op, ElementSize, Src1, Src2);
 
   StoreResult(FPRClass, Op, Res, -1);
@@ -2003,8 +2010,8 @@ OrderedNode* OpDispatchBuilder::PSRLDOpImpl(OpcodeArgs, size_t ElementSize,
 
 template<size_t ElementSize>
 void OpDispatchBuilder::PSRLDOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = PSRLDOpImpl(Op, ElementSize, Dest, Src);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -2019,8 +2026,8 @@ void OpDispatchBuilder::PSRLDOp<8>(OpcodeArgs);
 
 template <size_t ElementSize>
 void OpDispatchBuilder::VPSRLDOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Shift = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Shift = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   OrderedNode *Result = PSRLDOpImpl(Op, ElementSize, Src, Shift);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -2044,7 +2051,7 @@ void OpDispatchBuilder::PSRLI(OpcodeArgs) {
 
   const auto Size = GetSrcSize(Op);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
   OrderedNode *Shift = _VUShrI(Size, ElementSize, Dest, ShiftConstant);
   StoreResult(FPRClass, Op, Shift, -1);
 }
@@ -2063,7 +2070,7 @@ void OpDispatchBuilder::VPSRLIOp(OpcodeArgs) {
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   const uint64_t ShiftConstant = Op->Src[1].Data.Literal.Value;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = Src;
 
   if (ShiftConstant != 0) [[likely]] {
@@ -2099,7 +2106,7 @@ void OpDispatchBuilder::PSLLI(OpcodeArgs) {
     return;
   }
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
   OrderedNode *Result = PSLLIImpl(Op, ElementSize, Dest, ShiftConstant);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -2117,7 +2124,7 @@ void OpDispatchBuilder::VPSLLIOp(OpcodeArgs) {
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   const uint64_t ShiftConstant = Op->Src[1].Data.Literal.Value;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = PSLLIImpl(Op, ElementSize, Src, ShiftConstant);
   StoreResult(FPRClass, Op, Result, -1);
 }
@@ -2139,8 +2146,8 @@ OrderedNode* OpDispatchBuilder::PSLLImpl(OpcodeArgs, size_t ElementSize,
 
 template<size_t ElementSize>
 void OpDispatchBuilder::PSLL(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = PSLLImpl(Op, ElementSize, Dest, Src);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -2155,8 +2162,8 @@ void OpDispatchBuilder::PSLL<8>(OpcodeArgs);
 
 template <size_t ElementSize>
 void OpDispatchBuilder::VPSLLOp(OpcodeArgs) {
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], 16, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], 16, Op->Flags);
   OrderedNode *Result = PSLLImpl(Op, ElementSize, Src1, Src2);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -2179,8 +2186,8 @@ OrderedNode* OpDispatchBuilder::PSRAOpImpl(OpcodeArgs, size_t ElementSize,
 
 template<size_t ElementSize>
 void OpDispatchBuilder::PSRAOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = PSRAOpImpl(Op, ElementSize, Dest, Src);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -2193,8 +2200,8 @@ void OpDispatchBuilder::PSRAOp<4>(OpcodeArgs);
 
 template <size_t ElementSize>
 void OpDispatchBuilder::VPSRAOp(OpcodeArgs) {
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   OrderedNode *Result = PSRAOpImpl(Op, ElementSize, Src1, Src2);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -2215,7 +2222,7 @@ void OpDispatchBuilder::PSRLDQ(OpcodeArgs) {
 
   const auto Size = GetDstSize(Op);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
   OrderedNode *Result = LoadAndCacheNamedVectorConstant(Size, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
 
   if (Shift < Size) {
@@ -2231,7 +2238,7 @@ void OpDispatchBuilder::VPSRLDQOp(OpcodeArgs) {
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   const uint64_t Shift = Op->Src[1].Data.Literal.Value;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   OrderedNode *Result{};
   if (Shift == 0) [[unlikely]] {
@@ -2266,7 +2273,7 @@ void OpDispatchBuilder::PSLLDQ(OpcodeArgs) {
 
   const auto Size = GetDstSize(Op);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
   OrderedNode *Result = LoadAndCacheNamedVectorConstant(Size, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
   if (Shift < Size) {
     Result = _VExtr(Size, 1, Dest, Result, Size - Shift);
@@ -2282,7 +2289,7 @@ void OpDispatchBuilder::VPSLLDQOp(OpcodeArgs) {
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   const uint64_t Shift = Op->Src[1].Data.Literal.Value;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   OrderedNode *Result = Src;
   if (Shift != 0) {
@@ -2314,7 +2321,7 @@ void OpDispatchBuilder::PSRAIOp(OpcodeArgs) {
 
   const auto Size = GetDstSize(Op);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
   OrderedNode *Result = _VSShrI(Size, ElementSize, Dest, Shift);
   StoreResult(FPRClass, Op, Result, -1);
 }
@@ -2330,7 +2337,7 @@ void OpDispatchBuilder::VPSRAIOp(OpcodeArgs) {
   const uint64_t Shift = Op->Src[1].Data.Literal.Value;
   const auto Size = GetDstSize(Op);
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = Src;
 
   if (Shift != 0) [[likely]] {
@@ -2349,8 +2356,8 @@ void OpDispatchBuilder::AVXVariableShiftImpl(OpcodeArgs, IROps IROp) {
   const auto DstSize = GetDstSize(Op);
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Vector = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], DstSize, Op->Flags, -1);
-  OrderedNode *ShiftVector = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], DstSize, Op->Flags, -1);
+  OrderedNode *Vector = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], DstSize, Op->Flags);
+  OrderedNode *ShiftVector = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], DstSize, Op->Flags);
 
   auto Shift = _VUShr(DstSize, SrcSize, Vector, ShiftVector, true);
   Shift.first->Header.Op = IROp;
@@ -2375,7 +2382,7 @@ void OpDispatchBuilder::MOVDDUPOp(OpcodeArgs) {
   // unnecessarily zero extend the vector. Otherwise, if
   // memory, then we want to load the element size exactly.
   const auto SrcSize = Op->Src[0].IsGPR() ? 16U : GetSrcSize(Op);
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
   OrderedNode *Res = _VDupElement(16, GetSrcSize(Op), Src, 0);
 
   StoreResult(FPRClass, Op, Res, -1);
@@ -2387,8 +2394,8 @@ void OpDispatchBuilder::VMOVDDUPOp(OpcodeArgs) {
   const auto Is256Bit = SrcSize == Core::CPUState::XMM_AVX_REG_SIZE;
   const auto MemSize = Is256Bit ? 32 : 8;
 
-  OrderedNode *Src = IsSrcGPR ? LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1)
-                              : LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], MemSize, Op->Flags, -1);
+  OrderedNode *Src = IsSrcGPR ? LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags)
+                              : LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], MemSize, Op->Flags);
 
   OrderedNode *Res{};
   if (Is256Bit) {
@@ -2405,24 +2412,24 @@ OrderedNode* OpDispatchBuilder::CVTGPR_To_FPRImpl(OpcodeArgs, size_t DstElementS
                                                   const X86Tables::DecodedOperand& Src2Op) {
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, 16, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, 16, Op->Flags);
   OrderedNode *Converted{};
   if (Src2Op.IsGPR()) {
     // If the source is a GPR then convert directly from the GPR.
-    auto Src2 = LoadSource_WithOpSize(GPRClass, Op, Src2Op, CTX->GetGPRSize(), Op->Flags, -1);
+    auto Src2 = LoadSource_WithOpSize(GPRClass, Op, Src2Op, CTX->GetGPRSize(), Op->Flags);
     Converted = _Float_FromGPR_S(DstElementSize, SrcSize, Src2);
   }
   else if (SrcSize != DstElementSize) {
     // If the source is from memory but the Source size and destination size aren't the same,
     // then it is more optimal to load in to a GPR and convert between GPR->FPR.
     // ARM GPR->FPR conversion supports different size source and destinations while FPR->FPR doesn't.
-    auto Src2 = LoadSource(GPRClass, Op, Src2Op, Op->Flags, -1);
+    auto Src2 = LoadSource(GPRClass, Op, Src2Op, Op->Flags);
     Converted = _Float_FromGPR_S(DstElementSize, SrcSize, Src2);
   }
   else {
     // In the case of cvtsi2s{s,d} where the source and destination are the same size,
     // then it is more optimal to load in to the FPR register directly and convert there.
-    auto Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags, -1);
+    auto Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags);
     Converted = _Vector_SToF(SrcSize, SrcSize, Src2);
   }
 
@@ -2456,7 +2463,7 @@ void OpDispatchBuilder::CVTFPR_To_GPR(OpcodeArgs) {
   // unnecessarily zero extend the vector. Otherwise, if
   // memory, then we want to load the element size exactly.
   const auto SrcSize = Op->Src[0].IsGPR() ? 16U : GetSrcSize(Op);
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
 
   // GPR size is determined by REX.W
   // Source Element size is determined by instruction
@@ -2491,9 +2498,9 @@ OrderedNode* OpDispatchBuilder::Vector_CVT_Int_To_FloatImpl(OpcodeArgs, size_t S
       // unnecessarily zero extend the vector. Otherwise, if
       // memory, then we want to load the element size exactly.
       const auto LoadSize = Op->Src[0].IsGPR() ? 16U : 8 * (Size / 16);
-      return LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], LoadSize, Op->Flags, -1);
+      return LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], LoadSize, Op->Flags);
     } else {
-      return LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      return LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   }();
 
@@ -2533,7 +2540,7 @@ OrderedNode* OpDispatchBuilder::Vector_CVT_Float_To_IntImpl(OpcodeArgs, size_t S
   const size_t DstSize = GetDstSize(Op);
   size_t ElementSize = SrcElementSize;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   if (Narrow) {
     Src = _Vector_FToF(DstSize, SrcElementSize >> 1, Src, SrcElementSize);
@@ -2600,8 +2607,8 @@ OrderedNode* OpDispatchBuilder::Scalar_CVT_Float_To_FloatImpl(OpcodeArgs, size_t
   // Otherwise, if it's a memory load, then we only want to load its exact size.
   const auto Src2Size = Src2Op.IsGPR() ? 16U : SrcElementSize;
 
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, 16, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, Src2Size, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, 16, Op->Flags);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, Src2Size, Op->Flags);
 
   OrderedNode *Converted = _Float_FToF(DstElementSize, SrcElementSize, Src2);
 
@@ -2640,7 +2647,7 @@ void OpDispatchBuilder::Vector_CVT_Float_To_FloatImpl(OpcodeArgs, size_t DstElem
     SrcSize / 2 :
     SrcSize;
 
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], LoadSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], LoadSize, Op->Flags);
 
   OrderedNode *Result{};
   if (DstElementSize > SrcElementSize) {
@@ -2663,7 +2670,7 @@ template
 void OpDispatchBuilder::Vector_CVT_Float_To_Float<8, 4>(OpcodeArgs);
 
 void OpDispatchBuilder::MMX_To_XMM_Vector_CVT_Int_To_Float(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   // Always 32-bit.
   size_t ElementSize = 4;
@@ -2684,7 +2691,7 @@ void OpDispatchBuilder::XMM_To_MMX_Vector_CVT_Float_To_Int(OpcodeArgs) {
   // unnecessarily zero extend the vector. Otherwise, if
   // memory, then we want to load the element size exactly.
   const auto SrcSize = Op->Src[0].IsGPR() ? 16U : GetSrcSize(Op);
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
 
   size_t ElementSize = SrcElementSize;
   size_t Size = GetDstSize(Op);
@@ -2716,12 +2723,12 @@ void OpDispatchBuilder::XMM_To_MMX_Vector_CVT_Float_To_Int<8, true, true>(Opcode
 void OpDispatchBuilder::MASKMOVOp(OpcodeArgs) {
   const auto Size = GetSrcSize(Op);
 
-  OrderedNode *MaskSrc = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *MaskSrc = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   // Mask only cares about the top bit of each byte
   MaskSrc = _VCMPLTZ(Size, 1, MaskSrc);
 
   // Vector that will overwrite byte elements.
-  OrderedNode *VectorSrc = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *VectorSrc = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
 
   // RDI source
   auto MemDest = LoadGPRRegister(X86State::REG_RDI);
@@ -2741,14 +2748,15 @@ void OpDispatchBuilder::VMASKMOVOpImpl(OpcodeArgs, size_t ElementSize, size_t Da
                                        const X86Tables::DecodedOperand& DataOp) {
 
   const auto MakeAddress = [this, Op](const X86Tables::DecodedOperand& Data) {
-    OrderedNode *BaseAddr = LoadSource_WithOpSize(GPRClass, Op, Data, CTX->GetGPRSize(), Op->Flags, -1, false);
+    OrderedNode *BaseAddr = LoadSource_WithOpSize(GPRClass, Op, Data, CTX->GetGPRSize(), Op->Flags,
+                                                  {.LoadData = false});
     return AppendSegmentOffset(BaseAddr, Op->Flags);
   };
 
-  OrderedNode *Mask = LoadSource_WithOpSize(FPRClass, Op, MaskOp, DataSize, Op->Flags, -1);
+  OrderedNode *Mask = LoadSource_WithOpSize(FPRClass, Op, MaskOp, DataSize, Op->Flags);
 
   if (IsStore) {
-    OrderedNode *Data = LoadSource_WithOpSize(FPRClass, Op, DataOp, DataSize, Op->Flags, -1);
+    OrderedNode *Data = LoadSource_WithOpSize(FPRClass, Op, DataOp, DataSize, Op->Flags);
     OrderedNode *Address = MakeAddress(Op->Dest);
     _VStoreVectorMasked(DataSize, ElementSize, Mask, Data, Address, Invalid(), MEM_OFFSET_SXTX, 1);
   } else {
@@ -2785,19 +2793,19 @@ void OpDispatchBuilder::MOVBetweenGPR_FPR(OpcodeArgs) {
       Op->Dest.Data.GPR.GPR >= FEXCore::X86State::REG_XMM_0) {
     if (Op->Src[0].IsGPR()) {
       // Loading from GPR and moving to Vector.
-      OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], CTX->GetGPRSize(), Op->Flags, -1);
+      OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], CTX->GetGPRSize(), Op->Flags);
       // zext to 128bit
       auto Converted = _VCastFromGPR(16, GetSrcSize(Op), Src);
       StoreResult(FPRClass, Op, Op->Dest, Converted, -1);
     }
     else {
       // Loading from Memory as a scalar. Zero extend
-      OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       StoreResult(FPRClass, Op, Op->Dest, Src, -1);
     }
   }
   else {
-    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0],Op->Flags, -1);
+    OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0],Op->Flags);
 
     if (Op->Dest.IsGPR()) {
       auto ElementSize = GetDstSize(Op);
@@ -2807,7 +2815,7 @@ void OpDispatchBuilder::MOVBetweenGPR_FPR(OpcodeArgs) {
     }
     else {
       // Storing first element to memory.
-      OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+      OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
       _StoreMem(FPRClass, GetDstSize(Op), Dest, Src, 1);
     }
   }
@@ -2860,8 +2868,8 @@ void OpDispatchBuilder::VFCMPOp(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
   const auto DstSize = GetDstSize(Op);
 
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
-  OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, DstSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
+  OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, DstSize, Op->Flags);
   const uint8_t CompType = Op->Src[1].Data.Literal.Value;
 
   OrderedNode* Result = VFCMPOpImpl(Op, ElementSize, Dest, Src, CompType);
@@ -2884,8 +2892,8 @@ void OpDispatchBuilder::AVXVFCMPOp(OpcodeArgs) {
   LOGMAN_THROW_A_FMT(Op->Src[2].IsLiteral(), "Src[2] needs to be literal");
   const uint8_t CompType = Op->Src[2].Data.Literal.Value;
 
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], DstSize, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], SrcSize, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], DstSize, Op->Flags);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], SrcSize, Op->Flags);
   OrderedNode *Result = VFCMPOpImpl(Op, ElementSize, Src1, Src2, CompType);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -2897,7 +2905,7 @@ template
 void OpDispatchBuilder::AVXVFCMPOp<8>(OpcodeArgs);
 
 void OpDispatchBuilder::FXSaveOp(OpcodeArgs) {
-  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
   Mem = AppendSegmentOffset(Mem, Op->Flags);
 
   SaveX87State(Op, Mem);
@@ -2911,7 +2919,7 @@ void OpDispatchBuilder::XSaveOp(OpcodeArgs) {
 
 void OpDispatchBuilder::XSaveOpImpl(OpcodeArgs) {
   const auto XSaveBase = [this, Op] {
-    OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     return AppendSegmentOffset(Mem, Op->Flags);
   };
 
@@ -3104,7 +3112,7 @@ OrderedNode *OpDispatchBuilder::GetMXCSR() {
 void OpDispatchBuilder::FXRStoreOp(OpcodeArgs) {
   const auto OpSize = IR::SizeToOpSize(CTX->GetGPRSize());
 
-  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
+  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.LoadData = false});
   Mem = AppendSegmentOffset(Mem, Op->Flags);
 
   RestoreX87State(Mem);
@@ -3119,7 +3127,7 @@ void OpDispatchBuilder::XRstorOpImpl(OpcodeArgs) {
   const auto OpSize = IR::SizeToOpSize(CTX->GetGPRSize());
 
   const auto XSaveBase = [this, Op] {
-    OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+    OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
     return AppendSegmentOffset(Mem, Op->Flags);
   };
 
@@ -3283,8 +3291,8 @@ OrderedNode* OpDispatchBuilder::PALIGNROpImpl(OpcodeArgs, const X86Tables::Decod
                                               const X86Tables::DecodedOperand& Imm) {
   LOGMAN_THROW_A_FMT(Imm.IsLiteral(), "Imm needs to be a literal");
 
-  OrderedNode *Src1Node = LoadSource(FPRClass, Op, Src1, Op->Flags, -1);
-  OrderedNode *Src2Node = LoadSource(FPRClass, Op, Src2, Op->Flags, -1);
+  OrderedNode *Src1Node = LoadSource(FPRClass, Op, Src1, Op->Flags);
+  OrderedNode *Src2Node = LoadSource(FPRClass, Op, Src2, Op->Flags);
 
   // For the 256-bit case we handle it as pairs of 128-bit halves.
   const auto DstSize = GetDstSize(Op);
@@ -3321,8 +3329,8 @@ void OpDispatchBuilder::VPALIGNROp(OpcodeArgs) {
 
 template<size_t ElementSize>
 void OpDispatchBuilder::UCOMISxOp(OpcodeArgs) {
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Res = _FCmp(ElementSize, Src1, Src2,
     (1 << FCMP_FLAG_EQ) |
     (1 << FCMP_FLAG_LT) |
@@ -3342,7 +3350,7 @@ template
 void OpDispatchBuilder::UCOMISxOp<8>(OpcodeArgs);
 
 void OpDispatchBuilder::LDMXCSR(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags);
   RestoreMXCSRState(Dest);
 }
 
@@ -3359,8 +3367,8 @@ OrderedNode* OpDispatchBuilder::PACKUSOpImpl(OpcodeArgs, size_t ElementSize,
 
 template<size_t ElementSize>
 void OpDispatchBuilder::PACKUSOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = PACKUSOpImpl(Op, ElementSize, Dest, Src);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -3376,8 +3384,8 @@ void OpDispatchBuilder::VPACKUSOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
   const auto Is256Bit = DstSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   OrderedNode *Result = PACKUSOpImpl(Op, ElementSize, Src1, Src2);
 
   if (Is256Bit) {
@@ -3401,8 +3409,8 @@ OrderedNode* OpDispatchBuilder::PACKSSOpImpl(OpcodeArgs, size_t ElementSize,
 
 template<size_t ElementSize>
 void OpDispatchBuilder::PACKSSOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = PACKSSOpImpl(Op, ElementSize, Dest, Src);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -3418,8 +3426,8 @@ void OpDispatchBuilder::VPACKSSOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
   const auto Is256Bit = DstSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   OrderedNode *Result = PACKSSOpImpl(Op, ElementSize, Src1, Src2);
 
   if (Is256Bit) {
@@ -3462,8 +3470,8 @@ void OpDispatchBuilder::PMULLOp(OpcodeArgs) {
   static_assert(ElementSize == sizeof(uint32_t),
                 "Currently only handles 32-bit -> 64-bit");
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Res = PMULLOpImpl(Op, ElementSize, Signed, Src1, Src2);
 
   StoreResult(FPRClass, Op, Res, -1);
@@ -3479,8 +3487,8 @@ void OpDispatchBuilder::VPMULLOp(OpcodeArgs) {
   static_assert(ElementSize == sizeof(uint32_t),
                 "Currently only handles 32-bit -> 64-bit");
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   OrderedNode *Result = PMULLOpImpl(Op, ElementSize, Signed, Src1, Src2);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -3493,7 +3501,7 @@ void OpDispatchBuilder::VPMULLOp<4, true>(OpcodeArgs);
 
 template<bool ToXMM>
 void OpDispatchBuilder::MOVQ2DQ(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   // This instruction is a bit special in that if the source is MMX then it zexts to 128bit
   if constexpr (ToXMM) {
@@ -3536,8 +3544,8 @@ OrderedNode* OpDispatchBuilder::ADDSUBPOpImpl(OpcodeArgs, size_t ElementSize,
 
 template<size_t ElementSize>
 void OpDispatchBuilder::ADDSUBPOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = ADDSUBPOpImpl(Op, ElementSize, Dest, Src);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -3550,8 +3558,8 @@ void OpDispatchBuilder::ADDSUBPOp<8>(OpcodeArgs);
 
 template<size_t ElementSize>
 void OpDispatchBuilder::VADDSUBPOp(OpcodeArgs) {
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   OrderedNode *Result = ADDSUBPOpImpl(Op, ElementSize, Src1, Src2);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -3565,8 +3573,8 @@ void OpDispatchBuilder::VADDSUBPOp<8>(OpcodeArgs);
 void OpDispatchBuilder::PFNACCOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   auto DestUnzip = _VUnZip(Size, 4, Dest, Src);
   auto SrcUnzip = _VUnZip2(Size, 4, Dest, Src);
@@ -3578,8 +3586,8 @@ void OpDispatchBuilder::PFNACCOp(OpcodeArgs) {
 void OpDispatchBuilder::PFPNACCOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   OrderedNode *ResAdd{};
   OrderedNode *ResSub{};
@@ -3595,14 +3603,14 @@ void OpDispatchBuilder::PFPNACCOp(OpcodeArgs) {
 
 void OpDispatchBuilder::PSWAPDOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   auto Result = _VRev64(Size, 4, Src);
   StoreResult(FPRClass, Op, Result, -1);
 }
 
 void OpDispatchBuilder::PI2FWOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   size_t Size = GetDstSize(Op);
 
@@ -3620,7 +3628,7 @@ void OpDispatchBuilder::PI2FWOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::PF2IWOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   size_t Size = GetDstSize(Op);
 
@@ -3639,8 +3647,8 @@ void OpDispatchBuilder::PF2IWOp(OpcodeArgs) {
 void OpDispatchBuilder::PMULHRWOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   OrderedNode *Res{};
 
@@ -3661,8 +3669,8 @@ void OpDispatchBuilder::PMULHRWOp(OpcodeArgs) {
 template<uint8_t CompType>
 void OpDispatchBuilder::VPFCMPOp(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, GetDstSize(Op), Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Dest = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, GetDstSize(Op), Op->Flags);
 
   OrderedNode *Result{};
   // This maps 1:1 to an AArch64 NEON Op
@@ -3704,8 +3712,8 @@ OrderedNode* OpDispatchBuilder::PMADDWDOpImpl(OpcodeArgs, const X86Tables::Decod
 
   auto Size = GetSrcSize(Op);
 
-  OrderedNode *Src1Node = LoadSource(FPRClass, Op, Src1, Op->Flags, -1);
-  OrderedNode *Src2Node = LoadSource(FPRClass, Op, Src2, Op->Flags, -1);
+  OrderedNode *Src1Node = LoadSource(FPRClass, Op, Src1, Op->Flags);
+  OrderedNode *Src2Node = LoadSource(FPRClass, Op, Src2, Op->Flags);
 
   if (Size == 8) {
     // MMX implementation can be slightly more optimal
@@ -3735,8 +3743,8 @@ OrderedNode* OpDispatchBuilder::PMADDUBSWOpImpl(OpcodeArgs, const X86Tables::Dec
                                                 const X86Tables::DecodedOperand& Src2Op) {
   const auto Size = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags);
 
   if (Size == 8) {
     // 64bit is more efficient
@@ -3801,8 +3809,8 @@ OrderedNode* OpDispatchBuilder::PMULHWOpImpl(OpcodeArgs, bool Signed,
 
 template<bool Signed>
 void OpDispatchBuilder::PMULHW(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = PMULHWOpImpl(Op, Signed, Dest, Src);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -3815,8 +3823,8 @@ void OpDispatchBuilder::PMULHW<true>(OpcodeArgs);
 
 template <bool Signed>
 void OpDispatchBuilder::VPMULHWOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   OrderedNode *Result = PMULHWOpImpl(Op, Signed, Dest, Src);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -3860,16 +3868,16 @@ OrderedNode* OpDispatchBuilder::PMULHRSWOpImpl(OpcodeArgs, OrderedNode *Src1, Or
 }
 
 void OpDispatchBuilder::PMULHRSW(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = PMULHRSWOpImpl(Op, Dest, Src);
 
   StoreResult(FPRClass, Op, Result, -1);
 }
 
 void OpDispatchBuilder::VPMULHRSWOp(OpcodeArgs) {
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   OrderedNode *Result = PMULHRSWOpImpl(Op, Dest, Src);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -3880,8 +3888,8 @@ OrderedNode* OpDispatchBuilder::HSUBPOpImpl(OpcodeArgs, size_t ElementSize,
                                             const X86Tables::DecodedOperand& Src2Op) {
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags);
 
   auto Even = _VUnZip(SrcSize, ElementSize, Src1, Src2);
   auto Odd = _VUnZip2(SrcSize, ElementSize, Src1, Src2);
@@ -3923,8 +3931,8 @@ OrderedNode* OpDispatchBuilder::PHSUBOpImpl(OpcodeArgs, const X86Tables::Decoded
                                             const X86Tables::DecodedOperand& Src2, size_t ElementSize) {
   const auto Size = GetSrcSize(Op);
 
-  OrderedNode *Src1V = LoadSource(FPRClass, Op, Src1, Op->Flags, -1);
-  OrderedNode *Src2V = LoadSource(FPRClass, Op, Src2, Op->Flags, -1);
+  OrderedNode *Src1V = LoadSource(FPRClass, Op, Src1, Op->Flags);
+  OrderedNode *Src2V = LoadSource(FPRClass, Op, Src2, Op->Flags);
 
   auto Even = _VUnZip(Size, ElementSize, Src1V, Src2V);
   auto Odd = _VUnZip2(Size, ElementSize, Src1V, Src2V);
@@ -3965,8 +3973,8 @@ OrderedNode* OpDispatchBuilder::PHADDSOpImpl(OpcodeArgs, const X86Tables::Decode
   const auto Size = GetSrcSize(Op);
   const uint8_t ElementSize = 2;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags);
 
   auto Even = _VUnZip(Size, ElementSize, Src1, Src2);
   auto Odd = _VUnZip2(Size, ElementSize, Src1, Src2);
@@ -4000,8 +4008,8 @@ OrderedNode* OpDispatchBuilder::PHSUBSOpImpl(OpcodeArgs, const X86Tables::Decode
   const auto Size = GetSrcSize(Op);
   const uint8_t ElementSize = 2;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags);
 
   auto Even = _VUnZip(Size, ElementSize, Src1, Src2);
   auto Odd = _VUnZip2(Size, ElementSize, Src1, Src2);
@@ -4040,8 +4048,8 @@ OrderedNode* OpDispatchBuilder::PSADBWOpImpl(OpcodeArgs,
   const auto Size = GetSrcSize(Op);
   const auto Is128Bit = Size == Core::CPUState::XMM_SSE_REG_SIZE;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags);
 
   if (Size == 8) {
     auto AbsResult = _VUABDL(Size * 2, 1, Src1, Src2);
@@ -4090,14 +4098,14 @@ OrderedNode* OpDispatchBuilder::ExtendVectorElementsImpl(OpcodeArgs, size_t Elem
 
   const auto GetSrc = [&] {
     if (Op->Src[0].IsGPR()) {
-      return LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], DstSize, Op->Flags, -1);
+      return LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], DstSize, Op->Flags);
     } else {
       // For memory operands the 256-bit variant loads twice the size specified in the table.
       const auto Is256Bit = DstSize == Core::CPUState::XMM_AVX_REG_SIZE;
       const auto SrcSize = GetSrcSize(Op);
       const auto LoadSize = Is256Bit ? SrcSize * 2 : SrcSize;
 
-      return LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], LoadSize, Op->Flags, -1);
+      return LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], LoadSize, Op->Flags);
     }
   };
 
@@ -4176,7 +4184,7 @@ void OpDispatchBuilder::VectorRound(OpcodeArgs) {
   // No need to zero extend the vector in the event we have a
   // scalar source, especially since it's only inserted into another vector.
   const auto SrcSize = GetSrcSize(Op);
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   const uint64_t Mode = Op->Src[1].Data.Literal.Value;
@@ -4200,7 +4208,7 @@ void OpDispatchBuilder::AVXVectorRound(OpcodeArgs) {
   // scalar source, especially since it's only inserted into another vector.
   const auto SrcSize = GetSrcSize(Op);
 
-  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags, -1);
+  OrderedNode *Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
   OrderedNode *Result = VectorRoundImpl(Op, ElementSize, Src, Mode);
 
   StoreResult(FPRClass, Op, Result, -1);
@@ -4218,8 +4226,8 @@ void OpDispatchBuilder::VectorBlend(OpcodeArgs) {
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   uint8_t Select = Op->Src[1].Data.Literal.Value;
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   if constexpr (ElementSize == 4) {
     Select &= 0b1111;
@@ -4354,8 +4362,8 @@ template<size_t ElementSize>
 void OpDispatchBuilder::VectorVariableBlend(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   auto Mask = LoadXMMRegister(0);
 
@@ -4382,8 +4390,8 @@ void OpDispatchBuilder::AVXVectorVariableBlend(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
   constexpr auto ElementSizeBits = ElementSize * 8;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[2].IsLiteral(), "Src[2] needs to be literal here");
   const auto Src3Selector = Op->Src[2].Data.Literal.Value;
@@ -4408,8 +4416,8 @@ void OpDispatchBuilder::PTestOp(OpcodeArgs) {
 
   auto Size = GetSrcSize(Op);
 
-  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Dest = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   OrderedNode *Test1 = _VAnd(Size, 1, Dest, Src);
   OrderedNode *Test2 = _VBic(Size, 1, Src, Dest);
@@ -4453,8 +4461,8 @@ void OpDispatchBuilder::VTESTOpImpl(OpcodeArgs, size_t ElementSize) {
   const auto ElementSizeInBits = ElementSize * 8;
   const auto MaskConstant = uint64_t{1} << (ElementSizeInBits - 1);
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Dest, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Dest, Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   OrderedNode *Mask = _VDupFromGPR(SrcSize, ElementSize, _Constant(MaskConstant));
 
@@ -4505,7 +4513,7 @@ void OpDispatchBuilder::VTESTPOp<8>(OpcodeArgs);
 OrderedNode* OpDispatchBuilder::PHMINPOSUWOpImpl(OpcodeArgs) {
   const auto Size = GetSrcSize(Op);
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   // Setup a vector swizzle
   // Initially load a 64-bit mask of immediates
@@ -4556,8 +4564,8 @@ OrderedNode* OpDispatchBuilder::DPPOpImpl(OpcodeArgs, const X86Tables::DecodedOp
 
   const auto DstSize = GetDstSize(Op);
 
-  OrderedNode *Src1V = LoadSource(FPRClass, Op, Src1, Op->Flags, -1);
-  OrderedNode *Src2V = LoadSource(FPRClass, Op, Src2, Op->Flags, -1);
+  OrderedNode *Src1V = LoadSource(FPRClass, Op, Src1, Op->Flags);
+  OrderedNode *Src2V = LoadSource(FPRClass, Op, Src2, Op->Flags);
 
   OrderedNode *ZeroVec = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
 
@@ -4701,8 +4709,8 @@ OrderedNode* OpDispatchBuilder::MPSADBWOpImpl(OpcodeArgs, const X86Tables::Decod
   const uint8_t Select_Src1_Low = ((Select & 0b100) >> 2) * 32 / 8;
   const uint8_t Select_Src2_Low = Select & 0b11;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Src1Op, Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Src2Op, Op->Flags);
 
   OrderedNode *Lower = LaneHelper(Select_Src1_Low, Select_Src2_Low, Src1, Src2);
   if (Is128Bit) {
@@ -4730,8 +4738,8 @@ void OpDispatchBuilder::VMPSADBWOp(OpcodeArgs) {
 
 void OpDispatchBuilder::VINSERTOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], 16, Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[1], 16, Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[2].IsLiteral(), "Src2 needs to be literal here");
   const auto Selector = Op->Src[2].Data.Literal.Value & 1;
@@ -4743,8 +4751,8 @@ void OpDispatchBuilder::VINSERTOp(OpcodeArgs) {
 
 void OpDispatchBuilder::VPERM2Op(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[2].IsLiteral(), "Src2 needs to be literal here");
   const auto Selector = Op->Src[2].Data.Literal.Value;
@@ -4776,8 +4784,8 @@ void OpDispatchBuilder::VPERM2Op(OpcodeArgs) {
 void OpDispatchBuilder::VPERMDOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
 
-  OrderedNode *Indices = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Indices = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
 
   // Get rid of any junk unrelated to the relevant selector index bits (bits [2:0])
   OrderedNode *IndexMask = _VectorImm(DstSize, 4, 0b111);
@@ -4850,7 +4858,7 @@ void OpDispatchBuilder::VPERMDOp(OpcodeArgs) {
 
 void OpDispatchBuilder::VPERMQOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   const auto Selector = Op->Src[1].Data.Literal.Value;
@@ -4891,8 +4899,8 @@ void OpDispatchBuilder::VBLENDPDOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
   const auto Is256Bit = DstSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[2].IsLiteral(), "Src[2] needs to be literal here");
   const auto Selector = Op->Src[2].Data.Literal.Value;
@@ -4916,8 +4924,8 @@ void OpDispatchBuilder::VPBLENDDOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
   const auto Is256Bit = DstSize == Core::CPUState::XMM_AVX_REG_SIZE;
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[2].IsLiteral(), "Src[2] needs to be literal here");
   const auto Selector = Op->Src[2].Data.Literal.Value;
@@ -4956,8 +4964,8 @@ void OpDispatchBuilder::VPBLENDDOp(OpcodeArgs) {
 void OpDispatchBuilder::VPBLENDWOp(OpcodeArgs) {
   const auto DstSize = GetDstSize(Op);
 
-  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src1 = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Src2 = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
 
   LOGMAN_THROW_A_FMT(Op->Src[2].IsLiteral(), "Src[2] needs to be literal here");
   const auto Selector = Op->Src[2].Data.Literal.Value;
@@ -5014,7 +5022,7 @@ void OpDispatchBuilder::VPERMILImmOp(OpcodeArgs) {
   LOGMAN_THROW_A_FMT(Op->Src[1].IsLiteral(), "Src1 needs to be literal here");
   const auto Selector = Op->Src[1].Data.Literal.Value & 0xFF;
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
   OrderedNode *Result = LoadAndCacheNamedVectorConstant(DstSize, FEXCore::IR::NamedVectorConstant::NAMED_VECTOR_ZERO);
 
   if constexpr (ElementSize == 8) {
@@ -5064,8 +5072,8 @@ void OpDispatchBuilder::VPERMILRegOp(OpcodeArgs) {
     return _VAnd(DstSize, 1, Indices, IndexMask);
   };
 
-  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
-  OrderedNode *Indices = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags, -1);
+  OrderedNode *Src = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+  OrderedNode *Indices = LoadSource(FPRClass, Op, Op->Src[1], Op->Flags);
   if constexpr (IsPD) {
     // VPERMILPD stores the selector in the second bit, rather than the
     // first bit of each element in the index vector. So move it over by one.
@@ -5121,8 +5129,9 @@ void OpDispatchBuilder::PCMPXSTRXOpImpl(OpcodeArgs, bool IsExplicit, bool IsMask
   //       instructions in the Intel Software Development Manual).
   //
   //       So, we specify Src2 as having an alignment of 1 to indicate this.
-  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, 16, Op->Flags, -1);
-  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 16, Op->Flags, 1);
+  OrderedNode *Src1 = LoadSource_WithOpSize(FPRClass, Op, Op->Dest, 16, Op->Flags);
+  OrderedNode *Src2 = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 16, Op->Flags,
+                                            {.Align = 1});
 
   OrderedNode *IntermediateResult{};
   if (IsExplicit) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -139,7 +139,7 @@ void OpDispatchBuilder::FLD(OpcodeArgs) {
 
   if (!Op->Src[0].IsNone()) {
     // Read from memory
-    data = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], read_width, Op->Flags, -1);
+    data = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], read_width, Op->Flags);
   }
   else {
     // Implicit arg
@@ -178,7 +178,7 @@ void OpDispatchBuilder::FBLD(OpcodeArgs) {
   SetX87Top(top);
 
   // Read from memory
-  OrderedNode *data = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 16, Op->Flags, -1);
+  OrderedNode *data = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 16, Op->Flags);
   OrderedNode *converted = _F80BCDLoad(data);
   _StoreContextIndexed(converted, top, 16, MMBaseOffset(), 16, FPRClass);
 }
@@ -238,7 +238,7 @@ void OpDispatchBuilder::FILD(OpcodeArgs) {
   size_t read_width = GetSrcSize(Op);
 
   // Read from memory
-  auto data = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], read_width, Op->Flags, -1);
+  auto data = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], read_width, Op->Flags);
 
   auto zero = _Constant(0);
 
@@ -334,11 +334,11 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
     // Memory arg
     if constexpr (width == 16 || width == 32 || width == 64) {
       if constexpr (Integer) {
-        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTToInt(arg, width / 8);
       }
       else {
-        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTTo(arg, width / 8);
       }
     }
@@ -395,11 +395,11 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
 
     if constexpr (width == 16 || width == 32 || width == 64) {
       if constexpr (Integer) {
-        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTToInt(arg, width / 8);
       }
       else {
-        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTTo(arg, width / 8);
       }
     }
@@ -458,11 +458,11 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
 
     if constexpr (width == 16 || width == 32 || width == 64) {
       if constexpr (Integer) {
-        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTToInt(arg, width / 8);
       }
       else {
-        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTTo(arg, width / 8);
       }
     }
@@ -543,11 +543,11 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
 
     if constexpr (width == 16 || width == 32 || width == 64) {
       if constexpr (Integer) {
-        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTToInt(arg, width / 8);
       }
       else {
-        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTTo(arg, width / 8);
       }
     }
@@ -724,11 +724,11 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
     // Memory arg
     if constexpr (width == 16 || width == 32 || width == 64) {
       if constexpr (Integer) {
-        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+        arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTToInt(arg, width / 8);
       }
       else {
-        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+        arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTTo(arg, width / 8);
       }
     }
@@ -1014,7 +1014,7 @@ void OpDispatchBuilder::X87ATAN(OpcodeArgs) {
 
 void OpDispatchBuilder::X87LDENV(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
-  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
+  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.LoadData = false});
   Mem = AppendSegmentOffset(Mem, Op->Flags);
 
   auto NewFCW = _LoadMem(GPRClass, 2, Mem, 2);
@@ -1052,7 +1052,7 @@ void OpDispatchBuilder::X87FNSTENV(OpcodeArgs) {
   // 4 bytes : data pointer selector
 
   auto Size = GetDstSize(Op);
-  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
   Mem = AppendSegmentOffset(Mem, Op->Flags);
 
   {
@@ -1099,7 +1099,7 @@ void OpDispatchBuilder::X87FNSTENV(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FLDCW(OpcodeArgs) {
-  OrderedNode *NewFCW = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *NewFCW = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 }
 
@@ -1110,7 +1110,7 @@ void OpDispatchBuilder::X87FSTCW(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87LDSW(OpcodeArgs) {
-  OrderedNode *NewFSW = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *NewFSW = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   ReconstructX87StateFromFSW(NewFSW);
 }
 
@@ -1139,7 +1139,7 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
   // 4 bytes : data pointer selector
 
   auto Size = GetDstSize(Op);
-  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
   Mem = AppendSegmentOffset(Mem, Op->Flags);
 
   OrderedNode *Top = GetX87Top();
@@ -1213,7 +1213,7 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
 
 void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
-  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
+  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.LoadData = false});
   Mem = AppendSegmentOffset(Mem, Op->Flags);
 
   auto NewFCW = _LoadMem(GPRClass, 2, Mem, 2);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -66,7 +66,7 @@ void OpDispatchBuilder::FNINITF64(OpcodeArgs) {
 
 void OpDispatchBuilder::X87LDENVF64(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
-  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
+  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.LoadData = false});
   Mem = AppendSegmentOffset(Mem, Op->Flags);
 
   auto NewFCW = _LoadMem(GPRClass, 2, Mem, 2);
@@ -89,7 +89,7 @@ void OpDispatchBuilder::X87LDENVF64(OpcodeArgs) {
 
 
 void OpDispatchBuilder::X87FLDCWF64(OpcodeArgs) {
-  OrderedNode *NewFCW = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+  OrderedNode *NewFCW = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   //ignore the rounding precision, we're always 64-bit in F64.
   //extract rounding mode
   OrderedNode *roundingMode = _Bfe(OpSize::i32Bit, 3, 10, NewFCW);
@@ -112,7 +112,7 @@ void OpDispatchBuilder::FLDF64(OpcodeArgs) {
 
   if (!Op->Src[0].IsNone()) {
     // Read from memory
-    data = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], read_width, Op->Flags, -1);
+    data = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], read_width, Op->Flags);
      // Convert to 64bit float
     if constexpr (width == 32) {
       converted = _Float_FToF(8, 4, data);
@@ -153,7 +153,7 @@ void OpDispatchBuilder::FBLDF64(OpcodeArgs) {
   SetX87Top(top);
 
   // Read from memory
-  OrderedNode *data = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 16, Op->Flags, -1);
+  OrderedNode *data = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], 16, Op->Flags);
   OrderedNode *converted = _F80BCDLoad(data);
   converted = _F80CVT(8, converted);
   _StoreContextIndexed(converted, top, 8, MMBaseOffset(), 16, FPRClass);
@@ -210,7 +210,7 @@ void OpDispatchBuilder::FILDF64(OpcodeArgs) {
 
   size_t read_width = GetSrcSize(Op);
   // Read from memory
-  auto data = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], read_width, Op->Flags, -1);
+  auto data = LoadSource_WithOpSize(GPRClass, Op, Op->Src[0], read_width, Op->Flags);
   if(read_width == 2) {
     data = _Sbfe(OpSize::i64Bit, read_width * 8, 0, data);
   }
@@ -292,16 +292,16 @@ void OpDispatchBuilder::FADDF64(OpcodeArgs) {
   if (!Op->Src[0].IsNone()) {
     // Memory arg
     if constexpr (Integer) {
-      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       if(width == 16) {
         arg = _Sbfe(OpSize::i64Bit, 16, 0, arg);
       }
       b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
     } else if constexpr (width == 32) {
-      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       b = _Float_FToF(8, 4, arg);
     } else if constexpr (width == 64) {
-      b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   } else {
     // Implicit arg
@@ -353,16 +353,16 @@ void OpDispatchBuilder::FMULF64(OpcodeArgs) {
   if (!Op->Src[0].IsNone()) {
     // Memory arg
     if constexpr (Integer) {
-      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       if(width == 16) {
         arg = _Sbfe(OpSize::i64Bit, 16, 0, arg);
       }
       b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
     } else if constexpr (width == 32) {
-      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       b = _Float_FToF(8, 4, arg);
     } else if constexpr (width == 64) {
-      b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   } else {
     // Implicit arg
@@ -417,16 +417,16 @@ void OpDispatchBuilder::FDIVF64(OpcodeArgs) {
  if (!Op->Src[0].IsNone()) {
     // Memory arg
     if constexpr (Integer) {
-      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       if(width == 16) {
         arg = _Sbfe(OpSize::i64Bit, 16, 0, arg);
       }
       b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
     } else if constexpr (width == 32) {
-      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       b = _Float_FToF(8, 4, arg);
     } else if constexpr (width == 64) {
-      b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   } else {
     // Implicit arg
@@ -503,16 +503,16 @@ void OpDispatchBuilder::FSUBF64(OpcodeArgs) {
  if (!Op->Src[0].IsNone()) {
     // Memory arg
     if constexpr (Integer) {
-      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       if(width == 16) {
         arg = _Sbfe(OpSize::i64Bit, 16, 0, arg);
       }
       b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
     } else if constexpr (width == 32) {
-      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       b = _Float_FToF(8, 4, arg);
     } else if constexpr (width == 64) {
-      b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   } else {
     // Implicit arg
@@ -661,16 +661,16 @@ void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
   if (!Op->Src[0].IsNone()) {
     // Memory arg
     if constexpr (Integer) {
-      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1);
+      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       if(width == 16) {
         arg = _Sbfe(OpSize::i64Bit, 16, 0, arg);
       }
       b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
     } else if constexpr (width == 32) {
-      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       b = _Float_FToF(8, 4, arg);
     } else if constexpr (width == 64) {
-      b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags, -1);
+      b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   } else {
     // Implicit arg
@@ -921,7 +921,7 @@ void OpDispatchBuilder::X87FNSAVEF64(OpcodeArgs) {
   // 4 bytes : data pointer selector
 
   auto Size = GetDstSize(Op);
-  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, -1, false);
+  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
   Mem = AppendSegmentOffset(Mem, Op->Flags);
 
   OrderedNode *Top = GetX87Top();
@@ -999,7 +999,7 @@ void OpDispatchBuilder::X87FNSAVEF64(OpcodeArgs) {
 
 void OpDispatchBuilder::X87FRSTORF64(OpcodeArgs) {
   auto Size = GetSrcSize(Op);
-  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, -1, false);
+  OrderedNode *Mem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.LoadData = false});
   Mem = AppendSegmentOffset(Mem, Op->Flags);
 
   auto NewFCW = _LoadMem(GPRClass, 2, Mem, 2);


### PR DESCRIPTION
Allows for easier expansion without needing to expand the function definitons.

Also makes a few usages significantly less verbose and makes specifying options a little more declarative, rather than having to memorize what each argument is specifying.