### PR TITLE
InstCountCI: Update rounds{s,d} classification

### DIFF
--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -162,7 +162,7 @@
     },
     "roundss xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Nearest rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -174,7 +174,7 @@
     },
     "roundss xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -186,7 +186,7 @@
     },
     "roundss xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -198,7 +198,7 @@
     },
     "roundss xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -210,7 +210,7 @@
     },
     "roundss xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "host rounding mode rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -222,7 +222,7 @@
     },
     "roundsd xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "Nearest rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -234,7 +234,7 @@
     },
     "roundsd xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -246,7 +246,7 @@
     },
     "roundsd xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -258,7 +258,7 @@
     },
     "roundsd xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -270,7 +270,7 @@
     },
     "roundsd xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
+      "Optimal": "Yes",
       "Comment": [
         "host rounding mode rounding",
         "0x66 0x0f 0x3a 0x0b"


### PR DESCRIPTION
This is optimal without AFP. We already test these with AFP in a different file.