### PR TITLE
OpcodeDispatcher: Optimize three sha instructions

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ASIMDOps.inl
@@ -60,7 +60,7 @@ public:
   }
   void sha256su1(FEXCore::ARMEmitter::VRegister rd, FEXCore::ARMEmitter::VRegister rn, FEXCore::ARMEmitter::VRegister rm) {
     constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'00 << 10;
-    Crypto3RegSHA(Op, 0b100, rd, rn, rm);
+    Crypto3RegSHA(Op, 0b110, rd, rn, rm);
   }
 
   // Cryptographic two-register SHA

--- a/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -180,11 +180,13 @@ static void OverrideFeatures(HostFeatures *Features) {
   if (EnableCrypto) {
     Features->SupportsAES = true;
     Features->SupportsCRC = true;
+    Features->SupportsSHA = true;
     Features->SupportsPMULL_128Bit = true;
   }
   else if (DisableCrypto) {
     Features->SupportsAES = false;
     Features->SupportsCRC = false;
+    Features->SupportsSHA = false;
     Features->SupportsPMULL_128Bit = false;
   }
   if (EnableRPRES) {
@@ -211,6 +213,8 @@ HostFeatures::HostFeatures() {
 
   SupportsAES = Features.Has(vixl::CPUFeatures::Feature::kAES);
   SupportsCRC = Features.Has(vixl::CPUFeatures::Feature::kCRC32);
+  SupportsSHA = Features.Has(vixl::CPUFeatures::Feature::kSHA1) &&
+                Features.Has(vixl::CPUFeatures::Feature::kSHA2);
   SupportsAtomics = Features.Has(vixl::CPUFeatures::Feature::kAtomics);
   SupportsRAND = Features.Has(vixl::CPUFeatures::Feature::kRNG);
 
@@ -238,7 +242,6 @@ HostFeatures::HostFeatures() {
 #endif
   // TODO: AVX2 is currently unsupported. Disable until the remaining features are implemented.
   SupportsAVX2 = false;
-  SupportsSHA = true;
   SupportsBMI1 = true;
   SupportsBMI2 = true;
   SupportsCLWB = true;
@@ -283,6 +286,8 @@ HostFeatures::HostFeatures() {
 #ifdef VIXL_SIMULATOR
   // simulator doesn't support dc(ZVA)
   SupportsCLZERO = false;
+  // Simulator doesn't support SHA
+  SupportsSHA = false;
 #else
   // Check if we can support cacheline clears
   uint32_t DCZID = GetDCZID();

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/EncryptionOps.cpp
@@ -179,6 +179,32 @@ DEF_OP(CRC32) {
   }
 }
 
+DEF_OP(VSha1H) {
+  auto Op = IROp->C<IR::IROp_VSha1H>();
+
+  const auto Dst = GetVReg(Node);
+  const auto Src = GetVReg(Op->Src.ID());
+
+  sha1h(Dst.S(), Src.S());
+}
+
+DEF_OP(VSha256U0) {
+  auto Op = IROp->C<IR::IROp_VSha256U0>();
+
+  const auto Dst = GetVReg(Node);
+  const auto Src1 = GetVReg(Op->Src1.ID());
+  const auto Src2 = GetVReg(Op->Src2.ID());
+
+  if (Dst == Src1) {
+    sha256su0(Dst, Src2);
+  }
+  else {
+    mov(VTMP1.Q(), Src1.Q());
+    sha256su0(VTMP1, Src2);
+    mov(Dst.Q(), Src1.Q());
+  }
+}
+
 DEF_OP(PCLMUL) {
   const auto Op = IROp->C<IR::IROp_PCLMUL>();
   const auto OpSize = IROp->Size;

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1626,6 +1626,10 @@
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
+      "FPR = VUShraI u8:#RegisterSize, u8:#ElementSize, FPR:$DestVector, FPR:$Vector, u8:$BitShift": {
+        "DestSize": "RegisterSize",
+        "NumElements": "RegisterSize / ElementSize"
+      },
       "FPR = VSShrI u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, u8:$BitShift": {
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -2159,6 +2159,14 @@
         "Desc": "Assists in key generation",
         "DestSize": "16"
       },
+      "FPR = VSha1H FPR:$Src": {
+        "Desc": "Does vector scalar SHA1H instruction",
+        "DestSize": "FEXCore::IR::OpSize::i32Bit"
+      },
+      "FPR = VSha256U0 FPR:$Src1, FPR:$Src2": {
+        "Desc": "Does vector scalar VSha256U0 instruction",
+        "DestSize": "FEXCore::IR::OpSize::i128Bit"
+      },
       "GPR = CRC32 GPR:$Src1, GPR:$Src2, u8:$SrcSize": {
         "Desc": ["CRC32 using polynomial 0x1EDC6F41"
                 ],

--- a/Scripts/InstructionCountParser.py
+++ b/Scripts/InstructionCountParser.py
@@ -52,6 +52,7 @@ class HostFeatures(Flag) :
     FEATURE_RPRES  = (1 << 7)
     FEATURE_FLAGM  = (1 << 8)
     FEATURE_FLAGM2 = (1 << 9)
+    FEATURE_CRYPTO = (1 << 10)
 
 HostFeaturesLookup = {
     "SVE128"  : HostFeatures.FEATURE_SVE128,
@@ -64,6 +65,7 @@ HostFeaturesLookup = {
     "RPRES"   : HostFeatures.FEATURE_RPRES,
     "FLAGM"   : HostFeatures.FEATURE_FLAGM,
     "FLAGM2"  : HostFeatures.FEATURE_FLAGM2,
+    "CRYPTO"  : HostFeatures.FEATURE_CRYPTO,
 }
 
 def GetHostFeatures(data):

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -466,6 +466,7 @@ int main(int argc, char **argv, char **const envp) {
     FEATURE_RPRES  = (1U << 7),
     FEATURE_FLAGM  = (1U << 8),
     FEATURE_FLAGM2 = (1U << 9),
+    FEATURE_CRYPTO = (1U << 10),
   };
 
   uint64_t SVEWidth = 0;
@@ -502,11 +503,12 @@ int main(int argc, char **argv, char **const envp) {
   if (TestHeaderData->EnabledHostFeatures & FEATURE_FLAGM2) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEFLAGM2);
   }
+  if (TestHeaderData->EnabledHostFeatures & FEATURE_CRYPTO) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLECRYPTO);
+  }
 
   // Always enable ARMv8.1 LSE atomics.
   HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEATOMICS);
-  // Always enable crypto extensions.
-  HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLECRYPTO);
 
   if (TestHeaderData->DisabledHostFeatures & FEATURE_SVE128) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLESVE);
@@ -537,6 +539,9 @@ int main(int argc, char **argv, char **const envp) {
   }
   if (TestHeaderData->DisabledHostFeatures & FEATURE_FLAGM2) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLEFLAGM2);
+  }
+  if (TestHeaderData->DisabledHostFeatures & FEATURE_CRYPTO) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLECRYPTO);
   }
 
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_HOSTFEATURES, fextl::fmt::format("{}", HostFeatureControl));

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -1,0 +1,138 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "CRYPTO"
+    ],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256",
+      "AFP"
+    ]
+  },
+  "Instructions": {
+    "sha1nexte xmm0, xmm1": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "0x66 0x0f 0x38 0xc8"
+      ],
+      "ExpectedArm64ASM": [
+        "dup v2.4s, v16.s[3]",
+        "unimplemented (Unimplemented)",
+        "dup v2.4s, v2.s[0]",
+        "add v2.4s, v17.4s, v2.4s",
+        "mov v16.16b, v17.16b",
+        "mov v16.s[3], v2.s[3]"
+      ]
+    },
+    "sha256msg1 xmm0, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "0x66 0x0f 0x38 0xcc"
+      ],
+      "ExpectedArm64ASM": [
+        "unimplemented (Unimplemented)"
+      ]
+    },
+    "aesimc xmm0, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "0x66 0x0f 0x38 0xdb"
+      ],
+      "ExpectedArm64ASM": [
+        "unimplemented (Unimplemented)"
+      ]
+    },
+    "aesenc xmm0, xmm1": {
+      "ExpectedInstructionCount": 4,
+      "Comment": [
+        "0x66 0x0f 0x38 0xdc"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "unimplemented (Unimplemented)",
+        "unimplemented (Unimplemented)",
+        "eor v16.16b, v16.16b, v17.16b"
+      ]
+    },
+    "aesenclast xmm0, xmm1": {
+      "ExpectedInstructionCount": 3,
+      "Comment": [
+        "0x66 0x0f 0x38 0xdd"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "unimplemented (Unimplemented)",
+        "eor v16.16b, v16.16b, v17.16b"
+      ]
+    },
+    "aesdec xmm0, xmm1": {
+      "ExpectedInstructionCount": 4,
+      "Comment": [
+        "0x66 0x0f 0x38 0xde"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "unimplemented (Unimplemented)",
+        "unimplemented (Unimplemented)",
+        "eor v16.16b, v16.16b, v17.16b"
+      ]
+    },
+    "aesdeclast xmm0, xmm1": {
+      "ExpectedInstructionCount": 3,
+      "Comment": [
+        "0x66 0x0f 0x38 0xdf"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
+        "unimplemented (Unimplemented)",
+        "eor v16.16b, v16.16b, v17.16b"
+      ]
+    },
+    "crc32 eax, bl": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "0xf2 0x0f 0x38 0xf0"
+      ],
+      "ExpectedArm64ASM": [
+        "crc32cb w4, w4, w7"
+      ]
+    },
+    "crc32 eax, bx": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "0xf2 0x0f 0x38 0xf1"
+      ],
+      "ExpectedArm64ASM": [
+        "crc32ch w4, w4, w7"
+      ]
+    },
+    "crc32 eax, ebx": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "0xf2 0x0f 0x38 0xf1"
+      ],
+      "ExpectedArm64ASM": [
+        "crc32cw w4, w4, w7"
+      ]
+    },
+    "crc32 rax, bl": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "0xf2 0x0f 0x38 0xf0"
+      ],
+      "ExpectedArm64ASM": [
+        "crc32cb w4, w4, w7"
+      ]
+    },
+    "crc32 rax, rbx": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "0xf2 0x0f 0x38 0xf1"
+      ],
+      "ExpectedArm64ASM": [
+        "crc32cx w4, w4, x7"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/Crypto/H0F3A.json
+++ b/unittests/InstructionCountCI/Crypto/H0F3A.json
@@ -1,0 +1,82 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "CRYPTO"
+    ],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256",
+      "AFP"
+    ]
+  },
+  "Instructions": {
+    "pclmulqdq xmm0, xmm1, 00000b": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "0x66 0x0f 0x3a 0x44"
+      ],
+      "ExpectedArm64ASM": [
+        "unallocated (Unallocated)"
+      ]
+    },
+    "pclmulqdq xmm0, xmm1, 00001b": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "0x66 0x0f 0x3a 0x44"
+      ],
+      "ExpectedArm64ASM": [
+        "dup v0.2d, v16.d[1]",
+        "unallocated (Unallocated)"
+      ]
+    },
+    "pclmulqdq xmm0, xmm1, 10000b": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "0x66 0x0f 0x3a 0x44"
+      ],
+      "ExpectedArm64ASM": [
+        "dup v0.2d, v17.d[1]",
+        "unallocated (Unallocated)"
+      ]
+    },
+    "pclmulqdq xmm0, xmm1, 10001b": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "0x66 0x0f 0x3a 0x44"
+      ],
+      "ExpectedArm64ASM": [
+        "unallocated (Unallocated)"
+      ]
+    },
+    "aeskeygenassist xmm0, xmm1, 0": {
+      "ExpectedInstructionCount": 5,
+      "Comment": [
+        "0x66 0x0f 0x3a 0xdf"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #2064]",
+        "movi v3.2d, #0x0",
+        "mov v16.16b, v17.16b",
+        "unimplemented (Unimplemented)",
+        "tbl v16.16b, {v16.16b}, v2.16b"
+      ]
+    },
+    "aeskeygenassist xmm0, xmm1, 0xFF": {
+      "ExpectedInstructionCount": 8,
+      "Comment": [
+        "0x66 0x0f 0x3a 0xdf"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #2064]",
+        "movi v3.2d, #0x0",
+        "mov v16.16b, v17.16b",
+        "unimplemented (Unimplemented)",
+        "tbl v16.16b, {v16.16b}, v2.16b",
+        "mov x0, #0xff00000000",
+        "dup v1.2d, x0",
+        "eor v16.16b, v16.16b, v1.16b"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -6,7 +6,8 @@
       "SVE128",
       "SVE256",
       "FLAGM",
-      "FLAGM2"
+      "FLAGM2",
+      "CRYPTO"
     ]
   },
   "Instructions": {
@@ -637,17 +638,16 @@
       ]
     },
     "sha1nexte xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0x66 0x0f 0x38 0xc8"
       ],
       "ExpectedArm64ASM": [
-        "mov w20, v16.s[3]",
-        "ror w20, w20, #2",
-        "mov w21, v17.s[3]",
-        "add w20, w21, w20",
+        "shl v2.4s, v16.4s, #30",
+        "usra v2.4s, v16.4s, #2",
+        "add v2.4s, v17.4s, v2.4s",
         "mov v16.16b, v17.16b",
-        "mov v16.s[3], w20"
+        "mov v16.s[3], v2.s[3]"
       ]
     },
     "sha1msg1 xmm0, xmm1": {
@@ -661,32 +661,26 @@
       ]
     },
     "sha1msg2 xmm0, xmm1": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 15,
       "Comment": [
         "0x66 0x0f 0x38 0xca"
       ],
       "ExpectedArm64ASM": [
-        "mov w20, v17.s[2]",
-        "mov w21, v17.s[1]",
-        "mov w22, v17.s[0]",
-        "mov w23, v16.s[3]",
-        "eor w20, w23, w20",
-        "ror w20, w20, #31",
-        "mov w23, v16.s[2]",
-        "eor w21, w23, w21",
-        "ror w21, w21, #31",
-        "mov w23, v16.s[1]",
-        "eor w22, w23, w22",
-        "ror w22, w22, #31",
-        "mov w23, v16.s[0]",
-        "eor w23, w23, w20",
-        "ror w23, w23, #31",
-        "mov v2.16b, v16.16b",
-        "mov v2.s[3], w20",
-        "mov v2.s[2], w21",
-        "mov v2.s[1], w22",
+        "movi v2.2d, #0x0",
+        "ext v2.16b, v2.16b, v17.16b, #12",
+        "eor v2.16b, v16.16b, v2.16b",
+        "shl v3.4s, v2.4s, #1",
+        "mov v0.16b, v3.16b",
+        "usra v0.4s, v2.4s, #31",
+        "mov v2.16b, v0.16b",
+        "dup v3.4s, v2.s[3]",
+        "eor v3.16b, v16.16b, v3.16b",
+        "shl v4.4s, v3.4s, #1",
+        "mov v0.16b, v4.16b",
+        "usra v0.4s, v3.4s, #31",
+        "mov v3.16b, v0.16b",
         "mov v16.16b, v2.16b",
-        "mov v16.s[0], w23"
+        "mov v16.s[0], v3.s[0]"
       ]
     },
     "sha256rnds2 xmm0, xmm1": {
@@ -890,61 +884,6 @@
         "mov v16.s[0], w20"
       ]
     },
-    "aesimc xmm0, xmm1": {
-      "ExpectedInstructionCount": 1,
-      "Comment": [
-        "0x66 0x0f 0x38 0xdb"
-      ],
-      "ExpectedArm64ASM": [
-        "unimplemented (Unimplemented)"
-      ]
-    },
-    "aesenc xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Comment": [
-        "0x66 0x0f 0x38 0xdc"
-      ],
-      "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "unimplemented (Unimplemented)",
-        "unimplemented (Unimplemented)",
-        "eor v16.16b, v16.16b, v17.16b"
-      ]
-    },
-    "aesenclast xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Comment": [
-        "0x66 0x0f 0x38 0xdd"
-      ],
-      "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "unimplemented (Unimplemented)",
-        "eor v16.16b, v16.16b, v17.16b"
-      ]
-    },
-    "aesdec xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
-      "Comment": [
-        "0x66 0x0f 0x38 0xde"
-      ],
-      "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "unimplemented (Unimplemented)",
-        "unimplemented (Unimplemented)",
-        "eor v16.16b, v16.16b, v17.16b"
-      ]
-    },
-    "aesdeclast xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
-      "Comment": [
-        "0x66 0x0f 0x38 0xdf"
-      ],
-      "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "unimplemented (Unimplemented)",
-        "eor v16.16b, v16.16b, v17.16b"
-      ]
-    },
     "movbe ax, word [rbx]": {
       "ExpectedInstructionCount": 3,
       "Comment": [
@@ -974,51 +913,6 @@
       "ExpectedArm64ASM": [
         "ldr x20, [x7]",
         "rev x4, x20"
-      ]
-    },
-    "crc32 eax, bl": {
-      "ExpectedInstructionCount": 1,
-      "Comment": [
-        "0xf2 0x0f 0x38 0xf0"
-      ],
-      "ExpectedArm64ASM": [
-        "crc32cb w4, w4, w7"
-      ]
-    },
-    "crc32 eax, bx": {
-      "ExpectedInstructionCount": 1,
-      "Comment": [
-        "0xf2 0x0f 0x38 0xf1"
-      ],
-      "ExpectedArm64ASM": [
-        "crc32ch w4, w4, w7"
-      ]
-    },
-    "crc32 eax, ebx": {
-      "ExpectedInstructionCount": 1,
-      "Comment": [
-        "0xf2 0x0f 0x38 0xf1"
-      ],
-      "ExpectedArm64ASM": [
-        "crc32cw w4, w4, w7"
-      ]
-    },
-    "crc32 rax, bl": {
-      "ExpectedInstructionCount": 1,
-      "Comment": [
-        "0xf2 0x0f 0x38 0xf0"
-      ],
-      "ExpectedArm64ASM": [
-        "crc32cb w4, w4, w7"
-      ]
-    },
-    "crc32 rax, rbx": {
-      "ExpectedInstructionCount": 1,
-      "Comment": [
-        "0xf2 0x0f 0x38 0xf1"
-      ],
-      "ExpectedArm64ASM": [
-        "crc32cx w4, w4, x7"
       ]
     },
     "adcx eax, ebx": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -5,7 +5,8 @@
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256",
-      "AFP"
+      "AFP",
+      "CRYPTO"
     ]
   },
   "Comment": [
@@ -1336,44 +1337,6 @@
         "addp v16.8h, v4.8h, v2.8h"
       ]
     },
-    "pclmulqdq xmm0, xmm1, 00000b": {
-      "ExpectedInstructionCount": 1,
-      "Comment": [
-        "0x66 0x0f 0x3a 0x44"
-      ],
-      "ExpectedArm64ASM": [
-        "unallocated (Unallocated)"
-      ]
-    },
-    "pclmulqdq xmm0, xmm1, 00001b": {
-      "ExpectedInstructionCount": 2,
-      "Comment": [
-        "0x66 0x0f 0x3a 0x44"
-      ],
-      "ExpectedArm64ASM": [
-        "dup v0.2d, v16.d[1]",
-        "unallocated (Unallocated)"
-      ]
-    },
-    "pclmulqdq xmm0, xmm1, 10000b": {
-      "ExpectedInstructionCount": 2,
-      "Comment": [
-        "0x66 0x0f 0x3a 0x44"
-      ],
-      "ExpectedArm64ASM": [
-        "dup v0.2d, v17.d[1]",
-        "unallocated (Unallocated)"
-      ]
-    },
-    "pclmulqdq xmm0, xmm1, 10001b": {
-      "ExpectedInstructionCount": 1,
-      "Comment": [
-        "0x66 0x0f 0x3a 0x44"
-      ],
-      "ExpectedArm64ASM": [
-        "unallocated (Unallocated)"
-      ]
-    },
     "sha1rnds4 xmm0, xmm1, 00b": {
       "ExpectedInstructionCount": 59,
       "Comment": [
@@ -1640,35 +1603,6 @@
         "mov v16.16b, v2.16b",
         "mov v16.s[0], w20",
         "add sp, sp, #0x20 (32)"
-      ]
-    },
-    "aeskeygenassist xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 5,
-      "Comment": [
-        "0x66 0x0f 0x3a 0xdf"
-      ],
-      "ExpectedArm64ASM": [
-        "ldr q2, [x28, #2064]",
-        "movi v3.2d, #0x0",
-        "mov v16.16b, v17.16b",
-        "unimplemented (Unimplemented)",
-        "tbl v16.16b, {v16.16b}, v2.16b"
-      ]
-    },
-    "aeskeygenassist xmm0, xmm1, 0xFF": {
-      "ExpectedInstructionCount": 8,
-      "Comment": [
-        "0x66 0x0f 0x3a 0xdf"
-      ],
-      "ExpectedArm64ASM": [
-        "ldr q2, [x28, #2064]",
-        "movi v3.2d, #0x0",
-        "mov v16.16b, v17.16b",
-        "unimplemented (Unimplemented)",
-        "tbl v16.16b, {v16.16b}, v2.16b",
-        "mov x0, #0xff00000000",
-        "dup v1.2d, x0",
-        "eor v16.16b, v16.16b, v1.16b"
       ]
     }
   }


### PR DESCRIPTION
- sha1nexte
   - Takes advantage of sha1h if supported
   - Does the operation in a vector otherwise
- sha1msg2
   - Instead of dumping everything to GPRs, we can do this with vectors
   - Mostly matches ARM's sha1su1 instruction, but it is /just/
     different enough to be annoying.
- sha256msg1
   - Directly matches sha256u0
   - Leaves the previous implementation alone