### PR TITLE
IR: Optimize unused result atomic fetch mop to just atomic mop

### DIFF
--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -650,6 +650,15 @@
           "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
+      "AtomicCLR OpSize:#Size, GPR:$Value, GPR:$Addr": {
+        "HasSideEffects": true,
+        "Desc": ["Atomic integer binary clear"
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
+      },
       "AtomicOr OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer or"
@@ -662,6 +671,15 @@
       "AtomicXor OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer xor"
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
+      },
+      "AtomicNeg OpSize:#Size, GPR:$Addr": {
+        "HasSideEffects": true,
+        "Desc": ["Atomic integer two's complement negate"
                 ],
         "DestSize": "Size",
         "EmitValidation": [

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -625,7 +625,8 @@
       },
       "AtomicAdd OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
-        "Desc": ["Atomic integer add"
+        "Desc": ["Atomic integer add",
+                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -634,7 +635,8 @@
       },
       "AtomicSub OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
-        "Desc": ["Atomic integer sub"
+        "Desc": ["Atomic integer sub",
+                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -643,7 +645,8 @@
       },
       "AtomicAnd OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
-        "Desc": ["Atomic integer and"
+        "Desc": ["Atomic integer and",
+                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -652,7 +655,8 @@
       },
       "AtomicCLR OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
-        "Desc": ["Atomic integer binary clear"
+        "Desc": ["Atomic integer binary clear",
+                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -661,7 +665,8 @@
       },
       "AtomicOr OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
-        "Desc": ["Atomic integer or"
+        "Desc": ["Atomic integer or",
+                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -670,7 +675,8 @@
       },
       "AtomicXor OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
-        "Desc": ["Atomic integer xor"
+        "Desc": ["Atomic integer xor",
+                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -679,7 +685,8 @@
       },
       "AtomicNeg OpSize:#Size, GPR:$Addr": {
         "HasSideEffects": true,
-        "Desc": ["Atomic integer two's complement negate"
+        "Desc": ["Atomic integer two's complement negate",
+                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -699,7 +706,8 @@
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and add",
                  "Atomically fetches %Addr and adds %value to the memory location",
-                 "Dest is the value prior to operating on the value in memory"
+                 "Dest is the value prior to operating on the value in memory",
+                 "IR layout must match NonFetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -710,7 +718,8 @@
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and sub",
                  "Atomically fetches %Addr and subtracts %value to the memory location",
-                 "Dest is the value prior to operating on the value in memory"
+                 "Dest is the value prior to operating on the value in memory",
+                 "IR layout must match NonFetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -721,7 +730,8 @@
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and binary and",
                  "Atomically fetches %Addr and binary ands %value to the memory location",
-                 "Dest is the value prior to operating on the value in memory"
+                 "Dest is the value prior to operating on the value in memory",
+                 "IR layout must match NonFetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -734,7 +744,8 @@
                  "Atomically fetches %Addr and binary clears %value to the memory location",
                  "Dest is the value prior to operating on the value in memory",
                  "Matches ARM ldclral semantics",
-                 "eg: Dest[Addr] &= ~Value"
+                 "eg: Dest[Addr] &= ~Value",
+                 "IR layout must match NonFetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -745,7 +756,8 @@
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and binary or",
                  "Atomically fetches %Addr and binary ors %value to the memory location",
-                 "Dest is the value prior to operating on the value in memory"
+                 "Dest is the value prior to operating on the value in memory",
+                 "IR layout must match NonFetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -756,7 +768,8 @@
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and binary exclusive or",
                  "Atomically fetches %Addr and binary exclusive ors %value to the memory location",
-                 "Dest is the value prior to operating on the value in memory"
+                 "Dest is the value prior to operating on the value in memory",
+                 "IR layout must match NonFetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [
@@ -766,7 +779,8 @@
       "GPR = AtomicFetchNeg OpSize:#Size, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer fetch and two's complement negate",
-                 "Dest is the value prior to operating on the value in memory"
+                 "Dest is the value prior to operating on the value in memory",
+                 "IR layout must match NonFetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",
         "EmitValidation": [

--- a/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/DeadCodeElimination.cpp
@@ -26,7 +26,7 @@ private:
 bool DeadCodeElimination::Run(IREmitter *IREmit) {
   FEXCORE_PROFILE_SCOPED("PassManager::DCE");
   auto CurrentIR = IREmit->ViewIR();
-  int NumRemoved = 0;
+  bool Changed = false;
 
   for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
 
@@ -41,28 +41,71 @@ bool DeadCodeElimination::Run(IREmitter *IREmit) {
       auto [CodeNode, IROp] = CodeLast();
 
       bool HasSideEffects = IR::HasSideEffects(IROp->Op);
-      if (IROp->Op == OP_SYSCALL ||
-          IROp->Op == OP_INLINESYSCALL) {
-        FEXCore::IR::SyscallFlags Flags{};
-        if (IROp->Op == OP_SYSCALL) {
-          auto Op = IROp->C<IR::IROp_Syscall>();
-          Flags = Op->Flags;
-        }
-        else {
-          auto Op = IROp->C<IR::IROp_InlineSyscall>();
-          Flags = Op->Flags;
-        }
 
-        if ((Flags & FEXCore::IR::SyscallFlags::NOSIDEEFFECTS) == FEXCore::IR::SyscallFlags::NOSIDEEFFECTS) {
-          HasSideEffects = false;
+      switch (IROp->Op) {
+        case OP_SYSCALL:
+        case OP_INLINESYSCALL: {
+          FEXCore::IR::SyscallFlags Flags{};
+          if (IROp->Op == OP_SYSCALL) {
+            auto Op = IROp->C<IR::IROp_Syscall>();
+            Flags = Op->Flags;
+          }
+          else {
+            auto Op = IROp->C<IR::IROp_InlineSyscall>();
+            Flags = Op->Flags;
+          }
+
+          if ((Flags & FEXCore::IR::SyscallFlags::NOSIDEEFFECTS) == FEXCore::IR::SyscallFlags::NOSIDEEFFECTS) {
+            HasSideEffects = false;
+          }
+
+          break;
         }
+        case OP_ATOMICFETCHADD:
+        case OP_ATOMICFETCHSUB:
+        case OP_ATOMICFETCHAND:
+        case OP_ATOMICFETCHCLR:
+        case OP_ATOMICFETCHOR:
+        case OP_ATOMICFETCHXOR:
+        case OP_ATOMICFETCHNEG: {
+          // If the result of the atomic fetch is completely unused, convert it to a non-fetching atomic operation.
+          if (CodeNode->GetUses() == 0) {
+            switch (IROp->Op) {
+              case OP_ATOMICFETCHADD:
+                IROp->Op = OP_ATOMICADD;
+                break;
+              case OP_ATOMICFETCHSUB:
+                IROp->Op = OP_ATOMICSUB;
+                break;
+              case OP_ATOMICFETCHAND:
+                IROp->Op = OP_ATOMICAND;
+                break;
+              case OP_ATOMICFETCHCLR:
+                IROp->Op = OP_ATOMICCLR;
+                break;
+              case OP_ATOMICFETCHOR:
+                IROp->Op = OP_ATOMICOR;
+                break;
+              case OP_ATOMICFETCHXOR:
+                IROp->Op = OP_ATOMICXOR;
+                break;
+              case OP_ATOMICFETCHNEG:
+                IROp->Op = OP_ATOMICNEG;
+                break;
+              default: FEX_UNREACHABLE;
+            }
+            Changed = true;
+          }
+          break;
+        }
+        default: break;
       }
 
       // Skip over anything that has side effects
       // Use count tracking can't safely remove anything with side effects
       if (!HasSideEffects) {
         if (CodeNode->GetUses() == 0) {
-          NumRemoved++;
+          Changed = true;
           IREmit->Remove(CodeNode);
         }
       }
@@ -74,7 +117,7 @@ bool DeadCodeElimination::Run(IREmitter *IREmit) {
     }
   }
 
-  return NumRemoved != 0;
+  return Changed;
 }
 
 void DeadCodeElimination::markUsed(OrderedNodeWrapper *CodeOp, IROp_Header *IROp) {


### PR DESCRIPTION
When the result of an atomic fetch operation is unused then we can
safely convert it to a non-fetching version of the operation.

This happens hundreds of times per process as far as I can tell. No idea
if this actually helps any hardware, but theoretically it can allow CPUs
to not stall waiting for writeback of the atomic operation.
Couldn't detect any performance improvements in the various little
things I was poking at least. Very trivial to support so add it.

Unaligned variants are already handled in our unaligned fault handler
since the only difference is the acquire semantic is dropped and the
destination register is the zero register.