### PR TITLE
JIT: Implements Print support for vixl sim

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -143,7 +143,17 @@ DEF_OP(Print) {
     ldr(ARMEmitter::XReg::x3, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.PrintVectorValue));
   }
 
-  blr(ARMEmitter::Reg::r3);
+  if (!CTX->Config.DisableVixlIndirectCalls) [[unlikely]] {
+    if (IsGPR(Op->Value.ID())) {
+      GenerateIndirectRuntimeCall<void, uint64_t>(ARMEmitter::Reg::r3);
+    }
+    else {
+      GenerateIndirectRuntimeCall<void, uint64_t, uint64_t>(ARMEmitter::Reg::r3);
+    }
+  }
+  else {
+    blr(ARMEmitter::Reg::r3);
+  }
 
   FillStaticRegs();
   PopDynamicRegsAndLR();


### PR DESCRIPTION
Everytime I want to quickly output a value for testing I tend to use Print which didn't work under the simulator.
Give this a quick fix to wire up the jump to the vixl sim.