### PR TITLE
IR: Print assert code for IR EmitValidation

### DIFF
--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -702,7 +702,8 @@ def print_ir_allocator_helpers():
                 output_file.write("\t\t#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED\n")
 
                 for Validation in op.EmitValidation:
-                    output_file.write("\tLOGMAN_THROW_A_FMT({}, \"\");\n".format(Validation))
+                    Sanitized = Validation.replace("\"", "\\\"")
+                    output_file.write("\tLOGMAN_THROW_A_FMT({}, \"{}\");\n".format(Validation, Sanitized))
                 output_file.write("\t\t#endif\n")
 
             output_file.write("\t\treturn Op;\n")


### PR DESCRIPTION
Currently we don't get why an IR emit failed in the assert message. Put the code in to the message so it is easier to see. This also resolved the issue that when in RelWithDebInfo the assert line would typically be the end of the IR emission function, so you couldn't see which assert actually triggered. Now since the message is printed this is easier

Before:
```
[ASSERT]
```

After:
```
[ASSERT] Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit
```

This is a lot easier and better data than what #3227 proposed.