### PR TITLE
FEXCore/FileLoading: Updates helper to load file that is backed by memory

### DIFF
--- a/FEXCore/unittests/APITests/FileLoading.cpp
+++ b/FEXCore/unittests/APITests/FileLoading.cpp
@@ -1,0 +1,22 @@
+#include <FEXCore/Utils/FileLoading.h>
+#include <catch2/catch.hpp>
+
+TEST_CASE("LoadFile-Doesn'tExist") {
+  fextl::string MapsFile;
+  auto Read = FEXCore::FileLoading::LoadFile(MapsFile, "/tmp/a/b/c/d/e/z");
+  REQUIRE(MapsFile.size() == 0);
+  REQUIRE(Read == false);
+}
+
+TEST_CASE("LoadFile-procfs") {
+  fextl::string MapsFile;
+  FEXCore::FileLoading::LoadFile(MapsFile, "/proc/self/maps");
+  REQUIRE(MapsFile.size() != 0);
+}
+
+TEST_CASE("LoadFile-Buffer") {
+  fextl::string MapsFile;
+  MapsFile.resize(16);
+  auto Read = FEXCore::FileLoading::LoadFileToBuffer("/proc/self/maps", MapsFile);
+  REQUIRE(MapsFile.size() == Read);
+}


### PR DESCRIPTION
When attempting to read files that aren't backed by a filesystem then
our current read file helpers fail since they query the file size
upfront.

Change the helper so that it doesn't query the size and just reads the file if it
can be opened. This lets us read `/proc/self/maps` using helpers.