### PR TITLE
Thunks/libX11: Change lock functions to nullptr by default

### DIFF
--- a/ThunkLibs/libX11/libX11_Guest.cpp
+++ b/ThunkLibs/libX11/libX11_Guest.cpp
@@ -232,14 +232,6 @@ extern "C" {
       return rv;
     }
 
-    static void LockMutexFunction(LockInfoPtr) {
-      fprintf(stderr, "libX11: LockMutex\n");
-    }
-
-    static void UnlockMutexFunction(LockInfoPtr) {
-      fprintf(stderr, "libX11: LockMutex\n");
-    }
-
   int XFree(void* ptr) {
     // This function must be able to handle both guest heap pointers *and* host heap pointers,
     // so it only forwards to the native host library for the latter.
@@ -368,8 +360,8 @@ extern "C" {
     return fexfn_pack_XUnregisterIMInstantiateCallback(dpy, rdb, res_name, res_class, AllocateHostTrampolineForGuestFunction(callback), client_data);
   }
 
-  void (*_XLockMutex_fn)(LockInfoPtr) = LockMutexFunction;
-  void (*_XUnlockMutex_fn)(LockInfoPtr) = UnlockMutexFunction;
+  void (*_XLockMutex_fn)(LockInfoPtr) = nullptr;
+  void (*_XUnlockMutex_fn)(LockInfoPtr) = nullptr;
   LockInfoPtr _Xglobal_lock = (LockInfoPtr)0x4142434445464748ULL;
 }
 


### PR DESCRIPTION
These are setup to be nullptr by default. Instead of providing no-op lock instructions just have them be nullptr.

It's already part of the API that they need to be nullptr checked before calling and this matches behaviour of the real libX11 library. Removes some spam that is unnecessary.