### PR TITLE
Thunks: Skip data layout analysis for types that are always assumed compatible

### DIFF
--- a/ThunkLibs/Generator/analysis.cpp
+++ b/ThunkLibs/Generator/analysis.cpp
@@ -410,12 +410,12 @@ void AnalysisAction::ParseInterface(clang::ASTContext& context) {
                             types.emplace(context.getCanonicalType(param_type.getTypePtr()), RepackedType { });
                         } else if (param_type->isPointerType()) {
                             auto pointee_type = param_type->getPointeeType()->getLocallyUnqualifiedSingleStepDesugaredType();
-                            if ((types.contains(context.getCanonicalType(pointee_type.getTypePtr())) && LookupType(context, pointee_type.getTypePtr()).assumed_compatible)) {
-                                // Nothing to do
+                            if (types.contains(context.getCanonicalType(pointee_type.getTypePtr())) && LookupType(context, pointee_type.getTypePtr()).assumed_compatible) {
+                                // Parameter points to a type that is assumed compatible
                                 data.param_annotations[param_idx].assume_compatible = true;
-                            } else if ( pointee_type->isStructureType() &&
-                                        !(types.contains(context.getCanonicalType(pointee_type.getTypePtr())) &&
-                                          LookupType(context, pointee_type.getTypePtr()).assumed_compatible)) {
+                            } else if (pointee_type->isStructureType()) {
+                                // Unannotated pointer to unannotated structure.
+                                // Append the structure type to the type list for checking data layout compatibility.
                                 check_struct_type(pointee_type.getTypePtr());
                                 types.emplace(context.getCanonicalType(pointee_type.getTypePtr()), RepackedType { });
                             } else if (data.param_annotations[param_idx].is_passthrough) {

--- a/ThunkLibs/Generator/analysis.cpp
+++ b/ThunkLibs/Generator/analysis.cpp
@@ -410,7 +410,9 @@ void AnalysisAction::ParseInterface(clang::ASTContext& context) {
                             types.emplace(context.getCanonicalType(param_type.getTypePtr()), RepackedType { });
                         } else if (param_type->isPointerType()) {
                             auto pointee_type = param_type->getPointeeType()->getLocallyUnqualifiedSingleStepDesugaredType();
-                            if (types.contains(context.getCanonicalType(pointee_type.getTypePtr())) && LookupType(context, pointee_type.getTypePtr()).assumed_compatible) {
+                            if (data.param_annotations[param_idx].assume_compatible) {
+                                // Nothing to do
+                            } else if (types.contains(context.getCanonicalType(pointee_type.getTypePtr())) && LookupType(context, pointee_type.getTypePtr()).assumed_compatible) {
                                 // Parameter points to a type that is assumed compatible
                                 data.param_annotations[param_idx].assume_compatible = true;
                             } else if (pointee_type->isStructureType()) {
@@ -423,8 +425,6 @@ void AnalysisAction::ParseInterface(clang::ASTContext& context) {
                                     throw report_error(param_loc, "Passthrough annotation requires custom host implementation");
                                 }
 
-                                // Nothing to do
-                            } else if (data.param_annotations[param_idx].assume_compatible) {
                                 // Nothing to do
                             } else if (false /* TODO: Can't check if this is unsupported until data layout analysis is complete */) {
                                 throw report_error(param_loc, "Unsupported parameter type")

--- a/ThunkLibs/libX11/libX11_interface.cpp
+++ b/ThunkLibs/libX11/libX11_interface.cpp
@@ -72,7 +72,6 @@ template<> struct fex_gen_type<_XContextDB> : fexgen::opaque_type {};
 template<> struct fex_gen_type<_XDisplayAtoms> : fexgen::opaque_type {};
 template<> struct fex_gen_type<_XLockInfo> : fexgen::opaque_type {};
 template<> struct fex_gen_type<_XIMFilter> : fexgen::opaque_type {};
-template<> struct fex_gen_type<_XErrorThreadInfo> : fexgen::opaque_type {};
 template<> struct fex_gen_type<_XKeytrans> : fexgen::opaque_type {};
 template<> struct fex_gen_type<_X11XCBPrivate> : fexgen::opaque_type {};
 

--- a/ThunkLibs/libXext/libXext_interface.cpp
+++ b/ThunkLibs/libXext/libXext_interface.cpp
@@ -30,7 +30,6 @@ struct fex_gen_type {};
 template<> struct fex_gen_type<_X11XCBPrivate> : fexgen::opaque_type {};
 template<> struct fex_gen_type<_XContextDB> : fexgen::opaque_type {};
 template<> struct fex_gen_type<_XDisplayAtoms> : fexgen::opaque_type {};
-template<> struct fex_gen_type<_XErrorThreadInfo> : fexgen::opaque_type {};
 template<> struct fex_gen_type<_XIMFilter> : fexgen::opaque_type {};
 template<> struct fex_gen_type<_XkbInfoRec> : fexgen::opaque_type {};
 template<> struct fex_gen_type<_XKeytrans> : fexgen::opaque_type {};


### PR DESCRIPTION
Also cleaned up the surrounding code a bit, particularly since it redundantly checked a complex subcondition twice.

This should fix thunks building on Ubuntu 20.04, where EGL was failing due to `XDisplay` being an incomplete type (even though it's only ever used in an `assume_compatible_data_layout` context).