### PR TITLE
FEXCore: Adds ability to clear InterruptableConditionVariable mutex

### DIFF
--- a/FEXCore/include/FEXCore/Utils/InterruptableConditionVariable.h
+++ b/FEXCore/include/FEXCore/Utils/InterruptableConditionVariable.h
@@ -71,6 +71,9 @@ namespace FEXCore {
         DoNotify(INT_MAX);
       }
 
+      void ClearMutex() {
+        Mutex = UNSIGNALED;
+      }
     private:
       std::atomic<uint32_t> Mutex{};
       constexpr static uint32_t SIGNALED = 1;
@@ -136,6 +139,9 @@ namespace FEXCore {
         DoNotify(true);
       }
 
+      void ClearMutex() {
+        Mutex = UNSIGNALED;
+      }
     private:
       std::atomic<uint32_t> Mutex{};
       constexpr static uint32_t SIGNALED = 1;


### PR DESCRIPTION
There was no way to change this from the signaled state but there are cases where we need to unsignal and wait on the mutex again.