### PR TITLE
FEXCore: Support forcing all allocations to the upper 48-bits

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -474,6 +474,15 @@
         "Desc": [
           "Override for a FEXServer socket path. Only useful for chroots."
         ]
+      },
+      "ForceFEX48BitAlloc": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "When running on a 48-bit VA system, force all FEX allocations in to that upper address space.",
+          "Only works when the host system supports 48-bit virtual address space.",
+          "Debug only feature that may not be entirely stable"
+        ]
       }
     }
   },

--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -123,8 +123,8 @@ namespace FEXCore::Allocator {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  void SetupHooks() {
-    Alloc64 = Alloc::OSAllocator::Create64BitAllocator();
+  void SetupHooks(fextl::vector<MemoryRegion> *MemoryRegion) {
+    Alloc64 = Alloc::OSAllocator::Create64BitAllocator(MemoryRegion);
 #ifdef ENABLE_JEMALLOC
     je___mmap_hook   = FEX_mmap;
     je___munmap_hook = FEX_munmap;

--- a/FEXCore/Source/Utils/Allocator/HostAllocator.h
+++ b/FEXCore/Source/Utils/Allocator/HostAllocator.h
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 #pragma once
+
+#include <FEXCore/Utils/Allocator.h>
+
 #include <FEXCore/fextl/allocator.h>
 #include <FEXCore/fextl/memory.h>
+#include <FEXCore/fextl/vector.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -46,5 +50,5 @@ namespace Alloc {
 namespace Alloc::OSAllocator {
 void RegisterTLSData(FEXCore::Core::InternalThreadState *Thread);
 void UninstallTLSData(FEXCore::Core::InternalThreadState *Thread);
-fextl::unique_ptr<Alloc::HostAllocator> Create64BitAllocator();
+fextl::unique_ptr<Alloc::HostAllocator> Create64BitAllocator(fextl::vector<FEXCore::Allocator::MemoryRegion> *MemoryRegion = nullptr);
 }

--- a/FEXCore/include/FEXCore/Utils/Allocator.h
+++ b/FEXCore/include/FEXCore/Utils/Allocator.h
@@ -9,7 +9,12 @@
 #include <sys/types.h>
 
 namespace FEXCore::Allocator {
-  FEX_DEFAULT_VISIBILITY void SetupHooks();
+  struct MemoryRegion {
+    void *Ptr;
+    size_t Size;
+  };
+
+  FEX_DEFAULT_VISIBILITY void SetupHooks(fextl::vector<MemoryRegion> *MemoryRegion = nullptr);
   FEX_DEFAULT_VISIBILITY void ClearHooks();
 
   FEX_DEFAULT_VISIBILITY size_t DetermineVASize();
@@ -66,11 +71,6 @@ namespace FEXCore::Allocator {
 
   // Allow sbrk again. Pass in the pointer returned by `DisableSBRKAllocations`
   FEX_DEFAULT_VISIBILITY void ReenableSBRKAllocations(void* Ptr);
-
-  struct MemoryRegion {
-    void *Ptr;
-    size_t Size;
-  };
 
   FEX_DEFAULT_VISIBILITY fextl::vector<MemoryRegion> StealMemoryRegion(uintptr_t Begin, uintptr_t End);
   FEX_DEFAULT_VISIBILITY void ReclaimMemoryRegion(const fextl::vector<MemoryRegion> & Regions);

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -419,6 +419,12 @@ int main(int argc, char **argv, char **const envp) {
   if (Loader.Is64BitMode()) {
     // Destroy the 48th bit if it exists
     Base48Bit = FEXCore::Allocator::Steal48BitVA();
+    if (!Base48Bit.empty()) {
+      FEX_CONFIG_OPT(Force48BitAlloc, FORCEFEX48BITALLOC);
+      if (Force48BitAlloc) {
+        FEXCore::Allocator::SetupHooks(&Base48Bit);
+      }
+    }
   } else {
     FEX_CONFIG_OPT(Use32BitAllocator, FORCE32BITALLOCATOR);
     if (KernelVersion < FEX::HLE::SyscallHandler::KernelVersion(4, 17)) {


### PR DESCRIPTION
This is a debug feature that is not entirely stable but is super useful when trying to profile FEX's memory allocations on 64-bit applications.

Typically FEX just mixes its own allocations with the guest application's allocations for 64-bit, but we can pass the 48-bit allocation to our memory allocator and force everything in to that space with very little effort. This sets the jemalloc hooks when enabled which adds a little bit of overhead.

Once the option is enabled you can look at pmap -x <pid> to see the separation between FEX and guest allocations since all FEX allocations end up in the high bits after VDSO is loaded.

Very handy!