### PR TITLE
VectorOps: Handle SVE VExtr a little better

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -3788,11 +3788,15 @@ DEF_OP(VExtr) {
   if (HostSupportsSVE256 && Is256Bit) {
     if (Dst == LowerBits) {
       // Trivial case where we don't need to do any moves
-      ext<FEXCore::ARMEmitter::OpType::Destructive>(Dst.Z(), Dst.Z(), UpperBits.Z(), CopyFromByte);
-    } else {
+      ext<ARMEmitter::OpType::Destructive>(Dst.Z(), Dst.Z(), UpperBits.Z(), CopyFromByte);
+    } else if (Dst == UpperBits) {
       movprfx(VTMP2.Z(), LowerBits.Z());
-      ext<FEXCore::ARMEmitter::OpType::Destructive>(VTMP2.Z(), VTMP2.Z(), UpperBits.Z(), CopyFromByte);
+      ext<ARMEmitter::OpType::Destructive>(VTMP2.Z(), VTMP2.Z(), UpperBits.Z(), CopyFromByte);
       mov(Dst.Z(), VTMP2.Z());
+    } else {
+      // No registers alias the destination, so we can safely move into it.
+      movprfx(Dst.Z(), LowerBits.Z());
+      ext<ARMEmitter::OpType::Destructive>(Dst.Z(), Dst.Z(), UpperBits.Z(), CopyFromByte);
     }
   } else {
     if (OpSize == 8) {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -21,6 +21,19 @@
       ]
     },
     "vaddsubpd ymm0, ymm0, ymm2": {
+      "ExpectedInstructionCount": 3,
+      "Optimal": "No",
+      "Comment": [
+        "Aliasing source and destination",
+        "Map 1 0b01 0xd0 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movprfx z2, z18",
+        "ext z2.b, z2.b, z18.b, #8",
+        "fcadd z16.d, p7/m, z16.d, z2.d, #90"
+      ]
+    },
+    "vaddsubpd ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
@@ -28,37 +41,21 @@
         "Map 1 0b01 0xd0 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z1, z18",
-        "ext z1.b, z1.b, z18.b, #8",
-        "mov z2.d, z1.d",
-        "fcadd z16.d, p7/m, z16.d, z2.d, #90"
-      ]
-    },
-    "vaddsubpd ymm0, ymm1, ymm0": {
-      "ExpectedInstructionCount": 5,
-      "Optimal": "No",
-      "Comment": [
-        "Aliasing source and destination",
-        "Map 1 0b01 0xd0 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "movprfx z1, z16",
-        "ext z1.b, z1.b, z16.b, #8",
-        "mov z2.d, z1.d",
+        "movprfx z2, z16",
+        "ext z2.b, z2.b, z16.b, #8",
         "movprfx z16, z17",
         "fcadd z16.d, p7/m, z16.d, z2.d, #90"
       ]
     },
     "vaddsubpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd0 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z1, z18",
-        "ext z1.b, z1.b, z18.b, #8",
-        "mov z2.d, z1.d",
+        "movprfx z2, z18",
+        "ext z2.b, z2.b, z18.b, #8",
         "movprfx z16, z17",
         "fcadd z16.d, p7/m, z16.d, z2.d, #90"
       ]


### PR DESCRIPTION
If the source registers don't alias the destination, then we can safely move the lower bits over to it without using a temporary.