### PR TITLE
Config: Fixes string enum parser with multiple arguments

### DIFF
--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -118,7 +118,7 @@ namespace Handler {
       }
       Begin = End + 1;
       End = View.find_first_of(',', Begin);
-      Option = View.substr(Begin, End);
+      Option = View.substr(Begin, End - Begin);
     }
 
     return fextl::fmt::format("{}", EnumMask);


### PR DESCRIPTION
Messed up when originally implementing this, substr's second argument is requested substring length, not the ending position.

Noticed this while trying to parse multiple FEX_HOSTFEATURES options.