### PR TITLE
OpcodeDispatcher: Remove unnecessary 128-bit truncating moves from StoreResult

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -1520,13 +1520,13 @@ DEF_OP(VBroadcastFromMem) {
                       ElementSize == 4 || ElementSize == 8 ||
                       ElementSize == 16, "Invalid element size");
 
-  if (HostSupportsSVE128 || HostSupportsSVE256) {
-    if (Is256Bit) {
-      LOGMAN_THROW_A_FMT(HostSupportsSVE256, "Need SVE256 support in order to use SVE 256-bit broadcast");
-    }
+  if (Is256Bit && !HostSupportsSVE256) {
+    LOGMAN_MSG_A_FMT("{}: 256-bit vectors must support SVE256", __func__);
+    return;
+  }
 
-    const auto GoverningPredicate = Is256Bit ? PRED_TMP_32B.Zeroing()
-                                             : PRED_TMP_16B.Zeroing();
+  if (Is256Bit && HostSupportsSVE256) {
+    const auto GoverningPredicate = PRED_TMP_32B.Zeroing();
 
     switch (ElementSize) {
     case 1:

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -482,6 +482,9 @@ public:
   template<FEXCore::IR::IROps IROp, size_t ElementSize>
   void AVXVectorScalarUnaryInsertALUOp(OpcodeArgs);
 
+  template<size_t DstElementSize, size_t SrcElementSize>
+  void AVXVector_CVT_Float_To_Float(OpcodeArgs);
+
   void InsertMMX_To_XMM_Vector_CVT_Int_To_Float(OpcodeArgs);
   template<size_t DstElementSize>
   void InsertCVTGPR_To_FPR(OpcodeArgs);
@@ -551,6 +554,9 @@ public:
 
   void VMOVSDOp(OpcodeArgs);
   void VMOVSSOp(OpcodeArgs);
+
+  void VMOVAPS_VMOVAPDOp(OpcodeArgs);
+  void VMOVUPS_VMOVUPDOp(OpcodeArgs);
 
   void VMPSADBWOp(OpcodeArgs);
 
@@ -1121,7 +1127,7 @@ private:
                                              const X86Tables::DecodedOperand& Src1Op,
                                              const X86Tables::DecodedOperand& Src2Op);
 
-  void Vector_CVT_Float_To_FloatImpl(OpcodeArgs, size_t DstElementSize, size_t SrcElementSize);
+  void Vector_CVT_Float_To_FloatImpl(OpcodeArgs, size_t DstElementSize, size_t SrcElementSize, bool IsAVX);
 
   OrderedNode* Vector_CVT_Float_To_IntImpl(OpcodeArgs, size_t SrcElementSize, bool Narrow, bool HostRoundingMode);
 

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -435,6 +435,58 @@
         "mov v16.16b, v17.16b",
         "fmax d16, d17, d18"
       ]
+    },
+    "vminps xmm0, xmm1, xmm2": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b00 0x5d 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcmgt v0.4s, v18.4s, v17.4s",
+        "mov v16.16b, v17.16b",
+        "bif v16.16b, v18.16b, v0.16b"
+      ]
+    },
+    "vminps ymm0, ymm1, ymm2": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b00 0x5d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcmgt p0.s, p7/z, z18.s, z17.s",
+        "not p0.b, p7/z, p0.b",
+        "mov z0.d, z17.d",
+        "mov z0.s, p0/m, z18.s",
+        "mov z16.d, z0.d"
+      ]
+    },
+    "vminpd xmm0, xmm1, xmm2": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b01 0x5d 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcmgt v0.2d, v18.2d, v17.2d",
+        "mov v16.16b, v17.16b",
+        "bif v16.16b, v18.16b, v0.16b"
+      ]
+    },
+    "vminpd ymm0, ymm1, ymm2": {
+      "ExpectedInstructionCount": 5,
+      "Optimal": "No",
+      "Comment": [
+        "Map 1 0b01 0x5d 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcmgt p0.d, p7/z, z18.d, z17.d",
+        "not p0.b, p7/z, p0.b",
+        "mov z0.d, z17.d",
+        "mov z0.d, p0/m, z18.d",
+        "mov z16.d, z0.d"
+      ]
     }
   }
 }

--- a/unittests/InstructionCountCI/RPRES/VEX_map1.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1.json
@@ -12,14 +12,13 @@
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x52 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frsqrte v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "frsqrte v16.4s, v17.4s"
       ]
     },
     "vrsqrtps ymm0, ymm1": {
@@ -46,14 +45,13 @@
       ]
     },
     "vrcpps xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x53 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frecpe v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "frecpe v16.4s, v17.4s"
       ]
     },
     "vrcpps ymm0, ymm1": {

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -11,14 +11,13 @@
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x52 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frsqrte v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "frsqrte v16.4s, v17.4s"
       ]
     },
     "vrsqrtps ymm0, ymm1": {
@@ -44,14 +43,13 @@
       ]
     },
     "vrcpps xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x53 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frecpe v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "frecpe v16.4s, v17.4s"
       ]
     },
     "vrcpps ymm0, ymm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -9,29 +9,25 @@
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "SVE-256bit changes behaviour slightly",
         "0x66 0x0f 0xe4"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z2, z16",
-        "umulh z2.h, p6/m, z2.h, z17.h",
-        "mov v16.16b, v2.16b"
+        "umulh z16.h, p6/m, z16.h, z17.h"
       ]
     },
     "pmulhw xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "SVE-256bit changes behaviour slightly",
         "0x66 0x0f 0xe5"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z2, z16",
-        "smulh z2.h, p6/m, z2.h, z17.h",
-        "mov v16.16b, v2.16b"
+        "smulh z16.h, p6/m, z16.h, z17.h"
       ]
     }
   }

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -110,16 +110,15 @@
       ]
     },
     "vmovss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b10 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.s[0], v18.s[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.s[0], v18.s[0]"
       ]
     },
     "vmovsd xmm0, [rax]": {
@@ -134,16 +133,15 @@
       ]
     },
     "vmovsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b11 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.d[0], v18.d[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.d[0], v18.d[0]"
       ]
     },
     "vmovups [rax], xmm0": {
@@ -197,7 +195,7 @@
       ]
     },
     "db 0xc5, 0xf2, 0x11, 0xc2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "vmovss xmm2, xmm1, xmm0",
@@ -206,9 +204,8 @@
         "Map 1 0b10 0x11 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.s[0], v16.s[0]",
-        "mov v18.16b, v2.16b"
+        "mov v18.16b, v17.16b",
+        "mov v18.s[0], v16.s[0]"
       ]
     },
     "vmovsd [rax], xmm0": {
@@ -222,7 +219,7 @@
       ]
     },
     "db 0xc5, 0xf3, 0x11, 0xc2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "vmovsd xmm2, xmm1, xmm0",
@@ -231,13 +228,12 @@
         "Map 1 0b11 0x11 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.d[0], v16.d[0]",
-        "mov v18.16b, v2.16b"
+        "mov v18.16b, v17.16b",
+        "mov v18.d[0], v16.d[0]"
       ]
     },
     "vmovlps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
@@ -245,14 +241,12 @@
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
-        "mov v0.16b, v17.16b",
-        "mov v0.d[0], v2.d[0]",
-        "mov v2.16b, v0.16b",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.d[0], v2.d[0]"
       ]
     },
     "vmovlpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
@@ -260,22 +254,19 @@
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
-        "mov v0.16b, v17.16b",
-        "mov v0.d[0], v2.d[0]",
-        "mov v2.16b, v0.16b",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.d[0], v2.d[0]"
       ]
     },
     "vmovsldup xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x12 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
-        "trn1 v2.4s, v2.4s, v2.4s",
-        "mov v16.16b, v2.16b"
+        "trn1 v16.4s, v2.4s, v2.4s"
       ]
     },
     "vmovsldup ymm0, [rax]": {
@@ -294,15 +285,14 @@
       ]
     },
     "vmovddup xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x12 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
-        "dup v2.2d, v2.d[0]",
-        "mov v16.16b, v2.16b"
+        "dup v16.2d, v2.d[0]"
       ]
     },
     "vmovddup ymm0, [rax]": {
@@ -341,15 +331,14 @@
       ]
     },
     "vunpcklps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x14 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
-        "zip1 v2.4s, v17.4s, v2.4s",
-        "mov v16.16b, v2.16b"
+        "zip1 v16.4s, v17.4s, v2.4s"
       ]
     },
     "vunpcklps ymm0, ymm1, [rax]": {
@@ -369,15 +358,14 @@
       ]
     },
     "vunpcklpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x14 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
-        "zip1 v2.2d, v17.2d, v2.2d",
-        "mov v16.16b, v2.16b"
+        "zip1 v16.2d, v17.2d, v2.2d"
       ]
     },
     "vunpcklpd ymm0, ymm1, [rax]": {
@@ -397,15 +385,14 @@
       ]
     },
     "vunpckhps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x15 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
-        "zip2 v2.4s, v17.4s, v2.4s",
-        "mov v16.16b, v2.16b"
+        "zip2 v16.4s, v17.4s, v2.4s"
       ]
     },
     "vunpckhps ymm0, ymm1, [rax]": {
@@ -424,15 +411,14 @@
       ]
     },
     "vunpckhpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x15 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
-        "zip2 v2.2d, v17.2d, v2.2d",
-        "mov v16.16b, v2.16b"
+        "zip2 v16.2d, v17.2d, v2.2d"
       ]
     },
     "vunpckhpd ymm0, ymm1, [rax]": {
@@ -459,8 +445,8 @@
       "ExpectedArm64ASM": [
         "mov v2.8b, v17.8b",
         "ldr d3, [x4]",
-        "mov v2.d[1], v3.d[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v3.d[0]"
       ]
     },
     "vmovhpd xmm0, xmm1, [rax]": {
@@ -472,20 +458,19 @@
       "ExpectedArm64ASM": [
         "mov v2.8b, v17.8b",
         "ldr d3, [x4]",
-        "mov v2.d[1], v3.d[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v3.d[0]"
       ]
     },
     "vmovshdup xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
-        "trn2 v2.4s, v2.4s, v2.4s",
-        "mov v16.16b, v2.16b"
+        "trn2 v16.4s, v2.4s, v2.4s"
       ]
     },
     "vmovshdup ymm0, [rax]": {
@@ -631,14 +616,13 @@
       ]
     },
     "vsqrtps xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x51 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fsqrt v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "fsqrt v16.4s, v17.4s"
       ]
     },
     "vsqrtps ymm0, ymm1": {
@@ -652,14 +636,13 @@
       ]
     },
     "vsqrtpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x51 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fsqrt v2.2d, v17.2d",
-        "mov v16.16b, v2.16b"
+        "fsqrt v16.2d, v17.2d"
       ]
     },
     "vsqrtpd ymm0, ymm1": {
@@ -697,7 +680,7 @@
       ]
     },
     "vrsqrtps xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x52 128-bit"
@@ -705,8 +688,7 @@
       "ExpectedArm64ASM": [
         "fmov v0.4s, #0x70 (1.0000)",
         "fsqrt v1.4s, v17.4s",
-        "fdiv v2.4s, v0.4s, v1.4s",
-        "mov v16.16b, v2.16b"
+        "fdiv v16.4s, v0.4s, v1.4s"
       ]
     },
     "vrsqrtps ymm0, ymm1": {
@@ -736,15 +718,14 @@
       ]
     },
     "vrcpps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x53 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmov v0.4s, #0x70 (1.0000)",
-        "fdiv v2.4s, v0.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "fdiv v16.4s, v0.4s, v17.4s"
       ]
     },
     "vrcpps ymm0, ymm1": {
@@ -773,14 +754,13 @@
       ]
     },
     "vandps xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x54 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "and v2.16b, v16.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "and v16.16b, v16.16b, v17.16b"
       ]
     },
     "vandps ymm0, ymm1": {
@@ -794,14 +774,13 @@
       ]
     },
     "vandpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x54 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "and v2.16b, v16.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "and v16.16b, v16.16b, v17.16b"
       ]
     },
     "vandpd ymm0, ymm1": {
@@ -815,14 +794,13 @@
       ]
     },
     "vandnps xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x55 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "bic v2.16b, v17.16b, v16.16b",
-        "mov v16.16b, v2.16b"
+        "bic v16.16b, v17.16b, v16.16b"
       ]
     },
     "vandnps ymm0, ymm1": {
@@ -836,14 +814,13 @@
       ]
     },
     "vandnpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x55 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "bic v2.16b, v17.16b, v16.16b",
-        "mov v16.16b, v2.16b"
+        "bic v16.16b, v17.16b, v16.16b"
       ]
     },
     "vandnpd ymm0, ymm1": {
@@ -857,14 +834,13 @@
       ]
     },
     "vorps xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x56 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "orr v2.16b, v16.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "orr v16.16b, v16.16b, v17.16b"
       ]
     },
     "vorps ymm0, ymm1": {
@@ -878,14 +854,13 @@
       ]
     },
     "vorpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x56 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "orr v2.16b, v16.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "orr v16.16b, v16.16b, v17.16b"
       ]
     },
     "vorpd ymm0, ymm1": {
@@ -899,14 +874,13 @@
       ]
     },
     "vxorps xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x57 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "eor v2.16b, v16.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "eor v16.16b, v16.16b, v17.16b"
       ]
     },
     "vxorps ymm0, ymm1": {
@@ -920,14 +894,13 @@
       ]
     },
     "vxorpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x57 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "eor v2.16b, v16.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "eor v16.16b, v16.16b, v17.16b"
       ]
     },
     "vxorpd ymm0, ymm1": {
@@ -941,14 +914,13 @@
       ]
     },
     "vpunpcklbw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x60 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "zip1 v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "zip1 v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpunpcklbw ymm0, ymm1, ymm2": {
@@ -967,14 +939,13 @@
       ]
     },
     "vpunpcklwd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x61 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "zip1 v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "zip1 v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpunpcklwd ymm0, ymm1, ymm2": {
@@ -993,14 +964,13 @@
       ]
     },
     "vpunpckldq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x62 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "zip1 v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "zip1 v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpunpckldq ymm0, ymm1, ymm2": {
@@ -1019,15 +989,14 @@
       ]
     },
     "vpacksswb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x63 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sqxtn v2.8b, v17.8h",
-        "sqxtn2 v2.16b, v18.8h",
-        "mov v16.16b, v2.16b"
+        "sqxtn v16.8b, v17.8h",
+        "sqxtn2 v16.16b, v18.8h"
       ]
     },
     "vpacksswb ymm0, ymm1, ymm2": {
@@ -1055,14 +1024,13 @@
       ]
     },
     "vpcmpgtb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x64 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "cmgt v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "cmgt v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpcmpgtb ymm0, ymm1, ymm2": {
@@ -1079,14 +1047,13 @@
       ]
     },
     "vpcmpgtw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x65 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "cmgt v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "cmgt v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpcmpgtw ymm0, ymm1, ymm2": {
@@ -1103,14 +1070,13 @@
       ]
     },
     "vpcmpgtd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x66 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "cmgt v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "cmgt v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpcmpgtd ymm0, ymm1, ymm2": {
@@ -1127,15 +1093,14 @@
       ]
     },
     "vpackuswb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x67 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sqxtun v2.8b, v17.8h",
-        "sqxtun2 v2.16b, v18.8h",
-        "mov v16.16b, v2.16b"
+        "sqxtun v16.8b, v17.8h",
+        "sqxtun2 v16.16b, v18.8h"
       ]
     },
     "vpackuswb ymm0, ymm1, ymm2": {
@@ -1173,8 +1138,8 @@
         "mov v2.s[0], v17.s[0]",
         "mov v2.s[1], v17.s[0]",
         "mov v2.s[2], v17.s[0]",
-        "mov v2.s[3], v17.s[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[0]"
       ]
     },
     "vpshufd xmm0, xmm1, 01b": {
@@ -1188,8 +1153,8 @@
         "mov v2.s[0], v17.s[1]",
         "mov v2.s[1], v17.s[0]",
         "mov v2.s[2], v17.s[0]",
-        "mov v2.s[3], v17.s[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[0]"
       ]
     },
     "vpshufd xmm0, xmm1, 10b": {
@@ -1203,8 +1168,8 @@
         "mov v2.s[0], v17.s[2]",
         "mov v2.s[1], v17.s[0]",
         "mov v2.s[2], v17.s[0]",
-        "mov v2.s[3], v17.s[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[0]"
       ]
     },
     "vpshufd xmm0, xmm1, 11b": {
@@ -1218,8 +1183,8 @@
         "mov v2.s[0], v17.s[3]",
         "mov v2.s[1], v17.s[0]",
         "mov v2.s[2], v17.s[0]",
-        "mov v2.s[3], v17.s[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[0]"
       ]
     },
     "vpshufd ymm0, ymm1, 00b": {
@@ -1405,8 +1370,8 @@
         "mov v2.h[4], v17.h[4]",
         "mov v2.h[5], v17.h[4]",
         "mov v2.h[6], v17.h[4]",
-        "mov v2.h[7], v17.h[4]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.h[7], v17.h[4]"
       ]
     },
     "vpshufhw xmm0, xmm1, 01b": {
@@ -1420,8 +1385,8 @@
         "mov v2.h[4], v17.h[5]",
         "mov v2.h[5], v17.h[4]",
         "mov v2.h[6], v17.h[4]",
-        "mov v2.h[7], v17.h[4]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.h[7], v17.h[4]"
       ]
     },
     "vpshufhw xmm0, xmm1, 10b": {
@@ -1435,8 +1400,8 @@
         "mov v2.h[4], v17.h[6]",
         "mov v2.h[5], v17.h[4]",
         "mov v2.h[6], v17.h[4]",
-        "mov v2.h[7], v17.h[4]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.h[7], v17.h[4]"
       ]
     },
     "vpshufhw xmm0, xmm1, 11b": {
@@ -1450,8 +1415,8 @@
         "mov v2.h[4], v17.h[7]",
         "mov v2.h[5], v17.h[4]",
         "mov v2.h[6], v17.h[4]",
-        "mov v2.h[7], v17.h[4]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.h[7], v17.h[4]"
       ]
     },
     "vpshufhw ymm0, ymm1, 00b": {
@@ -1637,8 +1602,8 @@
         "mov v2.h[0], v17.h[0]",
         "mov v2.h[1], v17.h[0]",
         "mov v2.h[2], v17.h[0]",
-        "mov v2.h[3], v17.h[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.h[3], v17.h[0]"
       ]
     },
     "vpshuflw xmm0, xmm1, 01b": {
@@ -1652,8 +1617,8 @@
         "mov v2.h[0], v17.h[1]",
         "mov v2.h[1], v17.h[0]",
         "mov v2.h[2], v17.h[0]",
-        "mov v2.h[3], v17.h[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.h[3], v17.h[0]"
       ]
     },
     "vpshuflw xmm0, xmm1, 10b": {
@@ -1667,8 +1632,8 @@
         "mov v2.h[0], v17.h[2]",
         "mov v2.h[1], v17.h[0]",
         "mov v2.h[2], v17.h[0]",
-        "mov v2.h[3], v17.h[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.h[3], v17.h[0]"
       ]
     },
     "vpshuflw xmm0, xmm1, 11b": {
@@ -1682,8 +1647,8 @@
         "mov v2.h[0], v17.h[3]",
         "mov v2.h[1], v17.h[0]",
         "mov v2.h[2], v17.h[0]",
-        "mov v2.h[3], v17.h[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.h[3], v17.h[0]"
       ]
     },
     "vpshuflw ymm0, ymm1, 00b": {
@@ -1859,14 +1824,13 @@
       ]
     },
     "vpcmpeqb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x74 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "cmeq v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "cmeq v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpcmpeqb ymm0, ymm1, ymm2": {
@@ -1883,14 +1847,13 @@
       ]
     },
     "vpcmpeqw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x75 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "cmeq v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "cmeq v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpcmpeqw ymm0, ymm1, ymm2": {
@@ -1907,14 +1870,13 @@
       ]
     },
     "vpcmpeqd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x76 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "cmeq v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "cmeq v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpcmpeqd ymm0, ymm1, ymm2": {
@@ -1982,14 +1944,13 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcmeq v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "fcmeq v16.4s, v17.4s, v18.4s"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x00": {
@@ -2006,14 +1967,13 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcmgt v2.4s, v18.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "fcmgt v16.4s, v18.4s, v17.4s"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x01": {
@@ -2030,14 +1990,13 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcmge v2.4s, v18.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "fcmge v16.4s, v18.4s, v17.4s"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x02": {
@@ -2054,7 +2013,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
@@ -2062,9 +2021,8 @@
       "ExpectedArm64ASM": [
         "fcmge v0.4s, v17.4s, v18.4s",
         "fcmgt v1.4s, v18.4s, v17.4s",
-        "orr v2.16b, v0.16b, v1.16b",
-        "mvn v2.16b, v2.16b",
-        "mov v16.16b, v2.16b"
+        "orr v16.16b, v0.16b, v1.16b",
+        "mvn v16.16b, v16.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x03": {
@@ -2081,15 +2039,14 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcmeq v2.4s, v17.4s, v18.4s",
-        "mvn v2.16b, v2.16b",
-        "mov v16.16b, v2.16b"
+        "fcmeq v16.4s, v17.4s, v18.4s",
+        "mvn v16.16b, v16.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x04": {
@@ -2106,15 +2063,14 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmgt v2.4s, v18.4s, v17.4s",
-        "mvn v2.16b, v2.16b",
-        "mov v16.16b, v2.16b"
+        "mvn v16.16b, v2.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x05": {
@@ -2132,15 +2088,14 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmge v2.4s, v18.4s, v17.4s",
-        "mvn v2.16b, v2.16b",
-        "mov v16.16b, v2.16b"
+        "mvn v16.16b, v2.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x06": {
@@ -2158,7 +2113,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
@@ -2166,8 +2121,7 @@
       "ExpectedArm64ASM": [
         "fcmge v0.4s, v17.4s, v18.4s",
         "fcmgt v1.4s, v18.4s, v17.4s",
-        "orr v2.16b, v0.16b, v1.16b",
-        "mov v16.16b, v2.16b"
+        "orr v16.16b, v0.16b, v1.16b"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x07": {
@@ -2185,14 +2139,13 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcmeq v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "fcmeq v16.2d, v17.2d, v18.2d"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x00": {
@@ -2209,14 +2162,13 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcmgt v2.2d, v18.2d, v17.2d",
-        "mov v16.16b, v2.16b"
+        "fcmgt v16.2d, v18.2d, v17.2d"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x01": {
@@ -2233,14 +2185,13 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcmge v2.2d, v18.2d, v17.2d",
-        "mov v16.16b, v2.16b"
+        "fcmge v16.2d, v18.2d, v17.2d"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x02": {
@@ -2257,7 +2208,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
@@ -2265,9 +2216,8 @@
       "ExpectedArm64ASM": [
         "fcmge v0.2d, v17.2d, v18.2d",
         "fcmgt v1.2d, v18.2d, v17.2d",
-        "orr v2.16b, v0.16b, v1.16b",
-        "mvn v2.16b, v2.16b",
-        "mov v16.16b, v2.16b"
+        "orr v16.16b, v0.16b, v1.16b",
+        "mvn v16.16b, v16.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x03": {
@@ -2284,15 +2234,14 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcmeq v2.2d, v17.2d, v18.2d",
-        "mvn v2.16b, v2.16b",
-        "mov v16.16b, v2.16b"
+        "fcmeq v16.2d, v17.2d, v18.2d",
+        "mvn v16.16b, v16.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x04": {
@@ -2309,15 +2258,14 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmgt v2.2d, v18.2d, v17.2d",
-        "mvn v2.16b, v2.16b",
-        "mov v16.16b, v2.16b"
+        "mvn v16.16b, v2.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x05": {
@@ -2335,15 +2283,14 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmge v2.2d, v18.2d, v17.2d",
-        "mvn v2.16b, v2.16b",
-        "mov v16.16b, v2.16b"
+        "mvn v16.16b, v2.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x06": {
@@ -2361,7 +2308,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
@@ -2369,8 +2316,7 @@
       "ExpectedArm64ASM": [
         "fcmge v0.2d, v17.2d, v18.2d",
         "fcmgt v1.2d, v18.2d, v17.2d",
-        "orr v2.16b, v0.16b, v1.16b",
-        "mov v16.16b, v2.16b"
+        "orr v16.16b, v0.16b, v1.16b"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x07": {
@@ -2595,40 +2541,49 @@
         "mov v16.d[0], v0.d[0]"
       ]
     },
-    "vpinsrw xmm0, xmm1, eax, 000b": {
+    "vpinsrw xmm0, xmm0, eax, 000b": {
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
+        "mov v2.16b, v16.16b",
         "mov v2.h[0], w4",
         "mov v16.16b, v2.16b"
       ]
     },
-    "vpinsrw xmm0, xmm1, eax, 001b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+    "vpinsrw xmm0, xmm1, eax, 000b": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.h[1], w4",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.h[0], w4"
+      ]
+    },
+    "vpinsrw xmm0, xmm1, eax, 001b": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 1 0b01 0xC4 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov v16.16b, v17.16b",
+        "mov v16.h[1], w4"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 111b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.h[7], w4",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.h[7], w4"
       ]
     },
     "vpextrw eax, xmm0, 000b": {
@@ -2692,7 +2647,7 @@
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 00b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
@@ -2700,8 +2655,7 @@
       "ExpectedArm64ASM": [
         "dup v2.4s, v17.s[0]",
         "dup v3.4s, v18.s[0]",
-        "zip1 v2.2d, v2.2d, v3.2d",
-        "mov v16.16b, v2.16b"
+        "zip1 v16.2d, v2.2d, v3.2d"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 00b": {
@@ -2748,7 +2702,7 @@
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 01b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
@@ -2756,8 +2710,7 @@
       "ExpectedArm64ASM": [
         "ldr x0, [x28, #1632]",
         "ldr q2, [x0, #16]",
-        "tbl v2.16b, {v17.16b, v18.16b}, v2.16b",
-        "mov v16.16b, v2.16b"
+        "tbl v16.16b, {v17.16b, v18.16b}, v2.16b"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 01b": {
@@ -2804,7 +2757,7 @@
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 10b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
@@ -2812,8 +2765,7 @@
       "ExpectedArm64ASM": [
         "ldr x0, [x28, #1632]",
         "ldr q2, [x0, #32]",
-        "tbl v2.16b, {v17.16b, v18.16b}, v2.16b",
-        "mov v16.16b, v2.16b"
+        "tbl v16.16b, {v17.16b, v18.16b}, v2.16b"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 10b": {
@@ -2860,7 +2812,7 @@
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 11b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
@@ -2868,8 +2820,7 @@
       "ExpectedArm64ASM": [
         "ldr x0, [x28, #1632]",
         "ldr q2, [x0, #48]",
-        "tbl v2.16b, {v17.16b, v18.16b}, v2.16b",
-        "mov v16.16b, v2.16b"
+        "tbl v16.16b, {v17.16b, v18.16b}, v2.16b"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 11b": {
@@ -2916,14 +2867,13 @@
       ]
     },
     "vshufpd xmm0, xmm1, xmm2, 0b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "zip1 v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "zip1 v16.2d, v17.2d, v18.2d"
       ]
     },
     "vshufpd ymm0, ymm1, ymm2, 0b": {
@@ -2954,14 +2904,13 @@
       ]
     },
     "vshufpd xmm0, xmm1, xmm2, 1b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ext v2.16b, v17.16b, v18.16b, #8",
-        "mov v16.16b, v2.16b"
+        "ext v16.16b, v17.16b, v18.16b, #8"
       ]
     },
     "vshufpd ymm0, ymm1, ymm2, 1b": {
@@ -3405,14 +3354,13 @@
       ]
     },
     "vaddps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fadd v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "fadd v16.4s, v17.4s, v18.4s"
       ]
     },
     "vaddps ymm0, ymm1, ymm2": {
@@ -3426,14 +3374,13 @@
       ]
     },
     "vaddpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fadd v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "fadd v16.2d, v17.2d, v18.2d"
       ]
     },
     "vaddpd ymm0, ymm1, ymm2": {
@@ -3471,14 +3418,13 @@
       ]
     },
     "vmulps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fmul v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "fmul v16.4s, v17.4s, v18.4s"
       ]
     },
     "vmulps ymm0, ymm1, ymm2": {
@@ -3492,14 +3438,13 @@
       ]
     },
     "vmulpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fmul v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "fmul v16.2d, v17.2d, v18.2d"
       ]
     },
     "vmulpd ymm0, ymm1, ymm2": {
@@ -3538,7 +3483,7 @@
     },
     "vcvtps2pd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5a 128-bit"
       ],
@@ -3547,15 +3492,38 @@
         "mov v16.16b, v2.16b"
       ]
     },
-    "vcvtpd2ps xmm0, xmm1": {
+    "vcvtpd2ps xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtn v2.2s, v17.2d",
+        "ldr q2, [x4]",
+        "fcvtn v16.2s, v2.2d"
+      ]
+    },
+    "vcvtpd2ps xmm0, yword [rax]": {
+      "ExpectedInstructionCount": 4,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 1 0b01 0x5a 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ld1b {z2.b}, p7/z, [x4]",
+        "fcvtnt z2.s, p7/m, z2.d",
+        "uzp2 z2.s, z2.s, z2.s",
         "mov v16.16b, v2.16b"
+      ]
+    },
+    "vcvtpd2ps xmm0, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 1 0b01 0x5a 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcvtn v16.2s, v17.2d"
       ]
     },
     "vcvtss2sd xmm0, xmm1, xmm2": {
@@ -3583,14 +3551,13 @@
       ]
     },
     "vcvtdq2ps xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "scvtf v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "scvtf v16.4s, v17.4s"
       ]
     },
     "vcvtdq2ps ymm0, ymm1": {
@@ -3604,15 +3571,14 @@
       ]
     },
     "vcvtps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti v2.4s, v17.4s",
-        "fcvtzs v2.4s, v2.4s",
-        "mov v16.16b, v2.16b"
+        "frinti v16.4s, v17.4s",
+        "fcvtzs v16.4s, v16.4s"
       ]
     },
     "vcvtps2dq ymm0, ymm1": {
@@ -3627,14 +3593,13 @@
       ]
     },
     "vcvttps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtzs v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "fcvtzs v16.4s, v17.4s"
       ]
     },
     "vcvttps2dq ymm0, ymm1": {
@@ -3648,14 +3613,13 @@
       ]
     },
     "vsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fsub v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "fsub v16.4s, v17.4s, v18.4s"
       ]
     },
     "vsubps ymm0, ymm1, ymm2": {
@@ -3669,14 +3633,13 @@
       ]
     },
     "vsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fsub v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "fsub v16.2d, v17.2d, v18.2d"
       ]
     },
     "vsubpd ymm0, ymm1, ymm2": {
@@ -3714,16 +3677,15 @@
       ]
     },
     "vminps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmgt v0.4s, v18.4s, v17.4s",
-        "mov v2.16b, v17.16b",
-        "bif v2.16b, v18.16b, v0.16b",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "bif v16.16b, v18.16b, v0.16b"
       ]
     },
     "vminps ymm0, ymm1, ymm2": {
@@ -3741,16 +3703,15 @@
       ]
     },
     "vminpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmgt v0.2d, v18.2d, v17.2d",
-        "mov v2.16b, v17.16b",
-        "bif v2.16b, v18.16b, v0.16b",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "bif v16.16b, v18.16b, v0.16b"
       ]
     },
     "vminpd ymm0, ymm1, ymm2": {
@@ -3794,14 +3755,13 @@
       ]
     },
     "vdivps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fdiv v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "fdiv v16.4s, v17.4s, v18.4s"
       ]
     },
     "vdivps ymm0, ymm1, ymm2": {
@@ -3817,14 +3777,13 @@
       ]
     },
     "vdivpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fdiv v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "fdiv v16.2d, v17.2d, v18.2d"
       ]
     },
     "vdivpd ymm0, ymm1, ymm2": {
@@ -3864,16 +3823,15 @@
       ]
     },
     "vmaxps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmgt v0.4s, v18.4s, v17.4s",
-        "mov v2.16b, v17.16b",
-        "bit v2.16b, v18.16b, v0.16b",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "bit v16.16b, v18.16b, v0.16b"
       ]
     },
     "vmaxps ymm0, ymm1, ymm2": {
@@ -3890,16 +3848,15 @@
       ]
     },
     "vmaxpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmgt v0.2d, v18.2d, v17.2d",
-        "mov v2.16b, v17.16b",
-        "bit v2.16b, v18.16b, v0.16b",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "bit v16.16b, v18.16b, v0.16b"
       ]
     },
     "vmaxpd ymm0, ymm1, ymm2": {
@@ -3942,14 +3899,13 @@
       ]
     },
     "vpunpckhbw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x68 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "zip2 v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "zip2 v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpunpckhbw ymm0, ymm1, ymm2": {
@@ -3967,14 +3923,13 @@
       ]
     },
     "vpunpckhwd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x69 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "zip2 v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "zip2 v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpunpckhwd ymm0, ymm1, ymm2": {
@@ -3992,14 +3947,13 @@
       ]
     },
     "vpunpckhdq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "zip2 v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "zip2 v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpunpckhdq ymm0, ymm1, ymm2": {
@@ -4017,15 +3971,14 @@
       ]
     },
     "vpackssdw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sqxtn v2.4h, v17.4s",
-        "sqxtn2 v2.8h, v18.4s",
-        "mov v16.16b, v2.16b"
+        "sqxtn v16.4h, v17.4s",
+        "sqxtn2 v16.8h, v18.4s"
       ]
     },
     "vpackssdw ymm0, ymm1, ymm2": {
@@ -4053,14 +4006,13 @@
       ]
     },
     "vpunpcklqdq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "zip1 v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "zip1 v16.2d, v17.2d, v18.2d"
       ]
     },
     "vpunpcklqdq ymm0, ymm1, ymm2": {
@@ -4079,14 +4031,13 @@
       ]
     },
     "vpunpckhqdq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "zip2 v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "zip2 v16.2d, v17.2d, v18.2d"
       ]
     },
     "vpunpckhqdq ymm0, ymm1, ymm2": {
@@ -4164,14 +4115,13 @@
       ]
     },
     "vhaddpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x7c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "faddp v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "faddp v16.2d, v17.2d, v18.2d"
       ]
     },
     "vhaddpd ymm0, ymm1, ymm2": {
@@ -4199,14 +4149,13 @@
       ]
     },
     "vhaddps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x7c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "faddp v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "faddp v16.4s, v17.4s, v18.4s"
       ]
     },
     "vhaddps ymm0, ymm1, ymm2": {
@@ -4234,7 +4183,7 @@
       ]
     },
     "vhsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7d 128-bit"
@@ -4242,8 +4191,7 @@
       "ExpectedArm64ASM": [
         "uzp1 v2.2d, v17.2d, v18.2d",
         "uzp2 v3.2d, v17.2d, v18.2d",
-        "fsub v2.2d, v2.2d, v3.2d",
-        "mov v16.16b, v2.16b"
+        "fsub v16.2d, v2.2d, v3.2d"
       ]
     },
     "vhsubpd ymm0, ymm1, ymm2": {
@@ -4269,7 +4217,7 @@
       ]
     },
     "vhsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x7d 128-bit"
@@ -4277,8 +4225,7 @@
       "ExpectedArm64ASM": [
         "uzp1 v2.4s, v17.4s, v18.4s",
         "uzp2 v3.4s, v17.4s, v18.4s",
-        "fsub v2.4s, v2.4s, v3.4s",
-        "mov v16.16b, v2.16b"
+        "fsub v16.4s, v2.4s, v3.4s"
       ]
     },
     "vhsubps ymm0, ymm1, ymm2": {
@@ -4367,7 +4314,7 @@
       ]
     },
     "vaddsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd0 128-bit"
@@ -4375,8 +4322,7 @@
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #1952]",
         "eor v2.16b, v18.16b, v2.16b",
-        "fadd v2.2d, v17.2d, v2.2d",
-        "mov v16.16b, v2.16b"
+        "fadd v16.2d, v17.2d, v2.2d"
       ]
     },
     "vaddsubpd ymm0, ymm1, ymm2": {
@@ -4393,7 +4339,7 @@
       ]
     },
     "vaddsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xd0 128-bit"
@@ -4401,8 +4347,7 @@
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #1920]",
         "eor v2.16b, v18.16b, v2.16b",
-        "fadd v2.4s, v17.4s, v2.4s",
-        "mov v16.16b, v2.16b"
+        "fadd v16.4s, v17.4s, v2.4s"
       ]
     },
     "vaddsubps ymm0, ymm1, ymm2": {
@@ -4494,14 +4439,13 @@
       ]
     },
     "vpaddq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "add v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "add v16.2d, v17.2d, v18.2d"
       ]
     },
     "vpaddq ymm0, ymm1, ymm2": {
@@ -4515,14 +4459,13 @@
       ]
     },
     "vpmullw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd5 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mul v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "mul v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpmullw ymm0, ymm1, ymm2": {
@@ -4594,14 +4537,13 @@
       ]
     },
     "vpsubusb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd8 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "uqsub v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "uqsub v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpsubusb ymm0, ymm1, ymm2": {
@@ -4615,14 +4557,13 @@
       ]
     },
     "vpsubusw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd9 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "uqsub v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "uqsub v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpsubusw ymm0, ymm1, ymm2": {
@@ -4636,14 +4577,13 @@
       ]
     },
     "vpminub xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xda 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "umin v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "umin v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpminub ymm0, ymm1, ymm2": {
@@ -4659,14 +4599,13 @@
       ]
     },
     "vpand xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdb 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "and v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "and v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpand ymm0, ymm1, ymm2": {
@@ -4680,14 +4619,13 @@
       ]
     },
     "vpaddusb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdc 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "uqadd v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "uqadd v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpaddusb ymm0, ymm1, ymm2": {
@@ -4701,14 +4639,13 @@
       ]
     },
     "vpaddusw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdd 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "uqadd v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "uqadd v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpaddusw ymm0, ymm1, ymm2": {
@@ -4722,14 +4659,13 @@
       ]
     },
     "vpmaxub xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdd 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "umax v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "umax v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpmaxub ymm0, ymm1, ymm2": {
@@ -4745,14 +4681,13 @@
       ]
     },
     "vpandn xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdf 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "bic v2.16b, v18.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "bic v16.16b, v18.16b, v17.16b"
       ]
     },
     "vpandn ymm0, ymm1, ymm2": {
@@ -4766,14 +4701,13 @@
       ]
     },
     "vpavgb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe0 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "urhadd v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "urhadd v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpavgb ymm0, ymm1, ymm2": {
@@ -4839,14 +4773,13 @@
       ]
     },
     "vpavgw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe3 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "urhadd v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "urhadd v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpavgw ymm0, ymm1, ymm2": {
@@ -4906,7 +4839,7 @@
       ]
     },
     "vcvttpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe6 128-bit"
@@ -4914,7 +4847,6 @@
       "ExpectedArm64ASM": [
         "fcvtn v2.2s, v17.2d",
         "fcvtzs v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4932,15 +4864,14 @@
       ]
     },
     "vcvtdq2pd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xe6 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sxtl v2.2d, v17.2s",
-        "scvtf v2.2d, v2.2d",
-        "mov v16.16b, v2.16b"
+        "scvtf v16.2d, v2.2d"
       ]
     },
     "vcvtdq2pd ymm0, xmm1": {
@@ -4955,7 +4886,7 @@
       ]
     },
     "vcvtpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xe6 128-bit"
@@ -4964,7 +4895,6 @@
         "fcvtn v2.2s, v17.2d",
         "frinti v2.4s, v2.4s",
         "fcvtzs v2.4s, v2.4s",
-        "mov v2.16b, v2.16b",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -5003,14 +4933,13 @@
       ]
     },
     "vpsubsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe8 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sqsub v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "sqsub v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpsubsb ymm0, ymm1, ymm2": {
@@ -5024,14 +4953,13 @@
       ]
     },
     "vpsubsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe9 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sqsub v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "sqsub v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpsubsw ymm0, ymm1, ymm2": {
@@ -5045,14 +4973,13 @@
       ]
     },
     "vpminsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xea 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "smin v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "smin v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpminsw ymm0, ymm1, ymm2": {
@@ -5068,14 +4995,13 @@
       ]
     },
     "vpor xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xeb 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "orr v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "orr v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpor ymm0, ymm1, ymm2": {
@@ -5089,14 +5015,13 @@
       ]
     },
     "vpaddsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xec 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sqadd v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "sqadd v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpaddsb ymm0, ymm1, ymm2": {
@@ -5110,14 +5035,13 @@
       ]
     },
     "vpaddsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xed 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sqadd v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "sqadd v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpaddsw ymm0, ymm1, ymm2": {
@@ -5131,14 +5055,13 @@
       ]
     },
     "vpmaxsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xee 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "smax v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "smax v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpmaxsw ymm0, ymm1, ymm2": {
@@ -5154,14 +5077,13 @@
       ]
     },
     "vpxor xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xef 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "eor v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "eor v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpxor ymm0, ymm1, ymm2": {
@@ -5270,7 +5192,7 @@
       ]
     },
     "vpmuludq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf4 128-bit"
@@ -5278,8 +5200,7 @@
       "ExpectedArm64ASM": [
         "uzp1 v2.4s, v17.4s, v17.4s",
         "uzp1 v3.4s, v18.4s, v18.4s",
-        "umull v2.2d, v2.2s, v3.2s",
-        "mov v16.16b, v2.16b"
+        "umull v16.2d, v2.2s, v3.2s"
       ]
     },
     "vpmuludq ymm0, ymm1, ymm2": {
@@ -5297,7 +5218,7 @@
       ]
     },
     "vpmaddwd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf5 128-bit"
@@ -5305,8 +5226,7 @@
       "ExpectedArm64ASM": [
         "smull v2.4s, v17.4h, v18.4h",
         "smull2 v3.4s, v17.8h, v18.8h",
-        "addp v2.4s, v2.4s, v3.4s",
-        "mov v16.16b, v2.16b"
+        "addp v16.4s, v2.4s, v3.4s"
       ]
     },
     "vpmaddwd ymm0, ymm1, ymm2": {
@@ -5330,7 +5250,7 @@
       ]
     },
     "vpsadbw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf6 128-bit"
@@ -5340,8 +5260,7 @@
         "uabdl2 v3.8h, v17.16b, v18.16b",
         "addv h2, v2.8h",
         "addv h3, v3.8h",
-        "zip1 v2.2d, v2.2d, v3.2d",
-        "mov v16.16b, v2.16b"
+        "zip1 v16.2d, v2.2d, v3.2d"
       ]
     },
     "vpsadbw ymm0, ymm1, ymm2": {
@@ -5398,14 +5317,13 @@
       ]
     },
     "vpsubb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf8 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sub v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "sub v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpsubb ymm0, ymm1, ymm2": {
@@ -5419,14 +5337,13 @@
       ]
     },
     "vpsubw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf9 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sub v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "sub v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpsubw ymm0, ymm1, ymm2": {
@@ -5440,14 +5357,13 @@
       ]
     },
     "vpsubd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfa 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sub v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "sub v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpsubd ymm0, ymm1, ymm2": {
@@ -5461,14 +5377,13 @@
       ]
     },
     "vpsubq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfb 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sub v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "sub v16.2d, v17.2d, v18.2d"
       ]
     },
     "vpsubq ymm0, ymm1, ymm2": {
@@ -5482,14 +5397,13 @@
       ]
     },
     "vpaddb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfc 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "add v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "add v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpaddb ymm0, ymm1, ymm2": {
@@ -5503,14 +5417,13 @@
       ]
     },
     "vpaddw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfd 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "add v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "add v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpaddw ymm0, ymm1, ymm2": {
@@ -5524,14 +5437,13 @@
       ]
     },
     "vpaddd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfe 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "add v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "add v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpaddd ymm0, ymm1, ymm2": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -10,15 +10,14 @@
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd0 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ext v2.16b, v18.16b, v18.16b, #8",
-        "fcadd v2.2d, v17.2d, v2.2d, #90",
-        "mov v16.16b, v2.16b"
+        "fcadd v16.2d, v17.2d, v2.2d, #90"
       ]
     },
     "vaddsubpd ymm0, ymm1, ymm2": {
@@ -37,15 +36,14 @@
       ]
     },
     "vaddsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xd0 128-bit"
       ],
       "ExpectedArm64ASM": [
         "rev64 v2.4s, v18.4s",
-        "fcadd v2.4s, v17.4s, v2.4s, #90",
-        "mov v16.16b, v2.16b"
+        "fcadd v16.4s, v17.4s, v2.4s, #90"
       ]
     },
     "vaddsubps ymm0, ymm1, ymm2": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -10,16 +10,15 @@
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x00 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.16b, #0x8f",
         "and v2.16b, v18.16b, v2.16b",
-        "tbl v2.16b, {v17.16b}, v2.16b",
-        "mov v16.16b, v2.16b"
+        "tbl v16.16b, {v17.16b}, v2.16b"
       ]
     },
     "vpshufb ymm0, ymm1, ymm2": {
@@ -43,14 +42,13 @@
       ]
     },
     "vphaddw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x01 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "addp v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "addp v16.8h, v17.8h, v18.8h"
       ]
     },
     "vphaddw ymm0, ymm1, ymm2": {
@@ -78,14 +76,13 @@
       ]
     },
     "vphaddd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "addp v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "addp v16.4s, v17.4s, v18.4s"
       ]
     },
     "vphaddd ymm0, ymm1, ymm2": {
@@ -113,16 +110,15 @@
       ]
     },
     "vphaddsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x03 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uzp1 v2.8h, v17.8h, v18.8h",
         "uzp2 v3.8h, v17.8h, v18.8h",
-        "sqadd v2.8h, v2.8h, v3.8h",
-        "mov v16.16b, v2.16b"
+        "sqadd v16.8h, v2.8h, v3.8h"
       ]
     },
     "vphaddsw ymm0, ymm1, ymm2": {
@@ -148,7 +144,7 @@
       ]
     },
     "vpmaddubsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x04 128-bit"
@@ -162,8 +158,7 @@
         "mul v3.8h, v3.8h, v4.8h",
         "uzp1 v4.8h, v2.8h, v3.8h",
         "uzp2 v2.8h, v2.8h, v3.8h",
-        "sqadd v2.8h, v4.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "sqadd v16.8h, v4.8h, v2.8h"
       ]
     },
     "vpmaddubsw ymm0, ymm1, ymm2": {
@@ -185,16 +180,15 @@
       ]
     },
     "vphsubw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x05 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uzp1 v2.8h, v17.8h, v18.8h",
         "uzp2 v3.8h, v17.8h, v18.8h",
-        "sub v2.8h, v2.8h, v3.8h",
-        "mov v16.16b, v2.16b"
+        "sub v16.8h, v2.8h, v3.8h"
       ]
     },
     "vphsubw ymm0, ymm1, ymm2": {
@@ -220,16 +214,15 @@
       ]
     },
     "vphsubd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x06 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uzp1 v2.4s, v17.4s, v18.4s",
         "uzp2 v3.4s, v17.4s, v18.4s",
-        "sub v2.4s, v2.4s, v3.4s",
-        "mov v16.16b, v2.16b"
+        "sub v16.4s, v2.4s, v3.4s"
       ]
     },
     "vphsubd ymm0, ymm1, ymm2": {
@@ -255,16 +248,15 @@
       ]
     },
     "vphsubsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x07 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uzp1 v2.8h, v17.8h, v18.8h",
         "uzp2 v3.8h, v17.8h, v18.8h",
-        "sqsub v2.8h, v2.8h, v3.8h",
-        "mov v16.16b, v2.16b"
+        "sqsub v16.8h, v2.8h, v3.8h"
       ]
     },
     "vphsubsw ymm0, ymm1, ymm2": {
@@ -290,16 +282,15 @@
       ]
     },
     "vpsignb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqshl v2.16b, v18.16b, #7",
         "srshr v2.16b, v2.16b, #7",
-        "mul v2.16b, v17.16b, v2.16b",
-        "mov v16.16b, v2.16b"
+        "mul v16.16b, v17.16b, v2.16b"
       ]
     },
     "vpsignb ymm0, ymm1, ymm2": {
@@ -316,16 +307,15 @@
       ]
     },
     "vpsignw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqshl v2.8h, v18.8h, #15",
         "srshr v2.8h, v2.8h, #15",
-        "mul v2.8h, v17.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "mul v16.8h, v17.8h, v2.8h"
       ]
     },
     "vpsignw ymm0, ymm1, ymm2": {
@@ -342,16 +332,15 @@
       ]
     },
     "vpsignd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x0a 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqshl v2.4s, v18.4s, #31",
         "srshr v2.4s, v2.4s, #31",
-        "mul v2.4s, v17.4s, v2.4s",
-        "mov v16.16b, v2.16b"
+        "mul v16.4s, v17.4s, v2.4s"
       ]
     },
     "vpsignd ymm0, ymm1, ymm2": {
@@ -368,7 +357,7 @@
       ]
     },
     "vpmulhrsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 11,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0b 128-bit"
@@ -382,8 +371,9 @@
         "add v2.4s, v2.4s, v4.4s",
         "add v3.4s, v3.4s, v4.4s",
         "shrn v2.4h, v2.4s, #1",
-        "shrn2 v2.8h, v3.4s, #1",
-        "mov v16.16b, v2.16b"
+        "mov v0.16b, v2.16b",
+        "shrn2 v0.8h, v3.4s, #1",
+        "mov v16.16b, v0.16b"
       ]
     },
     "vpmulhrsw ymm0, ymm1, ymm2": {
@@ -413,7 +403,7 @@
       ]
     },
     "vpermilps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0c 128-bit"
@@ -428,8 +418,7 @@
         "movk w20, #0x302, lsl #16",
         "dup v3.4s, w20",
         "add v2.16b, v3.16b, v2.16b",
-        "tbl v2.16b, {v17.16b}, v2.16b",
-        "mov v16.16b, v2.16b"
+        "tbl v16.16b, {v17.16b}, v2.16b"
       ]
     },
     "vpermilps ymm0, ymm1, ymm2": {
@@ -458,7 +447,7 @@
       ]
     },
     "vpermilpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0d 128-bit"
@@ -478,8 +467,7 @@
         "movk x20, #0x706, lsl #48",
         "dup v3.2d, x20",
         "add v2.16b, v3.16b, v2.16b",
-        "tbl v2.16b, {v17.16b}, v2.16b",
-        "mov v16.16b, v2.16b"
+        "tbl v16.16b, {v17.16b}, v2.16b"
       ]
     },
     "vpermilpd ymm0, ymm1, ymm2": {
@@ -764,14 +752,13 @@
       ]
     },
     "vbroadcastss xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x18 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1rw {z2.s}, p6/z, [x4]",
-        "mov v16.16b, v2.16b"
+        "ld1r {v16.4s}, [x4]"
       ]
     },
     "vbroadcastss ymm0, [rax]": {
@@ -805,19 +792,18 @@
       ]
     },
     "vpabsb xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "abs v2.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "abs v16.16b, v17.16b"
       ]
     },
     "vpabsb ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1c 256-bit"
       ],
@@ -826,19 +812,18 @@
       ]
     },
     "vpabsw xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "abs v2.8h, v17.8h",
-        "mov v16.16b, v2.16b"
+        "abs v16.8h, v17.8h"
       ]
     },
     "vpabsw ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1d 256-bit"
       ],
@@ -847,19 +832,18 @@
       ]
     },
     "vpabsd xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "abs v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "abs v16.4s, v17.4s"
       ]
     },
     "vpabsd ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1e 256-bit"
       ],
@@ -868,19 +852,18 @@
       ]
     },
     "vpmovsxbw xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sxtl v2.8h, v17.8b",
-        "mov v16.16b, v2.16b"
+        "sxtl v16.8h, v17.8b"
       ]
     },
     "vpmovsxbw ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x20 256-bit"
       ],
@@ -889,15 +872,14 @@
       ]
     },
     "vpmovsxbd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sxtl v2.8h, v17.8b",
-        "sxtl v2.4s, v2.4h",
-        "mov v16.16b, v2.16b"
+        "sxtl v16.4s, v2.4h"
       ]
     },
     "vpmovsxbd ymm0, xmm1": {
@@ -912,16 +894,15 @@
       ]
     },
     "vpmovsxbq xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sxtl v2.8h, v17.8b",
         "sxtl v2.4s, v2.4h",
-        "sxtl v2.2d, v2.2s",
-        "mov v16.16b, v2.16b"
+        "sxtl v16.2d, v2.2s"
       ]
     },
     "vpmovsxbq ymm0, xmm1": {
@@ -937,19 +918,18 @@
       ]
     },
     "vpmovsxwd xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x23 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sxtl v2.4s, v17.4h",
-        "mov v16.16b, v2.16b"
+        "sxtl v16.4s, v17.4h"
       ]
     },
     "vpmovsxwd ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x23 256-bit"
       ],
@@ -958,15 +938,14 @@
       ]
     },
     "vpmovsxwq xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x24 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sxtl v2.4s, v17.4h",
-        "sxtl v2.2d, v2.2s",
-        "mov v16.16b, v2.16b"
+        "sxtl v16.2d, v2.2s"
       ]
     },
     "vpmovsxwq ymm0, xmm1": {
@@ -981,19 +960,18 @@
       ]
     },
     "vpmovsxdq xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x25 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sxtl v2.2d, v17.2s",
-        "mov v16.16b, v2.16b"
+        "sxtl v16.2d, v17.2s"
       ]
     },
     "vpmovsxdq ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x25 256-bit"
       ],
@@ -1002,16 +980,15 @@
       ]
     },
     "vpmuldq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 3,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x28 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uzp1 v2.4s, v17.4s, v17.4s",
         "uzp1 v3.4s, v18.4s, v18.4s",
-        "smull v2.2d, v2.2s, v3.2s",
-        "mov v16.16b, v2.16b"
+        "smull v16.2d, v2.2s, v3.2s"
       ]
     },
     "vpmuldq ymm0, ymm1, ymm2": {
@@ -1029,14 +1006,13 @@
       ]
     },
     "vpcmpeqq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x29 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "cmeq v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "cmeq v16.2d, v17.2d, v18.2d"
       ]
     },
     "vpcmpeqq ymm0, ymm1, ymm2": {
@@ -1073,15 +1049,14 @@
       ]
     },
     "vpackusdw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sqxtun v2.4h, v17.4s",
-        "sqxtun2 v2.8h, v18.4s",
-        "mov v16.16b, v2.16b"
+        "sqxtun v16.4h, v17.4s",
+        "sqxtun2 v16.8h, v18.4s"
       ]
     },
     "vpackusdw ymm0, ymm1, ymm2": {
@@ -1199,19 +1174,18 @@
       ]
     },
     "vpmovzxbw xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x30 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "uxtl v2.8h, v17.8b",
-        "mov v16.16b, v2.16b"
+        "uxtl v16.8h, v17.8b"
       ]
     },
     "vpmovzxbw ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x30 256-bit"
       ],
@@ -1220,20 +1194,19 @@
       ]
     },
     "vpmovzxbd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x31 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uxtl v2.8h, v17.8b",
-        "uxtl v2.4s, v2.4h",
-        "mov v16.16b, v2.16b"
+        "uxtl v16.4s, v2.4h"
       ]
     },
     "vpmovzxbd ymm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x31 256-bit"
       ],
@@ -1243,7 +1216,7 @@
       ]
     },
     "vpmovzxbq xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x32 128-bit"
@@ -1251,8 +1224,7 @@
       "ExpectedArm64ASM": [
         "uxtl v2.8h, v17.8b",
         "uxtl v2.4s, v2.4h",
-        "uxtl v2.2d, v2.2s",
-        "mov v16.16b, v2.16b"
+        "uxtl v16.2d, v2.2s"
       ]
     },
     "vpmovzxbq ymm0, xmm1": {
@@ -1268,19 +1240,18 @@
       ]
     },
     "vpmovzxwd xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x33 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "uxtl v2.4s, v17.4h",
-        "mov v16.16b, v2.16b"
+        "uxtl v16.4s, v17.4h"
       ]
     },
     "vpmovzxwd ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x33 256-bit"
       ],
@@ -1289,15 +1260,14 @@
       ]
     },
     "vpmovzxwq xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x34 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uxtl v2.4s, v17.4h",
-        "uxtl v2.2d, v2.2s",
-        "mov v16.16b, v2.16b"
+        "uxtl v16.2d, v2.2s"
       ]
     },
     "vpmovzxwq ymm0, xmm1": {
@@ -1312,19 +1282,18 @@
       ]
     },
     "vpmovzxdq xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x35 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "uxtl v2.2d, v17.2s",
-        "mov v16.16b, v2.16b"
+        "uxtl v16.2d, v17.2s"
       ]
     },
     "vpmovzxdq ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x35 256-bit"
       ],
@@ -1352,14 +1321,13 @@
       ]
     },
     "vpcmpgtq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x37 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "cmgt v2.2d, v17.2d, v18.2d",
-        "mov v16.16b, v2.16b"
+        "cmgt v16.2d, v17.2d, v18.2d"
       ]
     },
     "vpcmpgtq ymm0, ymm1, ymm2": {
@@ -1376,14 +1344,13 @@
       ]
     },
     "vpminsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x38 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "smin v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "smin v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpminsb ymm0, ymm1, ymm2": {
@@ -1399,14 +1366,13 @@
       ]
     },
     "vpminsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x39 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "smin v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "smin v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpminsd ymm0, ymm1, ymm2": {
@@ -1422,14 +1388,13 @@
       ]
     },
     "vpminuw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "umin v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "umin v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpminuw ymm0, ymm1, ymm2": {
@@ -1445,14 +1410,13 @@
       ]
     },
     "vpminud xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "umin v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "umin v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpminud ymm0, ymm1, ymm2": {
@@ -1468,14 +1432,13 @@
       ]
     },
     "vpmaxsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "smax v2.16b, v17.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "smax v16.16b, v17.16b, v18.16b"
       ]
     },
     "vpmaxsb ymm0, ymm1, ymm2": {
@@ -1491,14 +1454,13 @@
       ]
     },
     "vpmaxsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "smax v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "smax v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpmaxsd ymm0, ymm1, ymm2": {
@@ -1514,14 +1476,13 @@
       ]
     },
     "vpmaxuw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "umax v2.8h, v17.8h, v18.8h",
-        "mov v16.16b, v2.16b"
+        "umax v16.8h, v17.8h, v18.8h"
       ]
     },
     "vpmaxuw ymm0, ymm1, ymm2": {
@@ -1537,14 +1498,13 @@
       ]
     },
     "vpmaxud xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x3f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "umax v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "umax v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpmaxud ymm0, ymm1, ymm2": {
@@ -1560,19 +1520,18 @@
       ]
     },
     "vpmulld xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mul v2.4s, v17.4s, v18.4s",
-        "mov v16.16b, v2.16b"
+        "mul v16.4s, v17.4s, v18.4s"
       ]
     },
     "vpmulld ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x40 256-bit"
       ],
@@ -1581,8 +1540,8 @@
       ]
     },
     "vphminposuw xmm0, xmm1": {
-      "ExpectedInstructionCount": 7,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 6,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x41 256-bit"
       ],
@@ -1592,12 +1551,11 @@
         "zip2 v2.8h, v2.8h, v17.8h",
         "umin v2.4s, v3.4s, v2.4s",
         "uminv s2, v2.4s",
-        "rev32 v2.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "rev32 v16.8h, v2.8h"
       ]
     },
     "vpsrlvd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 128-bit"
@@ -1606,8 +1564,7 @@
         "movi v0.4s, #0x20, lsl #0",
         "umin v0.4s, v0.4s, v18.4s",
         "neg v0.4s, v0.4s",
-        "ushl v2.4s, v17.4s, v0.4s",
-        "mov v16.16b, v2.16b"
+        "ushl v16.4s, v17.4s, v0.4s"
       ]
     },
     "vpsrlvd ymm0, ymm1, ymm2": {
@@ -1624,7 +1581,7 @@
       ]
     },
     "vpsrlvq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 128-bit"
@@ -1635,8 +1592,7 @@
         "cmhi v1.2d, v18.2d, v0.2d",
         "bif v0.16b, v18.16b, v1.16b",
         "neg v0.2d, v0.2d",
-        "ushl v2.2d, v17.2d, v0.2d",
-        "mov v16.16b, v2.16b"
+        "ushl v16.2d, v17.2d, v0.2d"
       ]
     },
     "vpsrlvq ymm0, ymm1, ymm2": {
@@ -1653,7 +1609,7 @@
       ]
     },
     "vpsravd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x46 128-bit"
@@ -1662,8 +1618,7 @@
         "movi v0.4s, #0x1f, lsl #0",
         "umin v0.4s, v0.4s, v18.4s",
         "neg v0.4s, v0.4s",
-        "sshl v2.4s, v17.4s, v0.4s",
-        "mov v16.16b, v2.16b"
+        "sshl v16.4s, v17.4s, v0.4s"
       ]
     },
     "vpsravd ymm0, ymm1, ymm2": {
@@ -1680,7 +1635,7 @@
       ]
     },
     "vpsllvd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 128-bit"
@@ -1688,8 +1643,7 @@
       "ExpectedArm64ASM": [
         "movi v0.4s, #0x20, lsl #0",
         "umin v0.4s, v0.4s, v18.4s",
-        "ushl v2.4s, v17.4s, v0.4s",
-        "mov v16.16b, v2.16b"
+        "ushl v16.4s, v17.4s, v0.4s"
       ]
     },
     "vpsllvd ymm0, ymm1, ymm2": {
@@ -1706,7 +1660,7 @@
       ]
     },
     "vpsllvq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 128-bit"
@@ -1716,8 +1670,7 @@
         "dup v0.2d, x0",
         "cmhi v1.2d, v18.2d, v0.2d",
         "bif v0.16b, v18.16b, v1.16b",
-        "ushl v2.2d, v17.2d, v0.2d",
-        "mov v16.16b, v2.16b"
+        "ushl v16.2d, v17.2d, v0.2d"
       ]
     },
     "vpsllvq ymm0, ymm1, ymm2": {
@@ -1734,30 +1687,28 @@
       ]
     },
     "vpbroadcastd xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "dup v2.4s, v17.s[0]",
-        "mov v16.16b, v2.16b"
+        "dup v16.4s, v17.s[0]"
       ]
     },
     "vpbroadcastd xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1rw {z2.s}, p6/z, [x4]",
-        "mov v16.16b, v2.16b"
+        "ld1r {v16.4s}, [x4]"
       ]
     },
     "vpbroadcastd ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x58 256-bit"
       ],
@@ -1776,30 +1727,28 @@
       ]
     },
     "vpbroadcastq xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "dup v2.2d, v17.d[0]",
-        "mov v16.16b, v2.16b"
+        "dup v16.2d, v17.d[0]"
       ]
     },
     "vpbroadcastq xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1rd {z2.d}, p6/z, [x4]",
-        "mov v16.16b, v2.16b"
+        "ld1r {v16.2d}, [x4]"
       ]
     },
     "vpbroadcastq ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x59 256-bit"
       ],
@@ -1829,30 +1778,28 @@
       ]
     },
     "vpbroadcastb xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "dup v2.16b, v17.b[0]",
-        "mov v16.16b, v2.16b"
+        "dup v16.16b, v17.b[0]"
       ]
     },
     "vpbroadcastb xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1rb {z2.b}, p6/z, [x4]",
-        "mov v16.16b, v2.16b"
+        "ld1r {v16.16b}, [x4]"
       ]
     },
     "vpbroadcastb ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x78 256-bit"
       ],
@@ -1872,30 +1819,28 @@
       ]
     },
     "vpbroadcastw xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "dup v2.8h, v17.h[0]",
-        "mov v16.16b, v2.16b"
+        "dup v16.8h, v17.h[0]"
       ]
     },
     "vpbroadcastw xmm0, [rax]": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1rh {z2.h}, p6/z, [x4]",
-        "mov v16.16b, v2.16b"
+        "ld1r {v16.8h}, [x4]"
       ]
     },
     "vpbroadcastw ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x79 256-bit"
       ],
@@ -3285,18 +3230,17 @@
       ]
     },
     "vaesimc xmm0, xmm1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0xdb 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "unimplemented (Unimplemented)",
-        "mov v16.16b, v2.16b"
+        "unimplemented (Unimplemented)"
       ]
     },
     "vaesenc xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdc 128-bit"
@@ -3306,8 +3250,7 @@
         "mov v0.16b, v17.16b",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
-        "eor v2.16b, v0.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "eor v16.16b, v0.16b, v18.16b"
       ]
     },
     "vaesenc ymm0, ymm1, ymm2": {
@@ -3319,7 +3262,7 @@
       ]
     },
     "vaesenclast xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdd 128-bit"
@@ -3328,8 +3271,7 @@
         "movi v2.2d, #0x0",
         "mov v0.16b, v17.16b",
         "unimplemented (Unimplemented)",
-        "eor v2.16b, v0.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "eor v16.16b, v0.16b, v18.16b"
       ]
     },
     "vaesenclast ymm0, ymm1, ymm2": {
@@ -3341,7 +3283,7 @@
       ]
     },
     "vaesdec xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xde 128-bit"
@@ -3351,8 +3293,7 @@
         "mov v0.16b, v17.16b",
         "unimplemented (Unimplemented)",
         "unimplemented (Unimplemented)",
-        "eor v2.16b, v0.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "eor v16.16b, v0.16b, v18.16b"
       ]
     },
     "vaesdec ymm0, ymm1, ymm2": {
@@ -3364,7 +3305,7 @@
       ]
     },
     "vaesdeclast xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdf 128-bit"
@@ -3373,8 +3314,7 @@
         "movi v2.2d, #0x0",
         "mov v0.16b, v17.16b",
         "unimplemented (Unimplemented)",
-        "eor v2.16b, v0.16b, v18.16b",
-        "mov v16.16b, v2.16b"
+        "eor v16.16b, v0.16b, v18.16b"
       ]
     },
     "vaesdeclast ymm0, ymm1, ymm2": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -437,8 +437,8 @@
         "mov v2.s[0], v17.s[0]",
         "mov v2.s[1], v17.s[0]",
         "mov v2.s[2], v17.s[0]",
-        "mov v2.s[3], v17.s[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[0]"
       ]
     },
     "vpermilps xmm0, xmm1, 01010101b": {
@@ -452,8 +452,8 @@
         "mov v2.s[0], v17.s[1]",
         "mov v2.s[1], v17.s[1]",
         "mov v2.s[2], v17.s[1]",
-        "mov v2.s[3], v17.s[1]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[1]"
       ]
     },
     "vpermilps xmm0, xmm1, 10101010b": {
@@ -467,8 +467,8 @@
         "mov v2.s[0], v17.s[2]",
         "mov v2.s[1], v17.s[2]",
         "mov v2.s[2], v17.s[2]",
-        "mov v2.s[3], v17.s[2]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[2]"
       ]
     },
     "vpermilps xmm0, xmm1, 11111111b": {
@@ -482,8 +482,8 @@
         "mov v2.s[0], v17.s[3]",
         "mov v2.s[1], v17.s[3]",
         "mov v2.s[2], v17.s[3]",
-        "mov v2.s[3], v17.s[3]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v17.s[3]"
       ]
     },
     "vpermilps ymm0, ymm1, 00000000b": {
@@ -667,8 +667,8 @@
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
         "mov v2.d[0], v17.d[0]",
-        "mov v2.d[1], v17.d[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v17.d[0]"
       ]
     },
     "vpermilpd xmm0, xmm1, 01b": {
@@ -680,8 +680,8 @@
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
         "mov v2.d[0], v17.d[1]",
-        "mov v2.d[1], v17.d[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v17.d[0]"
       ]
     },
     "vpermilpd xmm0, xmm1, 10b": {
@@ -693,8 +693,8 @@
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
         "mov v2.d[0], v17.d[0]",
-        "mov v2.d[1], v17.d[1]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v17.d[1]"
       ]
     },
     "vpermilpd xmm0, xmm1, 11b": {
@@ -706,8 +706,8 @@
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
         "mov v2.d[0], v17.d[1]",
-        "mov v2.d[1], v17.d[1]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v17.d[1]"
       ]
     },
     "vpermilpd ymm0, ymm1, 0000b": {
@@ -1517,63 +1517,58 @@
       ]
     },
     "vroundps xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frintn v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "frintn v16.4s, v17.4s"
       ]
     },
     "vroundps xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frintm v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "frintm v16.4s, v17.4s"
       ]
     },
     "vroundps xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frintp v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "frintp v16.4s, v17.4s"
       ]
     },
     "vroundps xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frintz v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "frintz v16.4s, v17.4s"
       ]
     },
     "vroundps xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti v2.4s, v17.4s",
-        "mov v16.16b, v2.16b"
+        "frinti v16.4s, v17.4s"
       ]
     },
     "vroundps ymm0, ymm1, 00000000b": {
@@ -1632,63 +1627,58 @@
       ]
     },
     "vroundpd xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frintn v2.2d, v17.2d",
-        "mov v16.16b, v2.16b"
+        "frintn v16.2d, v17.2d"
       ]
     },
     "vroundpd xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frintm v2.2d, v17.2d",
-        "mov v16.16b, v2.16b"
+        "frintm v16.2d, v17.2d"
       ]
     },
     "vroundpd xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frintp v2.2d, v17.2d",
-        "mov v16.16b, v2.16b"
+        "frintp v16.2d, v17.2d"
       ]
     },
     "vroundpd xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frintz v2.2d, v17.2d",
-        "mov v16.16b, v2.16b"
+        "frintz v16.2d, v17.2d"
       ]
     },
     "vroundpd xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti v2.2d, v17.2d",
-        "mov v16.16b, v2.16b"
+        "frinti v16.2d, v17.2d"
       ]
     },
     "vroundpd ymm0, ymm1, 00000000b": {
@@ -1748,7 +1738,7 @@
     },
     "vroundss xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1761,7 +1751,7 @@
     },
     "vroundss xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1774,7 +1764,7 @@
     },
     "vroundss xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1787,7 +1777,7 @@
     },
     "vroundss xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1800,7 +1790,7 @@
     },
     "vroundss xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1813,7 +1803,7 @@
     },
     "vroundsd xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -1826,7 +1816,7 @@
     },
     "vroundsd xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -1839,7 +1829,7 @@
     },
     "vroundsd xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -1852,7 +1842,7 @@
     },
     "vroundsd xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -1865,7 +1855,7 @@
     },
     "vroundsd xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -1993,8 +1983,8 @@
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
         "mov v2.d[0], v18.d[0]",
-        "mov v2.d[1], v17.d[1]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v17.d[1]"
       ]
     },
     "vblendpd xmm0, xmm1, xmm2, 10b": {
@@ -2006,8 +1996,8 @@
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
         "mov v2.d[0], v17.d[0]",
-        "mov v2.d[1], v18.d[1]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v18.d[1]"
       ]
     },
     "vblendpd xmm0, xmm1, xmm2, 11b": {
@@ -2553,48 +2543,44 @@
       ]
     },
     "vpalignr xmm0, xmm1, xmm2, 0": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ext v2.16b, v18.16b, v17.16b, #0",
-        "mov v16.16b, v2.16b"
+        "ext v16.16b, v18.16b, v17.16b, #0"
       ]
     },
     "vpalignr xmm0, xmm1, xmm2, 1": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ext v2.16b, v18.16b, v17.16b, #1",
-        "mov v16.16b, v2.16b"
+        "ext v16.16b, v18.16b, v17.16b, #1"
       ]
     },
     "vpalignr xmm0, xmm1, xmm2, 15": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ext v2.16b, v18.16b, v17.16b, #15",
-        "mov v16.16b, v2.16b"
+        "ext v16.16b, v18.16b, v17.16b, #15"
       ]
     },
     "vpalignr xmm0, xmm1, xmm2, 16": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v0.2d, #0x0",
-        "ext v2.16b, v17.16b, v0.16b, #0",
-        "mov v16.16b, v2.16b"
+        "ext v16.16b, v17.16b, v0.16b, #0"
       ]
     },
     "vpalignr ymm0, ymm1, ymm2, 0": {
@@ -2959,111 +2945,138 @@
         "Map 3 0b01 0x1D 256-bit"
       ]
     },
-    "vpinsrb xmm0, xmm1, eax, 0": {
+    "vpinsrb xmm0, xmm0, eax, 0": {
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
+        "mov v2.16b, v16.16b",
         "mov v2.b[0], w4",
         "mov v16.16b, v2.16b"
       ]
     },
-    "vpinsrb xmm0, xmm1, eax, 15": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+    "vpinsrb xmm0, xmm1, eax, 0": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.b[15], w4",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.b[0], w4"
+      ]
+    },
+    "vpinsrb xmm0, xmm1, eax, 15": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x20 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov v16.16b, v17.16b",
+        "mov v16.b[15], w4"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b00 << 6) | (0b00 << 4) | (0b0000))": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.s[0], v18.s[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.s[0], v18.s[0]"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b00 << 6) | (0b00 << 4) | (0b1111))": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b11 << 6) | (0b11 << 4) | (0b0000))": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.s[3], v18.s[3]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.s[3], v18.s[3]"
       ]
     },
-    "vpinsrd xmm0, xmm1, eax, 0": {
+    "vpinsrd xmm0, xmm0, eax, 0": {
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
+        "mov v2.16b, v16.16b",
         "mov v2.s[0], w4",
         "mov v16.16b, v2.16b"
       ]
     },
-    "vpinsrd xmm0, xmm1, eax, 3": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+    "vpinsrd xmm0, xmm1, eax, 0": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.s[3], w4",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.s[0], w4"
       ]
     },
-    "vpinsrq xmm0, xmm1, rax, 0": {
+    "vpinsrd xmm0, xmm1, eax, 3": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x22 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov v16.16b, v17.16b",
+        "mov v16.s[3], w4"
+      ]
+    },
+    "vpinsrq xmm0, xmm0, rax, 0": {
       "ExpectedInstructionCount": 3,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
+        "mov v2.16b, v16.16b",
         "mov v2.d[0], x4",
         "mov v16.16b, v2.16b"
       ]
     },
-    "vpinsrq xmm0, xmm1, rax, 1": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+    "vpinsrq xmm0, xmm1, rax, 0": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.d[1], x4",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v17.16b",
+        "mov v16.d[0], x4"
+      ]
+    },
+    "vpinsrq xmm0, xmm1, rax, 1": {
+      "ExpectedInstructionCount": 2,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map 3 0b01 0x22 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov v16.16b, v17.16b",
+        "mov v16.d[1], x4"
       ]
     },
     "vinserti128 ymm0, ymm1, xmm2, 0": {
@@ -3113,14 +3126,13 @@
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 00000000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 00001111b": {
@@ -3141,19 +3153,18 @@
         "mov v2.s[0], v3.s[0]",
         "mov v2.s[1], v3.s[0]",
         "mov v2.s[2], v3.s[0]",
-        "mov v2.s[3], v3.s[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v3.s[0]"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 11110000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 11111111b": {
@@ -3170,8 +3181,8 @@
         "mov v2.s[0], v3.s[0]",
         "mov v2.s[1], v3.s[0]",
         "mov v2.s[2], v3.s[0]",
-        "mov v2.s[3], v3.s[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.s[3], v3.s[0]"
       ]
     },
     "vdpps ymm0, ymm1, ymm2, 00000000b": {
@@ -3335,14 +3346,13 @@
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 00000000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 00001111b": {
@@ -3358,19 +3368,18 @@
         "mov v3.d[1], v2.d[0]",
         "faddp v3.2d, v3.2d, v2.2d",
         "mov v2.d[0], v3.d[0]",
-        "mov v2.d[1], v3.d[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v3.d[0]"
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 11110000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 11111111b": {
@@ -3384,12 +3393,12 @@
         "fmul v3.2d, v17.2d, v18.2d",
         "faddp v3.2d, v3.2d, v2.2d",
         "mov v2.d[0], v3.d[0]",
-        "mov v2.d[1], v3.d[0]",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v3.d[0]"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 000b": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
@@ -3408,12 +3417,11 @@
         "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v4.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "addp v16.8h, v4.8h, v2.8h"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 001b": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
@@ -3432,12 +3440,11 @@
         "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v4.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "addp v16.8h, v4.8h, v2.8h"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 010b": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
@@ -3456,12 +3463,11 @@
         "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v4.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "addp v16.8h, v4.8h, v2.8h"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 011b": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
@@ -3480,12 +3486,11 @@
         "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v4.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "addp v16.8h, v4.8h, v2.8h"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 100b": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
@@ -3504,12 +3509,11 @@
         "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v4.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "addp v16.8h, v4.8h, v2.8h"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 101b": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
@@ -3528,12 +3532,11 @@
         "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v4.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "addp v16.8h, v4.8h, v2.8h"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 110b": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
@@ -3552,12 +3555,11 @@
         "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v4.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "addp v16.8h, v4.8h, v2.8h"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 111b": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 14,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
@@ -3576,8 +3578,7 @@
         "addp v2.8h, v4.8h, v2.8h",
         "trn1 v4.4s, v3.4s, v2.4s",
         "trn2 v2.4s, v3.4s, v2.4s",
-        "addp v2.8h, v4.8h, v2.8h",
-        "mov v16.16b, v2.16b"
+        "addp v16.8h, v4.8h, v2.8h"
       ]
     },
     "vmpsadbw ymm0, ymm1, ymm2, 000b": {
@@ -3925,49 +3926,45 @@
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 00000b": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "unallocated (Unallocated)",
-        "mov v16.16b, v2.16b"
+        "unallocated (Unallocated)"
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 00001b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
         "dup v0.2d, v17.d[1]",
-        "unallocated (Unallocated)",
-        "mov v16.16b, v2.16b"
+        "unallocated (Unallocated)"
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 10000b": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
-      "Comment": [
-        "Map 3 0b01 0x44 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "dup v0.2d, v18.d[1]",
-        "unallocated (Unallocated)",
-        "mov v16.16b, v2.16b"
-      ]
-    },
-    "vpclmulqdq xmm0, xmm1, xmm2, 10001b": {
       "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "unallocated (Unallocated)",
-        "mov v16.16b, v2.16b"
+        "dup v0.2d, v18.d[1]",
+        "unallocated (Unallocated)"
+      ]
+    },
+    "vpclmulqdq xmm0, xmm1, xmm2, 10001b": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "No",
+      "Comment": [
+        "Map 3 0b01 0x44 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "unallocated (Unallocated)"
       ]
     },
     "vpclmulqdq ymm0, ymm1, ymm2, 00000b": {
@@ -4384,8 +4381,8 @@
       ],
       "ExpectedArm64ASM": [
         "sshr v2.4s, v19.4s, #31",
-        "bsl v2.16b, v18.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "bsl v16.16b, v18.16b, v17.16b"
       ]
     },
     "vblendvps ymm0, ymm1, ymm2, ymm3": {
@@ -4410,8 +4407,8 @@
       ],
       "ExpectedArm64ASM": [
         "sshr v2.2d, v19.2d, #63",
-        "bsl v2.16b, v18.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "bsl v16.16b, v18.16b, v17.16b"
       ]
     },
     "vblendvpd ymm0, ymm1, ymm2, ymm3": {
@@ -4436,8 +4433,8 @@
       ],
       "ExpectedArm64ASM": [
         "sshr v2.16b, v19.16b, #7",
-        "bsl v2.16b, v18.16b, v17.16b",
-        "mov v16.16b, v2.16b"
+        "mov v16.16b, v2.16b",
+        "bsl v16.16b, v18.16b, v17.16b"
       ]
     },
     "vpblendvb ymm0, ymm1, ymm2, ymm3": {
@@ -4695,7 +4692,7 @@
       ]
     },
     "vaeskeygenassist xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0xdf 128-bit"
@@ -4703,14 +4700,13 @@
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2000]",
         "movi v3.2d, #0x0",
-        "mov v2.16b, v17.16b",
+        "mov v16.16b, v17.16b",
         "unimplemented (Unimplemented)",
-        "tbl v2.16b, {v2.16b}, v2.16b",
-        "mov v16.16b, v2.16b"
+        "tbl v16.16b, {v16.16b}, v2.16b"
       ]
     },
     "vaeskeygenassist xmm0, xmm1, 0xFF": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0xdf 128-bit"
@@ -4718,13 +4714,12 @@
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2000]",
         "movi v3.2d, #0x0",
-        "mov v2.16b, v17.16b",
+        "mov v16.16b, v17.16b",
         "unimplemented (Unimplemented)",
-        "tbl v2.16b, {v2.16b}, v2.16b",
+        "tbl v16.16b, {v16.16b}, v2.16b",
         "mov x0, #0xff00000000",
         "dup v1.2d, x0",
-        "eor v2.16b, v2.16b, v1.16b",
-        "mov v16.16b, v2.16b"
+        "eor v16.16b, v16.16b, v1.16b"
       ]
     },
     "rorx eax, ebx, 0": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -18,25 +18,23 @@
       ]
     },
     "vpsrlw xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ushr v2.8h, v17.8h, #15",
-        "mov v16.16b, v2.16b"
+        "ushr v16.8h, v17.8h, #15"
       ]
     },
     "vpsrlw xmm0, xmm1, 16": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsrlw ymm0, ymm1, 0": {
@@ -81,25 +79,23 @@
       ]
     },
     "vpsraw xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sshr v2.8h, v17.8h, #15",
-        "mov v16.16b, v2.16b"
+        "sshr v16.8h, v17.8h, #15"
       ]
     },
     "vpsraw xmm0, xmm1, 16": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sshr v2.8h, v17.8h, #15",
-        "mov v16.16b, v2.16b"
+        "sshr v16.8h, v17.8h, #15"
       ]
     },
     "vpsraw ymm0, ymm1, 0": {
@@ -145,25 +141,23 @@
       ]
     },
     "vpsllw xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "shl v2.8h, v17.8h, #15",
-        "mov v16.16b, v2.16b"
+        "shl v16.8h, v17.8h, #15"
       ]
     },
     "vpsllw xmm0, xmm1, 16": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsllw ymm0, ymm1, 0": {
@@ -208,25 +202,23 @@
       ]
     },
     "vpsrld xmm0, xmm1, 31": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ushr v2.4s, v17.4s, #31",
-        "mov v16.16b, v2.16b"
+        "ushr v16.4s, v17.4s, #31"
       ]
     },
     "vpsrld xmm0, xmm1, 32": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsrld ymm0, ymm1, 0": {
@@ -271,25 +263,23 @@
       ]
     },
     "vpsrad xmm0, xmm1, 31": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sshr v2.4s, v17.4s, #31",
-        "mov v16.16b, v2.16b"
+        "sshr v16.4s, v17.4s, #31"
       ]
     },
     "vpsrad xmm0, xmm1, 32": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "sshr v2.4s, v17.4s, #31",
-        "mov v16.16b, v2.16b"
+        "sshr v16.4s, v17.4s, #31"
       ]
     },
     "vpsrad ymm0, ymm1, 0": {
@@ -335,25 +325,23 @@
       ]
     },
     "vpslld xmm0, xmm1, 31": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "shl v2.4s, v17.4s, #31",
-        "mov v16.16b, v2.16b"
+        "shl v16.4s, v17.4s, #31"
       ]
     },
     "vpslld xmm0, xmm1, 32": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpslld ymm0, ymm1, 0": {
@@ -398,25 +386,23 @@
       ]
     },
     "vpsrlq xmm0, xmm1, 63": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ushr v2.2d, v17.2d, #63",
-        "mov v16.16b, v2.16b"
+        "ushr v16.2d, v17.2d, #63"
       ]
     },
     "vpsrlq xmm0, xmm1, 64": {
-      "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsrlq ymm0, ymm1, 0": {
@@ -461,18 +447,6 @@
       ]
     },
     "vpsrldq xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
-      "Comment": [
-        "Map group 14 0b011 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "ext v2.16b, v17.16b, v2.16b, #15",
-        "mov v16.16b, v2.16b"
-      ]
-    },
-    "vpsrldq xmm0, xmm1, 16": {
       "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
@@ -480,7 +454,17 @@
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "ext v16.16b, v17.16b, v2.16b, #15"
+      ]
+    },
+    "vpsrldq xmm0, xmm1, 16": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map group 14 0b011 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsrldq ymm0, ymm1, 0": {
@@ -532,25 +516,23 @@
       ]
     },
     "vpsllq xmm0, xmm1, 63": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "shl v2.2d, v17.2d, #63",
-        "mov v16.16b, v2.16b"
+        "shl v16.2d, v17.2d, #63"
       ]
     },
     "vpsllq xmm0, xmm1, 64": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Optimal": "No",
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "movi v16.2d, #0x0"
       ]
     },
     "vpsllq ymm0, ymm1, 0": {
@@ -595,18 +577,6 @@
       ]
     },
     "vpslldq xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 3,
-      "Optimal": "No",
-      "Comment": [
-        "Map group 14 0b111 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "ext v2.16b, v2.16b, v17.16b, #1",
-        "mov v16.16b, v2.16b"
-      ]
-    },
-    "vpslldq xmm0, xmm1, 16": {
       "ExpectedInstructionCount": 2,
       "Optimal": "No",
       "Comment": [
@@ -614,7 +584,17 @@
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov v16.16b, v2.16b"
+        "ext v16.16b, v2.16b, v17.16b, #1"
+      ]
+    },
+    "vpslldq xmm0, xmm1, 16": {
+      "ExpectedInstructionCount": 1,
+      "Optimal": "Yes",
+      "Comment": [
+        "Map group 14 0b111 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
       ]
     },
     "vpslldq ymm0, ymm1, 0": {


### PR DESCRIPTION
Removes the truncating move that we perform inside the StoreResult function and instead delegates the responsibility to the instruction implementations themselves.

This removes a lot of redundant moves that occur on 128-bit variants of AVX instructions.

Also fixes a weird case where we were handling 128-bit SVE in VBroadcastFromMem when we already have AdvSIMD instructions that will perfom the zero-extension behavior for us.