### PR TITLE
OpcodeDispatcher: Allow garbage in upper bits for more ALU ops 

### DIFF
--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -59,17 +59,16 @@
       ]
     },
     "lock add dword [rax], ecx": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
-        "mov w20, w5",
-        "ldaddal w20, w21, [x4]",
-        "add w22, w21, w20",
-        "eor w23, w21, w20",
-        "strb w23, [x28, #708]",
-        "strb w22, [x28, #706]",
-        "cmn w21, w20",
+        "ldaddal w5, w20, [x4]",
+        "add w21, w20, w5",
+        "eor w22, w20, w5",
+        "strb w22, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmn w20, w5",
         "mrs x20, nzcv",
         "str w20, [x28, #728]"
       ]
@@ -387,18 +386,17 @@
       ]
     },
     "lock sub dword [rax], ecx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
-        "mov w20, w5",
-        "neg w1, w20",
-        "ldaddal w1, w21, [x4]",
-        "sub w22, w21, w20",
-        "eor w23, w21, w20",
-        "strb w23, [x28, #708]",
-        "strb w22, [x28, #706]",
-        "cmp w21, w20",
+        "neg w1, w5",
+        "ldaddal w1, w20, [x4]",
+        "sub w21, w20, w5",
+        "eor w22, w20, w5",
+        "strb w22, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmp w20, w5",
         "mrs x20, nzcv",
         "eor w20, w20, #0x20000000",
         "str w20, [x28, #728]"

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -60,17 +60,16 @@
       ]
     },
     "lock add dword [rax], ecx": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
-        "mov w20, w5",
-        "ldaddal w20, w21, [x4]",
-        "add w22, w21, w20",
-        "eor w23, w21, w20",
-        "strb w23, [x28, #708]",
-        "strb w22, [x28, #706]",
-        "cmn w21, w20",
+        "ldaddal w5, w20, [x4]",
+        "add w21, w20, w5",
+        "eor w22, w20, w5",
+        "strb w22, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmn w20, w5",
         "mrs x20, nzcv",
         "str w20, [x28, #728]"
       ]
@@ -388,18 +387,17 @@
       ]
     },
     "lock sub dword [rax], ecx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
-        "mov w20, w5",
-        "neg w1, w20",
-        "ldaddal w1, w21, [x4]",
-        "sub w22, w21, w20",
-        "eor w23, w21, w20",
-        "strb w23, [x28, #708]",
-        "strb w22, [x28, #706]",
-        "cmp w21, w20",
+        "neg w1, w5",
+        "ldaddal w1, w20, [x4]",
+        "sub w21, w20, w5",
+        "eor w22, w20, w5",
+        "strb w22, [x28, #708]",
+        "strb w21, [x28, #706]",
+        "cmp w20, w5",
         "mrs x20, nzcv",
         "eor w20, w20, #0x20000000",
         "str w20, [x28, #728]"

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -62,17 +62,16 @@
       ]
     },
     "add ebx, ecx": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
-        "mov w20, w5",
-        "mov w21, w7",
-        "add w7, w21, w20",
-        "eor w22, w21, w20",
-        "strb w22, [x28, #708]",
+        "mov x20, x7",
+        "add w7, w20, w5",
+        "eor w21, w20, w5",
+        "strb w21, [x28, #708]",
         "strb w7, [x28, #706]",
-        "cmn w21, w20",
+        "cmn w20, w5",
         "mrs x20, nzcv",
         "str w20, [x28, #728]"
       ]
@@ -149,20 +148,19 @@
       ]
     },
     "db 0x03, 0xcb": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "0x03",
         "add ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "mov w20, w7",
-        "mov w21, w5",
-        "add w5, w21, w20",
-        "eor w22, w21, w20",
-        "strb w22, [x28, #708]",
+        "mov x20, x5",
+        "add w5, w20, w7",
+        "eor w21, w20, w7",
+        "strb w21, [x28, #708]",
         "strb w5, [x28, #706]",
-        "cmn w21, w20",
+        "cmn w20, w7",
         "mrs x20, nzcv",
         "str w20, [x28, #728]"
       ]
@@ -232,7 +230,7 @@
       "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "add w4, w20, #0x1 (1)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -307,7 +305,7 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
+        "mov x21, x4",
         "add w4, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -479,12 +477,11 @@
       ]
     },
     "or ax, 1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "orr w20, w20, #0x1",
+        "orr w20, w4, #0x1",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -494,12 +491,11 @@
       ]
     },
     "or eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "orr w4, w20, #0x1",
+        "orr w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -533,12 +529,11 @@
       ]
     },
     "or ax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "orr w20, w20, #0xffff",
+        "orr w20, w4, #0xffff",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -548,14 +543,13 @@
       ]
     },
     "or eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "orr w4, w21, w20",
+        "orr w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1584,12 +1578,11 @@
       ]
     },
     "and ax, 1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "and w20, w20, #0x1",
+        "and w20, w4, #0x1",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -1599,12 +1592,11 @@
       ]
     },
     "and eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "and w4, w20, #0x1",
+        "and w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1638,12 +1630,11 @@
       ]
     },
     "and ax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "and w20, w20, #0xffff",
+        "and w20, w4, #0xffff",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -1653,14 +1644,13 @@
       ]
     },
     "and eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "and w4, w21, w20",
+        "and w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1731,17 +1721,16 @@
       ]
     },
     "sub ebx, ecx": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
-        "mov w20, w5",
-        "mov w21, w7",
-        "sub w7, w21, w20",
-        "eor w22, w21, w20",
-        "strb w22, [x28, #708]",
+        "mov x20, x7",
+        "sub w7, w20, w5",
+        "eor w21, w20, w5",
+        "strb w21, [x28, #708]",
         "strb w7, [x28, #706]",
-        "cmp w21, w20",
+        "cmp w20, w5",
         "mrs x20, nzcv",
         "eor w20, w20, #0x20000000",
         "str w20, [x28, #728]"
@@ -1820,20 +1809,19 @@
       ]
     },
     "db 0x2B, 0xcb": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "0x2B",
         "sub ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "mov w20, w7",
-        "mov w21, w5",
-        "sub w5, w21, w20",
-        "eor w22, w21, w20",
-        "strb w22, [x28, #708]",
+        "mov x20, x5",
+        "sub w5, w20, w7",
+        "eor w21, w20, w7",
+        "strb w21, [x28, #708]",
         "strb w5, [x28, #706]",
-        "cmp w21, w20",
+        "cmp w20, w7",
         "mrs x20, nzcv",
         "eor w20, w20, #0x20000000",
         "str w20, [x28, #728]"
@@ -1905,7 +1893,7 @@
       "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "sub w4, w20, #0x1 (1)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -1982,7 +1970,7 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
+        "mov x21, x4",
         "sub w4, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -2141,12 +2129,11 @@
       ]
     },
     "xor ax, 1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "eor w20, w20, #0x1",
+        "eor w20, w4, #0x1",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -2156,12 +2143,11 @@
       ]
     },
     "xor eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "eor w4, w20, #0x1",
+        "eor w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -2219,12 +2205,11 @@
       ]
     },
     "xor ax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "eor w20, w20, #0xffff",
+        "eor w20, w4, #0xffff",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -2234,14 +2219,13 @@
       ]
     },
     "xor eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "eor w4, w21, w20",
+        "eor w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -374,7 +374,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "add w4, w20, #0x100 (256)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -530,7 +530,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "sub w4, w20, #0x100 (256)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -636,7 +636,7 @@
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "orr w20, wzr, #0xffffff00",
-        "mov w21, w4",
+        "mov x21, x4",
         "add w4, w21, w20",
         "strb w21, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -794,7 +794,7 @@
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "orr w20, wzr, #0xffffff00",
-        "mov w21, w4",
+        "mov x21, x4",
         "sub w4, w21, w20",
         "strb w21, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -901,7 +901,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "add w4, w20, #0x1 (1)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -925,12 +925,11 @@
       ]
     },
     "or eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "orr w4, w20, #0x1",
+        "orr w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1030,12 +1029,11 @@
       ]
     },
     "and eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "and w4, w20, #0x1",
+        "and w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1059,7 +1057,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "sub w4, w20, #0x1 (1)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -1085,12 +1083,11 @@
       ]
     },
     "xor eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "eor w4, w20, #0x1",
+        "eor w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1168,7 +1165,7 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
+        "mov x21, x4",
         "add w4, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -1195,14 +1192,13 @@
       ]
     },
     "or eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /-1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "orr w4, w21, w20",
+        "orr w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1309,14 +1305,13 @@
       ]
     },
     "and eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "and w4, w21, w20",
+        "and w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1343,7 +1338,7 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
+        "mov x21, x4",
         "sub w4, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -1372,14 +1367,13 @@
       ]
     },
     "xor eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "eor w4, w21, w20",
+        "eor w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -61,17 +61,16 @@
       ]
     },
     "add ebx, ecx": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
-        "mov w20, w5",
-        "mov w21, w7",
-        "add w7, w21, w20",
-        "eor w22, w21, w20",
-        "strb w22, [x28, #708]",
+        "mov x20, x7",
+        "add w7, w20, w5",
+        "eor w21, w20, w5",
+        "strb w21, [x28, #708]",
         "strb w7, [x28, #706]",
-        "cmn w21, w20",
+        "cmn w20, w5",
         "mrs x20, nzcv",
         "str w20, [x28, #728]"
       ]
@@ -148,20 +147,19 @@
       ]
     },
     "db 0x03, 0xcb": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Optimal": "No",
       "Comment": [
         "0x03",
         "add ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "mov w20, w7",
-        "mov w21, w5",
-        "add w5, w21, w20",
-        "eor w22, w21, w20",
-        "strb w22, [x28, #708]",
+        "mov x20, x5",
+        "add w5, w20, w7",
+        "eor w21, w20, w7",
+        "strb w21, [x28, #708]",
         "strb w5, [x28, #706]",
-        "cmn w21, w20",
+        "cmn w20, w7",
         "mrs x20, nzcv",
         "str w20, [x28, #728]"
       ]
@@ -231,7 +229,7 @@
       "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "add w4, w20, #0x1 (1)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -306,7 +304,7 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
+        "mov x21, x4",
         "add w4, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -478,12 +476,11 @@
       ]
     },
     "or ax, 1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "orr w20, w20, #0x1",
+        "orr w20, w4, #0x1",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -493,12 +490,11 @@
       ]
     },
     "or eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "orr w4, w20, #0x1",
+        "orr w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -532,12 +528,11 @@
       ]
     },
     "or ax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "orr w20, w20, #0xffff",
+        "orr w20, w4, #0xffff",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -547,14 +542,13 @@
       ]
     },
     "or eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "orr w4, w21, w20",
+        "orr w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1583,12 +1577,11 @@
       ]
     },
     "and ax, 1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "and w20, w20, #0x1",
+        "and w20, w4, #0x1",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -1598,12 +1591,11 @@
       ]
     },
     "and eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "and w4, w20, #0x1",
+        "and w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1637,12 +1629,11 @@
       ]
     },
     "and ax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "and w20, w20, #0xffff",
+        "and w20, w4, #0xffff",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -1652,14 +1643,13 @@
       ]
     },
     "and eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "and w4, w21, w20",
+        "and w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1730,17 +1720,16 @@
       ]
     },
     "sub ebx, ecx": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
-        "mov w20, w5",
-        "mov w21, w7",
-        "sub w7, w21, w20",
-        "eor w22, w21, w20",
-        "strb w22, [x28, #708]",
+        "mov x20, x7",
+        "sub w7, w20, w5",
+        "eor w21, w20, w5",
+        "strb w21, [x28, #708]",
         "strb w7, [x28, #706]",
-        "cmp w21, w20",
+        "cmp w20, w5",
         "mrs x20, nzcv",
         "eor w20, w20, #0x20000000",
         "str w20, [x28, #728]"
@@ -1819,20 +1808,19 @@
       ]
     },
     "db 0x2B, 0xcb": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Optimal": "No",
       "Comment": [
         "0x2B",
         "sub ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "mov w20, w7",
-        "mov w21, w5",
-        "sub w5, w21, w20",
-        "eor w22, w21, w20",
-        "strb w22, [x28, #708]",
+        "mov x20, x5",
+        "sub w5, w20, w7",
+        "eor w21, w20, w7",
+        "strb w21, [x28, #708]",
         "strb w5, [x28, #706]",
-        "cmp w21, w20",
+        "cmp w20, w7",
         "mrs x20, nzcv",
         "eor w20, w20, #0x20000000",
         "str w20, [x28, #728]"
@@ -1904,7 +1892,7 @@
       "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "sub w4, w20, #0x1 (1)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -1981,7 +1969,7 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
+        "mov x21, x4",
         "sub w4, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -2140,12 +2128,11 @@
       ]
     },
     "xor ax, 1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "eor w20, w20, #0x1",
+        "eor w20, w4, #0x1",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -2155,12 +2142,11 @@
       ]
     },
     "xor eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "eor w4, w20, #0x1",
+        "eor w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -2218,12 +2204,11 @@
       ]
     },
     "xor ax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "eor w20, w20, #0xffff",
+        "eor w20, w4, #0xffff",
         "bfxil x4, x20, #0, #16",
         "strb w20, [x28, #706]",
         "lsl w20, w20, #16",
@@ -2233,14 +2218,13 @@
       ]
     },
     "xor eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "eor w4, w21, w20",
+        "eor w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -377,7 +377,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "add w4, w20, #0x100 (256)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -533,7 +533,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "sub w4, w20, #0x100 (256)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -639,7 +639,7 @@
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "orr w20, wzr, #0xffffff00",
-        "mov w21, w4",
+        "mov x21, x4",
         "add w4, w21, w20",
         "strb w21, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -797,7 +797,7 @@
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "orr w20, wzr, #0xffffff00",
-        "mov w21, w4",
+        "mov x21, x4",
         "sub w4, w21, w20",
         "strb w21, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -904,7 +904,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "add w4, w20, #0x1 (1)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -928,12 +928,11 @@
       ]
     },
     "or eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "orr w4, w20, #0x1",
+        "orr w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1033,12 +1032,11 @@
       ]
     },
     "and eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "and w4, w20, #0x1",
+        "and w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1062,7 +1060,7 @@
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
+        "mov x20, x4",
         "sub w4, w20, #0x1 (1)",
         "strb w20, [x28, #708]",
         "strb w4, [x28, #706]",
@@ -1088,12 +1086,11 @@
       ]
     },
     "xor eax, 1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "eor w4, w20, #0x1",
+        "eor w4, w4, #0x1",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1171,7 +1168,7 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
+        "mov x21, x4",
         "add w4, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -1198,14 +1195,13 @@
       ]
     },
     "or eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /-1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "orr w4, w21, w20",
+        "orr w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1312,14 +1308,13 @@
       ]
     },
     "and eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "and w4, w21, w20",
+        "and w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",
@@ -1346,7 +1341,7 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
+        "mov x21, x4",
         "sub w4, w21, w20",
         "eor w22, w21, w20",
         "strb w22, [x28, #708]",
@@ -1375,14 +1370,13 @@
       ]
     },
     "xor eax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "movk w20, #0xffff, lsl #16",
-        "mov w21, w4",
-        "eor w4, w21, w20",
+        "eor w4, w4, w20",
         "strb w4, [x28, #706]",
         "tst w4, w4",
         "mrs x20, nzcv",


### PR DESCRIPTION
Secondary ALU operations were missed and when the operation is 4-bytes
in size we can also allow garbage upper bits since the JIT will emit a
32-bit operation for this instruction which is safe.

Optimizes some bad codegen around 32-bit ALU operations.