### PR TITLE
FEXCore: Removes gdb pause check handler

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -216,6 +216,9 @@ namespace FEXCore::Context {
       // this is for internal use
       bool ValidateIRarser { false };
 
+      // Used if the JIT needs to have its interrupt fault code emitted.
+      bool NeedsPendingInterruptFaultCheck { false };
+
       FEX_CONFIG_OPT(Multiblock, MULTIBLOCK);
       FEX_CONFIG_OPT(SingleStepConfig, SINGLESTEP);
       FEX_CONFIG_OPT(GdbServer, GDBSERVER);

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -368,6 +368,9 @@ namespace FEXCore::Context {
 
 #ifndef _WIN32
     ThunkHandler = FEXCore::ThunkHandler::Create();
+#else
+    // WIN32 always needs the interrupt fault check to be enabled.
+    Config.NeedsPendingInterruptFaultCheck = true;
 #endif
 
     using namespace FEXCore::Core;
@@ -1084,7 +1087,7 @@ namespace FEXCore::Context {
       // FEX currently throws away the CPUBackend::CompiledCode object other than the entrypoint
       // In the future with code caching getting wired up, we will pass the rest of the data forward.
       // TODO: Pass the data forward when code caching is wired up to this.
-      .CompiledCode = Thread->CPUBackend->CompileCode(GuestRIP, IRList, DebugData, RAData.get(), GetGdbServerStatus()).BlockEntry,
+      .CompiledCode = Thread->CPUBackend->CompileCode(GuestRIP, IRList, DebugData, RAData.get()).BlockEntry,
       .IRData = IRList,
       .DebugData = DebugData,
       .RAData = std::move(RAData),

--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -71,11 +71,6 @@ public:
 
   void InitThreadPointers(FEXCore::Core::InternalThreadState *Thread);
 
-  // These are across all arches for now
-  static constexpr size_t MaxGDBPauseCheckSize = 128;
-
-  size_t GenerateGDBPauseCheck(uint8_t *CodeBuffer, uint64_t GuestRIP);
-
 #ifdef VIXL_SIMULATOR
   void ExecuteDispatch(FEXCore::Core::CpuStateFrame *Frame) ;
   void ExecuteJITCallback(FEXCore::Core::CpuStateFrame *Frame, uint64_t RIP);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -44,7 +44,7 @@ public:
   [[nodiscard]] CPUBackend::CompiledCode CompileCode(uint64_t Entry,
                                   FEXCore::IR::IRListView const *IR,
                                   FEXCore::Core::DebugData *DebugData,
-                                  FEXCore::IR::RegisterAllocationData *RAData, bool GDBEnabled) override;
+                                  FEXCore::IR::RegisterAllocationData *RAData) override;
 
   [[nodiscard]] void *MapRegion(void* HostPtr, uint64_t, uint64_t) override { return HostPtr; }
 

--- a/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -136,7 +136,7 @@ namespace CPU {
     [[nodiscard]] virtual CompiledCode CompileCode(uint64_t Entry,
                                             FEXCore::IR::IRListView const *IR,
                                             FEXCore::Core::DebugData *DebugData,
-                                            FEXCore::IR::RegisterAllocationData *RAData, bool GDBEnabled) = 0;
+                                            FEXCore::IR::RegisterAllocationData *RAData) = 0;
 
     /**
      * @brief Relocates a block of code from the JIT code object cache


### PR DESCRIPTION
gdbserver is currently entirely broken so this doesn't change behaviour. The gdb pause check that we originally had an excessive amount of overhead.
Instead use the pending interrupt fault check that was wired up for wine.
This makes the check very lightweight and makes it more reasonable to implement a way to have gdbserver support attaching to a process.