### PR TITLE
Linux: Fixes issue with *at syscalls with absolute paths not working

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/FileManagement.cpp
@@ -416,8 +416,17 @@ fextl::string FileManager::GetEmulatedPath(const char *pathname, bool FollowSyml
 std::pair<int, const char*> FileManager::GetEmulatedFDPath(int dirfd, const char *pathname, bool FollowSymlink, FDPathTmpData &TmpFilename) {
   constexpr auto NoEntry = std::make_pair(-1, nullptr);
 
-  if (!pathname || // If no pathname
-      pathname[0] != '/' || // If relative
+  if (!pathname) {
+    // No pathname.
+    return NoEntry;
+  }
+
+  if (pathname[0] == '/') {
+    // If the path is absolute then dirfd is ignored.
+    dirfd = AT_FDCWD;
+  }
+
+  if (pathname[0] != '/' || // If relative
       pathname[1] == 0 || // If we are getting root
       dirfd != AT_FDCWD) { // If dirfd isn't special FDCWD
     return NoEntry;


### PR DESCRIPTION
When a syscall from the *at series is provided an FD but the path is absolute then dirfd should be ignored. We weren't correctly doing this. Now if the path is absolute, but set the argument to the special AT_FDCWD..
Fixes #3204