### PR TITLE
Thunks: Fix function pointer support on 32-bit

### DIFF
--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -393,7 +393,7 @@ void Dispatcher::EmitDispatcher() {
     LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, CTX->X86CodeGen.CallbackReturn);
 
     ldr(ARMEmitter::XReg::x2, STATE_PTR(CpuStateFrame, State.gregs[X86State::REG_RSP]));
-    sub(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r2, ARMEmitter::Reg::r2, 16);
+    sub(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r2, ARMEmitter::Reg::r2, CTX->Config.Is64BitMode ? 16 : 12);
     str(ARMEmitter::XReg::x2, STATE_PTR(CpuStateFrame, State.gregs[X86State::REG_RSP]));
 
     // Store the trampoline to the guest stack


### PR DESCRIPTION
Function pointers (either host-side or guest-side) weren't supported on 32-bit previously. However, it turns out only these minor fixes are needed to get them working:
* `uintptr_t` is replaced with `uint64_t` in the guest-side thunking headers, since 64-bit pointers are expected by the host-side thunking runtime (`LinkAddressToFunction`/...)
* Tweak the inline assembly on `CallHostFunction` to read the target function address (similarly to the 64-bit path, the code is chosen more or less by trial-and-error such that the compiler doesn't overwrite the `mm0` register before we read it)
* `THUNK_ABI` is used in more places, and `[[gnu::fastcall]]` is replaced by `__attribute__((fastcall))` since clang doesn't understand the former
* JIT logic around function pointer invocation is updated for ABI differences between 64-bit and 32-bit

Sadly, this doesn't fully get 32-bit support working yet, even ignoring the lack of 32-bit-specific annotations:
* The host stack is allocated in the upper 32-bit address space region, breaking host-side invocation of guest callbacks
* Some heap allocations still end up in the upper 32-bit address space region due to jemalloc reserving them internally before we block that address space region
