### PR TITLE
OpcodeDispatcher: Optimize a few 3DNow! operations 

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -836,6 +836,7 @@ DEF_OP(VectorImm) {
   const auto Dst = GetVReg(Node);
 
   if (HostSupportsSVE256 && Is256Bit) {
+    LOGMAN_THROW_A_FMT(Op->ShiftAmount == 0, "SVE VectorImm doesn't support a shift");
     if (ElementSize > 1 && (Op->Immediate & 0x80)) {
       // SVE dup uses sign extension where VectorImm wants zext
       LoadConstant(ARMEmitter::Size::i64Bit, TMP1, Op->Immediate);
@@ -847,11 +848,11 @@ DEF_OP(VectorImm) {
   } else {
     if (ElementSize == 8) {
       // movi with 64bit element size doesn't do what we want here
-      LoadConstant(ARMEmitter::Size::i64Bit, TMP1, Op->Immediate);
+      LoadConstant(ARMEmitter::Size::i64Bit, TMP1, static_cast<uint64_t>(Op->Immediate) << Op->ShiftAmount);
       dup(SubRegSize, Dst.Q(), TMP1.R());
     }
     else {
-      movi(SubRegSize, Dst.Q(), Op->Immediate);
+      movi(SubRegSize, Dst.Q(), Op->Immediate, Op->ShiftAmount);
     }
   }
 }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3720,7 +3720,7 @@ void OpDispatchBuilder::PI2FWOp(OpcodeArgs) {
 
   // We now need to transpose the lower 16-bits of each element together
   // Only needing to move the upper element down in this case
-  Src = _VInsElement(Size, 2, 1, 2, Src, Src);
+  Src = _VUnZip(Size, 2, Src, Src);
 
   // Now we need to sign extend the 16bit value to 32-bit
   Src = _VSXTL(Size, 2, Src);
@@ -3741,7 +3741,7 @@ void OpDispatchBuilder::PF2IWOp(OpcodeArgs) {
 
   // We now need to transpose the lower 16-bits of each element together
   // Only needing to move the upper element down in this case
-  Src = _VInsElement(Size, 2, 1, 2, Src, Src);
+  Src = _VUnZip(Size, 2, Src, Src);
 
   // Now we need to sign extend the 16bit value to 32-bit
   Src = _VSXTL(Size, 2, Src);
@@ -3760,7 +3760,8 @@ void OpDispatchBuilder::PMULHRWOp(OpcodeArgs) {
   // Multiplies 4 16bit values in to 4 32bit values
   Res = _VSMull(Size * 2, 2, Dest, Src);
 
-  OrderedNode *VConstant = _VDupFromGPR(16, 8, _Constant(0x0000'8000'0000'8000ULL));
+  // Load 0x0000_8000 in to each 32-bit element.
+  OrderedNode *VConstant = _VectorImm(16, 4, 0x80, 8);
 
   Res = _VAdd(Size * 2, 4, Res, VConstant);
 

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1464,7 +1464,7 @@
         "DestSize": "RegisterSize"
       },
 
-      "FPR = VectorImm u8:#RegisterSize, u8:#ElementSize, u8:$Immediate": {
+      "FPR = VectorImm u8:#RegisterSize, u8:#ElementSize, u8:$Immediate, u8:$ShiftAmount{0}": {
         "Desc": ["Generates a vector with each element containg the immediate zexted"
                 ],
         "DestSize": "RegisterSize",

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -16,16 +16,13 @@
   "Instructions": {
     "pi2fw mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Unknown",
+      "Optimal": "Yes",
       "Comment": [
-        "FPConvert instruction using 128-bit conversion instead of 64-bit.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
-        "This instruction implementation might not be correct.",
         "0x0f 0x0f 0x0c"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
-        "mov v2.h[1], v2.h[2]",
+        "uzp1 v2.4h, v2.4h, v2.4h",
         "sxtl v2.4s, v2.4h",
         "scvtf v2.2s, v2.2s",
         "str d2, [x28, #752]"
@@ -33,10 +30,8 @@
     },
     "pi2fd mm0, mm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
-        "FPConvert instruction using 128-bit conversion instead of 64-bit.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x0f 0x0f 0x0d"
       ],
       "ExpectedArm64ASM": [
@@ -47,27 +42,22 @@
     },
     "pf2iw mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Unknown",
+      "Optimal": "Yes",
       "Comment": [
-        "FPConvert instruction using 128-bit conversion instead of 64-bit.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
-        "This instruction implementation might not be correct.",
         "0x0f 0x0f 0x1c"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
         "fcvtzs v2.2s, v2.2s",
-        "mov v2.h[1], v2.h[2]",
+        "uzp1 v2.4h, v2.4h, v2.4h",
         "sxtl v2.4s, v2.4h",
         "str d2, [x28, #752]"
       ]
     },
     "pf2id mm0, mm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
-        "FPConvert instruction using 128-bit conversion instead of 64-bit.",
-        "This lowers throughput from 1 IPC to 1/2IPC",
         "0x0f 0x0f 0x1d"
       ],
       "ExpectedArm64ASM": [
@@ -306,20 +296,18 @@
       "ExpectedArm64ASM": []
     },
     "db 0x0f, 0x0f, 0xc1, 0xb7": {
-      "ExpectedInstructionCount": 8,
-      "Optimal": "No",
+      "ExpectedInstructionCount": 7,
+      "Optimal": "Yes",
       "Comment": [
         "nasm doesn't support emitting this instruction",
         "pmulhrw mm0, mm1",
-        "Might be able to use sqdmulh",
         "0x0f 0x0f 0xb7"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
         "ldr d3, [x28, #768]",
         "smull v2.4s, v2.4h, v3.4h",
-        "mov x20, #0x800000008000",
-        "dup v3.2d, x20",
+        "movi v3.4s, #0x80, lsl #8",
         "add v2.4s, v2.4s, v3.4s",
         "shrn v2.4h, v2.4s, #16",
         "str d2, [x28, #752]"


### PR DESCRIPTION
Instead of using VInsElement in pi2fw and pf2iw, just use uzp1 to ensure
we don't unintentionally add to RA pressure.

Additionally we can generate the constant needed for pmulhrw directly
using the movi instruction. Converts two instructions in to one.

Under FEX's current constraints this makes all 3DNow! instructions
optimal.