### PR TITLE
GdbServer: Switch over to a unix domain socket

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
@@ -93,6 +93,7 @@ private:
     std::array<bool, FEXCore::SignalDelegator::MAX_SIGNALS + 1> PassSignals{};
     uint32_t CurrentDebuggingThread{};
     int ListenSocket{};
+    fextl::string GdbUnixSocketPath{};
     FEX_CONFIG_OPT(Filename, APP_FILENAME);
     FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
 };


### PR DESCRIPTION
Resolving the issue that we can only ever have one gdbserver process running consuming port 8086 (even if the port number is cute).

Doesn't give us anything yet but in the future will allow us to have whole process trees running gdbservers that we can attach to.