### PR TITLE
Arm64: Minor optimization to bfxil and bfi 

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -1227,6 +1227,11 @@ DEF_OP(Bfi) {
     // If Dst and SrcDst match then this turns in to a simple BFI instruction.
     bfi(EmitSize, Dst, Src, Op->lsb, Op->Width);
   }
+  else if (Dst != Src) {
+    // If the destination isn't the source then we can move the DstSrc and insert directly.
+    mov(EmitSize, Dst, SrcDst);
+    bfi(EmitSize, Dst, Src, Op->lsb, Op->Width);
+  }
   else {
     // Destination didn't match the dst source register.
     // TODO: Inefficient until FEX can have RA constraints here.
@@ -1254,6 +1259,11 @@ DEF_OP(Bfxil) {
 
   if (Dst == SrcDst) {
     // If Dst and SrcDst match then this turns in to a single instruction.
+    bfxil(EmitSize, Dst, Src, Op->lsb, Op->Width);
+  }
+  else if (Dst != Src) {
+    // If the destination isn't the source then we can move the DstSrc and insert directly.
+    mov(EmitSize, Dst, SrcDst);
     bfxil(EmitSize, Dst, Src, Op->lsb, Op->Width);
   }
   else {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -2279,7 +2279,7 @@
       ]
     },
     "rcl eax, 1": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Optimal": "No",
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
@@ -2289,9 +2289,8 @@
         "lsr w23, w20, #31",
         "lsl w20, w20, #1",
         "orr w4, w20, w22",
-        "mov w0, w21",
-        "bfi w0, w23, #29, #1",
-        "mov w20, w0",
+        "mov w20, w21",
+        "bfi w20, w23, #29, #1",
         "lsr w21, w4, #31",
         "eor w21, w21, w23",
         "bfi w20, w21, #28, #1",

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -156,15 +156,14 @@
       ]
     },
     "bts ax, 0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "orr x21, x20, #0x1",
-        "mov x0, x20",
-        "bfxil x0, x21, #0, #16",
-        "mov x4, x0",
+        "mov x4, x20",
+        "bfxil x4, x21, #0, #16",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -396,15 +395,14 @@
       ]
     },
     "btr ax, 0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "and x21, x20, #0xfffffffffffffffe",
-        "mov x0, x20",
-        "bfxil x0, x21, #0, #16",
-        "mov x4, x0",
+        "mov x4, x20",
+        "bfxil x4, x21, #0, #16",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -636,15 +634,14 @@
       ]
     },
     "btc ax, 0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "eor x21, x20, #0x1",
-        "mov x0, x20",
-        "bfxil x0, x21, #0, #16",
-        "mov x4, x0",
+        "mov x4, x20",
+        "bfxil x4, x21, #0, #16",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -15771,7 +15771,7 @@
       ]
     },
     "fnsave [rax]": {
-      "ExpectedInstructionCount": 118,
+      "ExpectedInstructionCount": 117,
       "Optimal": "No",
       "Comment": [
         "0xdd !11b /6"
@@ -15781,9 +15781,8 @@
         "ldrh w21, [x28, #1008]",
         "str w21, [x4]",
         "mov w21, #0x0",
-        "mov x0, x21",
-        "bfi x0, x20, #11, #3",
-        "mov x22, x0",
+        "mov x22, x21",
+        "bfi x22, x20, #11, #3",
         "ldrb w23, [x28, #744]",
         "ldrb w24, [x28, #745]",
         "ldrb w25, [x28, #746]",

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -7526,7 +7526,7 @@
       ]
     },
     "fnsave [rax]": {
-      "ExpectedInstructionCount": 478,
+      "ExpectedInstructionCount": 477,
       "Optimal": "No",
       "Comment": [
         "0xdd !11b /6"
@@ -7536,9 +7536,8 @@
         "ldrh w21, [x28, #1008]",
         "str w21, [x4]",
         "mov w21, #0x0",
-        "mov x0, x21",
-        "bfi x0, x20, #11, #3",
-        "mov x22, x0",
+        "mov x22, x21",
+        "bfi x22, x20, #11, #3",
         "ldrb w23, [x28, #744]",
         "ldrb w24, [x28, #745]",
         "ldrb w25, [x28, #746]",

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -2282,7 +2282,7 @@
       ]
     },
     "rcl eax, 1": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Optimal": "No",
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
@@ -2292,9 +2292,8 @@
         "lsr w23, w20, #31",
         "lsl w20, w20, #1",
         "orr w4, w20, w22",
-        "mov w0, w21",
-        "bfi w0, w23, #29, #1",
-        "mov w20, w0",
+        "mov w20, w21",
+        "bfi w20, w23, #29, #1",
         "lsr w21, w4, #31",
         "eor w21, w21, w23",
         "bfi w20, w21, #28, #1",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -156,15 +156,14 @@
       ]
     },
     "bts ax, 0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "orr x21, x20, #0x1",
-        "mov x0, x20",
-        "bfxil x0, x21, #0, #16",
-        "mov x4, x0",
+        "mov x4, x20",
+        "bfxil x4, x21, #0, #16",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -396,15 +395,14 @@
       ]
     },
     "btr ax, 0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "and x21, x20, #0xfffffffffffffffe",
-        "mov x0, x20",
-        "bfxil x0, x21, #0, #16",
-        "mov x4, x0",
+        "mov x4, x20",
+        "bfxil x4, x21, #0, #16",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"
@@ -636,15 +634,14 @@
       ]
     },
     "btc ax, 0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
         "eor x21, x20, #0x1",
-        "mov x0, x20",
-        "bfxil x0, x21, #0, #16",
-        "mov x4, x0",
+        "mov x4, x20",
+        "bfxil x4, x21, #0, #16",
         "ubfx x20, x20, #0, #1",
         "lsl x20, x20, #29",
         "str w20, [x28, #728]"

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -15770,7 +15770,7 @@
       ]
     },
     "fnsave [rax]": {
-      "ExpectedInstructionCount": 118,
+      "ExpectedInstructionCount": 117,
       "Optimal": "No",
       "Comment": [
         "0xdd !11b /6"
@@ -15780,9 +15780,8 @@
         "ldrh w21, [x28, #1008]",
         "str w21, [x4]",
         "mov w21, #0x0",
-        "mov x0, x21",
-        "bfi x0, x20, #11, #3",
-        "mov x22, x0",
+        "mov x22, x21",
+        "bfi x22, x20, #11, #3",
         "ldrb w23, [x28, #744]",
         "ldrb w24, [x28, #745]",
         "ldrb w25, [x28, #746]",

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -7525,7 +7525,7 @@
       ]
     },
     "fnsave [rax]": {
-      "ExpectedInstructionCount": 478,
+      "ExpectedInstructionCount": 477,
       "Optimal": "No",
       "Comment": [
         "0xdd !11b /6"
@@ -7535,9 +7535,8 @@
         "ldrh w21, [x28, #1008]",
         "str w21, [x4]",
         "mov w21, #0x0",
-        "mov x0, x21",
-        "bfi x0, x20, #11, #3",
-        "mov x22, x0",
+        "mov x22, x21",
+        "bfi x22, x20, #11, #3",
         "ldrb w23, [x28, #744]",
         "ldrb w24, [x28, #745]",
         "ldrb w25, [x28, #746]",


### PR DESCRIPTION
When the destination doesn't alias the source, we can remove a final mov
from both of these operations.

Does some minor code improvement.