### PR TITLE
JITArm64: Fixes bug in rpres scalar operations 

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -384,7 +384,7 @@ DEF_OP(VFRSqrtScalarInsert) {
 
   auto ScalarEmitRPRES = [this, SubRegSize](ARMEmitter::VRegister Dst, std::variant<ARMEmitter::VRegister, ARMEmitter::Register> SrcVar) {
     auto Src = *std::get_if<ARMEmitter::VRegister>(&SrcVar);
-    frecpe(SubRegSize.Scalar, Dst.S(), Src.S());
+    frsqrte(SubRegSize.Scalar, Dst.S(), Src.S());
   };
 
   std::array<ScalarUnaryOpCaller, 2> Handlers = {
@@ -421,7 +421,7 @@ DEF_OP(VFRecpScalarInsert) {
 
   auto ScalarEmitRPRES = [this, SubRegSize](ARMEmitter::VRegister Dst, std::variant<ARMEmitter::VRegister, ARMEmitter::Register> SrcVar) {
     auto Src = *std::get_if<ARMEmitter::VRegister>(&SrcVar);
-    frsqrte(SubRegSize.Scalar, Dst, Src);
+    frecpe(SubRegSize.Scalar, Dst, Src);
   };
 
   std::array<ScalarUnaryOpCaller, 2> Handlers = {

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP.json
@@ -19,7 +19,7 @@
         "0xf3 0x0f 0x52"
       ],
       "ExpectedArm64ASM": [
-        "frecpe s0, s17",
+        "frsqrte s0, s17",
         "mov v16.s[0], v0.s[0]"
       ]
     },
@@ -31,7 +31,7 @@
         "0xf3 0x0f 0x53"
       ],
       "ExpectedArm64ASM": [
-        "frsqrte s0, s17",
+        "frecpe s0, s17",
         "mov v16.s[0], v0.s[0]"
       ]
     }

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -19,7 +19,7 @@
         "0xf3 0x0f 0x52"
       ],
       "ExpectedArm64ASM": [
-        "frecpe s16, s17"
+        "frsqrte s16, s17"
       ]
     },
     "rcpss xmm0, xmm1": {
@@ -30,7 +30,7 @@
         "0xf3 0x0f 0x53"
       ],
       "ExpectedArm64ASM": [
-        "frsqrte s16, s17"
+        "frecpe s16, s17"
       ]
     }
   }

--- a/unittests/InstructionCountCI/RPRES/VEX_map1.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1.json
@@ -40,7 +40,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
-        "frecpe s0, s18",
+        "frsqrte s0, s18",
         "mov v16.s[0], v0.s[0]"
       ]
     },
@@ -72,7 +72,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
-        "frsqrte s0, s18",
+        "frecpe s0, s18",
         "mov v16.s[0], v0.s[0]"
       ]
     }

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -39,7 +39,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
-        "frecpe s16, s18"
+        "frsqrte s16, s18"
       ]
     },
     "vrcpps xmm0, xmm1": {
@@ -70,7 +70,7 @@
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
-        "frsqrte s16, s18"
+        "frecpe s16, s18"
       ]
     }
   }


### PR DESCRIPTION
Noticed this during code investigation, these two operations were
swapped.

Would have caused issues if anything supported RPRES today.