### PR TITLE
Thunks: Annotate pointer parameters throughout all thunked libraries

### DIFF
--- a/ThunkLibs/Generator/analysis.cpp
+++ b/ThunkLibs/Generator/analysis.cpp
@@ -128,9 +128,7 @@ void AnalysisAction::ExecuteAction() {
 
     try {
         ParseInterface(context);
-        if (StrictModeEnabled(context)) {
-            CoverReferencedTypes(context);
-        }
+        CoverReferencedTypes(context);
         OnAnalysisComplete(context);
     } catch (ClangDiagnosticAsException& exception) {
         exception.Report(context.getDiagnostics());
@@ -348,9 +346,6 @@ void AnalysisAction::ParseInterface(clang::ASTContext& context) {
 
                         auto check_struct_type = [&](const clang::Type* type) {
                             if (type->isIncompleteType()) {
-                                if (!StrictModeEnabled(context)) {
-                                    return;
-                                }
                                 throw report_error(type->getAsTagDecl()->getBeginLoc(), "Unannotated pointer with incomplete struct type; consider using an opaque_type annotation")
                                       .addNote(report_error(emitted_function->getNameInfo().getLoc(), "in function", clang::DiagnosticsEngine::Note))
                                       .addNote(report_error(template_arg_loc, "used in annotation here", clang::DiagnosticsEngine::Note));

--- a/ThunkLibs/Generator/analysis.h
+++ b/ThunkLibs/Generator/analysis.h
@@ -187,11 +187,3 @@ inline std::string get_type_name(const clang::ASTContext& context, const clang::
     }
     return type_name;
 }
-
-// Analysis can't process interfaces of real libraries, yet. This function
-// defines a "strict mode" to use for tests, only. Real libraries will switch
-// to strict mode once analysis is more feature-complete.
-inline bool StrictModeEnabled(clang::ASTContext& context) {
-    auto filename = context.getSourceManager().getFileEntryForID(context.getSourceManager().getMainFileID())->getName();
-    return filename.endswith("libfex_thunk_test_interface.cpp") || filename.endswith("gen_input.cpp");
-}

--- a/ThunkLibs/Generator/data_layout.cpp
+++ b/ThunkLibs/Generator/data_layout.cpp
@@ -168,9 +168,7 @@ static std::array<uint8_t, 32> GetSha256(const std::string& function_name) {
 };
 
 void AnalyzeDataLayoutAction::OnAnalysisComplete(clang::ASTContext& context) {
-    if (StrictModeEnabled(context)) {
     type_abi = GetStableLayout(context, ComputeDataLayout(context, types));
-    }
 
     // Register functions that must be guest-callable through host function pointers
     for (auto funcptr_type_it = thunked_funcptrs.begin(); funcptr_type_it != thunked_funcptrs.end(); ++funcptr_type_it) {

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -55,13 +55,11 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
     // Compute data layout differences between host and guest
     auto type_compat = [&]() {
         std::unordered_map<const clang::Type*, TypeCompatibility> ret;
-        if (StrictModeEnabled(context)) {
         const auto host_abi = ComputeDataLayout(context, types);
         for (const auto& [type, type_repack_info] : types) {
             if (!type_repack_info.pointers_only) {
                 GetTypeCompatibility(context, type, host_abi, ret);
             }
-        }
         }
         return ret;
     }();
@@ -293,7 +291,7 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
             // Check data layout compatibility of parameter types
             // TODO: Also check non-struct/non-pointer types
             // TODO: Also check return type
-            for (size_t param_idx = 0; StrictModeEnabled(context) && param_idx != thunk.param_types.size(); ++param_idx) {
+            for (size_t param_idx = 0; param_idx != thunk.param_types.size(); ++param_idx) {
                 const auto& param_type = thunk.param_types[param_idx];
                 if (!param_type->isPointerType() || !param_type->getPointeeType()->isStructureType()) {
                     continue;
@@ -336,7 +334,7 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
             file << "static void fexfn_unpack_" << libname << "_" << function_name << "(" << struct_name << "* args) {\n";
             file << (thunk.return_type->isVoidType() ? "  " : "  args->rv = ") << function_to_call << "(";
 
-            for (unsigned param_idx = 0; StrictModeEnabled(context) && param_idx != thunk.param_types.size(); ++param_idx) {
+            for (unsigned param_idx = 0; param_idx != thunk.param_types.size(); ++param_idx) {
                 if (thunk.callbacks.contains(param_idx) && thunk.callbacks.at(param_idx).is_stub) {
                     continue;
                 }

--- a/ThunkLibs/libEGL/libEGL_interface.cpp
+++ b/ThunkLibs/libEGL/libEGL_interface.cpp
@@ -7,6 +7,10 @@ struct fex_gen_config {
     unsigned version = 1;
 };
 
+// Function, parameter index, parameter type [optional]
+template<auto, int, typename = void>
+struct fex_gen_param {};
+
 template<> struct fex_gen_config<eglBindAPI> {};
 template<> struct fex_gen_config<eglChooseConfig> {};
 template<> struct fex_gen_config<eglDestroyContext> {};
@@ -23,4 +27,7 @@ template<> struct fex_gen_config<eglCreateWindowSurface> {};
 template<> struct fex_gen_config<eglGetCurrentContext> {};
 template<> struct fex_gen_config<eglGetCurrentDisplay> {};
 template<> struct fex_gen_config<eglGetCurrentSurface> {};
+
+// EGLNativeDisplayType is a pointer to opaque data (wl_display/(X)Display/...)
 template<> struct fex_gen_config<eglGetDisplay> {};
+template<> struct fex_gen_param<eglGetDisplay, 0, EGLNativeDisplayType> : fexgen::assume_compatible_data_layout {};

--- a/ThunkLibs/libGL/libGL_interface.cpp
+++ b/ThunkLibs/libGL/libGL_interface.cpp
@@ -11,12 +11,33 @@
 #undef GL_ARB_viewport_array
 #include "glcorearb.h"
 
+#include <type_traits>
+
 template<auto>
 struct fex_gen_config {
     unsigned version = 1;
 };
 
 template<> struct fex_gen_config<glXGetProcAddress> : fexgen::custom_guest_entrypoint, fexgen::returns_guest_pointer {};
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<std::remove_pointer_t<GLXContext>> : fexgen::opaque_type {};
+template<> struct fex_gen_type<std::remove_pointer_t<GLXFBConfig>> : fexgen::opaque_type {};
+template<> struct fex_gen_type<std::remove_pointer_t<GLsync>> : fexgen::opaque_type {};
+
+// NOTE: These should be opaque, but actually aren't because the respective libraries aren't thunked
+template<> struct fex_gen_type<_cl_context> : fexgen::opaque_type {};
+template<> struct fex_gen_type<_cl_event> : fexgen::opaque_type {};
+
+// Opaque for the purpose of libGL
+template<> struct fex_gen_type<_XDisplay> : fexgen::opaque_type {};
+
+#ifndef IS_32BIT_THUNK
+// TODO: These are largely compatible, *but* contain function pointer members that need adjustment!
+template<> struct fex_gen_type<XExtData> : fexgen::assume_compatible_data_layout {};
+#endif
 
 // Symbols queryable through glXGetProcAddr
 namespace internal {

--- a/ThunkLibs/libX11/libX11_Guest.cpp
+++ b/ThunkLibs/libX11/libX11_Guest.cpp
@@ -14,6 +14,8 @@ extern "C" {
 #include <X11/Xproto.h>
 #include <X11/XKBlib.h>
 
+#include <X11/extensions/extutil.h>
+
 // Include Xlibint.h and undefine some of its macros that clash with the standard library
 #include <X11/Xlibint.h>
 #undef min

--- a/ThunkLibs/libX11/libX11_Host.cpp
+++ b/ThunkLibs/libX11/libX11_Host.cpp
@@ -20,12 +20,20 @@ extern "C" {
 #undef min
 #undef max
 
+#define XTRANS_SEND_FDS 1
+#include <X11/Xtrans/Xtransint.h>
+
 #include <X11/Xutil.h>
+#include <X11/Xregion.h>
 #include <X11/Xresource.h>
 
 #include <X11/Xproto.h>
 
+#include <X11/extensions/extutil.h>
 #include <X11/extensions/XKBstr.h>
+#include <X11/extensions/XKBgeom.h>
+
+#include <X11/Xtrans/Xtransint.h>
 }
 
 #include "common/Host.h"

--- a/ThunkLibs/libXext/libXext_Guest.cpp
+++ b/ThunkLibs/libXext/libXext_Guest.cpp
@@ -35,6 +35,8 @@ extern "C" {
 #include <X11/extensions/syncconst.h>
 #include <X11/extensions/syncproto.h>
 //#include <X11/extensions/XTest.h>
+#undef min
+#undef max
 
 
 #include "common/Guest.h"

--- a/ThunkLibs/libXext/libXext_Host.cpp
+++ b/ThunkLibs/libXext/libXext_Host.cpp
@@ -8,6 +8,7 @@ $end_info$
 
 #include <X11/Xlib.h>
 #include <X11/Xlibint.h>
+#include <X11/Xregion.h>
 #include <X11/Xutil.h>
 #include <X11/Xproto.h>
 #include <X11/extensions/Xext.h>
@@ -37,6 +38,12 @@ extern "C" {
 #include <X11/extensions/syncconst.h>
 #include <X11/extensions/syncproto.h>
 //#include <X11/extensions/XTest.h>
+
+#define XTRANS_SEND_FDS 1
+#include <X11/Xtrans/Xtransint.h>
+
+#undef min
+#undef max
 
 #include "common/Host.h"
 #include <dlfcn.h>

--- a/ThunkLibs/libXext/libXext_interface.cpp
+++ b/ThunkLibs/libXext/libXext_interface.cpp
@@ -2,6 +2,7 @@
 
 #include <X11/Xlib.h>
 #include <X11/Xlibint.h>
+#include <X11/Xregion.h>
 #include <X11/extensions/Xext.h>
 #include <X11/extensions/dpms.h>
 #include <X11/extensions/XEVI.h>
@@ -16,11 +17,51 @@
 extern "C" {
 #include <X11/extensions/extutil.h>
 }
+#include <X11/Xtrans/Xtransint.h>
 
 template<auto>
 struct fex_gen_config {
     unsigned version = 6;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<_X11XCBPrivate> : fexgen::opaque_type {};
+template<> struct fex_gen_type<_XContextDB> : fexgen::opaque_type {};
+template<> struct fex_gen_type<_XDisplayAtoms> : fexgen::opaque_type {};
+template<> struct fex_gen_type<_XErrorThreadInfo> : fexgen::opaque_type {};
+template<> struct fex_gen_type<_XIMFilter> : fexgen::opaque_type {};
+template<> struct fex_gen_type<_XkbInfoRec> : fexgen::opaque_type {};
+template<> struct fex_gen_type<_XKeytrans> : fexgen::opaque_type {};
+template<> struct fex_gen_type<_XLockInfo> : fexgen::opaque_type {};
+template<> struct fex_gen_type<_XrmHashBucketRec> : fexgen::opaque_type {};
+
+#ifndef IS_32BIT_THUNK
+// Union types
+template<> struct fex_gen_type<XEvent> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<xEvent> : fexgen::assume_compatible_data_layout {};
+
+// Linked-list types
+template<> struct fex_gen_type<_XtransConnFd> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<_XQEvent> : fexgen::assume_compatible_data_layout {};
+
+// TODO: These are largely compatible, *but* contain function pointer members that need adjustment!
+template<> struct fex_gen_type<_XConnectionInfo> : fexgen::assume_compatible_data_layout {}; // Also contains linked-list pointers
+template<> struct fex_gen_type<_XConnWatchInfo> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<_XDisplay> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<XExtData> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<XExtDisplayInfo> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<_XExtension> : fexgen::assume_compatible_data_layout {}; // Also contains linked-list pointers
+template<> struct fex_gen_type<_XInternalAsync> : fexgen::assume_compatible_data_layout {}; // Also contains linked-list pointers
+
+// Contains nontrivial circular pointer relationships
+template<> struct fex_gen_type<Screen> : fexgen::assume_compatible_data_layout {};
+
+// TODO: This contains a nested struct type of function pointer members
+template<> struct fex_gen_type<XImage> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<XExtensionHooks> : fexgen::assume_compatible_data_layout {};
+#endif
 
 template<> struct fex_gen_config<DPMSCapable> {};
 template<> struct fex_gen_config<DPMSDisable> {};

--- a/ThunkLibs/libXfixes/libXfixes_Host.cpp
+++ b/ThunkLibs/libXfixes/libXfixes_Host.cpp
@@ -6,9 +6,14 @@ $end_info$
 
 #include <stdio.h>
 
+extern "C" {
 #include <X11/Xlib.h>
+#include <X11/Xlibint.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/Xfixes.h>
+}
+#undef min
+#undef max
 
 #include "common/Host.h"
 #include <dlfcn.h>

--- a/ThunkLibs/libXfixes/libXfixes_interface.cpp
+++ b/ThunkLibs/libXfixes/libXfixes_interface.cpp
@@ -1,11 +1,23 @@
 #include <common/GeneratorInterface.h>
 
+extern "C" {
 #include <X11/extensions/Xfixes.h>
+#include <X11/Xlibint.h>
+}
 
 template<auto>
 struct fex_gen_config {
     unsigned version = 3;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+#ifndef IS_32BIT_THUNK
+// TODO: These are largely compatible, *but* contain function pointer members that need adjustment!
+template<> struct fex_gen_type<XExtData> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<_XDisplay> : fexgen::assume_compatible_data_layout {};
+#endif
 
 template<> struct fex_gen_config<XFixesGetCursorName> {};
 template<> struct fex_gen_config<XFixesQueryExtension> {};

--- a/ThunkLibs/libXrender/libXrender_Host.cpp
+++ b/ThunkLibs/libXrender/libXrender_Host.cpp
@@ -6,9 +6,15 @@ $end_info$
 
 #include <stdio.h>
 
+extern "C" {
 #include <X11/Xlib.h>
+#include <X11/Xlibint.h>
+#include <X11/Xregion.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/Xrender.h>
+}
+#undef min
+#undef max
 
 #include "common/Host.h"
 #include <dlfcn.h>

--- a/ThunkLibs/libXrender/libXrender_interface.cpp
+++ b/ThunkLibs/libXrender/libXrender_interface.cpp
@@ -2,10 +2,27 @@
 
 #include <X11/extensions/Xrender.h>
 
+#include <type_traits>
+
 template<auto>
 struct fex_gen_config {
     unsigned version = 1;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+// Struct with multi-dimensional array member. Compatible data layout across all architectures
+template<> struct fex_gen_type<_XTransform> : fexgen::assume_compatible_data_layout {};
+
+#ifndef IS_32BIT_THUNK
+// This has a public definition but is used as an opaque type in most APIs
+template<> struct fex_gen_type<std::remove_pointer_t<Region>> : fexgen::assume_compatible_data_layout {};
+
+// TODO: These are largely compatible, *but* contain function pointer members that need adjustment!
+template<> struct fex_gen_type<XExtData> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<_XDisplay> : fexgen::assume_compatible_data_layout {};
+#endif
 
 template<> struct fex_gen_config<XRenderCreateAnimCursor> {};
 template<> struct fex_gen_config<XRenderCreateCursor> {};

--- a/ThunkLibs/libasound/libasound_interface.cpp
+++ b/ThunkLibs/libasound/libasound_interface.cpp
@@ -3,10 +3,98 @@
 #include <alsa/asoundlib.h>
 #include <alsa/version.h>
 
+#include <type_traits>
+
 template<auto>
 struct fex_gen_config {
     unsigned version = 2;
 };
+
+// Function, parameter index, parameter type [optional]
+template<auto, int, typename = void>
+struct fex_gen_param {};
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<snd_pcm_status_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_shm_area> : fexgen::opaque_type {};
+
+template<> struct fex_gen_type<snd_async_handler_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<std::remove_pointer_t<snd_config_iterator_t>> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_config_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_config_update_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_ctl_card_info_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_ctl_elem_id_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_ctl_elem_info_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_ctl_elem_list_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_ctl_elem_value_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_ctl_event_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_ctl_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_devname_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_hctl_elem_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_hctl_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_hwdep_dsp_image_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_hwdep_dsp_status_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_hwdep_info_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_hwdep_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_input_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_midi_event_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_mixer_class_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_mixer_elem_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_mixer_selem_id_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_mixer_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_output_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_pcm_access_mask_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_pcm_format_mask_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_pcm_hook_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_pcm_hw_params_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_pcm_info_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_pcm_scope_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_pcm_subformat_mask_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_pcm_sw_params_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_pcm_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_rawmidi_info_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_rawmidi_params_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_rawmidi_status_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_rawmidi_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_sctl_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_client_info_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_client_pool_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_ev_ext_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_port_info_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_port_subscribe_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_query_subscribe_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_queue_info_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_queue_status_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_queue_tempo_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_queue_timer_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_remove_events_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_system_info_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_seq_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_timer_ginfo_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_timer_gparams_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_timer_gstatus_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_timer_id_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_timer_info_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_timer_params_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_timer_query_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_timer_status_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_timer_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<snd_timestamp_t> : fexgen::opaque_type {};
+
+template<> struct fex_gen_type<FILE> : fexgen::opaque_type {};
+
+// Union types with compatible data layout
+template<> struct fex_gen_type<snd_pcm_sync_id_t> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<snd_seq_timestamp> : fexgen::assume_compatible_data_layout {};
+// Has anonymous union member
+template<> struct fex_gen_type<snd_seq_event> : fexgen::assume_compatible_data_layout {};
+
+#ifndef IS_32BIT_THUNK
+// TODO: Convert vtable
+template<> struct fex_gen_type<snd_pcm_scope_ops_t> : fexgen::assume_compatible_data_layout {};
+#endif
 
 template<> struct fex_gen_config<snd_asoundlib_version> {};
 #if SND_LIB_VERSION < ((1 << 16) | (2 << 8) | (6))

--- a/ThunkLibs/libdrm/libdrm_interface.cpp
+++ b/ThunkLibs/libdrm/libdrm_interface.cpp
@@ -7,6 +7,21 @@ struct fex_gen_config {
     unsigned version = 2;
 };
 
+template<typename>
+struct fex_gen_type {};
+
+#ifndef IS_32BIT_THUNK
+// Union types with compatible data layout
+template<> struct fex_gen_type<drmDevice> : fexgen::assume_compatible_data_layout {};
+
+// Anonymous sub-structs
+template<> struct fex_gen_type<drmStatsT> : fexgen::assume_compatible_data_layout {};
+
+// TODO: Convert vtable
+template<> struct fex_gen_type<drmServerInfo> : fexgen::assume_compatible_data_layout {};
+template<> struct fex_gen_type<drmEventContext> : fexgen::assume_compatible_data_layout {};
+#endif
+
 size_t FEX_usable_size(void*);
 void FEX_free_on_host(void*);
 

--- a/ThunkLibs/libvulkan/Guest.cpp
+++ b/ThunkLibs/libvulkan/Guest.cpp
@@ -4,6 +4,8 @@ tags: thunklibs|Vulkan
 $end_info$
 */
 
+#define VK_USE_64_BIT_PTR_DEFINES 0
+
 #define VK_USE_PLATFORM_XLIB_XRANDR_EXT
 #define VK_USE_PLATFORM_XLIB_KHR
 #define VK_USE_PLATFORM_XCB_KHR

--- a/ThunkLibs/libvulkan/Host.cpp
+++ b/ThunkLibs/libvulkan/Host.cpp
@@ -4,6 +4,8 @@ tags: thunklibs|Vulkan
 $end_info$
 */
 
+#define VK_USE_64_BIT_PTR_DEFINES 0
+
 #define VK_USE_PLATFORM_XLIB_XRANDR_EXT
 #define VK_USE_PLATFORM_XLIB_KHR
 #define VK_USE_PLATFORM_XCB_KHR
@@ -91,8 +93,8 @@ static void FEXFN_IMPL(vkFreeMemory)(VkDevice a_0, VkDeviceMemory a_1, const VkA
   LDR_PTR(vkFreeMemory)(a_0, a_1, nullptr);
 }
 
-static VkResult FEXFN_IMPL(vkCreateDebugReportCallbackEXT)(VkInstance a_0, const VkDebugReportCallbackCreateInfoEXT* a_1, const VkAllocationCallbacks* a_2, VkDebugReportCallbackEXT* a_3) {
-  VkDebugReportCallbackCreateInfoEXT overridden_callback = *a_1;
+static VkResult FEXFN_IMPL(vkCreateDebugReportCallbackEXT)(VkInstance a_0, guest_layout<const VkDebugReportCallbackCreateInfoEXT*> a_1, const VkAllocationCallbacks* a_2, VkDebugReportCallbackEXT* a_3) {
+  VkDebugReportCallbackCreateInfoEXT overridden_callback = *a_1.data;
   overridden_callback.pfnCallback = DummyVkDebugReportCallback;
   (void*&)LDR_PTR(vkCreateDebugReportCallbackEXT) = (void*)LDR_PTR(vkGetInstanceProcAddr)(a_0, "vkCreateDebugReportCallbackEXT");
   return LDR_PTR(vkCreateDebugReportCallbackEXT)(a_0, &overridden_callback, nullptr, a_3);
@@ -101,6 +103,21 @@ static VkResult FEXFN_IMPL(vkCreateDebugReportCallbackEXT)(VkInstance a_0, const
 static void FEXFN_IMPL(vkDestroyDebugReportCallbackEXT)(VkInstance a_0, VkDebugReportCallbackEXT a_1, const VkAllocationCallbacks* a_2) {
   (void*&)LDR_PTR(vkDestroyDebugReportCallbackEXT) = (void*)LDR_PTR(vkGetInstanceProcAddr)(a_0, "vkDestroyDebugReportCallbackEXT");
   LDR_PTR(vkDestroyDebugReportCallbackEXT)(a_0, a_1, nullptr);
+}
+
+extern "C" VkBool32 DummyVkDebugUtilsMessengerCallback(
+    VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT,
+    const VkDebugUtilsMessengerCallbackDataEXT*, void*) {
+  return VK_FALSE;
+}
+
+static VkResult FEXFN_IMPL(vkCreateDebugUtilsMessengerEXT)(
+    VkInstance_T* a_0, guest_layout<const VkDebugUtilsMessengerCreateInfoEXT*> a_1,
+    const VkAllocationCallbacks* a_2, VkDebugUtilsMessengerEXT* a_3) {
+  VkDebugUtilsMessengerCreateInfoEXT overridden_callback = *a_1.data;
+  overridden_callback.pfnUserCallback = DummyVkDebugUtilsMessengerCallback;
+  (void*&)LDR_PTR(vkCreateDebugUtilsMessengerEXT) = (void*)LDR_PTR(vkGetInstanceProcAddr)(a_0, "vkCreateDebugUtilsMessengerEXT");
+  return LDR_PTR(vkCreateDebugUtilsMessengerEXT)(a_0, &overridden_callback, nullptr, a_3);
 }
 
 static PFN_vkVoidFunction FEXFN_IMPL(vkGetDeviceProcAddr)(VkDevice a_0, const char* a_1) {

--- a/ThunkLibs/libwayland-client/Host.cpp
+++ b/ThunkLibs/libwayland-client/Host.cpp
@@ -46,7 +46,7 @@ static void WaylandFinalizeHostTrampolineForGuestListener(void (*callback)()) {
 }
 
 extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_proxy *proxy,
-      guest_layout<void (**)(void)> callback_raw, guest_layout<void*> data) {
+      guest_layout<void (**)(void)> callback_raw, void* data) {
   auto guest_interface = ((wl_proxy_private*)proxy)->interface;
 
   for (int i = 0; i < guest_interface->event_count; ++i) {
@@ -162,7 +162,7 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
   }
 
   // Pass the original function pointer table to the host wayland library. This ensures the table is valid until the listener is unregistered.
-  return fexldr_ptr_libwayland_client_wl_proxy_add_listener(proxy, callback_raw.data, data.data);
+  return fexldr_ptr_libwayland_client_wl_proxy_add_listener(proxy, callback_raw.data, data);
 }
 
 wl_interface* fexfn_impl_libwayland_client_fex_wl_exchange_interface_pointer(wl_interface* guest_interface, char const* name) {

--- a/ThunkLibs/libwayland-client/libwayland-client_interface.cpp
+++ b/ThunkLibs/libwayland-client/libwayland-client_interface.cpp
@@ -14,6 +14,15 @@ struct fex_gen_type {};
 template<auto, int, typename = void>
 struct fex_gen_param {};
 
+template<> struct fex_gen_type<wl_display> : fexgen::opaque_type {};
+template<> struct fex_gen_type<wl_proxy> : fexgen::opaque_type {};
+template<> struct fex_gen_type<wl_interface> : fexgen::opaque_type {};
+
+template<> struct fex_gen_type<wl_event_queue> : fexgen::opaque_type {};
+
+// Passed over Wayland's wire protocol for some functions
+template<> struct fex_gen_type<wl_array> {};
+
 
 template<> struct fex_gen_config<wl_proxy_destroy> : fexgen::custom_guest_entrypoint {};
 
@@ -36,8 +45,10 @@ template<> struct fex_gen_config<wl_display_get_fd> {};
 template<> struct fex_gen_config<wl_event_queue_destroy> {};
 
 template<> struct fex_gen_config<wl_proxy_add_listener> : fexgen::custom_host_impl, fexgen::custom_guest_entrypoint {};
+// Callback table
 template<> struct fex_gen_param<wl_proxy_add_listener, 1, void(**)()> : fexgen::ptr_passthrough {};
-template<> struct fex_gen_param<wl_proxy_add_listener, 2, void*> : fexgen::ptr_passthrough {};
+// User-provided data pointer (not used in caller-provided callback)
+template<> struct fex_gen_param<wl_proxy_add_listener, 2, void*> : fexgen::assume_compatible_data_layout {};
 template<> struct fex_gen_config<wl_proxy_create> {};
 template<> struct fex_gen_config<wl_proxy_create_wrapper> {};
 template<> struct fex_gen_config<wl_proxy_get_tag> {};
@@ -45,6 +56,7 @@ template<> struct fex_gen_config<wl_proxy_get_user_data> {};
 template<> struct fex_gen_config<wl_proxy_get_version> {};
 template<> struct fex_gen_config<wl_proxy_set_queue> {};
 template<> struct fex_gen_config<wl_proxy_set_tag> {};
+// TODO: This has a void* parameter. Why does 32-bit accept this without annotations?
 template<> struct fex_gen_config<wl_proxy_set_user_data> {};
 template<> struct fex_gen_config<wl_proxy_wrapper_destroy> {};
 

--- a/ThunkLibs/libxcb-dri2/libxcb-dri2_interface.cpp
+++ b/ThunkLibs/libxcb-dri2/libxcb-dri2_interface.cpp
@@ -1,11 +1,17 @@
 #include <common/GeneratorInterface.h>
 
 #include <xcb/dri2.h>
+#include <xcb/xcbext.h>
 
 template<auto>
 struct fex_gen_config {
     unsigned version = 0;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<xcb_connection_t> : fexgen::opaque_type {};
 
 void FEX_xcb_dri2_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-dri3/libxcb-dri3_interface.cpp
+++ b/ThunkLibs/libxcb-dri3/libxcb-dri3_interface.cpp
@@ -1,11 +1,17 @@
 #include <common/GeneratorInterface.h>
 
 #include <xcb/dri3.h>
+#include <xcb/xcbext.h>
 
 template<auto>
 struct fex_gen_config {
     unsigned version = 0;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<xcb_connection_t> : fexgen::opaque_type {};
 
 void FEX_xcb_dri3_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-glx/libxcb-glx_interface.cpp
+++ b/ThunkLibs/libxcb-glx/libxcb-glx_interface.cpp
@@ -1,11 +1,17 @@
 #include <common/GeneratorInterface.h>
 
 #include <xcb/glx.h>
+#include <xcb/xcbext.h>
 
 template<auto>
 struct fex_gen_config {
     unsigned version = 0;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<xcb_connection_t> : fexgen::opaque_type {};
 
 void FEX_xcb_glx_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-present/libxcb-present_interface.cpp
+++ b/ThunkLibs/libxcb-present/libxcb-present_interface.cpp
@@ -1,11 +1,17 @@
 #include <common/GeneratorInterface.h>
 
 #include <xcb/present.h>
+#include <xcb/xcbext.h>
 
 template<auto>
 struct fex_gen_config {
     unsigned version = 0;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<xcb_connection_t> : fexgen::opaque_type {};
 
 void FEX_xcb_present_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-randr/libxcb-randr_interface.cpp
+++ b/ThunkLibs/libxcb-randr/libxcb-randr_interface.cpp
@@ -1,11 +1,22 @@
 #include <common/GeneratorInterface.h>
 
 #include <xcb/randr.h>
+#include <xcb/xcbext.h>
 
 template<auto>
 struct fex_gen_config {
     unsigned version = 0;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<xcb_connection_t> : fexgen::opaque_type {};
+
+// Union type (includes pointers, so only compatible across 64-bit architectures)
+#ifndef IS_32BIT_THUNK
+template<> struct fex_gen_type<xcb_randr_notify_data_t> : fexgen::assume_compatible_data_layout {};
+#endif
 
 void FEX_xcb_randr_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-shm/libxcb-shm_interface.cpp
+++ b/ThunkLibs/libxcb-shm/libxcb-shm_interface.cpp
@@ -1,11 +1,17 @@
 #include <common/GeneratorInterface.h>
 
 #include <xcb/shm.h>
+#include <xcb/xcbext.h>
 
 template<auto>
 struct fex_gen_config {
     unsigned version = 0;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<xcb_connection_t> : fexgen::opaque_type {};
 
 void FEX_xcb_shm_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-sync/libxcb-sync_interface.cpp
+++ b/ThunkLibs/libxcb-sync/libxcb-sync_interface.cpp
@@ -1,11 +1,17 @@
 #include <common/GeneratorInterface.h>
 
 #include <xcb/sync.h>
+#include <xcb/xcbext.h>
 
 template<auto>
 struct fex_gen_config {
     unsigned version = 1;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<xcb_connection_t> : fexgen::opaque_type {};
 
 void FEX_xcb_sync_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb-xfixes/libxcb-xfixes_interface.cpp
+++ b/ThunkLibs/libxcb-xfixes/libxcb-xfixes_interface.cpp
@@ -1,11 +1,17 @@
 #include <common/GeneratorInterface.h>
 
 #include <xcb/xfixes.h>
+#include <xcb/xcbext.h>
 
 template<auto>
 struct fex_gen_config {
     unsigned version = 0;
 };
+
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<xcb_connection_t> : fexgen::opaque_type {};
 
 void FEX_xcb_xfixes_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);

--- a/ThunkLibs/libxcb/libxcb_interface.cpp
+++ b/ThunkLibs/libxcb/libxcb_interface.cpp
@@ -11,6 +11,15 @@ struct fex_gen_config {
     unsigned version = 1;
 };
 
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<xcb_connection_t> : fexgen::opaque_type {};
+template<> struct fex_gen_type<xcb_special_event> : fexgen::opaque_type {};
+
+// Union type with consistent data layout across host/x86/x86-64
+template<> struct fex_gen_type<xcb_client_message_data_t> : fexgen::assume_compatible_data_layout {};
+
 void FEX_xcb_init_extension(xcb_connection_t*, xcb_extension_t*);
 size_t FEX_usable_size(void*);
 void FEX_free_on_host(void*);

--- a/ThunkLibs/libxshmfence/libxshmfence_interface.cpp
+++ b/ThunkLibs/libxshmfence/libxshmfence_interface.cpp
@@ -9,6 +9,11 @@ struct fex_gen_config {
     unsigned version = 1;
 };
 
+template<typename>
+struct fex_gen_type {};
+
+template<> struct fex_gen_type<xshmfence> : fexgen::opaque_type {};
+
 template<> struct fex_gen_config<xshmfence_trigger> {};
 template<> struct fex_gen_config<xshmfence_await> {};
 template<> struct fex_gen_config<xshmfence_query> {};


### PR DESCRIPTION
This allows us to enable data layout analysis (see https://github.com/FEX-Emu/FEX/pull/3156) everywhere (on 64-bit).

Further annotations will be required on 32-bit, since many `assume_compatible_data_layout` annotations don't apply there.
