### PR TITLE
More GdbServer improvements

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -105,7 +105,6 @@ namespace FEXServerClient {
   }
 
   fextl::string GetTempFolder() {
-    fextl::string Folder{};
     auto XDGRuntimeEnv = getenv("XDG_RUNTIME_DIR");
     if (XDGRuntimeEnv) {
       // If the XDG runtime directory works then use that.
@@ -113,8 +112,7 @@ namespace FEXServerClient {
     }
     // Fallback to `/tmp/` if XDG_RUNTIME_DIR doesn't exist.
     // Might not be ideal but we don't have much of a choice.
-    Folder = std::filesystem::temp_directory_path().string();
-    return Folder;
+    return fextl::string{std::filesystem::temp_directory_path().string()};
   }
 
   fextl::string GetServerMountFolder() {

--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -104,6 +104,19 @@ namespace FEXServerClient {
     return GetServerLockFolder() + "RootFS.lock";
   }
 
+  fextl::string GetTempFolder() {
+    fextl::string Folder{};
+    auto XDGRuntimeEnv = getenv("XDG_RUNTIME_DIR");
+    if (XDGRuntimeEnv) {
+      // If the XDG runtime directory works then use that.
+      return XDGRuntimeEnv;
+    }
+    // Fallback to `/tmp/` if XDG_RUNTIME_DIR doesn't exist.
+    // Might not be ideal but we don't have much of a choice.
+    Folder = std::filesystem::temp_directory_path().string();
+    return Folder;
+  }
+
   fextl::string GetServerMountFolder() {
     // We need a FEXServer mount directory that has some tricky requirements.
     // - We don't want to use `/tmp/` if possible.
@@ -119,17 +132,7 @@ namespace FEXServerClient {
     //   - If this path doesn't exist then fallback to `/tmp/` as a last resort.
     //   - pressure-vessel explicitly creates an internal XDG_RUNTIME_DIR inside its chroot.
     //     - This is okay since pressure-vessel rbinds the FEX rootfs from the host to `/run/pressure-vessel/interpreter-root`.
-    fextl::string Folder{};
-    auto XDGRuntimeEnv = getenv("XDG_RUNTIME_DIR");
-    if (XDGRuntimeEnv) {
-      // If the XDG runtime directory works then use that.
-      Folder = XDGRuntimeEnv;
-    }
-    else {
-      // Fallback to `/tmp/` if XDG_RUNTIME_DIR doesn't exist.
-      // Might not be ideal but we don't have much of a choice.
-      Folder = std::filesystem::temp_directory_path().string();
-    }
+    auto Folder = GetTempFolder();
 
     if (FEXCore::Config::FindContainer() == "pressure-vessel") {
       // In pressure-vessel the mount point changes location.

--- a/Source/Common/FEXServerClient.h
+++ b/Source/Common/FEXServerClient.h
@@ -50,6 +50,7 @@ namespace FEXServerClient {
   fextl::string GetServerLockFolder();
   fextl::string GetServerLockFile();
   fextl::string GetServerRootFSLockFile();
+  fextl::string GetTempFolder();
   fextl::string GetServerMountFolder();
   fextl::string GetServerSocketName();
   int GetServerFD();

--- a/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.cpp
@@ -1281,6 +1281,7 @@ void GdbServer::GdbServerLoop() {
   unlink(GdbUnixSocketPath.c_str());
 }
 static void* ThreadHandler(void *Arg) {
+  FEXCore::Threads::SetThreadName("FEX:gdbserver");
   auto This = reinterpret_cast<FEX::GdbServer*>(Arg);
   This->GdbServerLoop();
   return nullptr;

--- a/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
@@ -24,6 +24,7 @@ namespace FEX {
 class GdbServer {
 public:
     GdbServer(FEXCore::Context::Context *ctx, FEXCore::SignalDelegator *SignalDelegation, FEXCore::HLE::SyscallHandler *const SyscallHandler);
+    ~GdbServer();
 
     // Public for threading
     void GdbServerLoop();
@@ -36,6 +37,11 @@ private:
     void Break(int signal);
 
     void OpenListenSocket();
+    enum class WaitForConnectionResult {
+      RESULT_CONNECTION,
+      RESULT_ERROR,
+    };
+    WaitForConnectionResult WaitForConnection();
     fextl::unique_ptr<std::iostream> OpenSocket();
     void StartThread();
     fextl::string ReadPacket(std::iostream &stream);

--- a/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
@@ -38,8 +38,8 @@ private:
 
     void OpenListenSocket();
     enum class WaitForConnectionResult {
-      RESULT_CONNECTION,
-      RESULT_ERROR,
+      CONNECTION,
+      ERROR,
     };
     WaitForConnectionResult WaitForConnection();
     fextl::unique_ptr<std::iostream> OpenSocket();


### PR DESCRIPTION
Nothing too crazy in here, trying to avoid some of the bigger changes.
A couple of stand-out things

- Adds some lldb specific query commands.
- Set the thread name of gdbserver. Easier to pick out if a thread hung.
- Try binding twice, unlinking the unix domain socket path in between
- Poll the listen socket instead of waiting in accept. Removing a hang that could occur.