### PR TITLE
InstructionCountCI: Remove Optimal flags

### DIFF
--- a/Scripts/InstructionCountParser.py
+++ b/Scripts/InstructionCountParser.py
@@ -14,24 +14,18 @@ logger.setLevel(logging.ERROR)
 @dataclass
 class TestData:
     name: str
-    optimal: int
     expectedinstructioncount: int
     code: bytes
     instructions: list
-    def __init__(self, Name, Optimal, ExpectedInstructionCount, Code, Instructions):
+    def __init__(self, Name, ExpectedInstructionCount, Code, Instructions):
         self.name = Name
         self.expectedinstructioncount = ExpectedInstructionCount
-        self.optimal = Optimal
         self.code = Code
         self.instructions = Instructions
 
     @property
     def Name(self):
         return self.name
-
-    @property
-    def Optimal(self):
-        return self.optimal
 
     @property
     def ExpectedInstructionCount(self):
@@ -112,14 +106,9 @@ def parse_json_data(json_filepath, json_filename, json_data, output_binary_path)
 
     for key, items in json_data["Instructions"].items():
         ExpectedInstructionCount = 0
-        Optimal = 0
         Instructions = []
         if ("ExpectedInstructionCount" in items):
             ExpectedInstructionCount = int(items["ExpectedInstructionCount"])
-
-        if ("Optimal" in items):
-                if items["Optimal"].upper() == "YES":
-                    Optimal = 1
 
         if ("Skip" in items):
                 if items["Skip"].upper() == "YES":
@@ -163,7 +152,7 @@ def parse_json_data(json_filepath, json_filename, json_data, output_binary_path)
         with open(tmp_asm_out, "rb") as tmp_asm_out_file:
             binary_hex = tmp_asm_out_file.read()
 
-        TestDataMap[TestName] = TestData(key, Optimal, ExpectedInstructionCount, binary_hex, Instructions)
+        TestDataMap[TestName] = TestData(key, ExpectedInstructionCount, binary_hex, Instructions)
 
         os.remove(tmp_asm)
         os.remove(tmp_asm_out)
@@ -181,7 +170,6 @@ def parse_json_data(json_filepath, json_filename, json_data, output_binary_path)
         # };
         # struct TestInfo {
         #   char InstName[128];
-        #   uint64_t Optimal;
         #   int64_t ExpectedInstructionCount;
         #   uint64_t CodeSize;
         #   uint64_t x86InstCount;
@@ -208,7 +196,6 @@ def parse_json_data(json_filepath, json_filename, json_data, output_binary_path)
     # Add each test
     for key, item in TestDataMap.items():
         MemData += struct.pack('128s', item.Name.encode("ascii"))
-        MemData += struct.pack('Q', item.Optimal)
         MemData += struct.pack('q', item.ExpectedInstructionCount)
         MemData += struct.pack('Q', len(item.Code))
         MemData += struct.pack('Q', len(item.Instructions))

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -227,7 +227,6 @@ void AssertHandler(char const *Message) {
 
 struct TestInfo {
   char TestInst[128];
-  uint64_t Optimal;
   int64_t ExpectedInstructionCount;
   uint64_t CodeSize;
   uint64_t x86InstCount;
@@ -276,8 +275,8 @@ static bool TestInstructions(FEXCore::Context::Context *CTX, FEXCore::Core::Inte
 
     LogMan::Msg::IFmt("Testing instruction '{}': {} host instructions", CurrentTest->TestInst, INSTStats->first.HostCodeInstructions);
 
-    // Show the code if we know the implementation isn't optimal or if the count of instructions changed to something we didn't expect.
-    bool ShouldShowCode = CurrentTest->Optimal == 0 ||
+    // Show the code if the count of instructions changed to something we didn't expect.
+    bool ShouldShowCode =
       INSTStats->first.HostCodeInstructions != CurrentTest->ExpectedInstructionCount;
 
     if (ShouldShowCode) {

--- a/unittests/InstructionCountCI/AFP/H0F3A.json
+++ b/unittests/InstructionCountCI/AFP/H0F3A.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "roundss xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Nearest rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -23,7 +22,6 @@
     },
     "roundss xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -34,7 +32,6 @@
     },
     "roundss xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -45,7 +42,6 @@
     },
     "roundss xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -56,7 +52,6 @@
     },
     "roundss xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "host rounding mode rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -67,7 +62,6 @@
     },
     "roundsd xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Nearest rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -78,7 +72,6 @@
     },
     "roundsd xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -89,7 +82,6 @@
     },
     "roundsd xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -100,7 +92,6 @@
     },
     "roundsd xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -111,7 +102,6 @@
     },
     "roundsd xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "host rounding mode rounding",
         "0x66 0x0f 0x3a 0x0b"

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
@@ -11,7 +11,6 @@
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x2a"
       ],
@@ -22,7 +21,6 @@
     },
     "cvtpi2ps xmm0, mm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x2a"
       ],

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -11,7 +11,6 @@
   "Instructions": {
     "cvtsi2ss xmm0, eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x2a"
       ],
@@ -21,7 +20,6 @@
     },
     "cvtsi2ss xmm0, dword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x2a"
       ],
@@ -32,7 +30,6 @@
     },
     "cvtsi2ss xmm0, qword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x2a"
       ],
@@ -43,7 +40,6 @@
     },
     "sqrtss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x51",
       "ExpectedArm64ASM": [
         "fsqrt s16, s17"
@@ -51,7 +47,6 @@
     },
     "rsqrtss xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "0xf3 0x0f 0x52"
@@ -64,7 +59,6 @@
     },
     "rcpss xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "0xf3 0x0f 0x53"
@@ -76,7 +70,6 @@
     },
     "addss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x58"
       ],
@@ -86,7 +79,6 @@
     },
     "mulss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x59"
       ],
@@ -96,7 +88,6 @@
     },
     "cvtss2sd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x5a",
       "ExpectedArm64ASM": [
         "fcvt d16, s17"
@@ -104,7 +95,6 @@
     },
     "cvtss2sd xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x5a",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -113,7 +103,6 @@
     },
     "subss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5c"
       ],
@@ -123,7 +112,6 @@
     },
     "minss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5d"
       ],
@@ -133,7 +121,6 @@
     },
     "divss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5e"
       ],
@@ -143,7 +130,6 @@
     },
     "maxss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5f"
       ],
@@ -153,7 +139,6 @@
     },
     "cmpss xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -163,7 +148,6 @@
     },
     "cmpss xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -173,7 +157,6 @@
     },
     "cmpss xmm0, xmm1, 2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -183,7 +166,6 @@
     },
     "cmpss xmm0, xmm1, 3": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -198,7 +180,6 @@
     },
     "cmpss xmm0, xmm1, 4": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -211,7 +192,6 @@
     },
     "cmpss xmm0, xmm1, 5": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -223,7 +203,6 @@
     },
     "cmpss xmm0, xmm1, 6": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -235,7 +214,6 @@
     },
     "cmpss xmm0, xmm1, 7": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -11,7 +11,6 @@
   "Instructions": {
     "cvtsi2sd xmm0, eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -21,7 +20,6 @@
     },
     "cvtsi2sd xmm0, dword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -32,7 +30,6 @@
     },
     "cvtsi2sd xmm0, rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -42,7 +39,6 @@
     },
     "cvtsi2sd xmm0, qword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -53,7 +49,6 @@
     },
     "sqrtsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x51"
       ],
@@ -63,7 +58,6 @@
     },
     "addsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x58"
       ],
@@ -73,7 +67,6 @@
     },
     "mulsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x59"
       ],
@@ -83,7 +76,6 @@
     },
     "cvtsd2ss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5a"
       ],
@@ -93,7 +85,6 @@
     },
     "cvtsd2ss xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5a"
       ],
@@ -104,7 +95,6 @@
     },
     "subsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5c"
       ],
@@ -114,7 +104,6 @@
     },
     "minsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5d"
       ],
@@ -124,7 +113,6 @@
     },
     "divsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5e"
       ],
@@ -134,7 +122,6 @@
     },
     "maxsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5f"
       ],
@@ -144,7 +131,6 @@
     },
     "cmpsd xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -154,7 +140,6 @@
     },
     "cmpsd xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -164,7 +149,6 @@
     },
     "cmpsd xmm0, xmm1, 2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -174,7 +158,6 @@
     },
     "cmpsd xmm0, xmm1, 3": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -189,7 +172,6 @@
     },
     "cmpsd xmm0, xmm1, 4": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -202,7 +184,6 @@
     },
     "cmpsd xmm0, xmm1, 5": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -214,7 +195,6 @@
     },
     "cmpsd xmm0, xmm1, 6": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -226,7 +206,6 @@
     },
     "cmpsd xmm0, xmm1, 7": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],

--- a/unittests/InstructionCountCI/AFP/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/Secondary.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x2a"
       ],
@@ -23,7 +22,6 @@
     },
     "cvtpi2ps xmm0, mm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x2a"
       ],

--- a/unittests/InstructionCountCI/AFP/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REP.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "cvtsi2ss xmm0, eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x2a"
       ],
@@ -22,7 +21,6 @@
     },
     "cvtsi2ss xmm0, dword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x2a"
       ],
@@ -33,7 +31,6 @@
     },
     "cvtsi2ss xmm0, qword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x2a"
       ],
@@ -44,7 +41,6 @@
     },
     "sqrtss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x51",
       "ExpectedArm64ASM": [
         "fsqrt s16, s17"
@@ -52,7 +48,6 @@
     },
     "rsqrtss xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "0xf3 0x0f 0x52"
@@ -65,7 +60,6 @@
     },
     "rcpss xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "0xf3 0x0f 0x53"
@@ -77,7 +71,6 @@
     },
     "addss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x58"
       ],
@@ -87,7 +80,6 @@
     },
     "mulss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x59"
       ],
@@ -97,7 +89,6 @@
     },
     "cvtss2sd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x5a",
       "ExpectedArm64ASM": [
         "fcvt d16, s17"
@@ -105,7 +96,6 @@
     },
     "cvtss2sd xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x5a",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -114,7 +104,6 @@
     },
     "subss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5c"
       ],
@@ -124,7 +113,6 @@
     },
     "minss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5d"
       ],
@@ -134,7 +122,6 @@
     },
     "divss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5e"
       ],
@@ -144,7 +131,6 @@
     },
     "maxss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5f"
       ],
@@ -154,7 +140,6 @@
     },
     "cmpss xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -164,7 +149,6 @@
     },
     "cmpss xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -174,7 +158,6 @@
     },
     "cmpss xmm0, xmm1, 2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -184,7 +167,6 @@
     },
     "cmpss xmm0, xmm1, 3": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -198,7 +180,6 @@
     },
     "cmpss xmm0, xmm1, 4": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -210,7 +191,6 @@
     },
     "cmpss xmm0, xmm1, 5": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -222,7 +202,6 @@
     },
     "cmpss xmm0, xmm1, 6": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -234,7 +213,6 @@
     },
     "cmpss xmm0, xmm1, 7": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],

--- a/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "cvtsi2sd xmm0, eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -22,7 +21,6 @@
     },
     "cvtsi2sd xmm0, dword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -33,7 +31,6 @@
     },
     "cvtsi2sd xmm0, rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -43,7 +40,6 @@
     },
     "cvtsi2sd xmm0, qword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -54,7 +50,6 @@
     },
     "sqrtsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x51"
       ],
@@ -64,7 +59,6 @@
     },
     "addsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x58"
       ],
@@ -74,7 +68,6 @@
     },
     "mulsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x59"
       ],
@@ -84,7 +77,6 @@
     },
     "cvtsd2ss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5a"
       ],
@@ -94,7 +86,6 @@
     },
     "cvtsd2ss xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5a"
       ],
@@ -105,7 +96,6 @@
     },
     "subsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5c"
       ],
@@ -115,7 +105,6 @@
     },
     "minsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5d"
       ],
@@ -125,7 +114,6 @@
     },
     "divsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5e"
       ],
@@ -135,7 +123,6 @@
     },
     "maxsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5f"
       ],
@@ -145,7 +132,6 @@
     },
     "cmpsd xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -155,7 +141,6 @@
     },
     "cmpsd xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -165,7 +150,6 @@
     },
     "cmpsd xmm0, xmm1, 2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -175,7 +159,6 @@
     },
     "cmpsd xmm0, xmm1, 3": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -189,7 +172,6 @@
     },
     "cmpsd xmm0, xmm1, 4": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -201,7 +183,6 @@
     },
     "cmpsd xmm0, xmm1, 5": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -213,7 +194,6 @@
     },
     "cmpsd xmm0, xmm1, 6": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -225,7 +205,6 @@
     },
     "cmpsd xmm0, xmm1, 7": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -11,7 +11,6 @@
   "Instructions": {
     "vsqrtss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x51 128-bit"
       ],
@@ -22,7 +21,6 @@
     },
     "vsqrtsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x51 128-bit"
       ],
@@ -33,7 +31,6 @@
     },
     "vrsqrtss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "Map 1 0b10 0x52 128-bit"
@@ -47,7 +44,6 @@
     },
     "vrcpss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "FEAT_FPRES could make this more optimal",
         "Map 1 0b10 0x53 128-bit"
@@ -60,7 +56,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x00": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -71,7 +66,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x01": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -82,7 +76,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x02": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -93,7 +86,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x03": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -108,7 +100,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x04": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -121,7 +112,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x05": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -134,7 +124,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x06": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -147,7 +136,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x07": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -161,7 +149,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x00": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -172,7 +159,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x01": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -183,7 +169,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x02": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -194,7 +179,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x03": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -209,7 +193,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x04": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -222,7 +205,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x05": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -235,7 +217,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x06": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -248,7 +229,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x07": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -262,7 +242,6 @@
     },
     "vcvtsi2ss xmm0, xmm1, eax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2A 128-bit"
       ],
@@ -273,7 +252,6 @@
     },
     "vcvtsi2ss xmm0, xmm1, rax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2A 128-bit"
       ],
@@ -284,7 +262,6 @@
     },
     "vcvtsi2sd xmm0, xmm1, eax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2A 128-bit"
       ],
@@ -295,7 +272,6 @@
     },
     "vcvtsi2sd xmm0, xmm1, rax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2A 128-bit"
       ],
@@ -306,7 +282,6 @@
     },
     "vmulss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x59 128-bit"
       ],
@@ -317,7 +292,6 @@
     },
     "vmulsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x59 128-bit"
       ],
@@ -328,7 +302,6 @@
     },
     "vcvtss2sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5a 128-bit"
       ],
@@ -339,7 +312,6 @@
     },
     "vcvtsd2ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x5a 128-bit"
       ],
@@ -350,7 +322,6 @@
     },
     "vsubss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5c 128-bit"
       ],
@@ -361,7 +332,6 @@
     },
     "vsubsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x5c 128-bit"
       ],
@@ -372,7 +342,6 @@
     },
     "vminss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5d 128-bit"
       ],
@@ -383,7 +352,6 @@
     },
     "vminsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x5d 128-bit"
       ],
@@ -394,7 +362,6 @@
     },
     "vdivss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5e 128-bit"
       ],
@@ -405,7 +372,6 @@
     },
     "vdivsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x5e 128-bit"
       ],
@@ -416,7 +382,6 @@
     },
     "vmaxss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5f 128-bit"
       ],
@@ -427,7 +392,6 @@
     },
     "vmaxsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x5f 128-bit"
       ],
@@ -438,7 +402,6 @@
     },
     "vminps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5d 128-bit"
       ],
@@ -450,7 +413,6 @@
     },
     "vminps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5d 256-bit"
       ],
@@ -464,7 +426,6 @@
     },
     "vminpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5d 128-bit"
       ],
@@ -476,7 +437,6 @@
     },
     "vminpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5d 256-bit"
       ],

--- a/unittests/InstructionCountCI/AFP/VEX_map3.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map3.json
@@ -11,7 +11,6 @@
   "Instructions": {
     "vroundss xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -23,7 +22,6 @@
     },
     "vroundss xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -35,7 +33,6 @@
     },
     "vroundss xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -47,7 +44,6 @@
     },
     "vroundss xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -59,7 +55,6 @@
     },
     "vroundss xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -71,7 +66,6 @@
     },
     "vroundsd xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -83,7 +77,6 @@
     },
     "vroundsd xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -95,7 +88,6 @@
     },
     "vroundsd xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -107,7 +99,6 @@
     },
     "vroundsd xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -119,7 +110,6 @@
     },
     "vroundsd xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x0b 128-bit"

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "lock add byte [rax], cl": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0x00",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -35,7 +34,6 @@
     },
     "lock add word [rax], cx": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -58,7 +56,6 @@
     },
     "lock add dword [rax], ecx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "ldaddal w5, w20, [x4]",
@@ -71,7 +68,6 @@
     },
     "lock or byte [rax], cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x08",
       "ExpectedArm64ASM": [
         "ldsetalb w5, w20, [x4]",
@@ -82,7 +78,6 @@
     },
     "lock or word [rax], cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "ldsetalh w5, w20, [x4]",
@@ -93,7 +88,6 @@
     },
     "lock or dword [rax], ecx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "ldsetal w5, w20, [x4]",
@@ -104,7 +98,6 @@
     },
     "lock adc byte [rax], cl": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0x10",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -135,7 +128,6 @@
     },
     "lock adc word [rax], cx": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -166,7 +158,6 @@
     },
     "lock adc dword [rax], ecx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -182,7 +173,6 @@
     },
     "lock sbb byte [rax], cl": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "0x18",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -214,7 +204,6 @@
     },
     "lock sbb word [rax], cx": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -246,7 +235,6 @@
     },
     "lock sbb dword [rax], ecx": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -269,7 +257,6 @@
     },
     "lock and byte [rax], cl": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x20",
       "ExpectedArm64ASM": [
         "mvn w1, w5",
@@ -281,7 +268,6 @@
     },
     "lock and word [rax], cx": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
         "mvn w1, w5",
@@ -293,7 +279,6 @@
     },
     "lock and dword [rax], ecx": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
         "mvn w1, w5",
@@ -305,7 +290,6 @@
     },
     "lock sub byte [rax], cl": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0x28",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -329,7 +313,6 @@
     },
     "lock sub word [rax], cx": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0x28",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -353,7 +336,6 @@
     },
     "lock sub dword [rax], ecx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
         "neg w1, w5",
@@ -370,7 +352,6 @@
     },
     "lock xor byte [rax], cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x30",
       "ExpectedArm64ASM": [
         "ldeoralb w5, w20, [x4]",
@@ -381,7 +362,6 @@
     },
     "lock xor word [rax], cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "ldeoralh w5, w20, [x4]",
@@ -392,7 +372,6 @@
     },
     "lock xor dword [rax], ecx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "ldeoral w5, w20, [x4]",
@@ -403,7 +382,6 @@
     },
     "lock add qword [rax], rcx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "ldaddal x5, x20, [x4]",
@@ -416,7 +394,6 @@
     },
     "xchg byte [rax], cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x86",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -427,7 +404,6 @@
     },
     "xchg word [rax], cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -438,7 +414,6 @@
     },
     "xchg dword [rax], ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -448,7 +423,6 @@
     },
     "xchg qword [rax], rcx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
         "mov x1, x5",
@@ -457,7 +431,6 @@
     },
     "xadd byte [rax], bl": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -481,7 +454,6 @@
     },
     "xadd word [rax], bx": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -505,7 +477,6 @@
     },
     "xadd dword [rax], ebx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -519,7 +490,6 @@
     },
     "xadd qword [rax], rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -533,7 +503,6 @@
     },
     "lock add byte [rax], 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -553,7 +522,6 @@
     },
     "lock add byte [rax], 0xFF": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -574,7 +542,6 @@
     },
     "lock add word [rax], 0x100": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -594,7 +561,6 @@
     },
     "lock add word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -615,7 +581,6 @@
     },
     "lock add dword [rax], 0x100": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -628,7 +593,6 @@
     },
     "lock add dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -642,7 +606,6 @@
     },
     "lock add qword [rax], 0x100": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -655,7 +618,6 @@
     },
     "lock add qword [rax], -2147483647": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -668,7 +630,6 @@
     },
     "lock add word [rax], 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -688,7 +649,6 @@
     },
     "lock add dword [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -701,7 +661,6 @@
     },
     "lock add qword [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -714,7 +673,6 @@
     },
     "lock or byte [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -726,7 +684,6 @@
     },
     "lock or byte [rax], 0xFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -738,7 +695,6 @@
     },
     "lock or word [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -750,7 +706,6 @@
     },
     "lock or word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -762,7 +717,6 @@
     },
     "lock or dword [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -774,7 +728,6 @@
     },
     "lock or dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -786,7 +739,6 @@
     },
     "lock or qword [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -798,7 +750,6 @@
     },
     "lock or qword [rax], -2147483647": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -810,7 +761,6 @@
     },
     "lock or word [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -822,7 +772,6 @@
     },
     "lock or dword [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -834,7 +783,6 @@
     },
     "lock or qword [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -846,7 +794,6 @@
     },
     "lock adc byte [rax], 1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -874,7 +821,6 @@
     },
     "lock adc byte [rax], 0xFF": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -903,7 +849,6 @@
     },
     "lock adc word [rax], 0x100": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -931,7 +876,6 @@
     },
     "lock adc word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -960,7 +904,6 @@
     },
     "lock adc dword [rax], 0x100": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -975,7 +918,6 @@
     },
     "lock adc dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -991,7 +933,6 @@
     },
     "lock adc qword [rax], 0x100": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1006,7 +947,6 @@
     },
     "lock adc qword [rax], -2147483647": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -1021,7 +961,6 @@
     },
     "lock adc word [rax], 1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1049,7 +988,6 @@
     },
     "lock adc dword [rax], 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1064,7 +1002,6 @@
     },
     "lock adc qword [rax], 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1079,7 +1016,6 @@
     },
     "lock sbb byte [rax], 1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1108,7 +1044,6 @@
     },
     "lock sbb byte [rax], 0xFF": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1138,7 +1073,6 @@
     },
     "lock sbb word [rax], 0x100": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1167,7 +1101,6 @@
     },
     "lock sbb word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1197,7 +1130,6 @@
     },
     "lock sbb dword [rax], 0x100": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1219,7 +1151,6 @@
     },
     "lock sbb dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1242,7 +1173,6 @@
     },
     "lock sbb qword [rax], 0x100": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1264,7 +1194,6 @@
     },
     "lock sbb qword [rax], -2147483647": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -1286,7 +1215,6 @@
     },
     "lock sbb word [rax], 1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1315,7 +1243,6 @@
     },
     "lock sbb dword [rax], 1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1337,7 +1264,6 @@
     },
     "lock sbb qword [rax], 1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1359,7 +1285,6 @@
     },
     "lock and byte [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1372,7 +1297,6 @@
     },
     "lock and byte [rax], 0xFF": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1385,7 +1309,6 @@
     },
     "lock and word [rax], 0x100": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1398,7 +1321,6 @@
     },
     "lock and word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1411,7 +1333,6 @@
     },
     "lock and dword [rax], 0x100": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1424,7 +1345,6 @@
     },
     "lock and dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1437,7 +1357,6 @@
     },
     "lock and qword [rax], 0x100": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1450,7 +1369,6 @@
     },
     "lock and qword [rax], -2147483647": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -1463,7 +1381,6 @@
     },
     "lock and word [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1476,7 +1393,6 @@
     },
     "lock and dword [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1489,7 +1405,6 @@
     },
     "lock and qword [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1502,7 +1417,6 @@
     },
     "lock sub byte [rax], 1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1523,7 +1437,6 @@
     },
     "lock sub byte [rax], 0xFF": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1545,7 +1458,6 @@
     },
     "lock sub word [rax], 0x100": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1566,7 +1478,6 @@
     },
     "lock sub word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1588,7 +1499,6 @@
     },
     "lock sub dword [rax], 0x100": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1605,7 +1515,6 @@
     },
     "lock sub dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1623,7 +1532,6 @@
     },
     "lock sub qword [rax], 0x100": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1640,7 +1548,6 @@
     },
     "lock sub qword [rax], -2147483647": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -1657,7 +1564,6 @@
     },
     "lock sub word [rax], 1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1678,7 +1584,6 @@
     },
     "lock sub dword [rax], 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1695,7 +1600,6 @@
     },
     "lock sub qword [rax], 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1712,7 +1616,6 @@
     },
     "lock xor byte [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1724,7 +1627,6 @@
     },
     "lock xor byte [rax], 0xFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1736,7 +1638,6 @@
     },
     "lock xor word [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1748,7 +1649,6 @@
     },
     "lock xor word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1760,7 +1660,6 @@
     },
     "lock xor dword [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1772,7 +1671,6 @@
     },
     "lock xor dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1784,7 +1682,6 @@
     },
     "lock xor qword [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1796,7 +1693,6 @@
     },
     "lock xor qword [rax], -2147483647": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -1808,7 +1704,6 @@
     },
     "lock xor word [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1820,7 +1715,6 @@
     },
     "lock xor dword [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1832,7 +1726,6 @@
     },
     "lock xor qword [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1844,7 +1737,6 @@
     },
     "lock dec byte [rax]": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1865,7 +1757,6 @@
     },
     "lock not byte [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1874,7 +1765,6 @@
     },
     "lock not word [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1883,7 +1773,6 @@
     },
     "lock not dword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1892,7 +1781,6 @@
     },
     "lock not qword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1901,7 +1789,6 @@
     },
     "lock neg byte [rax]": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /3",
       "ExpectedArm64ASM": [
         "ldaxrb w1, [x4]",
@@ -1924,7 +1811,6 @@
     },
     "lock neg word [rax]": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "ldaxrh w1, [x4]",
@@ -1947,7 +1833,6 @@
     },
     "lock neg dword [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "ldaxr w1, [x4]",
@@ -1966,7 +1851,6 @@
     },
     "lock neg qword [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "ldaxr x1, [x4]",
@@ -1985,7 +1869,6 @@
     },
     "lock dec word [rax]": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -2006,7 +1889,6 @@
     },
     "lock dec dword [rax]": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -2024,7 +1906,6 @@
     },
     "lock dec qword [rax]": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -2042,7 +1923,6 @@
     },
     "lock inc byte [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -2062,7 +1942,6 @@
     },
     "lock inc word [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -2082,7 +1961,6 @@
     },
     "lock inc dword [rax]": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -2099,7 +1977,6 @@
     },
     "lock inc qword [rax]": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -16,7 +16,6 @@
   "Instructions": {
     "pi2fw mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x0c"
       ],
@@ -30,7 +29,6 @@
     },
     "pi2fd mm0, mm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x0d"
       ],
@@ -42,7 +40,6 @@
     },
     "pf2iw mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x1c"
       ],
@@ -56,7 +53,6 @@
     },
     "pf2id mm0, mm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x1d"
       ],
@@ -68,7 +64,6 @@
     },
     "pfrcpv mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x86"
       ],
@@ -81,7 +76,6 @@
     },
     "pfrsqrtv mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x87"
       ],
@@ -95,7 +89,6 @@
     },
     "pfnacc mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0x8a",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -108,7 +101,6 @@
     },
     "pfpnacc mm0, mm1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0x8e",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -122,7 +114,6 @@
     },
     "pfcmpge mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0x90",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -133,7 +124,6 @@
     },
     "pfmin mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0x94",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -145,7 +135,6 @@
     },
     "pfrcp mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x96"
       ],
@@ -159,7 +148,6 @@
     },
     "pfrsqrt mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x97"
       ],
@@ -174,7 +162,6 @@
     },
     "pfsub mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0x9a",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -185,7 +172,6 @@
     },
     "pfadd mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0x9e",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -196,7 +182,6 @@
     },
     "pfcmpgt mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xa0",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -207,7 +192,6 @@
     },
     "pfmax mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xa4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -219,7 +203,6 @@
     },
     "pfrcpit1 mm0, mm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xa6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -228,13 +211,11 @@
     },
     "pfrcpit1 mm0, mm0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xa6",
       "ExpectedArm64ASM": []
     },
     "pfrsqit1 mm0, mm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xa7",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -243,13 +224,11 @@
     },
     "pfrsqit1 mm0, mm0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xa7",
       "ExpectedArm64ASM": []
     },
     "pfsubr mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xaa",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -260,7 +239,6 @@
     },
     "pfcmpeq mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xb0",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -271,7 +249,6 @@
     },
     "pfmul mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xb4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -282,7 +259,6 @@
     },
     "pfrcpit2 mm0, mm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xb6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -291,13 +267,11 @@
     },
     "pfrcpit2 mm0, mm0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xb6",
       "ExpectedArm64ASM": []
     },
     "db 0x0f, 0x0f, 0xc1, 0xb7": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "nasm doesn't support emitting this instruction",
         "pmulhrw mm0, mm1",
@@ -315,7 +289,6 @@
     },
     "pswapd mm0, mm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xbb",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -325,7 +298,6 @@
     },
     "pavgusb mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0f 0xbf",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -15,7 +15,6 @@
   "Instructions": {
     "push ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Mergable 16-bit pushes. May or may not be an optimization."
       ],
@@ -30,7 +29,6 @@
     },
     "push rax, rbx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Mergable 64-bit pushes"
       ],
@@ -45,7 +43,6 @@
     },
     "adds xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Redundant scalar adds that can get eliminated without AFP."
       ],
@@ -62,7 +59,6 @@
     },
     "positive movsb": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
         "loads and stores can turn in to post-increment when known"
@@ -82,7 +78,6 @@
     },
     "positive movsw": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
         "loads and stores can turn in to post-increment when known"
@@ -102,7 +97,6 @@
     },
     "positive movsd": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
         "loads and stores can turn in to post-increment when known"
@@ -122,7 +116,6 @@
     },
     "positive movsq": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
         "loads and stores can turn in to post-increment when known"
@@ -142,7 +135,6 @@
     },
     "negative movsb": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
         "loads and stores can turn in to post-increment when known"
@@ -162,7 +154,6 @@
     },
     "negative movsw": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
         "loads and stores can turn in to post-increment when known"
@@ -182,7 +173,6 @@
     },
     "negative movsd": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
         "loads and stores can turn in to post-increment when known"
@@ -202,7 +192,6 @@
     },
     "negative movsq": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
         "loads and stores can turn in to post-increment when known"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -16,7 +16,6 @@
   "Instructions": {
     "adds xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Redundant scalar operations should get eliminated with AFP"
       ],

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -13,7 +13,6 @@
   "Instructions": {
     "lock add byte [rax], cl": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x00",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -32,7 +31,6 @@
     },
     "lock add word [rax], cx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -51,7 +49,6 @@
     },
     "lock add dword [rax], ecx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "ldaddal w5, w20, [x4]",
@@ -64,7 +61,6 @@
     },
     "lock or byte [rax], cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x08",
       "ExpectedArm64ASM": [
         "ldsetalb w5, w20, [x4]",
@@ -75,7 +71,6 @@
     },
     "lock or word [rax], cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "ldsetalh w5, w20, [x4]",
@@ -86,7 +81,6 @@
     },
     "lock or dword [rax], ecx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "ldsetal w5, w20, [x4]",
@@ -97,7 +91,6 @@
     },
     "lock adc byte [rax], cl": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "0x10",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -127,7 +120,6 @@
     },
     "lock adc word [rax], cx": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -157,7 +149,6 @@
     },
     "lock adc dword [rax], ecx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -173,7 +164,6 @@
     },
     "lock sbb byte [rax], cl": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0x18",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -204,7 +194,6 @@
     },
     "lock sbb word [rax], cx": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -235,7 +224,6 @@
     },
     "lock sbb dword [rax], ecx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -254,7 +242,6 @@
     },
     "lock and byte [rax], cl": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x20",
       "ExpectedArm64ASM": [
         "mvn w1, w5",
@@ -266,7 +253,6 @@
     },
     "lock and word [rax], cx": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
         "mvn w1, w5",
@@ -278,7 +264,6 @@
     },
     "lock and dword [rax], ecx": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
         "mvn w1, w5",
@@ -290,7 +275,6 @@
     },
     "lock sub byte [rax], cl": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x28",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -310,7 +294,6 @@
     },
     "lock sub word [rax], cx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x28",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -330,7 +313,6 @@
     },
     "lock sub dword [rax], ecx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
         "neg w1, w5",
@@ -345,7 +327,6 @@
     },
     "lock xor byte [rax], cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x30",
       "ExpectedArm64ASM": [
         "ldeoralb w5, w20, [x4]",
@@ -356,7 +337,6 @@
     },
     "lock xor word [rax], cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "ldeoralh w5, w20, [x4]",
@@ -367,7 +347,6 @@
     },
     "lock xor dword [rax], ecx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "ldeoral w5, w20, [x4]",
@@ -378,7 +357,6 @@
     },
     "lock add qword [rax], rcx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "ldaddal x5, x20, [x4]",
@@ -391,7 +369,6 @@
     },
     "xadd byte [rax], bl": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -411,7 +388,6 @@
     },
     "xadd word [rax], bx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -431,7 +407,6 @@
     },
     "xadd dword [rax], ebx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -445,7 +420,6 @@
     },
     "xadd qword [rax], rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -459,7 +433,6 @@
     },
     "lock add byte [rax], 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -475,7 +448,6 @@
     },
     "lock add byte [rax], 0xFF": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -492,7 +464,6 @@
     },
     "lock add word [rax], 0x100": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -508,7 +479,6 @@
     },
     "lock add word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -525,7 +495,6 @@
     },
     "lock add dword [rax], 0x100": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -538,7 +507,6 @@
     },
     "lock add dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -552,7 +520,6 @@
     },
     "lock add qword [rax], 0x100": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -565,7 +532,6 @@
     },
     "lock add qword [rax], -2147483647": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -578,7 +544,6 @@
     },
     "lock add word [rax], 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -594,7 +559,6 @@
     },
     "lock add dword [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -607,7 +571,6 @@
     },
     "lock add qword [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -620,7 +583,6 @@
     },
     "lock or byte [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -632,7 +594,6 @@
     },
     "lock or byte [rax], 0xFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -644,7 +605,6 @@
     },
     "lock or word [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -656,7 +616,6 @@
     },
     "lock or word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -668,7 +627,6 @@
     },
     "lock or dword [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -680,7 +638,6 @@
     },
     "lock or dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -692,7 +649,6 @@
     },
     "lock or qword [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -704,7 +660,6 @@
     },
     "lock or qword [rax], -2147483647": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -716,7 +671,6 @@
     },
     "lock or word [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -728,7 +682,6 @@
     },
     "lock or dword [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -740,7 +693,6 @@
     },
     "lock or qword [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -752,7 +704,6 @@
     },
     "lock adc byte [rax], 1": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -779,7 +730,6 @@
     },
     "lock adc byte [rax], 0xFF": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -807,7 +757,6 @@
     },
     "lock adc word [rax], 0x100": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -834,7 +783,6 @@
     },
     "lock adc word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -862,7 +810,6 @@
     },
     "lock adc dword [rax], 0x100": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -877,7 +824,6 @@
     },
     "lock adc dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -893,7 +839,6 @@
     },
     "lock adc qword [rax], 0x100": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -908,7 +853,6 @@
     },
     "lock adc qword [rax], -2147483647": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -923,7 +867,6 @@
     },
     "lock adc word [rax], 1": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -950,7 +893,6 @@
     },
     "lock adc dword [rax], 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -965,7 +907,6 @@
     },
     "lock adc qword [rax], 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -980,7 +921,6 @@
     },
     "lock sbb byte [rax], 1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1008,7 +948,6 @@
     },
     "lock sbb byte [rax], 0xFF": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1037,7 +976,6 @@
     },
     "lock sbb word [rax], 0x100": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1065,7 +1003,6 @@
     },
     "lock sbb word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1094,7 +1031,6 @@
     },
     "lock sbb dword [rax], 0x100": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1112,7 +1048,6 @@
     },
     "lock sbb dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1131,7 +1066,6 @@
     },
     "lock sbb qword [rax], 0x100": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1149,7 +1083,6 @@
     },
     "lock sbb qword [rax], -2147483647": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -1167,7 +1100,6 @@
     },
     "lock sbb word [rax], 1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1195,7 +1127,6 @@
     },
     "lock sbb dword [rax], 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1213,7 +1144,6 @@
     },
     "lock sbb qword [rax], 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1231,7 +1161,6 @@
     },
     "lock and byte [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1244,7 +1173,6 @@
     },
     "lock and byte [rax], 0xFF": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1257,7 +1185,6 @@
     },
     "lock and word [rax], 0x100": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1270,7 +1197,6 @@
     },
     "lock and word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1283,7 +1209,6 @@
     },
     "lock and dword [rax], 0x100": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1296,7 +1221,6 @@
     },
     "lock and dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1309,7 +1233,6 @@
     },
     "lock and qword [rax], 0x100": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1322,7 +1245,6 @@
     },
     "lock and qword [rax], -2147483647": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -1335,7 +1257,6 @@
     },
     "lock and word [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1348,7 +1269,6 @@
     },
     "lock and dword [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1361,7 +1281,6 @@
     },
     "lock and qword [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1374,7 +1293,6 @@
     },
     "lock sub byte [rax], 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1391,7 +1309,6 @@
     },
     "lock sub byte [rax], 0xFF": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1409,7 +1326,6 @@
     },
     "lock sub word [rax], 0x100": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1426,7 +1342,6 @@
     },
     "lock sub word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1444,7 +1359,6 @@
     },
     "lock sub dword [rax], 0x100": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1459,7 +1373,6 @@
     },
     "lock sub dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1475,7 +1388,6 @@
     },
     "lock sub qword [rax], 0x100": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1490,7 +1402,6 @@
     },
     "lock sub qword [rax], -2147483647": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -1505,7 +1416,6 @@
     },
     "lock sub word [rax], 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1522,7 +1432,6 @@
     },
     "lock sub dword [rax], 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1537,7 +1446,6 @@
     },
     "lock sub qword [rax], 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1552,7 +1460,6 @@
     },
     "lock xor byte [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1564,7 +1471,6 @@
     },
     "lock xor byte [rax], 0xFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1576,7 +1482,6 @@
     },
     "lock xor word [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1588,7 +1493,6 @@
     },
     "lock xor word [rax], 0xFFFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1600,7 +1504,6 @@
     },
     "lock xor dword [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1612,7 +1515,6 @@
     },
     "lock xor dword [rax], 0xFFFFFFFF": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1624,7 +1526,6 @@
     },
     "lock xor qword [rax], 0x100": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -1636,7 +1537,6 @@
     },
     "lock xor qword [rax], -2147483647": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
@@ -1648,7 +1548,6 @@
     },
     "lock xor word [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1660,7 +1559,6 @@
     },
     "lock xor dword [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1672,7 +1570,6 @@
     },
     "lock xor qword [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1684,7 +1581,6 @@
     },
     "lock dec byte [rax]": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1702,7 +1598,6 @@
     },
     "lock not byte [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1711,7 +1606,6 @@
     },
     "lock not word [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1720,7 +1614,6 @@
     },
     "lock not dword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1729,7 +1622,6 @@
     },
     "lock not qword [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1738,7 +1630,6 @@
     },
     "lock neg byte [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /3",
       "ExpectedArm64ASM": [
         "ldaxrb w1, [x4]",
@@ -1757,7 +1648,6 @@
     },
     "lock neg word [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "ldaxrh w1, [x4]",
@@ -1776,7 +1666,6 @@
     },
     "lock neg dword [rax]": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "ldaxr w1, [x4]",
@@ -1793,7 +1682,6 @@
     },
     "lock neg qword [rax]": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "ldaxr x1, [x4]",
@@ -1810,7 +1698,6 @@
     },
     "lock dec word [rax]": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1828,7 +1715,6 @@
     },
     "lock dec dword [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1844,7 +1730,6 @@
     },
     "lock dec qword [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1860,7 +1745,6 @@
     },
     "lock inc byte [rax]": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1877,7 +1761,6 @@
     },
     "lock inc word [rax]": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1894,7 +1777,6 @@
     },
     "lock inc dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1909,7 +1791,6 @@
     },
     "lock inc qword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",

--- a/unittests/InstructionCountCI/FlagM/H0F38.json
+++ b/unittests/InstructionCountCI/FlagM/H0F38.json
@@ -13,7 +13,6 @@
   "Instructions": {
     "ptest xmm0, xmm1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0x17"
       ],
@@ -41,7 +40,6 @@
     },
     "adcx eax, ebx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xf6"
       ],
@@ -64,7 +62,6 @@
     },
     "adcx rax, rbx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "Unknown",
       "Comment": [
         "0x66 REX.W 0x0f 0x38 0xf6"
       ],
@@ -85,7 +82,6 @@
     },
     "adox eax, ebx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xf3 0x0f 0x38 0xf6"
       ],
@@ -108,7 +104,6 @@
     },
     "adox rax, rbx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "Unknown",
       "Comment": [
         "0xf3 REX.W 0x0f 0x38 0xf6"
       ],

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -13,7 +13,6 @@
   "Instructions": {
     "add bl, cl": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x00",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -33,7 +32,6 @@
     },
     "add bx, cx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -53,7 +51,6 @@
     },
     "add ebx, ecx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -66,7 +63,6 @@
     },
     "add rbx, rcx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -79,7 +75,6 @@
     },
     "db 0x02, 0xcb": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0x02",
         "add bl, cl but modrm.rm as source"
@@ -102,7 +97,6 @@
     },
     "db 0x66, 0x03, 0xcb": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0x03",
         "add bx, cx but modrm.rm as source"
@@ -125,7 +119,6 @@
     },
     "db 0x03, 0xcb": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x03",
         "add ebx, ecx but modrm.rm as source"
@@ -141,7 +134,6 @@
     },
     "db 0x48, 0x03, 0xcb": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x03",
         "add rbx, rcx but modrm.rm as source"
@@ -157,7 +149,6 @@
     },
     "add al, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x04",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -173,7 +164,6 @@
     },
     "add ax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -189,7 +179,6 @@
     },
     "add eax, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -201,7 +190,6 @@
     },
     "add rax, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -213,7 +201,6 @@
     },
     "add al, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x04",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -230,7 +217,6 @@
     },
     "add ax, -1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -248,7 +234,6 @@
     },
     "add eax, -1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -262,7 +247,6 @@
     },
     "add rax, -1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -276,7 +260,6 @@
     },
     "or bl, bh": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "",
       "ExpectedArm64ASM": [
         "lsr w20, w7, #8",
@@ -288,7 +271,6 @@
     },
     "or bl, cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x08",
       "ExpectedArm64ASM": [
         "orr w20, w7, w5",
@@ -299,7 +281,6 @@
     },
     "or bx, cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "orr w20, w7, w5",
@@ -310,7 +291,6 @@
     },
     "or ebx, ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "orr w7, w7, w5",
@@ -320,7 +300,6 @@
     },
     "or rbx, rcx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "orr x7, x7, x5",
@@ -330,7 +309,6 @@
     },
     "db 0x0A, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x0A",
         "or bl, cl but modrm.rm as source"
@@ -344,7 +322,6 @@
     },
     "db 0x66, 0x0B, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x0B",
         "or bx, cx but modrm.rm as source"
@@ -358,7 +335,6 @@
     },
     "db 0x0B, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x0B",
         "or ebx, ecx but modrm.rm as source"
@@ -371,7 +347,6 @@
     },
     "db 0x48, 0x0B, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x0B",
         "or rbx, rcx but modrm.rm as source"
@@ -384,7 +359,6 @@
     },
     "or al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0C",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0x1",
@@ -395,7 +369,6 @@
     },
     "or ax, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0x1",
@@ -406,7 +379,6 @@
     },
     "or eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x1",
@@ -416,7 +388,6 @@
     },
     "or rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x1",
@@ -426,7 +397,6 @@
     },
     "or al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0C",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0xff",
@@ -437,7 +407,6 @@
     },
     "or ax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0xffff",
@@ -448,7 +417,6 @@
     },
     "or eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -459,7 +427,6 @@
     },
     "or rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -470,7 +437,6 @@
     },
     "adc bl, cl": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0x10",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -501,7 +467,6 @@
     },
     "adc bx, cx": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -532,7 +497,6 @@
     },
     "adc ebx, ecx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -548,7 +512,6 @@
     },
     "adc rbx, rcx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -563,7 +526,6 @@
     },
     "db 0x12, 0xcb": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0x12",
         "adc bl, cl but modrm.rm as source"
@@ -597,7 +559,6 @@
     },
     "db 0x66, 0x13, 0xcb": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0x13",
         "adc bx, cx but modrm.rm as source"
@@ -631,7 +592,6 @@
     },
     "db 0x13, 0xcb": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0x13",
         "adc ebx, ecx but modrm.rm as source"
@@ -650,7 +610,6 @@
     },
     "db 0x48, 0x13, 0xcb": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0x13",
         "adc rbx, rcx but modrm.rm as source"
@@ -668,7 +627,6 @@
     },
     "adc al, 1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "0x14",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -696,7 +654,6 @@
     },
     "adc ax, 1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -724,7 +681,6 @@
     },
     "adc eax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -739,7 +695,6 @@
     },
     "adc rax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -754,7 +709,6 @@
     },
     "adc al, -1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x14",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -783,7 +737,6 @@
     },
     "adc ax, -1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -812,7 +765,6 @@
     },
     "adc eax, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -828,7 +780,6 @@
     },
     "adc rax, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -844,7 +795,6 @@
     },
     "sbb bl, cl": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0x18",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -875,7 +825,6 @@
     },
     "sbb bx, cx": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -906,7 +855,6 @@
     },
     "sbb ebx, ecx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -924,7 +872,6 @@
     },
     "sbb rbx, rcx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -941,7 +888,6 @@
     },
     "db 0x1A, 0xcb": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0x1A",
         "sbb bl, cl but modrm.rm as source"
@@ -975,7 +921,6 @@
     },
     "db 0x66, 0x1B, 0xcb": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0x1B",
         "sbb bx, cx but modrm.rm as source"
@@ -1009,7 +954,6 @@
     },
     "db 0x1B, 0xcb": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0x1B",
         "sbb ebx, ecx but modrm.rm as source"
@@ -1030,7 +974,6 @@
     },
     "db 0x48, 0x1B, 0xcb": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0x1B",
         "sbb rbx, rcx but modrm.rm as source"
@@ -1050,7 +993,6 @@
     },
     "sbb al, 1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "0x1C",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1078,7 +1020,6 @@
     },
     "sbb ax, 1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1106,7 +1047,6 @@
     },
     "sbb eax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1123,7 +1063,6 @@
     },
     "sbb rax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1140,7 +1079,6 @@
     },
     "sbb al, -1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x1C",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1169,7 +1107,6 @@
     },
     "sbb ax, -1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1198,7 +1135,6 @@
     },
     "sbb eax, -1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1216,7 +1152,6 @@
     },
     "sbb rax, -1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1234,7 +1169,6 @@
     },
     "and bl, cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x20",
       "ExpectedArm64ASM": [
         "and w20, w7, w5",
@@ -1245,7 +1179,6 @@
     },
     "and bx, cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
         "and w20, w7, w5",
@@ -1256,7 +1189,6 @@
     },
     "and ebx, ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
         "and w7, w7, w5",
@@ -1266,7 +1198,6 @@
     },
     "and rbx, rcx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
         "and x7, x7, x5",
@@ -1276,7 +1207,6 @@
     },
     "db 0x22, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x22",
         "and bl, cl but modrm.rm as source"
@@ -1290,7 +1220,6 @@
     },
     "db 0x66, 0x23, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x23",
         "and bx, cx but modrm.rm as source"
@@ -1304,7 +1233,6 @@
     },
     "db 0x23, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x23",
         "and ebx, ecx but modrm.rm as source"
@@ -1317,7 +1245,6 @@
     },
     "db 0x48, 0x23, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x23",
         "and rbx, rcx but modrm.rm as source"
@@ -1330,7 +1257,6 @@
     },
     "and al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x24",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -1341,7 +1267,6 @@
     },
     "and ax, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -1352,7 +1277,6 @@
     },
     "and eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "and w4, w4, #0x1",
@@ -1362,7 +1286,6 @@
     },
     "and rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "and x4, x4, #0x1",
@@ -1372,7 +1295,6 @@
     },
     "and al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x24",
       "ExpectedArm64ASM": [
         "and w20, w4, #0xff",
@@ -1383,7 +1305,6 @@
     },
     "and ax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "and w20, w4, #0xffff",
@@ -1394,7 +1315,6 @@
     },
     "and eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1405,7 +1325,6 @@
     },
     "and rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1416,7 +1335,6 @@
     },
     "sub bl, cl": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x28",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -1436,7 +1354,6 @@
     },
     "sub bx, cx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -1456,7 +1373,6 @@
     },
     "sub ebx, ecx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -1470,7 +1386,6 @@
     },
     "sub rbx, rcx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -1484,7 +1399,6 @@
     },
     "db 0x2A, 0xcb": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0x2A",
         "sub bl, cl but modrm.rm as source"
@@ -1507,7 +1421,6 @@
     },
     "db 0x66, 0x2B, 0xcb": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0x2B",
         "sub bx, cx but modrm.rm as source"
@@ -1530,7 +1443,6 @@
     },
     "db 0x2B, 0xcb": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0x2B",
         "sub ebx, ecx but modrm.rm as source"
@@ -1547,7 +1459,6 @@
     },
     "db 0x48, 0x2B, 0xcb": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0x2B",
         "sub rbx, rcx but modrm.rm as source"
@@ -1564,7 +1475,6 @@
     },
     "sub al, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x2C",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1580,7 +1490,6 @@
     },
     "sub ax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1596,7 +1505,6 @@
     },
     "sub eax, 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1609,7 +1517,6 @@
     },
     "sub rax, 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1622,7 +1529,6 @@
     },
     "sub al, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x2C",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1639,7 +1545,6 @@
     },
     "sub ax, -1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1657,7 +1562,6 @@
     },
     "sub eax, -1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1672,7 +1576,6 @@
     },
     "sub rax, -1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1687,7 +1590,6 @@
     },
     "xor bl, cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x30",
       "ExpectedArm64ASM": [
         "eor w20, w7, w5",
@@ -1698,7 +1600,6 @@
     },
     "xor bx, cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "eor w20, w7, w5",
@@ -1709,7 +1610,6 @@
     },
     "xor ebx, ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "eor w7, w7, w5",
@@ -1719,7 +1619,6 @@
     },
     "xor rbx, rcx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "eor x7, x7, x5",
@@ -1729,7 +1628,6 @@
     },
     "db 0x32, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x32",
         "xor bl, cl but modrm.rm as source"
@@ -1743,7 +1641,6 @@
     },
     "db 0x66, 0x33, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x33",
         "xor bx, cx but modrm.rm as source"
@@ -1757,7 +1654,6 @@
     },
     "db 0x33, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x33",
         "xor ebx, ecx but modrm.rm as source"
@@ -1770,7 +1666,6 @@
     },
     "db 0x48, 0x33, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x33",
         "xor rbx, rcx but modrm.rm as source"
@@ -1783,7 +1678,6 @@
     },
     "xor al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x34",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0x1",
@@ -1794,7 +1688,6 @@
     },
     "xor ax, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0x1",
@@ -1805,7 +1698,6 @@
     },
     "xor eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x1",
@@ -1815,7 +1707,6 @@
     },
     "xor rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x1",
@@ -1825,7 +1716,6 @@
     },
     "cmp bl, cl": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x38",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -1844,7 +1734,6 @@
     },
     "xor al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x34",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0xff",
@@ -1855,7 +1744,6 @@
     },
     "xor ax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0xffff",
@@ -1866,7 +1754,6 @@
     },
     "xor eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1877,7 +1764,6 @@
     },
     "xor rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1888,7 +1774,6 @@
     },
     "cmp bx, cx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x39",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -1907,7 +1792,6 @@
     },
     "cmp ebx, ecx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x39",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -1922,7 +1806,6 @@
     },
     "cmp rbx, rcx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "0x39",
       "ExpectedArm64ASM": [
         "sub x20, x7, x5",
@@ -1935,7 +1818,6 @@
     },
     "db 0x3A, 0xcb": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0x3A",
         "cmp bl, cl but modrm.rm as source"
@@ -1957,7 +1839,6 @@
     },
     "db 0x66, 0x3B, 0xcb": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0x3B",
         "cmp bx, cx but modrm.rm as source"
@@ -1979,7 +1860,6 @@
     },
     "db 0x3B, 0xcb": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0x3B",
         "cmp ebx, ecx but modrm.rm as source"
@@ -1997,7 +1877,6 @@
     },
     "db 0x48, 0x3B, 0xcb": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "0x3B",
         "cmp rbx, rcx but modrm.rm as source"
@@ -2013,7 +1892,6 @@
     },
     "cmp al, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x3C",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2028,7 +1906,6 @@
     },
     "cmp ax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2043,7 +1920,6 @@
     },
     "cmp eax, 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2056,7 +1932,6 @@
     },
     "cmp rax, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "sub x20, x4, #0x1 (1)",
@@ -2068,7 +1943,6 @@
     },
     "cmp al, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x3C",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2084,7 +1958,6 @@
     },
     "cmp ax, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -2101,7 +1974,6 @@
     },
     "cmp eax, -1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -2116,7 +1988,6 @@
     },
     "cmp rax, -1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -2130,7 +2001,6 @@
     },
     "imul ax, bx, 257": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x69",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2149,7 +2019,6 @@
     },
     "imul eax, ebx, 257": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x69",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2168,7 +2037,6 @@
     },
     "imul rax, rbx, 257": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x69",
       "ExpectedArm64ASM": [
         "mov w20, #0x101",
@@ -2184,7 +2052,6 @@
     },
     "imul ax, bx, 3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x6b",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2203,7 +2070,6 @@
     },
     "imul eax, ebx, 3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x6b",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2222,7 +2088,6 @@
     },
     "imul rax, rbx, 3": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x6b",
       "ExpectedArm64ASM": [
         "mov w20, #0x3",
@@ -2238,7 +2103,6 @@
     },
     "test al, bl": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x84",
       "ExpectedArm64ASM": [
         "and w20, w4, w7",
@@ -2248,7 +2112,6 @@
     },
     "test ax, bx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x84",
       "ExpectedArm64ASM": [
         "and w20, w4, w7",
@@ -2258,7 +2121,6 @@
     },
     "test eax, ebx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x84",
       "ExpectedArm64ASM": [
         "and w20, w4, w7",
@@ -2268,7 +2130,6 @@
     },
     "test rax, rbx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x84",
       "ExpectedArm64ASM": [
         "and x20, x4, x7",
@@ -2278,7 +2139,6 @@
     },
     "pushf": {
       "ExpectedInstructionCount": 41,
-      "Optimal": "No",
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -2326,7 +2186,6 @@
     },
     "pushfq": {
       "ExpectedInstructionCount": 41,
-      "Optimal": "No",
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -2374,7 +2233,6 @@
     },
     "popf": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": "0x9d",
       "ExpectedArm64ASM": [
         "ldr x20, [x8]",
@@ -2415,7 +2273,6 @@
     },
     "sahf": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x9e",
       "ExpectedArm64ASM": [
         "ubfx w20, w4, #8, #8",
@@ -2433,7 +2290,6 @@
     },
     "lahf": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "Yes",
       "Comment": "0x9f",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -2457,7 +2313,6 @@
     },
     "cmpsb": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "0xa6"
       ],
@@ -2483,7 +2338,6 @@
     },
     "cmpsw": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "0xa7"
       ],
@@ -2509,7 +2363,6 @@
     },
     "cmpsd": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xa7"
       ],
@@ -2531,7 +2384,6 @@
     },
     "cmpsq": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xa7"
       ],
@@ -2553,7 +2405,6 @@
     },
     "repz cmpsb": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "0xa6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -2581,7 +2432,6 @@
     },
     "repz cmpsw": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -2609,7 +2459,6 @@
     },
     "repz cmpsd": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -2633,7 +2482,6 @@
     },
     "repz cmpsq": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -2657,7 +2505,6 @@
     },
     "repnz cmpsb": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "0xa6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -2685,7 +2532,6 @@
     },
     "repnz cmpsw": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -2713,7 +2559,6 @@
     },
     "repnz cmpsd": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -2737,7 +2582,6 @@
     },
     "repnz cmpsq": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -2761,7 +2605,6 @@
     },
     "test al, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa8",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -2771,7 +2614,6 @@
     },
     "test ax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -2781,7 +2623,6 @@
     },
     "test eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -2791,7 +2632,6 @@
     },
     "test rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "and x20, x4, #0x1",
@@ -2801,7 +2641,6 @@
     },
     "test al, -1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa8",
       "ExpectedArm64ASM": [
         "and w20, w4, #0xff",
@@ -2811,7 +2650,6 @@
     },
     "test ax, -1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "and w20, w4, #0xffff",
@@ -2821,7 +2659,6 @@
     },
     "test eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -2832,7 +2669,6 @@
     },
     "test rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -2843,7 +2679,6 @@
     },
     "scasb": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2866,7 +2701,6 @@
     },
     "scasw": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2889,7 +2723,6 @@
     },
     "scasd": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2908,7 +2741,6 @@
     },
     "scasq": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldr x20, [x11]",
@@ -2926,7 +2758,6 @@
     },
     "repz scasb": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -2953,7 +2784,6 @@
     },
     "repz scasw": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -2980,7 +2810,6 @@
     },
     "repz scasd": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3003,7 +2832,6 @@
     },
     "repz scasq": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3025,7 +2853,6 @@
     },
     "repnz scasb": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3052,7 +2879,6 @@
     },
     "repnz scasw": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3079,7 +2905,6 @@
     },
     "repnz scasd": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3102,7 +2927,6 @@
     },
     "repnz scasq": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3124,7 +2948,6 @@
     },
     "cmc": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0xf5",
       "ExpectedArm64ASM": [
         "cfinv"
@@ -3132,7 +2955,6 @@
     },
     "clc": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0xf8",
       "ExpectedArm64ASM": [
         "mov w20, #0x0",
@@ -3141,7 +2963,6 @@
     },
     "stc": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0xf9",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -13,7 +13,6 @@
   "Instructions": {
     "add al, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -29,7 +28,6 @@
     },
     "or al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /1",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0x1",
@@ -40,7 +38,6 @@
     },
     "adc al, 1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -68,7 +65,6 @@
     },
     "sbb al, 1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -96,7 +92,6 @@
     },
     "and al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /4",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -107,7 +102,6 @@
     },
     "sub al, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -123,7 +117,6 @@
     },
     "xor al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /6",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0x1",
@@ -134,7 +127,6 @@
     },
     "cmp al, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -149,7 +141,6 @@
     },
     "add al, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -166,7 +157,6 @@
     },
     "or al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /1",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0xff",
@@ -177,7 +167,6 @@
     },
     "adc al, -1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -206,7 +195,6 @@
     },
     "sbb al, -1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -235,7 +223,6 @@
     },
     "and al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /4",
       "ExpectedArm64ASM": [
         "and w20, w4, #0xff",
@@ -246,7 +233,6 @@
     },
     "sub al, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -263,7 +249,6 @@
     },
     "xor al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /6",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0xff",
@@ -274,7 +259,6 @@
     },
     "cmp al, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -290,7 +274,6 @@
     },
     "add ax, 256": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -306,7 +289,6 @@
     },
     "add eax, 256": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -318,7 +300,6 @@
     },
     "add rax, 256": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -330,7 +311,6 @@
     },
     "or eax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x100",
@@ -340,7 +320,6 @@
     },
     "or rax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x100",
@@ -350,7 +329,6 @@
     },
     "adc eax, 256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -365,7 +343,6 @@
     },
     "adc rax, 256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -380,7 +357,6 @@
     },
     "sbb eax, 256": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -397,7 +373,6 @@
     },
     "sbb rax, 256": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -414,7 +389,6 @@
     },
     "and eax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "and w4, w4, #0x100",
@@ -424,7 +398,6 @@
     },
     "and rax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "and x4, x4, #0x100",
@@ -434,7 +407,6 @@
     },
     "sub eax, 256": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -447,7 +419,6 @@
     },
     "sub rax, 256": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -460,7 +431,6 @@
     },
     "xor eax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x100",
@@ -470,7 +440,6 @@
     },
     "xor rax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x100",
@@ -480,7 +449,6 @@
     },
     "cmp eax, 256": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -493,7 +461,6 @@
     },
     "cmp rax, 256": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
         "sub x20, x4, #0x100 (256)",
@@ -505,7 +472,6 @@
     },
     "add ax, -256": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xff00",
@@ -522,7 +488,6 @@
     },
     "add eax, -256": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffff00",
@@ -535,7 +500,6 @@
     },
     "add rax, -256": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffff00",
@@ -548,7 +512,6 @@
     },
     "or eax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0xffffff00",
@@ -558,7 +521,6 @@
     },
     "or rax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0xffffffffffffff00",
@@ -568,7 +530,6 @@
     },
     "adc eax, -256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffff00",
@@ -583,7 +544,6 @@
     },
     "adc rax, -256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffff00",
@@ -598,7 +558,6 @@
     },
     "sbb eax, -256": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffff00",
@@ -615,7 +574,6 @@
     },
     "sbb rax, -256": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffff00",
@@ -632,7 +590,6 @@
     },
     "and eax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "and w4, w4, #0xffffff00",
@@ -642,7 +599,6 @@
     },
     "and rax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "and x4, x4, #0xffffffffffffff00",
@@ -652,7 +608,6 @@
     },
     "sub eax, -256": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffff00",
@@ -666,7 +621,6 @@
     },
     "sub rax, -256": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffff00",
@@ -680,7 +634,6 @@
     },
     "xor eax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0xffffff00",
@@ -690,7 +643,6 @@
     },
     "xor rax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0xffffffffffffff00",
@@ -700,7 +652,6 @@
     },
     "cmp eax, -256": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffff00",
@@ -714,7 +665,6 @@
     },
     "cmp rax, -256": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffff00",
@@ -727,7 +677,6 @@
     },
     "add ax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -743,7 +692,6 @@
     },
     "add eax, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -755,7 +703,6 @@
     },
     "add rax, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -767,7 +714,6 @@
     },
     "or eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x1",
@@ -777,7 +723,6 @@
     },
     "or rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x1",
@@ -787,7 +732,6 @@
     },
     "adc eax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -802,7 +746,6 @@
     },
     "adc rax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -817,7 +760,6 @@
     },
     "sbb eax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -834,7 +776,6 @@
     },
     "sbb rax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -851,7 +792,6 @@
     },
     "and eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "and w4, w4, #0x1",
@@ -861,7 +801,6 @@
     },
     "and rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "and x4, x4, #0x1",
@@ -871,7 +810,6 @@
     },
     "sub eax, 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -884,7 +822,6 @@
     },
     "sub rax, 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -897,7 +834,6 @@
     },
     "xor eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x1",
@@ -907,7 +843,6 @@
     },
     "xor rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x1",
@@ -917,7 +852,6 @@
     },
     "cmp eax, 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -930,7 +864,6 @@
     },
     "cmp rax, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
         "sub x20, x4, #0x1 (1)",
@@ -942,7 +875,6 @@
     },
     "add ax, -1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -960,7 +892,6 @@
     },
     "add eax, -1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -974,7 +905,6 @@
     },
     "add rax, -1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -988,7 +918,6 @@
     },
     "or eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /-1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -999,7 +928,6 @@
     },
     "or rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /-1",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1010,7 +938,6 @@
     },
     "adc eax, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1026,7 +953,6 @@
     },
     "adc rax, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1042,7 +968,6 @@
     },
     "sbb eax, -1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1060,7 +985,6 @@
     },
     "sbb rax, -1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1078,7 +1002,6 @@
     },
     "and eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1089,7 +1012,6 @@
     },
     "and rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1100,7 +1022,6 @@
     },
     "sub eax, -1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1115,7 +1036,6 @@
     },
     "sub rax, -1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1130,7 +1050,6 @@
     },
     "xor eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1141,7 +1060,6 @@
     },
     "xor rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1152,7 +1070,6 @@
     },
     "cmp eax, -1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1167,7 +1084,6 @@
     },
     "cmp rax, -1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1181,7 +1097,6 @@
     },
     "rol al, 2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1198,7 +1113,6 @@
     },
     "ror al, 2": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /1",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1214,7 +1128,6 @@
     },
     "rcl al, 2": {
       "ExpectedInstructionCount": 31,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /2",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1252,7 +1165,6 @@
     },
     "rcr al, 2": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /3",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1279,7 +1191,6 @@
     },
     "shl al, 2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /4",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1294,7 +1205,6 @@
     },
     "shr al, 2": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1310,7 +1220,6 @@
     },
     "sar al, 2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1325,7 +1234,6 @@
     },
     "rol ax, 2": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1341,7 +1249,6 @@
     },
     "rol eax, 2": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1355,7 +1262,6 @@
     },
     "rol rax, 2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xC1 /0",
       "ExpectedArm64ASM": [
         "ror x4, x4, #62",
@@ -1368,7 +1274,6 @@
     },
     "ror ax, 2": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1384,7 +1289,6 @@
     },
     "ror eax, 2": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1398,7 +1302,6 @@
     },
     "ror rax, 2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xC1 /1",
       "ExpectedArm64ASM": [
         "ror x4, x4, #2",
@@ -1411,7 +1314,6 @@
     },
     "rcl ax, 2": {
       "ExpectedInstructionCount": 27,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1445,7 +1347,6 @@
     },
     "rcl eax, 2": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x2",
@@ -1477,7 +1378,6 @@
     },
     "rcl rax, 2": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x2",
@@ -1509,7 +1409,6 @@
     },
     "rcr ax, 2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /3",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1535,7 +1434,6 @@
     },
     "rcr eax, 2": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x2",
@@ -1568,7 +1466,6 @@
     },
     "rcr rax, 2": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x2",
@@ -1601,7 +1498,6 @@
     },
     "shl ax, 2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /4",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1616,7 +1512,6 @@
     },
     "shl eax, 2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /4",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1629,7 +1524,6 @@
     },
     "shl rax, 2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xC1 /4",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1642,7 +1536,6 @@
     },
     "shr ax, 2": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /5",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1658,7 +1551,6 @@
     },
     "shr eax, 2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /5",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1673,7 +1565,6 @@
     },
     "shr rax, 2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xC1 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1688,7 +1579,6 @@
     },
     "sar ax, 2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /7",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1703,7 +1593,6 @@
     },
     "sar eax, 2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /7",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1716,7 +1605,6 @@
     },
     "sar rax, 2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xC1 /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1729,7 +1617,6 @@
     },
     "rol al, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1749,7 +1636,6 @@
     },
     "ror al, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /1",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1768,7 +1654,6 @@
     },
     "rcl al, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /2",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1785,7 +1670,6 @@
     },
     "rcr al, 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /3",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1803,7 +1687,6 @@
     },
     "shl al, 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /4",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1821,7 +1704,6 @@
     },
     "shr al, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1837,7 +1719,6 @@
     },
     "sar al, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1852,7 +1733,6 @@
     },
     "rol ax, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1871,7 +1751,6 @@
     },
     "rol eax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1888,7 +1767,6 @@
     },
     "rol rax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd1 /0",
       "ExpectedArm64ASM": [
         "ror x4, x4, #63",
@@ -1904,7 +1782,6 @@
     },
     "ror ax, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1923,7 +1800,6 @@
     },
     "ror eax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1940,7 +1816,6 @@
     },
     "ror rax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd1 /1",
       "ExpectedArm64ASM": [
         "ror x4, x4, #1",
@@ -1956,7 +1831,6 @@
     },
     "rcl ax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1973,7 +1847,6 @@
     },
     "rcl eax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1989,7 +1862,6 @@
     },
     "rcl rax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -2004,7 +1876,6 @@
     },
     "rcr ax, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /3",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2023,7 +1894,6 @@
     },
     "rcr eax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /3",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2039,7 +1909,6 @@
     },
     "rcr rax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /3",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2055,7 +1924,6 @@
     },
     "shl ax, 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /4",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2073,7 +1941,6 @@
     },
     "shl eax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /4",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2089,7 +1956,6 @@
     },
     "shl rax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd1 /4",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2105,7 +1971,6 @@
     },
     "shr ax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /5",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2121,7 +1986,6 @@
     },
     "shr eax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /5",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2136,7 +2000,6 @@
     },
     "shr rax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd1 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2151,7 +2014,6 @@
     },
     "sar ax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /7",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2166,7 +2028,6 @@
     },
     "sar eax, 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /7",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2179,7 +2040,6 @@
     },
     "sar rax, 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd1 /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2192,7 +2052,6 @@
     },
     "rol al, cl": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2218,7 +2077,6 @@
     },
     "ror al, cl": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /1",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2242,7 +2100,6 @@
     },
     "rcl al, cl": {
       "ExpectedInstructionCount": 39,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /2",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -2288,7 +2145,6 @@
     },
     "rcr al, cl": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /3",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -2317,7 +2173,6 @@
     },
     "shl al, cl": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /4",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2349,7 +2204,6 @@
     },
     "shr al, cl": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2379,7 +2233,6 @@
     },
     "sar al, cl": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2405,7 +2258,6 @@
     },
     "rol ax, cl": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2430,7 +2282,6 @@
     },
     "rol eax, cl": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2453,7 +2304,6 @@
     },
     "rol rax, cl": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /0",
       "ExpectedArm64ASM": [
         "and x20, x5, #0x3f",
@@ -2474,7 +2324,6 @@
     },
     "ror ax, cl": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2497,7 +2346,6 @@
     },
     "ror eax, cl": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2518,7 +2366,6 @@
     },
     "ror rax, cl": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /1",
       "ExpectedArm64ASM": [
         "and x20, x5, #0x3f",
@@ -2537,7 +2384,6 @@
     },
     "rcl ax, cl": {
       "ExpectedInstructionCount": 35,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -2579,7 +2425,6 @@
     },
     "rcl eax, cl": {
       "ExpectedInstructionCount": 33,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -2619,7 +2464,6 @@
     },
     "rcl rax, cl": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2658,7 +2502,6 @@
     },
     "rcr ax, cl": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -2686,7 +2529,6 @@
     },
     "rcr eax, cl": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -2727,7 +2569,6 @@
     },
     "rcr rax, cl": {
       "ExpectedInstructionCount": 33,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2767,7 +2608,6 @@
     },
     "shl ax, cl": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /4",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2799,7 +2639,6 @@
     },
     "shl eax, cl": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /4",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2829,7 +2668,6 @@
     },
     "shl rax, cl": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd3 /4",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2858,7 +2696,6 @@
     },
     "shr ax, cl": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /5",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2888,7 +2725,6 @@
     },
     "shr eax, cl": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /5",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2917,7 +2753,6 @@
     },
     "shr rax, cl": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd3 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2945,7 +2780,6 @@
     },
     "sar ax, cl": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /7",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2971,7 +2805,6 @@
     },
     "sar eax, cl": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /7",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2995,7 +2828,6 @@
     },
     "sar rax, cl": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd3 /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3018,7 +2850,6 @@
     },
     "test bl, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /0",
       "ExpectedArm64ASM": [
         "and w20, w7, #0x1",
@@ -3028,7 +2859,6 @@
     },
     "not bl": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xf6 /2",
       "ExpectedArm64ASM": [
         "eor x7, x7, #0xff"
@@ -3036,7 +2866,6 @@
     },
     "neg bl": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /3",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3052,7 +2881,6 @@
     },
     "mul bl": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /4",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3069,7 +2897,6 @@
     },
     "imul bl": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3088,7 +2915,6 @@
     },
     "div bl": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /6",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3108,7 +2934,6 @@
     },
     "idiv bl": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3126,7 +2951,6 @@
     },
     "test bx, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "and w20, w7, #0x1",
@@ -3136,7 +2960,6 @@
     },
     "test ebx, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "and w20, w7, #0x1",
@@ -3146,7 +2969,6 @@
     },
     "test rbx, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "and x20, x7, #0x1",
@@ -3156,7 +2978,6 @@
     },
     "test bx, -1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "and w20, w7, #0xffff",
@@ -3166,7 +2987,6 @@
     },
     "test ebx, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -3177,7 +2997,6 @@
     },
     "test rbx, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -3188,7 +3007,6 @@
     },
     "neg bx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -3204,7 +3022,6 @@
     },
     "neg ebx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -3217,7 +3034,6 @@
     },
     "neg rbx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -3230,7 +3046,6 @@
     },
     "mul bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -3248,7 +3063,6 @@
     },
     "mul ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -3265,7 +3079,6 @@
     },
     "mul rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3280,7 +3093,6 @@
     },
     "imul bx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /5",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -3300,7 +3112,6 @@
     },
     "imul ebx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /5",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -3321,7 +3132,6 @@
     },
     "imul rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3337,7 +3147,6 @@
     },
     "div bx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /6",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -3356,7 +3165,6 @@
     },
     "inc al": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP3 0xfe /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -3373,7 +3181,6 @@
     },
     "dec al": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -3390,7 +3197,6 @@
     },
     "inc ax": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3407,7 +3213,6 @@
     },
     "inc eax": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3421,7 +3226,6 @@
     },
     "inc rax": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3435,7 +3239,6 @@
     },
     "dec ax": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3452,7 +3255,6 @@
     },
     "dec eax": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3466,7 +3268,6 @@
     },
     "dec rax": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov x20, x4",

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -15,7 +15,6 @@
   "Instructions": {
     "ucomiss xmm0, xmm1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x0f 0x2e",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -44,7 +43,6 @@
     },
     "comiss xmm0, xmm1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x0f 0x2f",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -73,7 +71,6 @@
     },
     "cmovo ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x40",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, vs",
@@ -82,7 +79,6 @@
     },
     "cmovo eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x40",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, vs"
@@ -90,7 +86,6 @@
     },
     "cmovo rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x40",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, vs"
@@ -98,7 +93,6 @@
     },
     "cmovno ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x41",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, vc",
@@ -107,7 +101,6 @@
     },
     "cmovno eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x41",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, vc"
@@ -115,7 +108,6 @@
     },
     "cmovno rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x41",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, vc"
@@ -123,7 +115,6 @@
     },
     "cmovb ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x42",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, hs",
@@ -132,7 +123,6 @@
     },
     "cmovb eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x42",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, hs"
@@ -140,7 +130,6 @@
     },
     "cmovb rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x42",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, hs"
@@ -148,7 +137,6 @@
     },
     "cmovnb ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x43",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, lo",
@@ -157,7 +145,6 @@
     },
     "cmovnb eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x43",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, lo"
@@ -165,7 +152,6 @@
     },
     "cmovnb rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x43",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, lo"
@@ -173,7 +159,6 @@
     },
     "cmovz ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x44",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, eq",
@@ -182,7 +167,6 @@
     },
     "cmovz eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x44",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, eq"
@@ -190,7 +174,6 @@
     },
     "cmovz rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x44",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, eq"
@@ -198,7 +181,6 @@
     },
     "cmovnz ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x45",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, ne",
@@ -207,7 +189,6 @@
     },
     "cmovnz eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x45",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, ne"
@@ -215,7 +196,6 @@
     },
     "cmovnz rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x45",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, ne"
@@ -223,7 +203,6 @@
     },
     "cmovbe ax, bx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0x46",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, hs",
@@ -233,7 +212,6 @@
     },
     "cmovbe eax, ebx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x46",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, hs",
@@ -242,7 +220,6 @@
     },
     "cmovbe rax, rbx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x46",
       "ExpectedArm64ASM": [
         "csel x20, x7, x4, hs",
@@ -251,7 +228,6 @@
     },
     "cmovnbe ax, bx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0x47",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, lo",
@@ -261,7 +237,6 @@
     },
     "cmovnbe eax, ebx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x47",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, lo",
@@ -270,7 +245,6 @@
     },
     "cmovnbe rax, rbx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x47",
       "ExpectedArm64ASM": [
         "csel x20, x7, x4, lo",
@@ -279,7 +253,6 @@
     },
     "cmovs ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x48",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, mi",
@@ -288,7 +261,6 @@
     },
     "cmovs eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x48",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, mi"
@@ -296,7 +268,6 @@
     },
     "cmovs rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x48",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, mi"
@@ -304,7 +275,6 @@
     },
     "cmovns ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x49",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, pl",
@@ -313,7 +283,6 @@
     },
     "cmovns eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x49",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, pl"
@@ -321,7 +290,6 @@
     },
     "cmovns rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x49",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, pl"
@@ -329,7 +297,6 @@
     },
     "cmovpe ax, bx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0x4a",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -345,7 +312,6 @@
     },
     "cmovpe eax, ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0x4a",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -360,7 +326,6 @@
     },
     "cmovpe rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0x4a",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -375,7 +340,6 @@
     },
     "cmovnp ax, bx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0x4b",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -391,7 +355,6 @@
     },
     "cmovnp eax, ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0x4b",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -406,7 +369,6 @@
     },
     "cmovnp rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0x4b",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -421,7 +383,6 @@
     },
     "cmovl ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x4c",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, lt",
@@ -430,7 +391,6 @@
     },
     "cmovl eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4c",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, lt"
@@ -438,7 +398,6 @@
     },
     "cmovl rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x4c",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, lt"
@@ -446,7 +405,6 @@
     },
     "cmovnl ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x4d",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, ge",
@@ -455,7 +413,6 @@
     },
     "cmovnl eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4d",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, ge"
@@ -463,7 +420,6 @@
     },
     "cmovnl rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x4d",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, ge"
@@ -471,7 +427,6 @@
     },
     "cmovle ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x4e",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, le",
@@ -480,7 +435,6 @@
     },
     "cmovle eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4e",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, le"
@@ -488,7 +442,6 @@
     },
     "cmovle rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4e",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, le"
@@ -496,7 +449,6 @@
     },
     "cmovnle ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x4f",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, gt",
@@ -505,7 +457,6 @@
     },
     "cmovnle eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4f",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, gt"
@@ -513,7 +464,6 @@
     },
     "cmovnle rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4f",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, gt"
@@ -521,7 +471,6 @@
     },
     "seto al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x90",
       "ExpectedArm64ASM": [
         "cset x20, vs",
@@ -530,7 +479,6 @@
     },
     "setno al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x91",
       "ExpectedArm64ASM": [
         "cset x20, vc",
@@ -539,7 +487,6 @@
     },
     "setb al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x92",
       "ExpectedArm64ASM": [
         "cset x20, hs",
@@ -548,7 +495,6 @@
     },
     "setnb al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x93",
       "ExpectedArm64ASM": [
         "cset x20, lo",
@@ -557,7 +503,6 @@
     },
     "setz al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x94",
       "ExpectedArm64ASM": [
         "cset x20, eq",
@@ -566,7 +511,6 @@
     },
     "setnz al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x95",
       "ExpectedArm64ASM": [
         "cset x20, ne",
@@ -575,7 +519,6 @@
     },
     "setbe al": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0f 0x96",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -586,7 +529,6 @@
     },
     "setnbe al": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0x97",
       "ExpectedArm64ASM": [
         "cset x20, lo",
@@ -596,7 +538,6 @@
     },
     "sets al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x98",
       "ExpectedArm64ASM": [
         "cset x20, mi",
@@ -605,7 +546,6 @@
     },
     "setns al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x99",
       "ExpectedArm64ASM": [
         "cset x20, pl",
@@ -614,7 +554,6 @@
     },
     "setpe al": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x9a",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -628,7 +567,6 @@
     },
     "setnp al": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x9b",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -641,7 +579,6 @@
     },
     "setl al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x9c",
       "ExpectedArm64ASM": [
         "cset x20, lt",
@@ -650,7 +587,6 @@
     },
     "setnl al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x9d",
       "ExpectedArm64ASM": [
         "cset x20, ge",
@@ -659,7 +595,6 @@
     },
     "setle al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x9e",
       "ExpectedArm64ASM": [
         "cset x20, le",
@@ -668,7 +603,6 @@
     },
     "setnle al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x9f",
       "ExpectedArm64ASM": [
         "cset x20, gt",
@@ -677,7 +611,6 @@
     },
     "bt ax, bx": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -689,7 +622,6 @@
     },
     "bt [rax], bx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -703,7 +635,6 @@
     },
     "bt eax, ebx": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -715,7 +646,6 @@
     },
     "bt [rax], ebx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -729,7 +659,6 @@
     },
     "bt rax, rbx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "and x20, x7, #0x3f",
@@ -740,7 +669,6 @@
     },
     "bt [rax], rbx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -753,7 +681,6 @@
     },
     "shld ax, bx, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -773,7 +700,6 @@
     },
     "shld ax, bx, 15": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -790,7 +716,6 @@
     },
     "shld ax, bx, 16": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -806,7 +731,6 @@
     },
     "shld ax, bx, 31": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -823,7 +747,6 @@
     },
     "shld eax, ebx, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -840,7 +763,6 @@
     },
     "shld eax, ebx, 15": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -854,7 +776,6 @@
     },
     "shld eax, ebx, 16": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -868,7 +789,6 @@
     },
     "shld eax, ebx, 31": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -882,7 +802,6 @@
     },
     "shld rax, rbx, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -898,7 +817,6 @@
     },
     "shld rax, rbx, 15": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -911,7 +829,6 @@
     },
     "shld rax, rbx, 32": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -924,7 +841,6 @@
     },
     "shld rax, rbx, 63": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -937,7 +853,6 @@
     },
     "shld ax, bx, cl": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": "0x0f 0xad",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -978,7 +893,6 @@
     },
     "shld eax, ebx, cl": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": "0x0f 0xad",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1019,7 +933,6 @@
     },
     "shld rax, rbx, cl": {
       "ExpectedInstructionCount": 31,
-      "Optimal": "No",
       "Comment": "0x0f 0xad",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1057,7 +970,6 @@
     },
     "bts ax, bx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1073,7 +985,6 @@
     },
     "bts [rax], bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1091,7 +1002,6 @@
     },
     "bts eax, ebx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1107,7 +1017,6 @@
     },
     "bts [rax], ebx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1125,7 +1034,6 @@
     },
     "bts rax, rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "and x20, x7, #0x3f",
@@ -1139,7 +1047,6 @@
     },
     "bts [rax], rbx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -1156,7 +1063,6 @@
     },
     "lock bts [rax], bx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1173,7 +1079,6 @@
     },
     "lock bts [rax], ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1190,7 +1095,6 @@
     },
     "lock bts [rax], rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -1206,7 +1110,6 @@
     },
     "imul ax, bx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x0f 0xaf",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1226,7 +1129,6 @@
     },
     "imul eax, ebx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x0f 0xaf",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1246,7 +1148,6 @@
     },
     "imul rax, rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xaf",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1262,7 +1163,6 @@
     },
     "cmpxchg al, bl": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "0x0f 0xb0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -1288,7 +1188,6 @@
     },
     "cmpxchg [rax], bl": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0x0f 0xb0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -1311,7 +1210,6 @@
     },
     "cmpxchg ax, bx": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1337,7 +1235,6 @@
     },
     "cmpxchg [rax], bx": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1360,7 +1257,6 @@
     },
     "cmpxchg eax, ebx": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1386,7 +1282,6 @@
     },
     "cmpxchg [rax], ebx": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1408,7 +1303,6 @@
     },
     "cmpxchg rax, rbx": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1430,7 +1324,6 @@
     },
     "cmpxchg [rax], rbx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1449,7 +1342,6 @@
     },
     "btr ax, bx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1465,7 +1357,6 @@
     },
     "btr [rax], bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1483,7 +1374,6 @@
     },
     "btr eax, ebx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1499,7 +1389,6 @@
     },
     "btr [rax], ebx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1517,7 +1406,6 @@
     },
     "btr rax, rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "and x20, x7, #0x3f",
@@ -1531,7 +1419,6 @@
     },
     "btr [rax], rbx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -1548,7 +1435,6 @@
     },
     "lock btr [rax], bx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1565,7 +1451,6 @@
     },
     "lock btr [rax], ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1582,7 +1467,6 @@
     },
     "lock btr [rax], rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -1598,7 +1482,6 @@
     },
     "btc ax, bx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1614,7 +1497,6 @@
     },
     "btc [rax], bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1632,7 +1514,6 @@
     },
     "btc eax, ebx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1648,7 +1529,6 @@
     },
     "btc [rax], ebx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1666,7 +1546,6 @@
     },
     "btc rax, rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "and x20, x7, #0x3f",
@@ -1680,7 +1559,6 @@
     },
     "btc [rax], rbx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -1697,7 +1575,6 @@
     },
     "lock btc [rax], bx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1714,7 +1591,6 @@
     },
     "lock btc [rax], ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1731,7 +1607,6 @@
     },
     "lock btc [rax], rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -1747,7 +1622,6 @@
     },
     "bsf ax, bx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x0f 0xbc",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1768,7 +1642,6 @@
     },
     "bsf eax, ebx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xbc",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1787,7 +1660,6 @@
     },
     "bsf rax, rbx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xbc",
       "ExpectedArm64ASM": [
         "rbit x0, x7",
@@ -1804,7 +1676,6 @@
     },
     "bsr ax, bx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x0f 0xbd",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1825,7 +1696,6 @@
     },
     "bsr eax, ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xbd",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1842,7 +1712,6 @@
     },
     "bsr rax, rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xbd",
       "ExpectedArm64ASM": [
         "mov x0, #0x3f",
@@ -1858,7 +1727,6 @@
     },
     "xadd al, bl": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1879,7 +1747,6 @@
     },
     "xadd [rax], bl": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -1899,7 +1766,6 @@
     },
     "xadd ax, bx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1920,7 +1786,6 @@
     },
     "xadd [rax], bx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1940,7 +1805,6 @@
     },
     "xadd eax, ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1955,7 +1819,6 @@
     },
     "xadd [rax], ebx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1969,7 +1832,6 @@
     },
     "xadd rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1984,7 +1846,6 @@
     },
     "xadd [rax], rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -1998,7 +1859,6 @@
     },
     "pmovmskb eax, mm0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd7",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -2017,7 +1877,6 @@
     },
     "maskmovq mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf7",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -14,7 +14,6 @@
   "Instructions": {
     "sgdt [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP7 0x0F 0x1 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x0",
@@ -25,7 +24,6 @@
     },
     "bt ax, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #1",
@@ -34,7 +32,6 @@
     },
     "bt eax, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #1",
@@ -43,7 +40,6 @@
     },
     "bt rax, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #1",
@@ -52,7 +48,6 @@
     },
     "bt ax, 15": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #15",
@@ -62,7 +57,6 @@
     },
     "bt eax, 31": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
@@ -72,7 +66,6 @@
     },
     "bt rax, 63": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #63",
@@ -82,7 +75,6 @@
     },
     "bt word [rax], 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -92,7 +84,6 @@
     },
     "bt dword [rax], 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -102,7 +93,6 @@
     },
     "bt qword [rax], 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -112,7 +102,6 @@
     },
     "bt word [rax], 15": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #1]",
@@ -123,7 +112,6 @@
     },
     "bt dword [rax], 31": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #3]",
@@ -134,7 +122,6 @@
     },
     "bt qword [rax], 63": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #7]",
@@ -145,7 +132,6 @@
     },
     "bts ax, 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -158,7 +144,6 @@
     },
     "bts eax, 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -170,7 +155,6 @@
     },
     "bts rax, 0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -181,7 +165,6 @@
     },
     "bts ax, 15": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #15",
@@ -193,7 +176,6 @@
     },
     "bts eax, 31": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
@@ -205,7 +187,6 @@
     },
     "bts rax, 63": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #63",
@@ -216,7 +197,6 @@
     },
     "bts word [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -228,7 +208,6 @@
     },
     "bts dword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -240,7 +219,6 @@
     },
     "bts qword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -252,7 +230,6 @@
     },
     "bts word [rax], 15": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #1]",
@@ -265,7 +242,6 @@
     },
     "bts dword [rax], 31": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #3]",
@@ -278,7 +254,6 @@
     },
     "bts qword [rax], 63": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #7]",
@@ -291,7 +266,6 @@
     },
     "lock bts word [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -303,7 +277,6 @@
     },
     "lock bts dword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -315,7 +288,6 @@
     },
     "lock bts qword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -327,7 +299,6 @@
     },
     "lock bts word [rax], 15": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x1 (1)",
@@ -340,7 +311,6 @@
     },
     "lock bts dword [rax], 31": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x3 (3)",
@@ -353,7 +323,6 @@
     },
     "lock bts qword [rax], 63": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x7 (7)",
@@ -366,7 +335,6 @@
     },
     "btr ax, 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -379,7 +347,6 @@
     },
     "btr eax, 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -391,7 +358,6 @@
     },
     "btr rax, 0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -402,7 +368,6 @@
     },
     "btr ax, 15": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #15",
@@ -414,7 +379,6 @@
     },
     "btr eax, 31": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
@@ -426,7 +390,6 @@
     },
     "btr rax, 63": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #63",
@@ -437,7 +400,6 @@
     },
     "btr word [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -449,7 +411,6 @@
     },
     "btr dword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -461,7 +422,6 @@
     },
     "btr qword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -473,7 +433,6 @@
     },
     "btr word [rax], 15": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #1]",
@@ -486,7 +445,6 @@
     },
     "btr dword [rax], 31": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #3]",
@@ -499,7 +457,6 @@
     },
     "btr qword [rax], 63": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #7]",
@@ -512,7 +469,6 @@
     },
     "lock btr word [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -524,7 +480,6 @@
     },
     "lock btr dword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -536,7 +491,6 @@
     },
     "lock btr qword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -548,7 +502,6 @@
     },
     "lock btr word [rax], 15": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x1 (1)",
@@ -561,7 +514,6 @@
     },
     "lock btr dword [rax], 31": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x3 (3)",
@@ -574,7 +526,6 @@
     },
     "lock btr qword [rax], 63": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x7 (7)",
@@ -587,7 +538,6 @@
     },
     "btc ax, 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -600,7 +550,6 @@
     },
     "btc eax, 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -612,7 +561,6 @@
     },
     "btc rax, 0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -623,7 +571,6 @@
     },
     "btc ax, 15": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #15",
@@ -635,7 +582,6 @@
     },
     "btc eax, 31": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
@@ -647,7 +593,6 @@
     },
     "btc rax, 63": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #63",
@@ -658,7 +603,6 @@
     },
     "btc word [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -670,7 +614,6 @@
     },
     "btc dword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -682,7 +625,6 @@
     },
     "btc qword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -694,7 +636,6 @@
     },
     "btc word [rax], 15": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #1]",
@@ -707,7 +648,6 @@
     },
     "btc dword [rax], 31": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #3]",
@@ -720,7 +660,6 @@
     },
     "btc qword [rax], 63": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #7]",
@@ -733,7 +672,6 @@
     },
     "lock btc word [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -745,7 +683,6 @@
     },
     "lock btc dword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -757,7 +694,6 @@
     },
     "lock btc qword [rax], 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -769,7 +705,6 @@
     },
     "lock btc word [rax], 15": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x1 (1)",
@@ -782,7 +717,6 @@
     },
     "lock btc dword [rax], 31": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x3 (3)",
@@ -795,7 +729,6 @@
     },
     "lock btc qword [rax], 63": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x7 (7)",
@@ -808,7 +741,6 @@
     },
     "cmpxchg8b [rbp]": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /1",
       "ExpectedArm64ASM": [
         "add x20, x9, #0x0 (0)",
@@ -840,7 +772,6 @@
     },
     "cmpxchg16b [rbp]": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /1",
       "ExpectedArm64ASM": [
         "add x20, x9, #0x0 (0)",
@@ -868,7 +799,6 @@
     },
     "rdrand ax": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "mrs x20, rndr",
@@ -886,7 +816,6 @@
     },
     "rdrand eax": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "mrs x20, rndr",
@@ -904,7 +833,6 @@
     },
     "rdrand rax": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "mrs x20, rndr",
@@ -921,7 +849,6 @@
     },
     "rdseed ax": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /7",
       "ExpectedArm64ASM": [
         "mrs x20, rndrrs",
@@ -939,7 +866,6 @@
     },
     "rdseed eax": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /7",
       "ExpectedArm64ASM": [
         "mrs x20, rndrrs",
@@ -957,7 +883,6 @@
     },
     "rdseed rax": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /7",
       "ExpectedArm64ASM": [
         "mrs x20, rndrrs",
@@ -975,14 +900,12 @@
     "psrlw mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrlw mm0, 15": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -993,7 +916,6 @@
     "psrlw mm0, 16": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1004,14 +926,12 @@
     "psrlw xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrlw xmm0, 15": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ushr v16.8h, v16.8h, #15"
@@ -1020,7 +940,6 @@
     "psrlw xmm0, 16": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "No",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1029,14 +948,12 @@
     "psraw mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": []
     },
     "psraw mm0, 15": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1047,7 +964,6 @@
     "psraw mm0, 16": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1058,14 +974,12 @@
     "psraw xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": []
     },
     "psraw xmm0, 15": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "sshr v16.8h, v16.8h, #15"
@@ -1074,7 +988,6 @@
     "psraw xmm0, 16": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "sshr v16.8h, v16.8h, #15"
@@ -1083,14 +996,12 @@
     "psllw mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "psllw mm0, 15": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1101,7 +1012,6 @@
     "psllw mm0, 16": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1112,14 +1022,12 @@
     "psllw xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "psllw xmm0, 15": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "shl v16.8h, v16.8h, #15"
@@ -1128,7 +1036,6 @@
     "psllw xmm0, 16": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "No",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1137,14 +1044,12 @@
     "psrld mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrld mm0, 31": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1155,7 +1060,6 @@
     "psrld mm0, 32": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1166,14 +1070,12 @@
     "psrld xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrld xmm0, 31": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ushr v16.4s, v16.4s, #31"
@@ -1182,7 +1084,6 @@
     "psrld xmm0, 32": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "No",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1191,14 +1092,12 @@
     "psrad mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": []
     },
     "psrad mm0, 31": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1209,7 +1108,6 @@
     "psrad mm0, 32": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1220,14 +1118,12 @@
     "psrad xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": []
     },
     "psrad xmm0, 31": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "sshr v16.4s, v16.4s, #31"
@@ -1236,7 +1132,6 @@
     "psrad xmm0, 32": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "sshr v16.4s, v16.4s, #31"
@@ -1245,14 +1140,12 @@
     "pslld mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "pslld mm0, 31": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1263,7 +1156,6 @@
     "pslld mm0, 32": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1274,14 +1166,12 @@
     "pslld xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "pslld xmm0, 31": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "shl v16.4s, v16.4s, #31"
@@ -1290,7 +1180,6 @@
     "pslld xmm0, 32": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "No",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1299,14 +1188,12 @@
     "psrlq mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrlq mm0, 63": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1317,7 +1204,6 @@
     "psrlq mm0, 64": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1328,14 +1214,12 @@
     "psrlq xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrlq xmm0, 63": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ushr v16.2d, v16.2d, #63"
@@ -1344,7 +1228,6 @@
     "psrlq xmm0, 64": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1353,14 +1236,12 @@
     "psrldq xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /3",
       "ExpectedArm64ASM": []
     },
     "psrldq xmm0, 15": {
       "ExpectedInstructionCount": 2,
       "Type": "SSE",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
@@ -1370,7 +1251,6 @@
     "psrldq xmm0, 16": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1379,14 +1259,12 @@
     "psllq mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "psllq mm0, 63": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1397,7 +1275,6 @@
     "psllq mm0, 64": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1408,14 +1285,12 @@
     "psllq xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "psllq xmm0, 63": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "shl v16.2d, v16.2d, #63"
@@ -1424,7 +1299,6 @@
     "psllq xmm0, 64": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1432,7 +1306,6 @@
     },
     "fxsave [rax]": {
       "ExpectedInstructionCount": 58,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /0",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #1008]",
@@ -1497,7 +1370,6 @@
     },
     "rdfsbase eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /0",
       "ExpectedArm64ASM": [
         "ldr w4, [x28, #176]"
@@ -1505,7 +1377,6 @@
     },
     "rdfsbase rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /0",
       "ExpectedArm64ASM": [
         "ldr x4, [x28, #176]"
@@ -1513,7 +1384,6 @@
     },
     "fxrstor [rax]": {
       "ExpectedInstructionCount": 56,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /1",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
@@ -1576,7 +1446,6 @@
     },
     "rdgsbase eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /1",
       "ExpectedArm64ASM": [
         "ldr w4, [x28, #168]"
@@ -1584,7 +1453,6 @@
     },
     "rdgsbase rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /1",
       "ExpectedArm64ASM": [
         "ldr x4, [x28, #168]"
@@ -1592,7 +1460,6 @@
     },
     "ldmxcsr [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /2",
       "ExpectedArm64ASM": [
         "ldr w20, [x4]",
@@ -1608,7 +1475,6 @@
     },
     "wrfsbase eax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /2",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1617,7 +1483,6 @@
     },
     "wrfsbase rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /2",
       "ExpectedArm64ASM": [
         "str x4, [x28, #176]"
@@ -1625,7 +1490,6 @@
     },
     "stmxcsr [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1f80",
@@ -1639,7 +1503,6 @@
     },
     "wrgsbase eax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /3",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1648,7 +1511,6 @@
     },
     "wrgsbase rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /3",
       "ExpectedArm64ASM": [
         "str x4, [x28, #168]"
@@ -1656,7 +1518,6 @@
     },
     "xsave [rax]": {
       "ExpectedInstructionCount": 71,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /4",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1734,7 +1595,6 @@
     },
     "lfence": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /5",
       "ExpectedArm64ASM": [
         "dmb ld"
@@ -1742,7 +1602,6 @@
     },
     "xrstor [rax]": {
       "ExpectedInstructionCount": 104,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1853,7 +1712,6 @@
     },
     "mfence": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /6",
       "ExpectedArm64ASM": [
         "dmb sy"
@@ -1861,7 +1719,6 @@
     },
     "clwb [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /6",
       "ExpectedArm64ASM": [
         "dc cvac, x4"
@@ -1869,7 +1726,6 @@
     },
     "sfence": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /7",
       "ExpectedArm64ASM": [
         "dmb st"
@@ -1877,7 +1733,6 @@
     },
     "clflush [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /7",
       "ExpectedArm64ASM": [
         "dc civac, x4",
@@ -1886,7 +1741,6 @@
     },
     "clflushopt [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /7",
       "ExpectedArm64ASM": [
         "dc civac, x4"
@@ -1894,7 +1748,6 @@
     },
     "prefetchnta [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUP16 0x0F 0x18 /0",
         "NOP implementation"
@@ -1903,7 +1756,6 @@
     },
     "prefetcht0 [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUP16 0x0F 0x18 /1",
         "NOP implementation"
@@ -1912,7 +1764,6 @@
     },
     "prefetcht1 [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUP16 0x0F 0x18 /2",
         "NOP implementation"
@@ -1921,7 +1772,6 @@
     },
     "prefetcht2 [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUP16 0x0F 0x18 /3",
         "NOP implementation"
@@ -1930,7 +1780,6 @@
     },
     "db 0x0f, 0x18, 0x20;": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUP16 0x0F 0x18 /4",
         "nop dword [rax]",
@@ -1940,7 +1789,6 @@
     },
     "db 0x0f, 0x0d, 0x00": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUPP 0x0F 0x0D /0",
         "prefetch_exclusive [rax]",
@@ -1950,7 +1798,6 @@
     },
     "prefetchw [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUPP 0x0F 0x0D /1",
         "NOP implementation"
@@ -1959,7 +1806,6 @@
     },
     "prefetchwt1 [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUPP 0x0F 0x0D /2",
         "NOP implementation"

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -15,7 +15,6 @@
   "Instructions": {
     "xgetbv": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": "0xF 0x01 /2 RM-0",
       "ExpectedArm64ASM": [
         "sub sp, sp, #0xf0 (240)",
@@ -72,7 +71,6 @@
     },
     "rdtscp": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "0xF 0x01 /7 RM-1",
       "ExpectedArm64ASM": [
         "dmb ld",

--- a/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
@@ -14,7 +14,6 @@
   "Instructions": {
     "ucomisd xmm0, xmm1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x66 0x0f 0x2e",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -43,7 +42,6 @@
     },
     "comisd xmm0, xmm1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x66 0x0f 0x2f",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -72,7 +70,6 @@
     },
     "pmovmskb eax, xmm0": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd7",
       "ExpectedArm64ASM": [
         "mov x20, #0x201",
@@ -90,7 +87,6 @@
     },
     "maskmovdqu xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf7",
       "ExpectedArm64ASM": [
         "cmlt v2.16b, v17.16b, #0",

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -15,7 +15,6 @@
   "Instructions": {
     "popcnt ax, bx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xb8",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -36,7 +35,6 @@
     },
     "popcnt eax, ebx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xb8",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -56,7 +54,6 @@
     },
     "popcnt rax, rbx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xb8",
       "ExpectedArm64ASM": [
         "fmov d0, x7",
@@ -75,7 +72,6 @@
     },
     "tzcnt ax, bx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbc",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -92,7 +88,6 @@
     },
     "tzcnt eax, ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbc",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -107,7 +102,6 @@
     },
     "tzcnt rax, rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0xbc",
       "ExpectedArm64ASM": [
         "rbit x4, x7",
@@ -121,7 +115,6 @@
     },
     "lzcnt ax, bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbd",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -139,7 +132,6 @@
     },
     "lzcnt eax, ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbd",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -154,7 +146,6 @@
     },
     "lzcnt rax, rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbd",
       "ExpectedArm64ASM": [
         "clz x4, x7",

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -16,7 +16,6 @@
   "Instructions": {
     "vucomiss xmm0, xmm1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x2e 128-bit"
       ],
@@ -47,7 +46,6 @@
     },
     "vucomisd xmm0, xmm1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x2e 128-bit"
       ],
@@ -78,7 +76,6 @@
     },
     "vcomiss xmm0, xmm1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x2f 128-bit"
       ],
@@ -109,7 +106,6 @@
     },
     "vcomisd xmm0, xmm1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x2f 128-bit"
       ],
@@ -140,7 +136,6 @@
     },
     "vpmovmskb rax, xmm0": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd7 256-bit"
       ],
@@ -160,7 +155,6 @@
     },
     "vpmovmskb rax, ymm0": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd7 256-bit"
       ],
@@ -190,7 +184,6 @@
     },
     "vmaskmovdqu xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf7 128-bit"
       ],

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -13,7 +13,6 @@
   "Instructions": {
     "vtestps xmm0, xmm1": {
       "ExpectedInstructionCount": 28,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0e 128-bit"
       ],
@@ -50,7 +49,6 @@
     },
     "vtestps ymm0, ymm1": {
       "ExpectedInstructionCount": 36,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0e 256-bit"
       ],
@@ -95,7 +93,6 @@
     },
     "vtestpd xmm0, xmm1": {
       "ExpectedInstructionCount": 28,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0f 128-bit"
       ],
@@ -132,7 +129,6 @@
     },
     "vtestpd ymm0, ymm1": {
       "ExpectedInstructionCount": 36,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0f 256-bit"
       ],
@@ -177,7 +173,6 @@
     },
     "vptest xmm0, xmm1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x16 128-bit"
       ],
@@ -205,7 +200,6 @@
     },
     "vptest ymm0, ymm1": {
       "ExpectedInstructionCount": 27,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x16 256-bit"
       ],
@@ -241,7 +235,6 @@
     },
     "vmaskmovps xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2c 128-bit"
       ],
@@ -255,7 +248,6 @@
     },
     "vmaskmovps ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2c 256-bit"
       ],
@@ -268,7 +260,6 @@
     },
     "vmaskmovpd xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2d 128-bit"
       ],
@@ -282,7 +273,6 @@
     },
     "vmaskmovpd ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2d 256-bit"
       ],
@@ -295,7 +285,6 @@
     },
     "vmaskmovps [rax], xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2e 128-bit"
       ],
@@ -308,7 +297,6 @@
     },
     "vmaskmovps [rax], ymm0, ymm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2e 256-bit"
       ],
@@ -321,7 +309,6 @@
     },
     "vmaskmovpd [rax], xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2f 128-bit"
       ],
@@ -334,7 +321,6 @@
     },
     "vmaskmovpd [rax], ymm0, ymm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2f 256-bit"
       ],
@@ -347,7 +333,6 @@
     },
     "vpmaskmovd xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 128-bit"
       ],
@@ -361,7 +346,6 @@
     },
     "vpmaskmovd ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 256-bit"
       ],
@@ -374,7 +358,6 @@
     },
     "vpmaskmovq xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 128-bit"
       ],
@@ -388,7 +371,6 @@
     },
     "vpmaskmovq ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 256-bit"
       ],
@@ -401,7 +383,6 @@
     },
     "vpmaskmovd [rax], xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 128-bit"
       ],
@@ -414,7 +395,6 @@
     },
     "vpmaskmovd [rax], ymm0, ymm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 256-bit"
       ],
@@ -427,7 +407,6 @@
     },
     "vpmaskmovq [rax], xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 128-bit"
       ],
@@ -440,7 +419,6 @@
     },
     "vpmaskmovq [rax], ymm0, ymm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 256-bit"
       ],
@@ -453,7 +431,6 @@
     },
     "andn eax, ebx, ecx": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf2 32-bit"
       ],
@@ -467,7 +444,6 @@
     },
     "andn rax, rbx, rcx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf2 64-bit"
       ],
@@ -479,7 +455,6 @@
     },
     "bzhi eax, ebx, ecx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf5 32-bit"
       ],
@@ -496,7 +471,6 @@
     },
     "bzhi rax, rbx, rcx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf5 64-bit"
       ],
@@ -513,7 +487,6 @@
     },
     "pdep eax, ebx, ecx": {
       "ExpectedInstructionCount": 29,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b11 0xf5 32-bit"
       ],
@@ -551,7 +524,6 @@
     },
     "pdep rax, rbx, rcx": {
       "ExpectedInstructionCount": 27,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b11 0xf5 64-bit"
       ],
@@ -587,7 +559,6 @@
     },
     "bextr eax, ebx, ecx": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf7 32-bit"
       ],
@@ -615,7 +586,6 @@
     },
     "bextr rax, rbx, rcx": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf7 64-bit"
       ],

--- a/unittests/InstructionCountCI/FlagM/VEX_map_group.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map_group.json
@@ -11,7 +11,6 @@
   "Instructions": {
     "blsr eax, ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b001 32-bit"
       ],
@@ -30,7 +29,6 @@
     },
     "blsr rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b001 64-bit"
       ],
@@ -47,7 +45,6 @@
     },
     "blsmsk eax, ebx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b010 32-bit"
       ],
@@ -67,7 +64,6 @@
     },
     "blsmsk rax, rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b010 64-bit"
       ],
@@ -85,7 +81,6 @@
     },
     "blsi eax, ebx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b011 32-bit"
       ],
@@ -103,7 +98,6 @@
     },
     "blsi rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b011 64-bit"
       ],

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -15,7 +15,6 @@
   "Instructions": {
     "fadd dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /0"
       ],
@@ -131,7 +130,6 @@
     },
     "fmul dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /1"
       ],
@@ -247,7 +245,6 @@
     },
     "fcom dword [rax]": {
       "ExpectedInstructionCount": 113,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /2"
       ],
@@ -369,7 +366,6 @@
     },
     "fcomp dword [rax]": {
       "ExpectedInstructionCount": 121,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /3"
       ],
@@ -499,7 +495,6 @@
     },
     "fsub dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /4"
       ],
@@ -615,7 +610,6 @@
     },
     "fsubr dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /5"
       ],
@@ -731,7 +725,6 @@
     },
     "fdiv dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /6"
       ],
@@ -847,7 +840,6 @@
     },
     "fdivr dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /7"
       ],
@@ -963,7 +955,6 @@
     },
     "fadd st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc0 /0"
       ],
@@ -1033,7 +1024,6 @@
     },
     "fadd st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc1 /0"
       ],
@@ -1103,7 +1093,6 @@
     },
     "fadd st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc2 /0"
       ],
@@ -1173,7 +1162,6 @@
     },
     "fadd st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc3 /0"
       ],
@@ -1243,7 +1231,6 @@
     },
     "fadd st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc4 /0"
       ],
@@ -1313,7 +1300,6 @@
     },
     "fadd st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc5 /0"
       ],
@@ -1383,7 +1369,6 @@
     },
     "fadd st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc6 /0"
       ],
@@ -1453,7 +1438,6 @@
     },
     "fadd st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc7 /0"
       ],
@@ -1523,7 +1507,6 @@
     },
     "fmul st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc8 /1"
       ],
@@ -1593,7 +1576,6 @@
     },
     "fmul st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc9 /1"
       ],
@@ -1663,7 +1645,6 @@
     },
     "fmul st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xca /1"
       ],
@@ -1733,7 +1714,6 @@
     },
     "fmul st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcb /1"
       ],
@@ -1803,7 +1783,6 @@
     },
     "fmul st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcc /1"
       ],
@@ -1873,7 +1852,6 @@
     },
     "fmul st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcd /1"
       ],
@@ -1943,7 +1921,6 @@
     },
     "fmul st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xce /1"
       ],
@@ -2013,7 +1990,6 @@
     },
     "fmul st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcf /1"
       ],
@@ -2083,7 +2059,6 @@
     },
     "fcom st0, st0": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd0 /2"
       ],
@@ -2159,7 +2134,6 @@
     },
     "fcom st0, st1": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd1 /2"
       ],
@@ -2235,7 +2209,6 @@
     },
     "fcom st0, st2": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd2 /2"
       ],
@@ -2311,7 +2284,6 @@
     },
     "fcom st0, st3": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd3 /2"
       ],
@@ -2387,7 +2359,6 @@
     },
     "fcom st0, st4": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd4 /2"
       ],
@@ -2463,7 +2434,6 @@
     },
     "fcom st0, st5": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd5 /2"
       ],
@@ -2539,7 +2509,6 @@
     },
     "fcom st0, st6": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd6 /2"
       ],
@@ -2615,7 +2584,6 @@
     },
     "fcom st0, st7": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd7 /2"
       ],
@@ -2691,7 +2659,6 @@
     },
     "fcomp st0, st0": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd8 /3"
       ],
@@ -2775,7 +2742,6 @@
     },
     "fcomp st0, st1": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd9 /3"
       ],
@@ -2859,7 +2825,6 @@
     },
     "fcomp st0, st2": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xda /3"
       ],
@@ -2943,7 +2908,6 @@
     },
     "fcomp st0, st3": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdb /3"
       ],
@@ -3027,7 +2991,6 @@
     },
     "fcomp st0, st4": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdc /3"
       ],
@@ -3111,7 +3074,6 @@
     },
     "fcomp st0, st5": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdd /3"
       ],
@@ -3195,7 +3157,6 @@
     },
     "fcomp st0, st6": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xde /3"
       ],
@@ -3279,7 +3240,6 @@
     },
     "fcomp st0, st7": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdf /3"
       ],
@@ -3363,7 +3323,6 @@
     },
     "fsub st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe0 /4"
       ],
@@ -3433,7 +3392,6 @@
     },
     "fsub st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe1 /4"
       ],
@@ -3503,7 +3461,6 @@
     },
     "fsub st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe2 /4"
       ],
@@ -3573,7 +3530,6 @@
     },
     "fsub st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe3 /4"
       ],
@@ -3643,7 +3599,6 @@
     },
     "fsub st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe4 /4"
       ],
@@ -3713,7 +3668,6 @@
     },
     "fsub st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe5 /4"
       ],
@@ -3783,7 +3737,6 @@
     },
     "fsub st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe6 /4"
       ],
@@ -3853,7 +3806,6 @@
     },
     "fsub st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe7 /4"
       ],
@@ -3923,7 +3875,6 @@
     },
     "fsubr st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe8 /5"
       ],
@@ -3993,7 +3944,6 @@
     },
     "fsubr st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe9 /5"
       ],
@@ -4063,7 +4013,6 @@
     },
     "fsubr st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xea /5"
       ],
@@ -4133,7 +4082,6 @@
     },
     "fsubr st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xeb /5"
       ],
@@ -4203,7 +4151,6 @@
     },
     "fsubr st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xec /5"
       ],
@@ -4273,7 +4220,6 @@
     },
     "fsubr st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xed /5"
       ],
@@ -4343,7 +4289,6 @@
     },
     "fsubr st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xee /5"
       ],
@@ -4413,7 +4358,6 @@
     },
     "fsubr st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xef /5"
       ],
@@ -4483,7 +4427,6 @@
     },
     "fdiv st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf0 /6"
       ],
@@ -4553,7 +4496,6 @@
     },
     "fdiv st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf1 /6"
       ],
@@ -4623,7 +4565,6 @@
     },
     "fdiv st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf2 /6"
       ],
@@ -4693,7 +4634,6 @@
     },
     "fdiv st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf3 /6"
       ],
@@ -4763,7 +4703,6 @@
     },
     "fdiv st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf4 /6"
       ],
@@ -4833,7 +4772,6 @@
     },
     "fdiv st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf5 /6"
       ],
@@ -4903,7 +4841,6 @@
     },
     "fdiv st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf6 /6"
       ],
@@ -4973,7 +4910,6 @@
     },
     "fdiv st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf7 /6"
       ],
@@ -5043,7 +4979,6 @@
     },
     "fdivr st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf8 /7"
       ],
@@ -5113,7 +5048,6 @@
     },
     "fdivr st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf9 /7"
       ],
@@ -5183,7 +5117,6 @@
     },
     "fdivr st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfa /7"
       ],
@@ -5253,7 +5186,6 @@
     },
     "fdivr st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfb /7"
       ],
@@ -5323,7 +5255,6 @@
     },
     "fdivr st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfc /7"
       ],
@@ -5393,7 +5324,6 @@
     },
     "fdivr st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfd /7"
       ],
@@ -5463,7 +5393,6 @@
     },
     "fdivr st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfe /7"
       ],
@@ -5533,7 +5462,6 @@
     },
     "fdivr st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xff /7"
       ],
@@ -5603,7 +5531,6 @@
     },
     "fld dword [rax]": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /0"
       ],
@@ -5673,7 +5600,6 @@
     },
     "fst dword [rax]": {
       "ExpectedInstructionCount": 52,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /2"
       ],
@@ -5734,7 +5660,6 @@
     },
     "fstp dword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /3"
       ],
@@ -5803,7 +5728,6 @@
     },
     "fldenv [rax]": {
       "ExpectedInstructionCount": 48,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /4"
       ],
@@ -5860,7 +5784,6 @@
     },
     "fldcw [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /5"
       ],
@@ -5871,7 +5794,6 @@
     },
     "fnstenv [rax]": {
       "ExpectedInstructionCount": 64,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /6"
       ],
@@ -5944,7 +5866,6 @@
     },
     "fnstcw [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 !11b /7"
       ],
@@ -5955,7 +5876,6 @@
     },
     "fld st0": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc0 /0"
       ],
@@ -5979,7 +5899,6 @@
     },
     "fld st1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc1 /0"
       ],
@@ -6003,7 +5922,6 @@
     },
     "fld st2": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc2 /0"
       ],
@@ -6027,7 +5945,6 @@
     },
     "fld st3": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc3 /0"
       ],
@@ -6051,7 +5968,6 @@
     },
     "fld st4": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc4 /0"
       ],
@@ -6075,7 +5991,6 @@
     },
     "fld st5": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc5 /0"
       ],
@@ -6099,7 +6014,6 @@
     },
     "fld st6": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc6 /0"
       ],
@@ -6123,7 +6037,6 @@
     },
     "fld st7": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc7 /0"
       ],
@@ -6147,7 +6060,6 @@
     },
     "fxch st0, st0": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc8 /1"
       ],
@@ -6167,7 +6079,6 @@
     },
     "fxch st0, st1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc9 /1"
       ],
@@ -6187,7 +6098,6 @@
     },
     "fxch st0, st2": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xca /1"
       ],
@@ -6207,7 +6117,6 @@
     },
     "fxch st0, st3": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcb /1"
       ],
@@ -6227,7 +6136,6 @@
     },
     "fxch st0, st4": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcc /1"
       ],
@@ -6247,7 +6155,6 @@
     },
     "fxch st0, st5": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcd /1"
       ],
@@ -6267,7 +6174,6 @@
     },
     "fxch st0, st6": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xce /1"
       ],
@@ -6287,7 +6193,6 @@
     },
     "fxch st0, st7": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcf /1"
       ],
@@ -6307,7 +6212,6 @@
     },
     "fnop": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xd0 /2"
       ],
@@ -6315,7 +6219,6 @@
     },
     "fchs": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe0 /4"
       ],
@@ -6334,7 +6237,6 @@
     },
     "fabs": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe1 /4"
       ],
@@ -6353,7 +6255,6 @@
     },
     "ftst": {
       "ExpectedInstructionCount": 64,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe4 /4"
       ],
@@ -6426,7 +6327,6 @@
     },
     "fxam": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe5 /4"
       ],
@@ -6451,7 +6351,6 @@
     },
     "fld1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe8 /5"
       ],
@@ -6475,7 +6374,6 @@
     },
     "fldl2t": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe9 /5"
       ],
@@ -6502,7 +6400,6 @@
     },
     "fldl2e": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xea /5"
       ],
@@ -6529,7 +6426,6 @@
     },
     "fldpi": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xeb /5"
       ],
@@ -6556,7 +6452,6 @@
     },
     "fldlg2": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xec /5"
       ],
@@ -6583,7 +6478,6 @@
     },
     "fldln2": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xed /5"
       ],
@@ -6610,7 +6504,6 @@
     },
     "fldz": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xee /5"
       ],
@@ -6633,7 +6526,6 @@
     },
     "f2xm1": {
       "ExpectedInstructionCount": 55,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf0 /6"
       ],
@@ -6697,7 +6589,6 @@
     },
     "fyl2x": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf1 /6"
       ],
@@ -6773,7 +6664,6 @@
     },
     "fptan": {
       "ExpectedInstructionCount": 71,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf2 /6"
       ],
@@ -6853,7 +6743,6 @@
     },
     "fpatan": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf3 /6"
       ],
@@ -6929,7 +6818,6 @@
     },
     "fxtract": {
       "ExpectedInstructionCount": 115,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf4 /6"
       ],
@@ -7053,7 +6941,6 @@
     },
     "fprem1": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf5 /6"
       ],
@@ -7125,7 +7012,6 @@
     },
     "fdecstp": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xf6 /6"
       ],
@@ -7138,7 +7024,6 @@
     },
     "fincstp": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xf7 /6"
       ],
@@ -7151,7 +7036,6 @@
     },
     "fprem": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf8 /7"
       ],
@@ -7223,7 +7107,6 @@
     },
     "fyl2xp1": {
       "ExpectedInstructionCount": 123,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf9 /7"
       ],
@@ -7355,7 +7238,6 @@
     },
     "fsqrt": {
       "ExpectedInstructionCount": 55,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfa /7"
       ],
@@ -7419,7 +7301,6 @@
     },
     "fsincos": {
       "ExpectedInstructionCount": 117,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfb /7"
       ],
@@ -7545,7 +7426,6 @@
     },
     "frndint": {
       "ExpectedInstructionCount": 55,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfc /7"
       ],
@@ -7609,7 +7489,6 @@
     },
     "fscale": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfd /7"
       ],
@@ -7679,7 +7558,6 @@
     },
     "fsin": {
       "ExpectedInstructionCount": 57,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfe /7"
       ],
@@ -7745,7 +7623,6 @@
     },
     "fcos": {
       "ExpectedInstructionCount": 57,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xff /7"
       ],
@@ -7811,7 +7688,6 @@
     },
     "fiadd dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /0"
       ],
@@ -7927,7 +7803,6 @@
     },
     "fimul dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /1"
       ],
@@ -8043,7 +7918,6 @@
     },
     "ficom dword [rax]": {
       "ExpectedInstructionCount": 113,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /2"
       ],
@@ -8165,7 +8039,6 @@
     },
     "ficomp dword [rax]": {
       "ExpectedInstructionCount": 121,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /3"
       ],
@@ -8295,7 +8168,6 @@
     },
     "fisub dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /4"
       ],
@@ -8411,7 +8283,6 @@
     },
     "fisubr dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /5"
       ],
@@ -8527,7 +8398,6 @@
     },
     "fidiv dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /6"
       ],
@@ -8643,7 +8513,6 @@
     },
     "fidivr dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /7"
       ],
@@ -8759,7 +8628,6 @@
     },
     "fcmovb st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc0 /0"
       ],
@@ -8780,7 +8648,6 @@
     },
     "fcmovb st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc1 /0"
       ],
@@ -8801,7 +8668,6 @@
     },
     "fcmovb st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc2 /0"
       ],
@@ -8822,7 +8688,6 @@
     },
     "fcmovb st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc3 /0"
       ],
@@ -8843,7 +8708,6 @@
     },
     "fcmovb st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc4 /0"
       ],
@@ -8864,7 +8728,6 @@
     },
     "fcmovb st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc5 /0"
       ],
@@ -8885,7 +8748,6 @@
     },
     "fcmovb st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc6 /0"
       ],
@@ -8906,7 +8768,6 @@
     },
     "fcmovb st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc7 /0"
       ],
@@ -8927,7 +8788,6 @@
     },
     "fcmove st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc8 /1"
       ],
@@ -8948,7 +8808,6 @@
     },
     "fcmove st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc9 /1"
       ],
@@ -8969,7 +8828,6 @@
     },
     "fcmove st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xca /1"
       ],
@@ -8990,7 +8848,6 @@
     },
     "fcmove st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcb /1"
       ],
@@ -9011,7 +8868,6 @@
     },
     "fcmove st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcc /1"
       ],
@@ -9032,7 +8888,6 @@
     },
     "fcmove st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcd /1"
       ],
@@ -9053,7 +8908,6 @@
     },
     "fcmove st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xce /1"
       ],
@@ -9074,7 +8928,6 @@
     },
     "fcmove st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcf /1"
       ],
@@ -9095,7 +8948,6 @@
     },
     "fcmovbe st0, st0": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd0 /0"
       ],
@@ -9118,7 +8970,6 @@
     },
     "fcmovbe st0, st1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd1 /0"
       ],
@@ -9141,7 +8992,6 @@
     },
     "fcmovbe st0, st2": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd2 /0"
       ],
@@ -9164,7 +9014,6 @@
     },
     "fcmovbe st0, st3": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd3 /0"
       ],
@@ -9187,7 +9036,6 @@
     },
     "fcmovbe st0, st4": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd4 /0"
       ],
@@ -9210,7 +9058,6 @@
     },
     "fcmovbe st0, st5": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd5 /0"
       ],
@@ -9233,7 +9080,6 @@
     },
     "fcmovbe st0, st6": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd6 /0"
       ],
@@ -9256,7 +9102,6 @@
     },
     "fcmovbe st0, st7": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd7 /0"
       ],
@@ -9279,7 +9124,6 @@
     },
     "fcmovu st0, st0": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd8 /1"
       ],
@@ -9307,7 +9151,6 @@
     },
     "fcmovu st0, st1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd9 /1"
       ],
@@ -9335,7 +9178,6 @@
     },
     "fcmovu st0, st2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xda /1"
       ],
@@ -9363,7 +9205,6 @@
     },
     "fcmovu st0, st3": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdb /1"
       ],
@@ -9391,7 +9232,6 @@
     },
     "fcmovu st0, st4": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdc /1"
       ],
@@ -9419,7 +9259,6 @@
     },
     "fcmovu st0, st5": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdd /1"
       ],
@@ -9447,7 +9286,6 @@
     },
     "fcmovu st0, st6": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xde /1"
       ],
@@ -9475,7 +9313,6 @@
     },
     "fcmovu st0, st7": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdf /1"
       ],
@@ -9503,7 +9340,6 @@
     },
     "fucompp": {
       "ExpectedInstructionCount": 80,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xe9 /5"
       ],
@@ -9592,7 +9428,6 @@
     },
     "fild dword [rax]": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /5"
       ],
@@ -9635,7 +9470,6 @@
     },
     "fisttp dword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /1"
       ],
@@ -9704,7 +9538,6 @@
     },
     "fist dword [rax]": {
       "ExpectedInstructionCount": 52,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /2"
       ],
@@ -9765,7 +9598,6 @@
     },
     "fistp dword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /7"
       ],
@@ -9834,7 +9666,6 @@
     },
     "fld tword [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /5"
       ],
@@ -9855,7 +9686,6 @@
     },
     "fstp tword [rax]": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /7"
       ],
@@ -9878,7 +9708,6 @@
     },
     "fcmovnb st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc0 /0"
       ],
@@ -9899,7 +9728,6 @@
     },
     "fcmovnb st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc1 /0"
       ],
@@ -9920,7 +9748,6 @@
     },
     "fcmovnb st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc2 /0"
       ],
@@ -9941,7 +9768,6 @@
     },
     "fcmovnb st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc3 /0"
       ],
@@ -9962,7 +9788,6 @@
     },
     "fcmovnb st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc4 /0"
       ],
@@ -9983,7 +9808,6 @@
     },
     "fcmovnb st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc5 /0"
       ],
@@ -10004,7 +9828,6 @@
     },
     "fcmovnb st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc6 /0"
       ],
@@ -10025,7 +9848,6 @@
     },
     "fcmovnb st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc7 /0"
       ],
@@ -10046,7 +9868,6 @@
     },
     "fcmovne st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc8 /1"
       ],
@@ -10067,7 +9888,6 @@
     },
     "fcmovne st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc9 /1"
       ],
@@ -10088,7 +9908,6 @@
     },
     "fcmovne st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xca /1"
       ],
@@ -10109,7 +9928,6 @@
     },
     "fcmovne st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcb /1"
       ],
@@ -10130,7 +9948,6 @@
     },
     "fcmovne st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcc /1"
       ],
@@ -10151,7 +9968,6 @@
     },
     "fcmovne st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcd /1"
       ],
@@ -10172,7 +9988,6 @@
     },
     "fcmovne st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xce /1"
       ],
@@ -10193,7 +10008,6 @@
     },
     "fcmovne st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcf /1"
       ],
@@ -10214,7 +10028,6 @@
     },
     "fcmovnbe st0, st0": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd0 /2"
       ],
@@ -10236,7 +10049,6 @@
     },
     "fcmovnbe st0, st1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd1 /2"
       ],
@@ -10258,7 +10070,6 @@
     },
     "fcmovnbe st0, st2": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd2 /2"
       ],
@@ -10280,7 +10091,6 @@
     },
     "fcmovnbe st0, st3": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd3 /2"
       ],
@@ -10302,7 +10112,6 @@
     },
     "fcmovnbe st0, st4": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd4 /2"
       ],
@@ -10324,7 +10133,6 @@
     },
     "fcmovnbe st0, st5": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd5 /2"
       ],
@@ -10346,7 +10154,6 @@
     },
     "fcmovnbe st0, st6": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd6 /2"
       ],
@@ -10368,7 +10175,6 @@
     },
     "fcmovnbe st0, st7": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd7 /2"
       ],
@@ -10390,7 +10196,6 @@
     },
     "fcmovnu st0, st0": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd8 /3"
       ],
@@ -10418,7 +10223,6 @@
     },
     "fcmovnu st0, st1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd9 /3"
       ],
@@ -10446,7 +10250,6 @@
     },
     "fcmovnu st0, st2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xda /3"
       ],
@@ -10474,7 +10277,6 @@
     },
     "fcmovnu st0, st3": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdb /3"
       ],
@@ -10502,7 +10304,6 @@
     },
     "fcmovnu st0, st4": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdc /3"
       ],
@@ -10530,7 +10331,6 @@
     },
     "fcmovnu st0, st5": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdd /3"
       ],
@@ -10558,7 +10358,6 @@
     },
     "fcmovnu st0, st6": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xde /3"
       ],
@@ -10586,7 +10385,6 @@
     },
     "fcmovnu st0, st7": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdf /3"
       ],
@@ -10614,7 +10412,6 @@
     },
     "fnclex": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe2 /4"
       ],
@@ -10622,7 +10419,6 @@
     },
     "fninit": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe3 /4"
       ],
@@ -10640,7 +10436,6 @@
     },
     "fucomi st0, st0": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe8 /5"
       ],
@@ -10715,7 +10510,6 @@
     },
     "fucomi st0, st1": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe9 /5"
       ],
@@ -10790,7 +10584,6 @@
     },
     "fucomi st0, st2": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xea /5"
       ],
@@ -10865,7 +10658,6 @@
     },
     "fucomi st0, st3": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xeb /5"
       ],
@@ -10940,7 +10732,6 @@
     },
     "fucomi st0, st4": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xec /5"
       ],
@@ -11015,7 +10806,6 @@
     },
     "fucomi st0, st5": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xed /5"
       ],
@@ -11090,7 +10880,6 @@
     },
     "fucomi st0, st6": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xee /5"
       ],
@@ -11165,7 +10954,6 @@
     },
     "fucomi st0, st7": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xef /5"
       ],
@@ -11240,7 +11028,6 @@
     },
     "fcomi st0, st0": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf0 /6"
       ],
@@ -11315,7 +11102,6 @@
     },
     "fcomi st0, st1": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf1 /6"
       ],
@@ -11390,7 +11176,6 @@
     },
     "fcomi st0, st2": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf2 /6"
       ],
@@ -11465,7 +11250,6 @@
     },
     "fcomi st0, st3": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf3 /6"
       ],
@@ -11540,7 +11324,6 @@
     },
     "fcomi st0, st4": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf4 /6"
       ],
@@ -11615,7 +11398,6 @@
     },
     "fcomi st0, st5": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf5 /6"
       ],
@@ -11690,7 +11472,6 @@
     },
     "fcomi st0, st6": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf6 /6"
       ],
@@ -11765,7 +11546,6 @@
     },
     "fcomi st0, st7": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf7 /6"
       ],
@@ -11840,7 +11620,6 @@
     },
     "fadd qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /0"
       ],
@@ -11956,7 +11735,6 @@
     },
     "fmul qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /1"
       ],
@@ -12072,7 +11850,6 @@
     },
     "fcom qword [rax]": {
       "ExpectedInstructionCount": 113,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /2"
       ],
@@ -12194,7 +11971,6 @@
     },
     "fcomp qword [rax]": {
       "ExpectedInstructionCount": 121,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /3"
       ],
@@ -12324,7 +12100,6 @@
     },
     "fsub qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /4"
       ],
@@ -12440,7 +12215,6 @@
     },
     "fsubr qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /5"
       ],
@@ -12556,7 +12330,6 @@
     },
     "fdiv qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /6"
       ],
@@ -12672,7 +12445,6 @@
     },
     "fdivr qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /7"
       ],
@@ -12788,7 +12560,6 @@
     },
     "db 0xdc, 0xc0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fadd st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -12860,7 +12631,6 @@
     },
     "fadd st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc1 /0"
       ],
@@ -12930,7 +12700,6 @@
     },
     "fadd st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc2 /0"
       ],
@@ -13000,7 +12769,6 @@
     },
     "fadd st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc3 /0"
       ],
@@ -13070,7 +12838,6 @@
     },
     "fadd st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc4 /0"
       ],
@@ -13140,7 +12907,6 @@
     },
     "fadd st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc5 /0"
       ],
@@ -13210,7 +12976,6 @@
     },
     "fadd st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc6 /0"
       ],
@@ -13280,7 +13045,6 @@
     },
     "fadd st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc7 /0"
       ],
@@ -13350,7 +13114,6 @@
     },
     "db 0xdc, 0xc8": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fmul st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -13422,7 +13185,6 @@
     },
     "fmul st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc9 /1"
       ],
@@ -13492,7 +13254,6 @@
     },
     "fmul st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xca /1"
       ],
@@ -13562,7 +13323,6 @@
     },
     "fmul st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcb /1"
       ],
@@ -13632,7 +13392,6 @@
     },
     "fmul st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcc /1"
       ],
@@ -13702,7 +13461,6 @@
     },
     "fmul st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcd /1"
       ],
@@ -13772,7 +13530,6 @@
     },
     "fmul st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xce /1"
       ],
@@ -13842,7 +13599,6 @@
     },
     "fmul st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcf /1"
       ],
@@ -13912,7 +13668,6 @@
     },
     "db 0xdc, 0xe0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fsubr st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -13984,7 +13739,6 @@
     },
     "fsubr st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe1 /4"
       ],
@@ -14054,7 +13808,6 @@
     },
     "fsubr st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe2 /4"
       ],
@@ -14124,7 +13877,6 @@
     },
     "fsubr st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe3 /4"
       ],
@@ -14194,7 +13946,6 @@
     },
     "fsubr st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe4 /4"
       ],
@@ -14264,7 +14015,6 @@
     },
     "fsubr st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe5 /4"
       ],
@@ -14334,7 +14084,6 @@
     },
     "fsubr st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe6 /4"
       ],
@@ -14404,7 +14153,6 @@
     },
     "fsubr st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe7 /4"
       ],
@@ -14474,7 +14222,6 @@
     },
     "db 0xdc, 0xe8": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fsub st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -14546,7 +14293,6 @@
     },
     "fsub st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe9 /5"
       ],
@@ -14616,7 +14362,6 @@
     },
     "fsub st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xea /5"
       ],
@@ -14686,7 +14431,6 @@
     },
     "fsub st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xeb /5"
       ],
@@ -14756,7 +14500,6 @@
     },
     "fsub st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xec /5"
       ],
@@ -14826,7 +14569,6 @@
     },
     "fsub st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xed /5"
       ],
@@ -14896,7 +14638,6 @@
     },
     "fsub st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xee /5"
       ],
@@ -14966,7 +14707,6 @@
     },
     "fsub st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xef /5"
       ],
@@ -15036,7 +14776,6 @@
     },
     "db 0xdc, 0xf0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fdivr st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -15108,7 +14847,6 @@
     },
     "fdivr st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf1 /6"
       ],
@@ -15178,7 +14916,6 @@
     },
     "fdivr st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf2 /6"
       ],
@@ -15248,7 +14985,6 @@
     },
     "fdivr st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf3 /6"
       ],
@@ -15318,7 +15054,6 @@
     },
     "fdivr st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf4 /6"
       ],
@@ -15388,7 +15123,6 @@
     },
     "fdivr st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf5 /6"
       ],
@@ -15458,7 +15192,6 @@
     },
     "fdivr st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf6 /6"
       ],
@@ -15528,7 +15261,6 @@
     },
     "fdivr st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf7 /6"
       ],
@@ -15598,7 +15330,6 @@
     },
     "db 0xdc, 0xf8": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fdiv st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -15670,7 +15401,6 @@
     },
     "fdiv st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf9 /7"
       ],
@@ -15740,7 +15470,6 @@
     },
     "fdiv st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfa /7"
       ],
@@ -15810,7 +15539,6 @@
     },
     "fdiv st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfb /7"
       ],
@@ -15880,7 +15608,6 @@
     },
     "fdiv st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfc /7"
       ],
@@ -15950,7 +15677,6 @@
     },
     "fdiv st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfd /7"
       ],
@@ -16020,7 +15746,6 @@
     },
     "fdiv st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfe /7"
       ],
@@ -16090,7 +15815,6 @@
     },
     "fdiv st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xff /7"
       ],
@@ -16160,7 +15884,6 @@
     },
     "fld qword [rax]": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /0"
       ],
@@ -16230,7 +15953,6 @@
     },
     "fisttp qword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /1"
       ],
@@ -16299,7 +16021,6 @@
     },
     "fst qword [rax]": {
       "ExpectedInstructionCount": 52,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /2"
       ],
@@ -16360,7 +16081,6 @@
     },
     "fstp qword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /3"
       ],
@@ -16429,7 +16149,6 @@
     },
     "frstor [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /4"
       ],
@@ -16545,7 +16264,6 @@
     },
     "fnsave [rax]": {
       "ExpectedInstructionCount": 119,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /6"
       ],
@@ -16673,7 +16391,6 @@
     },
     "fnstsw [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /7"
       ],
@@ -16694,7 +16411,6 @@
     },
     "ffree st0": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc0 /0"
       ],
@@ -16711,7 +16427,6 @@
     },
     "ffree st1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc1 /0"
       ],
@@ -16728,7 +16443,6 @@
     },
     "ffree st2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc2 /0"
       ],
@@ -16745,7 +16459,6 @@
     },
     "ffree st3": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc3 /0"
       ],
@@ -16762,7 +16475,6 @@
     },
     "ffree st4": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc4 /0"
       ],
@@ -16779,7 +16491,6 @@
     },
     "ffree st5": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc5 /0"
       ],
@@ -16796,7 +16507,6 @@
     },
     "ffree st6": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc6 /0"
       ],
@@ -16813,7 +16523,6 @@
     },
     "ffree st7": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc7 /0"
       ],
@@ -16830,7 +16539,6 @@
     },
     "fst st0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd0 /2"
       ],
@@ -16846,7 +16554,6 @@
     },
     "fst st1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd1 /2"
       ],
@@ -16862,7 +16569,6 @@
     },
     "fst st2": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd2 /2"
       ],
@@ -16878,7 +16584,6 @@
     },
     "fst st3": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd3 /2"
       ],
@@ -16894,7 +16599,6 @@
     },
     "fst st4": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd4 /2"
       ],
@@ -16910,7 +16614,6 @@
     },
     "fst st5": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd5 /2"
       ],
@@ -16926,7 +16629,6 @@
     },
     "fst st6": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd6 /2"
       ],
@@ -16942,7 +16644,6 @@
     },
     "fst st7": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd7 /2"
       ],
@@ -16958,7 +16659,6 @@
     },
     "fstp st0": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd8 /3"
       ],
@@ -16982,7 +16682,6 @@
     },
     "fstp st1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd9 /3"
       ],
@@ -17006,7 +16705,6 @@
     },
     "fstp st2": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xda /3"
       ],
@@ -17030,7 +16728,6 @@
     },
     "fstp st3": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdb /3"
       ],
@@ -17054,7 +16751,6 @@
     },
     "fstp st4": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdc /3"
       ],
@@ -17078,7 +16774,6 @@
     },
     "fstp st5": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdd /3"
       ],
@@ -17102,7 +16797,6 @@
     },
     "fstp st6": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xde /3"
       ],
@@ -17126,7 +16820,6 @@
     },
     "fstp st7": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdf /3"
       ],
@@ -17150,7 +16843,6 @@
     },
     "fucom st0": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe0 /4"
       ],
@@ -17226,7 +16918,6 @@
     },
     "fucom st1": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe1 /4"
       ],
@@ -17302,7 +16993,6 @@
     },
     "fucom st2": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe2 /4"
       ],
@@ -17378,7 +17068,6 @@
     },
     "fucom st3": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe3 /4"
       ],
@@ -17454,7 +17143,6 @@
     },
     "fucom st4": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe4 /4"
       ],
@@ -17530,7 +17218,6 @@
     },
     "fucom st5": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe5 /4"
       ],
@@ -17606,7 +17293,6 @@
     },
     "fucom st6": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe6 /4"
       ],
@@ -17682,7 +17368,6 @@
     },
     "fucom st7": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe7 /4"
       ],
@@ -17758,7 +17443,6 @@
     },
     "fucomp st0": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe8 /5"
       ],
@@ -17842,7 +17526,6 @@
     },
     "fucomp st1": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe9 /5"
       ],
@@ -17926,7 +17609,6 @@
     },
     "fucomp st2": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xea /5"
       ],
@@ -18010,7 +17692,6 @@
     },
     "fucomp st3": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xeb /5"
       ],
@@ -18094,7 +17775,6 @@
     },
     "fucomp st4": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xec /5"
       ],
@@ -18178,7 +17858,6 @@
     },
     "fucomp st5": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xed /5"
       ],
@@ -18262,7 +17941,6 @@
     },
     "fucomp st6": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xee /5"
       ],
@@ -18346,7 +18024,6 @@
     },
     "fucomp st7": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xef /5"
       ],
@@ -18430,7 +18107,6 @@
     },
     "fiadd word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /0"
       ],
@@ -18546,7 +18222,6 @@
     },
     "fimul word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /1"
       ],
@@ -18662,7 +18337,6 @@
     },
     "ficom word [rax]": {
       "ExpectedInstructionCount": 113,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /2"
       ],
@@ -18784,7 +18458,6 @@
     },
     "ficomp word [rax]": {
       "ExpectedInstructionCount": 121,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /3"
       ],
@@ -18914,7 +18587,6 @@
     },
     "fisub word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /4"
       ],
@@ -19030,7 +18702,6 @@
     },
     "fisubr word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /5"
       ],
@@ -19146,7 +18817,6 @@
     },
     "fidiv word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /6"
       ],
@@ -19262,7 +18932,6 @@
     },
     "fidivr word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /7"
       ],
@@ -19378,7 +19047,6 @@
     },
     "faddp st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc0 /0"
       ],
@@ -19456,7 +19124,6 @@
     },
     "faddp st1": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc1 /0"
       ],
@@ -19534,7 +19201,6 @@
     },
     "faddp st2": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc2 /0"
       ],
@@ -19612,7 +19278,6 @@
     },
     "faddp st3": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc3 /0"
       ],
@@ -19690,7 +19355,6 @@
     },
     "faddp st4": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc4 /0"
       ],
@@ -19768,7 +19432,6 @@
     },
     "faddp st5": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc5 /0"
       ],
@@ -19846,7 +19509,6 @@
     },
     "faddp st6": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc6 /0"
       ],
@@ -19924,7 +19586,6 @@
     },
     "faddp st7": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc7 /0"
       ],
@@ -20002,7 +19663,6 @@
     },
     "fmulp st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc8 /1"
       ],
@@ -20080,7 +19740,6 @@
     },
     "fmulp st1": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc9 /1"
       ],
@@ -20158,7 +19817,6 @@
     },
     "fmulp st2": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xca /1"
       ],
@@ -20236,7 +19894,6 @@
     },
     "fmulp st3": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcb /1"
       ],
@@ -20314,7 +19971,6 @@
     },
     "fmulp st4": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcc /1"
       ],
@@ -20392,7 +20048,6 @@
     },
     "fmulp st5": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcd /1"
       ],
@@ -20470,7 +20125,6 @@
     },
     "fmulp st6": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xce /1"
       ],
@@ -20548,7 +20202,6 @@
     },
     "fmulp st7": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcf /1"
       ],
@@ -20626,7 +20279,6 @@
     },
     "fcompp": {
       "ExpectedInstructionCount": 80,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xd9 /3"
       ],
@@ -20715,7 +20367,6 @@
     },
     "db 0xde, 0xe0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "fsubrp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -20795,7 +20446,6 @@
     },
     "fsubrp st1, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe1 /4"
       ],
@@ -20873,7 +20523,6 @@
     },
     "fsubrp st2, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe2 /4"
       ],
@@ -20951,7 +20600,6 @@
     },
     "fsubrp st3, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe3 /4"
       ],
@@ -21029,7 +20677,6 @@
     },
     "fsubrp st4, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe4 /4"
       ],
@@ -21107,7 +20754,6 @@
     },
     "fsubrp st5, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe5 /4"
       ],
@@ -21185,7 +20831,6 @@
     },
     "fsubrp st6, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe6 /4"
       ],
@@ -21263,7 +20908,6 @@
     },
     "fsubrp st7, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe7 /4"
       ],
@@ -21341,7 +20985,6 @@
     },
     "db 0xde, 0xe8": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "fsubp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -21421,7 +21064,6 @@
     },
     "fsubp st1, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe9 /5"
       ],
@@ -21499,7 +21141,6 @@
     },
     "fsubp st2, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xea /5"
       ],
@@ -21577,7 +21218,6 @@
     },
     "fsubp st3, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xeb /5"
       ],
@@ -21655,7 +21295,6 @@
     },
     "fsubp st4, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xec /5"
       ],
@@ -21733,7 +21372,6 @@
     },
     "fsubp st5, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xed /5"
       ],
@@ -21811,7 +21449,6 @@
     },
     "fsubp st6, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xee /5"
       ],
@@ -21889,7 +21526,6 @@
     },
     "fsubp st7, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xef /5"
       ],
@@ -21967,7 +21603,6 @@
     },
     "db 0xde, 0xf0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "fdivrp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -22047,7 +21682,6 @@
     },
     "fdivrp st1, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf1 /6"
       ],
@@ -22125,7 +21759,6 @@
     },
     "fdivrp st2, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf2 /6"
       ],
@@ -22203,7 +21836,6 @@
     },
     "fdivrp st3, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf3 /6"
       ],
@@ -22281,7 +21913,6 @@
     },
     "fdivrp st4, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf4 /6"
       ],
@@ -22359,7 +21990,6 @@
     },
     "fdivrp st5, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf5 /6"
       ],
@@ -22437,7 +22067,6 @@
     },
     "fdivrp st6, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf6 /6"
       ],
@@ -22515,7 +22144,6 @@
     },
     "fdivrp st7, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf7 /6"
       ],
@@ -22593,7 +22221,6 @@
     },
     "db 0xde, 0xf8": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "fdivp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -22673,7 +22300,6 @@
     },
     "fdivp st1, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf9 /7"
       ],
@@ -22751,7 +22377,6 @@
     },
     "fdivp st2, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfa /7"
       ],
@@ -22829,7 +22454,6 @@
     },
     "fdivp st3, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfb /7"
       ],
@@ -22907,7 +22531,6 @@
     },
     "fdivp st4, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfc /7"
       ],
@@ -22985,7 +22608,6 @@
     },
     "fdivp st5, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfd /7"
       ],
@@ -23063,7 +22685,6 @@
     },
     "fdivp st6, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfe /7"
       ],
@@ -23141,7 +22762,6 @@
     },
     "fdivp st7, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xff /7"
       ],
@@ -23219,7 +22839,6 @@
     },
     "fild word [rax]": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /0"
       ],
@@ -23262,7 +22881,6 @@
     },
     "fisttp word [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /1"
       ],
@@ -23331,7 +22949,6 @@
     },
     "fist word [rax]": {
       "ExpectedInstructionCount": 52,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /2"
       ],
@@ -23392,7 +23009,6 @@
     },
     "fistp word [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /3"
       ],
@@ -23461,7 +23077,6 @@
     },
     "fbld tword [rax]": {
       "ExpectedInstructionCount": 62,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /4"
       ],
@@ -23532,7 +23147,6 @@
     },
     "fbstp tword [rax]": {
       "ExpectedInstructionCount": 64,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /6"
       ],
@@ -23605,7 +23219,6 @@
     },
     "ffreep st0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc0 /0"
       ],
@@ -23618,7 +23231,6 @@
     },
     "ffreep st1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc1 /0"
       ],
@@ -23631,7 +23243,6 @@
     },
     "ffreep st2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc2 /0"
       ],
@@ -23644,7 +23255,6 @@
     },
     "ffreep st3": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc3 /0"
       ],
@@ -23657,7 +23267,6 @@
     },
     "ffreep st4": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc4 /0"
       ],
@@ -23670,7 +23279,6 @@
     },
     "ffreep st5": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc5 /0"
       ],
@@ -23683,7 +23291,6 @@
     },
     "ffreep st6": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc6 /0"
       ],
@@ -23696,7 +23303,6 @@
     },
     "ffreep st7": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc7 /0"
       ],
@@ -23709,7 +23315,6 @@
     },
     "fnstsw ax": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe0 /4"
       ],
@@ -23730,7 +23335,6 @@
     },
     "fucomip st0": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe8 /5"
       ],
@@ -23813,7 +23417,6 @@
     },
     "fucomip st1": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe9 /5"
       ],
@@ -23896,7 +23499,6 @@
     },
     "fucomip st2": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xea /5"
       ],
@@ -23979,7 +23581,6 @@
     },
     "fucomip st3": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xeb /5"
       ],
@@ -24062,7 +23663,6 @@
     },
     "fucomip st4": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xec /5"
       ],
@@ -24145,7 +23745,6 @@
     },
     "fucomip st5": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xed /5"
       ],
@@ -24228,7 +23827,6 @@
     },
     "fucomip st6": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xee /5"
       ],
@@ -24311,7 +23909,6 @@
     },
     "fucomip st7": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xef /5"
       ],
@@ -24394,7 +23991,6 @@
     },
     "fcomip st0": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf0 /6"
       ],
@@ -24477,7 +24073,6 @@
     },
     "fcomip st1": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf1 /6"
       ],
@@ -24560,7 +24155,6 @@
     },
     "fcomip st2": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf2 /6"
       ],
@@ -24643,7 +24237,6 @@
     },
     "fcomip st3": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf3 /6"
       ],
@@ -24726,7 +24319,6 @@
     },
     "fcomip st4": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf4 /6"
       ],
@@ -24809,7 +24401,6 @@
     },
     "fcomip st5": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf5 /6"
       ],
@@ -24892,7 +24483,6 @@
     },
     "fcomip st6": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf6 /6"
       ],
@@ -24975,7 +24565,6 @@
     },
     "fcomip st7": {
       "ExpectedInstructionCount": 74,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf7 /6"
       ],

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -17,7 +17,6 @@
   "Instructions": {
     "fadd dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /0"
       ],
@@ -34,7 +33,6 @@
     },
     "fmul dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /1"
       ],
@@ -51,7 +49,6 @@
     },
     "fcom dword [rax]": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /2"
       ],
@@ -84,7 +81,6 @@
     },
     "fcomp dword [rax]": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /3"
       ],
@@ -125,7 +121,6 @@
     },
     "fsub dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /4"
       ],
@@ -142,7 +137,6 @@
     },
     "fsubr dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /5"
       ],
@@ -159,7 +153,6 @@
     },
     "fdiv dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /6"
       ],
@@ -176,7 +169,6 @@
     },
     "fdivr dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /7"
       ],
@@ -193,7 +185,6 @@
     },
     "fadd st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc0 /0"
       ],
@@ -212,7 +203,6 @@
     },
     "fadd st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc1 /0"
       ],
@@ -231,7 +221,6 @@
     },
     "fadd st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc2 /0"
       ],
@@ -250,7 +239,6 @@
     },
     "fadd st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc3 /0"
       ],
@@ -269,7 +257,6 @@
     },
     "fadd st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc4 /0"
       ],
@@ -288,7 +275,6 @@
     },
     "fadd st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc5 /0"
       ],
@@ -307,7 +293,6 @@
     },
     "fadd st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc6 /0"
       ],
@@ -326,7 +311,6 @@
     },
     "fadd st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc7 /0"
       ],
@@ -345,7 +329,6 @@
     },
     "fmul st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc8 /1"
       ],
@@ -364,7 +347,6 @@
     },
     "fmul st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc9 /1"
       ],
@@ -383,7 +365,6 @@
     },
     "fmul st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xca /1"
       ],
@@ -402,7 +383,6 @@
     },
     "fmul st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcb /1"
       ],
@@ -421,7 +401,6 @@
     },
     "fmul st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcc /1"
       ],
@@ -440,7 +419,6 @@
     },
     "fmul st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcd /1"
       ],
@@ -459,7 +437,6 @@
     },
     "fmul st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xce /1"
       ],
@@ -478,7 +455,6 @@
     },
     "fmul st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcf /1"
       ],
@@ -497,7 +473,6 @@
     },
     "fcom st0, st0": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd0 /2"
       ],
@@ -532,7 +507,6 @@
     },
     "fcom st0, st1": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd1 /2"
       ],
@@ -567,7 +541,6 @@
     },
     "fcom st0, st2": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd2 /2"
       ],
@@ -602,7 +575,6 @@
     },
     "fcom st0, st3": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd3 /2"
       ],
@@ -637,7 +609,6 @@
     },
     "fcom st0, st4": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd4 /2"
       ],
@@ -672,7 +643,6 @@
     },
     "fcom st0, st5": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd5 /2"
       ],
@@ -707,7 +677,6 @@
     },
     "fcom st0, st6": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd6 /2"
       ],
@@ -742,7 +711,6 @@
     },
     "fcom st0, st7": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd7 /2"
       ],
@@ -777,7 +745,6 @@
     },
     "fcomp st0, st0": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd8 /3"
       ],
@@ -820,7 +787,6 @@
     },
     "fcomp st0, st1": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd9 /3"
       ],
@@ -863,7 +829,6 @@
     },
     "fcomp st0, st2": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xda /3"
       ],
@@ -906,7 +871,6 @@
     },
     "fcomp st0, st3": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdb /3"
       ],
@@ -949,7 +913,6 @@
     },
     "fcomp st0, st4": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdc /3"
       ],
@@ -992,7 +955,6 @@
     },
     "fcomp st0, st5": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdd /3"
       ],
@@ -1035,7 +997,6 @@
     },
     "fcomp st0, st6": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xde /3"
       ],
@@ -1078,7 +1039,6 @@
     },
     "fcomp st0, st7": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdf /3"
       ],
@@ -1121,7 +1081,6 @@
     },
     "fsub st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe0 /4"
       ],
@@ -1140,7 +1099,6 @@
     },
     "fsub st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe1 /4"
       ],
@@ -1159,7 +1117,6 @@
     },
     "fsub st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe2 /4"
       ],
@@ -1178,7 +1135,6 @@
     },
     "fsub st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe3 /4"
       ],
@@ -1197,7 +1153,6 @@
     },
     "fsub st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe4 /4"
       ],
@@ -1216,7 +1171,6 @@
     },
     "fsub st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe5 /4"
       ],
@@ -1235,7 +1189,6 @@
     },
     "fsub st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe6 /4"
       ],
@@ -1254,7 +1207,6 @@
     },
     "fsub st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe7 /4"
       ],
@@ -1273,7 +1225,6 @@
     },
     "fsubr st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe8 /5"
       ],
@@ -1292,7 +1243,6 @@
     },
     "fsubr st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe9 /5"
       ],
@@ -1311,7 +1261,6 @@
     },
     "fsubr st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xea /5"
       ],
@@ -1330,7 +1279,6 @@
     },
     "fsubr st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xeb /5"
       ],
@@ -1349,7 +1297,6 @@
     },
     "fsubr st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xec /5"
       ],
@@ -1368,7 +1315,6 @@
     },
     "fsubr st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xed /5"
       ],
@@ -1387,7 +1333,6 @@
     },
     "fsubr st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xee /5"
       ],
@@ -1406,7 +1351,6 @@
     },
     "fsubr st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xef /5"
       ],
@@ -1425,7 +1369,6 @@
     },
     "fdiv st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf0 /6"
       ],
@@ -1444,7 +1387,6 @@
     },
     "fdiv st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf1 /6"
       ],
@@ -1463,7 +1405,6 @@
     },
     "fdiv st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf2 /6"
       ],
@@ -1482,7 +1423,6 @@
     },
     "fdiv st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf3 /6"
       ],
@@ -1501,7 +1441,6 @@
     },
     "fdiv st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf4 /6"
       ],
@@ -1520,7 +1459,6 @@
     },
     "fdiv st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf5 /6"
       ],
@@ -1539,7 +1477,6 @@
     },
     "fdiv st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf6 /6"
       ],
@@ -1558,7 +1495,6 @@
     },
     "fdiv st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf7 /6"
       ],
@@ -1577,7 +1513,6 @@
     },
     "fdivr st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf8 /7"
       ],
@@ -1596,7 +1531,6 @@
     },
     "fdivr st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf9 /7"
       ],
@@ -1615,7 +1549,6 @@
     },
     "fdivr st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfa /7"
       ],
@@ -1634,7 +1567,6 @@
     },
     "fdivr st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfb /7"
       ],
@@ -1653,7 +1585,6 @@
     },
     "fdivr st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfc /7"
       ],
@@ -1672,7 +1603,6 @@
     },
     "fdivr st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfd /7"
       ],
@@ -1691,7 +1621,6 @@
     },
     "fdivr st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfe /7"
       ],
@@ -1710,7 +1639,6 @@
     },
     "fdivr st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xff /7"
       ],
@@ -1729,7 +1657,6 @@
     },
     "fld dword [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /0"
       ],
@@ -1751,7 +1678,6 @@
     },
     "fst dword [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /2"
       ],
@@ -1765,7 +1691,6 @@
     },
     "fstp dword [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /3"
       ],
@@ -1787,7 +1712,6 @@
     },
     "fldenv [rax]": {
       "ExpectedInstructionCount": 56,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /4"
       ],
@@ -1852,7 +1776,6 @@
     },
     "fldcw [rax]": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /5"
       ],
@@ -1871,7 +1794,6 @@
     },
     "fnstenv [rax]": {
       "ExpectedInstructionCount": 64,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /6"
       ],
@@ -1944,7 +1866,6 @@
     },
     "fnstcw [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 !11b /7"
       ],
@@ -1955,7 +1876,6 @@
     },
     "fld st0": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc0 /0"
       ],
@@ -1979,7 +1899,6 @@
     },
     "fld st1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc1 /0"
       ],
@@ -2003,7 +1922,6 @@
     },
     "fld st2": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc2 /0"
       ],
@@ -2027,7 +1945,6 @@
     },
     "fld st3": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc3 /0"
       ],
@@ -2051,7 +1968,6 @@
     },
     "fld st4": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc4 /0"
       ],
@@ -2075,7 +1991,6 @@
     },
     "fld st5": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc5 /0"
       ],
@@ -2099,7 +2014,6 @@
     },
     "fld st6": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc6 /0"
       ],
@@ -2123,7 +2037,6 @@
     },
     "fld st7": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc7 /0"
       ],
@@ -2147,7 +2060,6 @@
     },
     "fxch st0, st0": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc8 /1"
       ],
@@ -2167,7 +2079,6 @@
     },
     "fxch st0, st1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc9 /1"
       ],
@@ -2187,7 +2098,6 @@
     },
     "fxch st0, st2": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xca /1"
       ],
@@ -2207,7 +2117,6 @@
     },
     "fxch st0, st3": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcb /1"
       ],
@@ -2227,7 +2136,6 @@
     },
     "fxch st0, st4": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcc /1"
       ],
@@ -2247,7 +2155,6 @@
     },
     "fxch st0, st5": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcd /1"
       ],
@@ -2267,7 +2174,6 @@
     },
     "fxch st0, st6": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xce /1"
       ],
@@ -2287,7 +2193,6 @@
     },
     "fxch st0, st7": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcf /1"
       ],
@@ -2307,7 +2212,6 @@
     },
     "fnop": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xd0 /2"
       ],
@@ -2315,7 +2219,6 @@
     },
     "fchs": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe0 /4"
       ],
@@ -2330,7 +2233,6 @@
     },
     "fabs": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe1 /4"
       ],
@@ -2345,7 +2247,6 @@
     },
     "ftst": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe4 /4"
       ],
@@ -2377,7 +2278,6 @@
     },
     "fxam": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe5 /4"
       ],
@@ -2404,7 +2304,6 @@
     },
     "fld1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe8 /5"
       ],
@@ -2426,7 +2325,6 @@
     },
     "fldl2t": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe9 /5"
       ],
@@ -2451,7 +2349,6 @@
     },
     "fldl2e": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xea /5"
       ],
@@ -2476,7 +2373,6 @@
     },
     "fldpi": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xeb /5"
       ],
@@ -2501,7 +2397,6 @@
     },
     "fldlg2": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xec /5"
       ],
@@ -2526,7 +2421,6 @@
     },
     "fldln2": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xed /5"
       ],
@@ -2551,7 +2445,6 @@
     },
     "fldz": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xee /5"
       ],
@@ -2573,7 +2466,6 @@
     },
     "f2xm1": {
       "ExpectedInstructionCount": 52,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf0 /6"
       ],
@@ -2634,7 +2526,6 @@
     },
     "fyl2x": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf1 /6"
       ],
@@ -2706,7 +2597,6 @@
     },
     "fptan": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf2 /6"
       ],
@@ -2781,7 +2671,6 @@
     },
     "fpatan": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf3 /6"
       ],
@@ -2853,7 +2742,6 @@
     },
     "fxtract": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf4 /6"
       ],
@@ -2885,7 +2773,6 @@
     },
     "fprem1": {
       "ExpectedInstructionCount": 59,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf5 /6"
       ],
@@ -2953,7 +2840,6 @@
     },
     "fdecstp": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xf6 /6"
       ],
@@ -2966,7 +2852,6 @@
     },
     "fincstp": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xf7 /6"
       ],
@@ -2979,7 +2864,6 @@
     },
     "fprem": {
       "ExpectedInstructionCount": 59,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf8 /7"
       ],
@@ -3047,7 +2931,6 @@
     },
     "fyl2xp1": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf9 /7"
       ],
@@ -3122,7 +3005,6 @@
     },
     "fsqrt": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfa /7"
       ],
@@ -3137,7 +3019,6 @@
     },
     "fsincos": {
       "ExpectedInstructionCount": 111,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfb /7"
       ],
@@ -3257,7 +3138,6 @@
     },
     "frndint": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfc /7"
       ],
@@ -3272,7 +3152,6 @@
     },
     "fscale": {
       "ExpectedInstructionCount": 57,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfd /7"
       ],
@@ -3338,7 +3217,6 @@
     },
     "fsin": {
       "ExpectedInstructionCount": 54,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfe /7"
       ],
@@ -3401,7 +3279,6 @@
     },
     "fcos": {
       "ExpectedInstructionCount": 54,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xff /7"
       ],
@@ -3464,7 +3341,6 @@
     },
     "fiadd dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /0"
       ],
@@ -3481,7 +3357,6 @@
     },
     "fimul dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /1"
       ],
@@ -3498,7 +3373,6 @@
     },
     "ficom dword [rax]": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /2"
       ],
@@ -3531,7 +3405,6 @@
     },
     "ficomp dword [rax]": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /3"
       ],
@@ -3572,7 +3445,6 @@
     },
     "fisub dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /4"
       ],
@@ -3589,7 +3461,6 @@
     },
     "fisubr dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /5"
       ],
@@ -3606,7 +3477,6 @@
     },
     "fidiv dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /6"
       ],
@@ -3623,7 +3493,6 @@
     },
     "fidivr dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /7"
       ],
@@ -3640,7 +3509,6 @@
     },
     "fcmovb st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc0 /0"
       ],
@@ -3661,7 +3529,6 @@
     },
     "fcmovb st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc1 /0"
       ],
@@ -3682,7 +3549,6 @@
     },
     "fcmovb st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc2 /0"
       ],
@@ -3703,7 +3569,6 @@
     },
     "fcmovb st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc3 /0"
       ],
@@ -3724,7 +3589,6 @@
     },
     "fcmovb st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc4 /0"
       ],
@@ -3745,7 +3609,6 @@
     },
     "fcmovb st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc5 /0"
       ],
@@ -3766,7 +3629,6 @@
     },
     "fcmovb st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc6 /0"
       ],
@@ -3787,7 +3649,6 @@
     },
     "fcmovb st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc7 /0"
       ],
@@ -3808,7 +3669,6 @@
     },
     "fcmove st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc8 /1"
       ],
@@ -3829,7 +3689,6 @@
     },
     "fcmove st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc9 /1"
       ],
@@ -3850,7 +3709,6 @@
     },
     "fcmove st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xca /1"
       ],
@@ -3871,7 +3729,6 @@
     },
     "fcmove st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcb /1"
       ],
@@ -3892,7 +3749,6 @@
     },
     "fcmove st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcc /1"
       ],
@@ -3913,7 +3769,6 @@
     },
     "fcmove st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcd /1"
       ],
@@ -3934,7 +3789,6 @@
     },
     "fcmove st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xce /1"
       ],
@@ -3955,7 +3809,6 @@
     },
     "fcmove st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcf /1"
       ],
@@ -3976,7 +3829,6 @@
     },
     "fcmovbe st0, st0": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd0 /0"
       ],
@@ -3999,7 +3851,6 @@
     },
     "fcmovbe st0, st1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd1 /0"
       ],
@@ -4022,7 +3873,6 @@
     },
     "fcmovbe st0, st2": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd2 /0"
       ],
@@ -4045,7 +3895,6 @@
     },
     "fcmovbe st0, st3": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd3 /0"
       ],
@@ -4068,7 +3917,6 @@
     },
     "fcmovbe st0, st4": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd4 /0"
       ],
@@ -4091,7 +3939,6 @@
     },
     "fcmovbe st0, st5": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd5 /0"
       ],
@@ -4114,7 +3961,6 @@
     },
     "fcmovbe st0, st6": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd6 /0"
       ],
@@ -4137,7 +3983,6 @@
     },
     "fcmovbe st0, st7": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd7 /0"
       ],
@@ -4160,7 +4005,6 @@
     },
     "fcmovu st0, st0": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd8 /1"
       ],
@@ -4188,7 +4032,6 @@
     },
     "fcmovu st0, st1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd9 /1"
       ],
@@ -4216,7 +4059,6 @@
     },
     "fcmovu st0, st2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xda /1"
       ],
@@ -4244,7 +4086,6 @@
     },
     "fcmovu st0, st3": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdb /1"
       ],
@@ -4272,7 +4113,6 @@
     },
     "fcmovu st0, st4": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdc /1"
       ],
@@ -4300,7 +4140,6 @@
     },
     "fcmovu st0, st5": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdd /1"
       ],
@@ -4328,7 +4167,6 @@
     },
     "fcmovu st0, st6": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xde /1"
       ],
@@ -4356,7 +4194,6 @@
     },
     "fcmovu st0, st7": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdf /1"
       ],
@@ -4384,7 +4221,6 @@
     },
     "fucompp": {
       "ExpectedInstructionCount": 39,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xe9 /5"
       ],
@@ -4432,7 +4268,6 @@
     },
     "fild dword [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /5"
       ],
@@ -4454,7 +4289,6 @@
     },
     "fisttp dword [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /1"
       ],
@@ -4476,7 +4310,6 @@
     },
     "fist dword [rax]": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /2"
       ],
@@ -4491,7 +4324,6 @@
     },
     "fistp dword [rax]": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /7"
       ],
@@ -4514,7 +4346,6 @@
     },
     "fld tword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /5"
       ],
@@ -4583,7 +4414,6 @@
     },
     "fstp tword [rax]": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /7"
       ],
@@ -4655,7 +4485,6 @@
     },
     "fcmovnb st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc0 /0"
       ],
@@ -4676,7 +4505,6 @@
     },
     "fcmovnb st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc1 /0"
       ],
@@ -4697,7 +4525,6 @@
     },
     "fcmovnb st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc2 /0"
       ],
@@ -4718,7 +4545,6 @@
     },
     "fcmovnb st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc3 /0"
       ],
@@ -4739,7 +4565,6 @@
     },
     "fcmovnb st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc4 /0"
       ],
@@ -4760,7 +4585,6 @@
     },
     "fcmovnb st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc5 /0"
       ],
@@ -4781,7 +4605,6 @@
     },
     "fcmovnb st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc6 /0"
       ],
@@ -4802,7 +4625,6 @@
     },
     "fcmovnb st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc7 /0"
       ],
@@ -4823,7 +4645,6 @@
     },
     "fcmovne st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc8 /1"
       ],
@@ -4844,7 +4665,6 @@
     },
     "fcmovne st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc9 /1"
       ],
@@ -4865,7 +4685,6 @@
     },
     "fcmovne st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xca /1"
       ],
@@ -4886,7 +4705,6 @@
     },
     "fcmovne st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcb /1"
       ],
@@ -4907,7 +4725,6 @@
     },
     "fcmovne st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcc /1"
       ],
@@ -4928,7 +4745,6 @@
     },
     "fcmovne st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcd /1"
       ],
@@ -4949,7 +4765,6 @@
     },
     "fcmovne st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xce /1"
       ],
@@ -4970,7 +4785,6 @@
     },
     "fcmovne st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcf /1"
       ],
@@ -4991,7 +4805,6 @@
     },
     "fcmovnbe st0, st0": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd0 /2"
       ],
@@ -5013,7 +4826,6 @@
     },
     "fcmovnbe st0, st1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd1 /2"
       ],
@@ -5035,7 +4847,6 @@
     },
     "fcmovnbe st0, st2": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd2 /2"
       ],
@@ -5057,7 +4868,6 @@
     },
     "fcmovnbe st0, st3": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd3 /2"
       ],
@@ -5079,7 +4889,6 @@
     },
     "fcmovnbe st0, st4": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd4 /2"
       ],
@@ -5101,7 +4910,6 @@
     },
     "fcmovnbe st0, st5": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd5 /2"
       ],
@@ -5123,7 +4931,6 @@
     },
     "fcmovnbe st0, st6": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd6 /2"
       ],
@@ -5145,7 +4952,6 @@
     },
     "fcmovnbe st0, st7": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd7 /2"
       ],
@@ -5167,7 +4973,6 @@
     },
     "fcmovnu st0, st0": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd8 /3"
       ],
@@ -5195,7 +5000,6 @@
     },
     "fcmovnu st0, st1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd9 /3"
       ],
@@ -5223,7 +5027,6 @@
     },
     "fcmovnu st0, st2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xda /3"
       ],
@@ -5251,7 +5054,6 @@
     },
     "fcmovnu st0, st3": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdb /3"
       ],
@@ -5279,7 +5081,6 @@
     },
     "fcmovnu st0, st4": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdc /3"
       ],
@@ -5307,7 +5108,6 @@
     },
     "fcmovnu st0, st5": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdd /3"
       ],
@@ -5335,7 +5135,6 @@
     },
     "fcmovnu st0, st6": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xde /3"
       ],
@@ -5363,7 +5162,6 @@
     },
     "fcmovnu st0, st7": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdf /3"
       ],
@@ -5391,7 +5189,6 @@
     },
     "fnclex": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe2 /4"
       ],
@@ -5399,7 +5196,6 @@
     },
     "fninit": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe3 /4"
       ],
@@ -5424,7 +5220,6 @@
     },
     "fucomi st0, st0": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe8 /5"
       ],
@@ -5457,7 +5252,6 @@
     },
     "fucomi st0, st1": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe9 /5"
       ],
@@ -5490,7 +5284,6 @@
     },
     "fucomi st0, st2": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xea /5"
       ],
@@ -5523,7 +5316,6 @@
     },
     "fucomi st0, st3": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xeb /5"
       ],
@@ -5556,7 +5348,6 @@
     },
     "fucomi st0, st4": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xec /5"
       ],
@@ -5589,7 +5380,6 @@
     },
     "fucomi st0, st5": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xed /5"
       ],
@@ -5622,7 +5412,6 @@
     },
     "fucomi st0, st6": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xee /5"
       ],
@@ -5655,7 +5444,6 @@
     },
     "fucomi st0, st7": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xef /5"
       ],
@@ -5688,7 +5476,6 @@
     },
     "fcomi st0, st0": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf0 /6"
       ],
@@ -5721,7 +5508,6 @@
     },
     "fcomi st0, st1": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf1 /6"
       ],
@@ -5754,7 +5540,6 @@
     },
     "fcomi st0, st2": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf2 /6"
       ],
@@ -5787,7 +5572,6 @@
     },
     "fcomi st0, st3": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf3 /6"
       ],
@@ -5820,7 +5604,6 @@
     },
     "fcomi st0, st4": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf4 /6"
       ],
@@ -5853,7 +5636,6 @@
     },
     "fcomi st0, st5": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf5 /6"
       ],
@@ -5886,7 +5668,6 @@
     },
     "fcomi st0, st6": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf6 /6"
       ],
@@ -5919,7 +5700,6 @@
     },
     "fcomi st0, st7": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf7 /6"
       ],
@@ -5952,7 +5732,6 @@
     },
     "fadd qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /0"
       ],
@@ -5968,7 +5747,6 @@
     },
     "fmul qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /1"
       ],
@@ -5984,7 +5762,6 @@
     },
     "fcom qword [rax]": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /2"
       ],
@@ -6016,7 +5793,6 @@
     },
     "fcomp qword [rax]": {
       "ExpectedInstructionCount": 31,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /3"
       ],
@@ -6056,7 +5832,6 @@
     },
     "fsub qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /4"
       ],
@@ -6072,7 +5847,6 @@
     },
     "fsubr qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /5"
       ],
@@ -6088,7 +5862,6 @@
     },
     "fdiv qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /6"
       ],
@@ -6104,7 +5877,6 @@
     },
     "fdivr qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /7"
       ],
@@ -6120,7 +5892,6 @@
     },
     "db 0xdc, 0xc0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fadd st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6141,7 +5912,6 @@
     },
     "fadd st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc1 /0"
       ],
@@ -6160,7 +5930,6 @@
     },
     "fadd st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc2 /0"
       ],
@@ -6179,7 +5948,6 @@
     },
     "fadd st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc3 /0"
       ],
@@ -6198,7 +5966,6 @@
     },
     "fadd st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc4 /0"
       ],
@@ -6217,7 +5984,6 @@
     },
     "fadd st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc5 /0"
       ],
@@ -6236,7 +6002,6 @@
     },
     "fadd st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc6 /0"
       ],
@@ -6255,7 +6020,6 @@
     },
     "fadd st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc7 /0"
       ],
@@ -6274,7 +6038,6 @@
     },
     "db 0xdc, 0xc8": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fmul st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6295,7 +6058,6 @@
     },
     "fmul st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc9 /1"
       ],
@@ -6314,7 +6076,6 @@
     },
     "fmul st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xca /1"
       ],
@@ -6333,7 +6094,6 @@
     },
     "fmul st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcb /1"
       ],
@@ -6352,7 +6112,6 @@
     },
     "fmul st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcc /1"
       ],
@@ -6371,7 +6130,6 @@
     },
     "fmul st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcd /1"
       ],
@@ -6390,7 +6148,6 @@
     },
     "fmul st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xce /1"
       ],
@@ -6409,7 +6166,6 @@
     },
     "fmul st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcf /1"
       ],
@@ -6428,7 +6184,6 @@
     },
     "db 0xdc, 0xe0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fsubr st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6449,7 +6204,6 @@
     },
     "fsubr st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe1 /4"
       ],
@@ -6468,7 +6222,6 @@
     },
     "fsubr st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe2 /4"
       ],
@@ -6487,7 +6240,6 @@
     },
     "fsubr st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe3 /4"
       ],
@@ -6506,7 +6258,6 @@
     },
     "fsubr st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe4 /4"
       ],
@@ -6525,7 +6276,6 @@
     },
     "fsubr st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe5 /4"
       ],
@@ -6544,7 +6294,6 @@
     },
     "fsubr st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe6 /4"
       ],
@@ -6563,7 +6312,6 @@
     },
     "fsubr st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe7 /4"
       ],
@@ -6582,7 +6330,6 @@
     },
     "db 0xdc, 0xe8": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fsub st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6603,7 +6350,6 @@
     },
     "fsub st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe9 /5"
       ],
@@ -6622,7 +6368,6 @@
     },
     "fsub st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xea /5"
       ],
@@ -6641,7 +6386,6 @@
     },
     "fsub st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xeb /5"
       ],
@@ -6660,7 +6404,6 @@
     },
     "fsub st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xec /5"
       ],
@@ -6679,7 +6422,6 @@
     },
     "fsub st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xed /5"
       ],
@@ -6698,7 +6440,6 @@
     },
     "fsub st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xee /5"
       ],
@@ -6717,7 +6458,6 @@
     },
     "fsub st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xef /5"
       ],
@@ -6736,7 +6476,6 @@
     },
     "db 0xdc, 0xf0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fdivr st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6757,7 +6496,6 @@
     },
     "fdivr st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf1 /6"
       ],
@@ -6776,7 +6514,6 @@
     },
     "fdivr st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf2 /6"
       ],
@@ -6795,7 +6532,6 @@
     },
     "fdivr st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf3 /6"
       ],
@@ -6814,7 +6550,6 @@
     },
     "fdivr st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf4 /6"
       ],
@@ -6833,7 +6568,6 @@
     },
     "fdivr st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf5 /6"
       ],
@@ -6852,7 +6586,6 @@
     },
     "fdivr st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf6 /6"
       ],
@@ -6871,7 +6604,6 @@
     },
     "fdivr st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf7 /6"
       ],
@@ -6890,7 +6622,6 @@
     },
     "db 0xdc, 0xf8": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fdiv st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6911,7 +6642,6 @@
     },
     "fdiv st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf9 /7"
       ],
@@ -6930,7 +6660,6 @@
     },
     "fdiv st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfa /7"
       ],
@@ -6949,7 +6678,6 @@
     },
     "fdiv st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfb /7"
       ],
@@ -6968,7 +6696,6 @@
     },
     "fdiv st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfc /7"
       ],
@@ -6987,7 +6714,6 @@
     },
     "fdiv st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfd /7"
       ],
@@ -7006,7 +6732,6 @@
     },
     "fdiv st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfe /7"
       ],
@@ -7025,7 +6750,6 @@
     },
     "fdiv st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xff /7"
       ],
@@ -7044,7 +6768,6 @@
     },
     "fld qword [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /0"
       ],
@@ -7065,7 +6788,6 @@
     },
     "fisttp qword [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /1"
       ],
@@ -7087,7 +6809,6 @@
     },
     "fst qword [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /2"
       ],
@@ -7100,7 +6821,6 @@
     },
     "fstp qword [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /3"
       ],
@@ -7121,7 +6841,6 @@
     },
     "frstor [rax]": {
       "ExpectedInstructionCount": 501,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /4"
       ],
@@ -7631,7 +7350,6 @@
     },
     "fnsave [rax]": {
       "ExpectedInstructionCount": 511,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /6"
       ],
@@ -8151,7 +7869,6 @@
     },
     "fnstsw [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /7"
       ],
@@ -8172,7 +7889,6 @@
     },
     "ffree st0": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc0 /0"
       ],
@@ -8189,7 +7905,6 @@
     },
     "ffree st1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc1 /0"
       ],
@@ -8206,7 +7921,6 @@
     },
     "ffree st2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc2 /0"
       ],
@@ -8223,7 +7937,6 @@
     },
     "ffree st3": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc3 /0"
       ],
@@ -8240,7 +7953,6 @@
     },
     "ffree st4": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc4 /0"
       ],
@@ -8257,7 +7969,6 @@
     },
     "ffree st5": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc5 /0"
       ],
@@ -8274,7 +7985,6 @@
     },
     "ffree st6": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc6 /0"
       ],
@@ -8291,7 +8001,6 @@
     },
     "ffree st7": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc7 /0"
       ],
@@ -8308,7 +8017,6 @@
     },
     "fst st0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd0 /2"
       ],
@@ -8324,7 +8032,6 @@
     },
     "fst st1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd1 /2"
       ],
@@ -8340,7 +8047,6 @@
     },
     "fst st2": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd2 /2"
       ],
@@ -8356,7 +8062,6 @@
     },
     "fst st3": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd3 /2"
       ],
@@ -8372,7 +8077,6 @@
     },
     "fst st4": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd4 /2"
       ],
@@ -8388,7 +8092,6 @@
     },
     "fst st5": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd5 /2"
       ],
@@ -8404,7 +8107,6 @@
     },
     "fst st6": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd6 /2"
       ],
@@ -8420,7 +8122,6 @@
     },
     "fst st7": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd7 /2"
       ],
@@ -8436,7 +8137,6 @@
     },
     "fstp st0": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd8 /3"
       ],
@@ -8460,7 +8160,6 @@
     },
     "fstp st1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd9 /3"
       ],
@@ -8484,7 +8183,6 @@
     },
     "fstp st2": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xda /3"
       ],
@@ -8508,7 +8206,6 @@
     },
     "fstp st3": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdb /3"
       ],
@@ -8532,7 +8229,6 @@
     },
     "fstp st4": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdc /3"
       ],
@@ -8556,7 +8252,6 @@
     },
     "fstp st5": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdd /3"
       ],
@@ -8580,7 +8275,6 @@
     },
     "fstp st6": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xde /3"
       ],
@@ -8604,7 +8298,6 @@
     },
     "fstp st7": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdf /3"
       ],
@@ -8628,7 +8321,6 @@
     },
     "fucom st0": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe0 /4"
       ],
@@ -8663,7 +8355,6 @@
     },
     "fucom st1": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe1 /4"
       ],
@@ -8698,7 +8389,6 @@
     },
     "fucom st2": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe2 /4"
       ],
@@ -8733,7 +8423,6 @@
     },
     "fucom st3": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe3 /4"
       ],
@@ -8768,7 +8457,6 @@
     },
     "fucom st4": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe4 /4"
       ],
@@ -8803,7 +8491,6 @@
     },
     "fucom st5": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe5 /4"
       ],
@@ -8838,7 +8525,6 @@
     },
     "fucom st6": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe6 /4"
       ],
@@ -8873,7 +8559,6 @@
     },
     "fucom st7": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe7 /4"
       ],
@@ -8908,7 +8593,6 @@
     },
     "fucomp st0": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe8 /5"
       ],
@@ -8951,7 +8635,6 @@
     },
     "fucomp st1": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe9 /5"
       ],
@@ -8994,7 +8677,6 @@
     },
     "fucomp st2": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xea /5"
       ],
@@ -9037,7 +8719,6 @@
     },
     "fucomp st3": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xeb /5"
       ],
@@ -9080,7 +8761,6 @@
     },
     "fucomp st4": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xec /5"
       ],
@@ -9123,7 +8803,6 @@
     },
     "fucomp st5": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xed /5"
       ],
@@ -9166,7 +8845,6 @@
     },
     "fucomp st6": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xee /5"
       ],
@@ -9209,7 +8887,6 @@
     },
     "fucomp st7": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xef /5"
       ],
@@ -9252,7 +8929,6 @@
     },
     "fiadd word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /0"
       ],
@@ -9270,7 +8946,6 @@
     },
     "fimul word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /1"
       ],
@@ -9288,7 +8963,6 @@
     },
     "ficom word [rax]": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /2"
       ],
@@ -9322,7 +8996,6 @@
     },
     "ficomp word [rax]": {
       "ExpectedInstructionCount": 33,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /3"
       ],
@@ -9364,7 +9037,6 @@
     },
     "fisub word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /4"
       ],
@@ -9382,7 +9054,6 @@
     },
     "fisubr word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /5"
       ],
@@ -9400,7 +9071,6 @@
     },
     "fidiv word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /6"
       ],
@@ -9418,7 +9088,6 @@
     },
     "fidivr word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /7"
       ],
@@ -9436,7 +9105,6 @@
     },
     "faddp st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc0 /0"
       ],
@@ -9463,7 +9131,6 @@
     },
     "faddp st1": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc1 /0"
       ],
@@ -9490,7 +9157,6 @@
     },
     "faddp st2": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc2 /0"
       ],
@@ -9517,7 +9183,6 @@
     },
     "faddp st3": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc3 /0"
       ],
@@ -9544,7 +9209,6 @@
     },
     "faddp st4": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc4 /0"
       ],
@@ -9571,7 +9235,6 @@
     },
     "faddp st5": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc5 /0"
       ],
@@ -9598,7 +9261,6 @@
     },
     "faddp st6": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc6 /0"
       ],
@@ -9625,7 +9287,6 @@
     },
     "faddp st7": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc7 /0"
       ],
@@ -9652,7 +9313,6 @@
     },
     "fmulp st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc8 /1"
       ],
@@ -9679,7 +9339,6 @@
     },
     "fmulp st1": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc9 /1"
       ],
@@ -9706,7 +9365,6 @@
     },
     "fmulp st2": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xca /1"
       ],
@@ -9733,7 +9391,6 @@
     },
     "fmulp st3": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcb /1"
       ],
@@ -9760,7 +9417,6 @@
     },
     "fmulp st4": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcc /1"
       ],
@@ -9787,7 +9443,6 @@
     },
     "fmulp st5": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcd /1"
       ],
@@ -9814,7 +9469,6 @@
     },
     "fmulp st6": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xce /1"
       ],
@@ -9841,7 +9495,6 @@
     },
     "fmulp st7": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcf /1"
       ],
@@ -9868,7 +9521,6 @@
     },
     "fcompp": {
       "ExpectedInstructionCount": 39,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xd9 /3"
       ],
@@ -9916,7 +9568,6 @@
     },
     "db 0xde, 0xe0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "fsubrp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -9945,7 +9596,6 @@
     },
     "fsubrp st1, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe1 /4"
       ],
@@ -9972,7 +9622,6 @@
     },
     "fsubrp st2, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe2 /4"
       ],
@@ -9999,7 +9648,6 @@
     },
     "fsubrp st3, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe3 /4"
       ],
@@ -10026,7 +9674,6 @@
     },
     "fsubrp st4, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe4 /4"
       ],
@@ -10053,7 +9700,6 @@
     },
     "fsubrp st5, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe5 /4"
       ],
@@ -10080,7 +9726,6 @@
     },
     "fsubrp st6, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe6 /4"
       ],
@@ -10107,7 +9752,6 @@
     },
     "fsubrp st7, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe7 /4"
       ],
@@ -10134,7 +9778,6 @@
     },
     "db 0xde, 0xe8": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "fsubp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -10163,7 +9806,6 @@
     },
     "fsubp st1, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe9 /5"
       ],
@@ -10190,7 +9832,6 @@
     },
     "fsubp st2, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xea /5"
       ],
@@ -10217,7 +9858,6 @@
     },
     "fsubp st3, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xeb /5"
       ],
@@ -10244,7 +9884,6 @@
     },
     "fsubp st4, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xec /5"
       ],
@@ -10271,7 +9910,6 @@
     },
     "fsubp st5, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xed /5"
       ],
@@ -10298,7 +9936,6 @@
     },
     "fsubp st6, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xee /5"
       ],
@@ -10325,7 +9962,6 @@
     },
     "fsubp st7, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xef /5"
       ],
@@ -10352,7 +9988,6 @@
     },
     "db 0xde, 0xf0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "fdivrp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -10381,7 +10016,6 @@
     },
     "fdivrp st1, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf1 /6"
       ],
@@ -10408,7 +10042,6 @@
     },
     "fdivrp st2, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf2 /6"
       ],
@@ -10435,7 +10068,6 @@
     },
     "fdivrp st3, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf3 /6"
       ],
@@ -10462,7 +10094,6 @@
     },
     "fdivrp st4, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf4 /6"
       ],
@@ -10489,7 +10120,6 @@
     },
     "fdivrp st5, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf5 /6"
       ],
@@ -10516,7 +10146,6 @@
     },
     "fdivrp st6, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf6 /6"
       ],
@@ -10543,7 +10172,6 @@
     },
     "fdivrp st7, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf7 /6"
       ],
@@ -10570,7 +10198,6 @@
     },
     "db 0xde, 0xf8": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "fdivp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -10599,7 +10226,6 @@
     },
     "fdivp st1, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf9 /7"
       ],
@@ -10626,7 +10252,6 @@
     },
     "fdivp st2, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfa /7"
       ],
@@ -10653,7 +10278,6 @@
     },
     "fdivp st3, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfb /7"
       ],
@@ -10680,7 +10304,6 @@
     },
     "fdivp st4, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfc /7"
       ],
@@ -10707,7 +10330,6 @@
     },
     "fdivp st5, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfd /7"
       ],
@@ -10734,7 +10356,6 @@
     },
     "fdivp st6, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfe /7"
       ],
@@ -10761,7 +10382,6 @@
     },
     "fdivp st7, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xff /7"
       ],
@@ -10788,7 +10408,6 @@
     },
     "fild word [rax]": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /0"
       ],
@@ -10811,7 +10430,6 @@
     },
     "fisttp word [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /1"
       ],
@@ -10833,7 +10451,6 @@
     },
     "fist word [rax]": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /2"
       ],
@@ -10848,7 +10465,6 @@
     },
     "fistp word [rax]": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /3"
       ],
@@ -10871,7 +10487,6 @@
     },
     "fbld tword [rax]": {
       "ExpectedInstructionCount": 110,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /4"
       ],
@@ -10990,7 +10605,6 @@
     },
     "fbstp tword [rax]": {
       "ExpectedInstructionCount": 113,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /6"
       ],
@@ -11112,7 +10726,6 @@
     },
     "ffreep st0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc0 /0"
       ],
@@ -11125,7 +10738,6 @@
     },
     "ffreep st1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc1 /0"
       ],
@@ -11138,7 +10750,6 @@
     },
     "ffreep st2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc2 /0"
       ],
@@ -11151,7 +10762,6 @@
     },
     "ffreep st3": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc3 /0"
       ],
@@ -11164,7 +10774,6 @@
     },
     "ffreep st4": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc4 /0"
       ],
@@ -11177,7 +10786,6 @@
     },
     "ffreep st5": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc5 /0"
       ],
@@ -11190,7 +10798,6 @@
     },
     "ffreep st6": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc6 /0"
       ],
@@ -11203,7 +10810,6 @@
     },
     "ffreep st7": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc7 /0"
       ],
@@ -11216,7 +10822,6 @@
     },
     "fnstsw ax": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe0 /4"
       ],
@@ -11237,7 +10842,6 @@
     },
     "fucomip st0": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe8 /5"
       ],
@@ -11278,7 +10882,6 @@
     },
     "fucomip st1": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe9 /5"
       ],
@@ -11319,7 +10922,6 @@
     },
     "fucomip st2": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xea /5"
       ],
@@ -11360,7 +10962,6 @@
     },
     "fucomip st3": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xeb /5"
       ],
@@ -11401,7 +11002,6 @@
     },
     "fucomip st4": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xec /5"
       ],
@@ -11442,7 +11042,6 @@
     },
     "fucomip st5": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xed /5"
       ],
@@ -11483,7 +11082,6 @@
     },
     "fucomip st6": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xee /5"
       ],
@@ -11524,7 +11122,6 @@
     },
     "fucomip st7": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xef /5"
       ],
@@ -11565,7 +11162,6 @@
     },
     "fcomip st0": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf0 /6"
       ],
@@ -11606,7 +11202,6 @@
     },
     "fcomip st1": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf1 /6"
       ],
@@ -11647,7 +11242,6 @@
     },
     "fcomip st2": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf2 /6"
       ],
@@ -11688,7 +11282,6 @@
     },
     "fcomip st3": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf3 /6"
       ],
@@ -11729,7 +11322,6 @@
     },
     "fcomip st4": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf4 /6"
       ],
@@ -11770,7 +11362,6 @@
     },
     "fcomip st5": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf5 /6"
       ],
@@ -11811,7 +11402,6 @@
     },
     "fcomip st6": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf6 /6"
       ],
@@ -11852,7 +11442,6 @@
     },
     "fcomip st7": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf7 /6"
       ],

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "pshufb mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x00"
       ],
@@ -27,7 +26,6 @@
     },
     "pshufb xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x00"
       ],
@@ -39,7 +37,6 @@
     },
     "phaddw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x01"
       ],
@@ -52,7 +49,6 @@
     },
     "phaddw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x01"
       ],
@@ -62,7 +58,6 @@
     },
     "phaddd mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x02"
       ],
@@ -75,7 +70,6 @@
     },
     "phaddd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x02"
       ],
@@ -85,7 +79,6 @@
     },
     "phaddsw mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x03"
       ],
@@ -100,7 +93,6 @@
     },
     "phaddsw xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x03"
       ],
@@ -112,7 +104,6 @@
     },
     "pmaddubsw mm0, mm1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Unknown",
       "Comment": [
         "NP 0x0f 0x38 0x04"
       ],
@@ -130,7 +121,6 @@
     },
     "pmaddubsw xmm0, xmm1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "{u,s}xtl{,2} and uzp{1,2} can be more optimal",
         "Up-front zero extend and sign extend the elements in place",
@@ -152,7 +142,6 @@
     },
     "phsubw mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x05"
       ],
@@ -167,7 +156,6 @@
     },
     "phsubw xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x05"
       ],
@@ -179,7 +167,6 @@
     },
     "phsubd mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x06"
       ],
@@ -194,7 +181,6 @@
     },
     "phsubd xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x06"
       ],
@@ -206,7 +192,6 @@
     },
     "phsubsw mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x07"
       ],
@@ -221,7 +206,6 @@
     },
     "phsubsw xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x07"
       ],
@@ -233,7 +217,6 @@
     },
     "psignb mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x08"
       ],
@@ -248,7 +231,6 @@
     },
     "psignb xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x08"
       ],
@@ -260,7 +242,6 @@
     },
     "psignw mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x09"
       ],
@@ -275,7 +256,6 @@
     },
     "psignw xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x09"
       ],
@@ -287,7 +267,6 @@
     },
     "psignd mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x0a"
       ],
@@ -302,7 +281,6 @@
     },
     "psignd xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x0a"
       ],
@@ -314,7 +292,6 @@
     },
     "pmulhrsw mm0, mm1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "Might be able to use sqdmulh",
         "NP 0x0f 0x38 0x0b"
@@ -332,7 +309,6 @@
     },
     "pmulhrsw xmm0, xmm1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "Might be able to use sqdmulh",
         "0x66 0x0f 0x38 0x0b"
@@ -353,7 +329,6 @@
     },
     "pblendvb xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x10"
       ],
@@ -364,7 +339,6 @@
     },
     "blendvps xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x14"
       ],
@@ -375,7 +349,6 @@
     },
     "blendvpd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x15"
       ],
@@ -386,7 +359,6 @@
     },
     "pblendvb xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x10"
       ],
@@ -397,7 +369,6 @@
     },
     "blendvps xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x14"
       ],
@@ -408,7 +379,6 @@
     },
     "blendvpd xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x15"
       ],
@@ -419,7 +389,6 @@
     },
     "ptest xmm0, xmm1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0x17"
       ],
@@ -447,7 +416,6 @@
     },
     "pabsb mm0, mm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x1c"
       ],
@@ -459,7 +427,6 @@
     },
     "pabsb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x1c"
       ],
@@ -469,7 +436,6 @@
     },
     "pabsw mm0, mm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x1d"
       ],
@@ -481,7 +447,6 @@
     },
     "pabsw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x1d"
       ],
@@ -491,7 +456,6 @@
     },
     "pabsd mm0, mm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x38 0x1e"
       ],
@@ -503,7 +467,6 @@
     },
     "pabsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x1e"
       ],
@@ -513,7 +476,6 @@
     },
     "pmovzxbw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x30"
       ],
@@ -523,7 +485,6 @@
     },
     "pmovzxbd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x31"
       ],
@@ -534,7 +495,6 @@
     },
     "pmovzxbq xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x32"
       ],
@@ -546,7 +506,6 @@
     },
     "pmovzxwd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x33"
       ],
@@ -556,7 +515,6 @@
     },
     "pmovzxwq xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x34"
       ],
@@ -567,7 +525,6 @@
     },
     "pmovzxdq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x35"
       ],
@@ -577,7 +534,6 @@
     },
     "pcmpgtq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x37"
       ],
@@ -587,7 +543,6 @@
     },
     "pminsb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x38"
       ],
@@ -597,7 +552,6 @@
     },
     "pminsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x39"
       ],
@@ -607,7 +561,6 @@
     },
     "pminuw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x3a"
       ],
@@ -617,7 +570,6 @@
     },
     "pminud xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x3b"
       ],
@@ -627,7 +579,6 @@
     },
     "pmaxsb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x3c"
       ],
@@ -637,7 +588,6 @@
     },
     "pmaxsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x3d"
       ],
@@ -647,7 +597,6 @@
     },
     "pmaxuw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x3e"
       ],
@@ -657,7 +606,6 @@
     },
     "pmaxud xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x3f"
       ],
@@ -667,7 +615,6 @@
     },
     "pmulld xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x40"
       ],
@@ -677,7 +624,6 @@
     },
     "phminposuw xmm0, xmm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0x41"
       ],
@@ -692,7 +638,6 @@
     },
     "sha1nexte xmm0, xmm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xc8"
       ],
@@ -707,7 +652,6 @@
     },
     "sha1msg1 xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xc9"
       ],
@@ -718,7 +662,6 @@
     },
     "sha1msg2 xmm0, xmm1": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xca"
       ],
@@ -748,7 +691,6 @@
     },
     "sha256rnds2 xmm0, xmm1": {
       "ExpectedInstructionCount": 106,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xcb"
       ],
@@ -863,7 +805,6 @@
     },
     "sha256msg1 xmm0, xmm1": {
       "ExpectedInstructionCount": 35,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xcc"
       ],
@@ -907,7 +848,6 @@
     },
     "sha256msg2 xmm0, xmm1": {
       "ExpectedInstructionCount": 36,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xcd"
       ],
@@ -952,7 +892,6 @@
     },
     "aesimc xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xdb"
       ],
@@ -962,7 +901,6 @@
     },
     "aesenc xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xdc"
       ],
@@ -975,7 +913,6 @@
     },
     "aesenclast xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xdd"
       ],
@@ -987,7 +924,6 @@
     },
     "aesdec xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xde"
       ],
@@ -1000,7 +936,6 @@
     },
     "aesdeclast xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xdf"
       ],
@@ -1012,7 +947,6 @@
     },
     "movbe ax, word [rbx]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xf0"
       ],
@@ -1024,7 +958,6 @@
     },
     "movbe eax, dword [rbx]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x38 0xf0"
       ],
@@ -1035,7 +968,6 @@
     },
     "movbe rax, qword [rbx]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "REX.W 0x66 0x0f 0x38 0xf0"
       ],
@@ -1046,7 +978,6 @@
     },
     "crc32 eax, bl": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x38 0xf0"
       ],
@@ -1056,7 +987,6 @@
     },
     "crc32 eax, bx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x38 0xf1"
       ],
@@ -1066,7 +996,6 @@
     },
     "crc32 eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x38 0xf1"
       ],
@@ -1076,7 +1005,6 @@
     },
     "crc32 rax, bl": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x38 0xf0"
       ],
@@ -1086,7 +1014,6 @@
     },
     "crc32 rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x38 0xf1"
       ],
@@ -1096,7 +1023,6 @@
     },
     "adcx eax, ebx": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x38 0xf6"
       ],
@@ -1121,7 +1047,6 @@
     },
     "adcx rax, rbx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "Unknown",
       "Comment": [
         "0x66 REX.W 0x0f 0x38 0xf6"
       ],
@@ -1144,7 +1069,6 @@
     },
     "adox eax, ebx": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xf3 0x0f 0x38 0xf6"
       ],
@@ -1169,7 +1093,6 @@
     },
     "adox rax, rbx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "Unknown",
       "Comment": [
         "0xf3 REX.W 0x0f 0x38 0xf6"
       ],

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -15,7 +15,6 @@
   "Instructions": {
     "palignr mm0, mm1, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x3a 0x0f"
       ],
@@ -26,7 +25,6 @@
     },
     "palignr mm0, mm1, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x3a 0x0f"
       ],
@@ -39,7 +37,6 @@
     },
     "palignr mm0, mm1, 255": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "NP 0x0f 0x3a 0x0f"
       ],
@@ -50,7 +47,6 @@
     },
     "roundps xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Nearest rounding",
         "0x66 0x0f 0x3a 0x08"
@@ -61,7 +57,6 @@
     },
     "roundps xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "0x66 0x0f 0x3a 0x08"
@@ -72,7 +67,6 @@
     },
     "roundps xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "0x66 0x0f 0x3a 0x08"
@@ -83,7 +77,6 @@
     },
     "roundps xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "0x66 0x0f 0x3a 0x08"
@@ -94,7 +87,6 @@
     },
     "roundps xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "host rounding mode rounding",
         "0x66 0x0f 0x3a 0x08"
@@ -105,7 +97,6 @@
     },
     "roundpd xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Nearest rounding",
         "0x66 0x0f 0x3a 0x09"
@@ -116,7 +107,6 @@
     },
     "roundpd xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "0x66 0x0f 0x3a 0x09"
@@ -127,7 +117,6 @@
     },
     "roundpd xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "0x66 0x0f 0x3a 0x09"
@@ -138,7 +127,6 @@
     },
     "roundpd xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "0x66 0x0f 0x3a 0x09"
@@ -149,7 +137,6 @@
     },
     "roundpd xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "yes",
       "Comment": [
         "host rounding mode rounding",
         "0x66 0x0f 0x3a 0x09"
@@ -160,7 +147,6 @@
     },
     "roundss xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Nearest rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -172,7 +158,6 @@
     },
     "roundss xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -184,7 +169,6 @@
     },
     "roundss xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -196,7 +180,6 @@
     },
     "roundss xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -208,7 +191,6 @@
     },
     "roundss xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "host rounding mode rounding",
         "0x66 0x0f 0x3a 0x0a"
@@ -220,7 +202,6 @@
     },
     "roundsd xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Nearest rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -232,7 +213,6 @@
     },
     "roundsd xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -244,7 +224,6 @@
     },
     "roundsd xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -256,7 +235,6 @@
     },
     "roundsd xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -268,7 +246,6 @@
     },
     "roundsd xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "host rounding mode rounding",
         "0x66 0x0f 0x3a 0x0b"
@@ -280,7 +257,6 @@
     },
     "blendps xmm0, xmm1, 0000b": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -288,7 +264,6 @@
     },
     "blendps xmm0, xmm1, 0001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -298,7 +273,6 @@
     },
     "blendps xmm0, xmm1, 0010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -308,7 +282,6 @@
     },
     "blendps xmm0, xmm1, 0011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -318,7 +291,6 @@
     },
     "blendps xmm0, xmm1, 0100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -328,7 +300,6 @@
     },
     "blendps xmm0, xmm1, 0101b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -339,7 +310,6 @@
     },
     "blendps xmm0, xmm1, 0110b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -350,7 +320,6 @@
     },
     "blendps xmm0, xmm1, 0111b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -361,7 +330,6 @@
     },
     "blendps xmm0, xmm1, 1000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -371,7 +339,6 @@
     },
     "blendps xmm0, xmm1, 1001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -382,7 +349,6 @@
     },
     "blendps xmm0, xmm1, 1010b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -393,7 +359,6 @@
     },
     "blendps xmm0, xmm1, 1011b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -404,7 +369,6 @@
     },
     "blendps xmm0, xmm1, 1100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -414,7 +378,6 @@
     },
     "blendps xmm0, xmm1, 1101b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -425,7 +388,6 @@
     },
     "blendps xmm0, xmm1, 1110b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -436,7 +398,6 @@
     },
     "blendps xmm0, xmm1, 1111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0c"
       ],
@@ -446,7 +407,6 @@
     },
     "blendpd xmm0, xmm1, 00b": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0d"
       ],
@@ -454,7 +414,6 @@
     },
     "blendpd xmm0, xmm1, 01b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0d"
       ],
@@ -464,7 +423,6 @@
     },
     "blendpd xmm0, xmm1, 10b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0d"
       ],
@@ -474,7 +432,6 @@
     },
     "blendpd xmm0, xmm1, 11b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0d"
       ],
@@ -484,7 +441,6 @@
     },
     "pblendw xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
@@ -492,7 +448,6 @@
     },
     "pblendw xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
@@ -502,7 +457,6 @@
     },
     "pblendw xmm0, xmm1, 11010111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
@@ -514,7 +468,6 @@
     },
     "pblendw xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
@@ -524,7 +477,6 @@
     },
     "pblendw xmm0, xmm1, 00001100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
@@ -534,7 +486,6 @@
     },
     "pblendw xmm0, xmm1, 00110000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
@@ -544,7 +495,6 @@
     },
     "pblendw xmm0, xmm1, 11000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
@@ -554,7 +504,6 @@
     },
     "pblendw xmm0, xmm1, 00001111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
@@ -564,7 +513,6 @@
     },
     "pblendw xmm0, xmm1, 11110000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
@@ -574,7 +522,6 @@
     },
     "pblendw xmm0, xmm1, 11111111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0e"
       ],
@@ -584,7 +531,6 @@
     },
     "palignr xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0f"
       ],
@@ -594,7 +540,6 @@
     },
     "palignr xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0f"
       ],
@@ -604,7 +549,6 @@
     },
     "palignr xmm0, xmm1, 255": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x0f"
       ],
@@ -614,7 +558,6 @@
     },
     "pextrb eax, xmm0, 0000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x14"
       ],
@@ -624,7 +567,6 @@
     },
     "pextrb eax, xmm0, 1111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x14"
       ],
@@ -634,7 +576,6 @@
     },
     "pextrw eax, xmm0, 000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x15"
       ],
@@ -644,7 +585,6 @@
     },
     "pextrw eax, xmm0, 111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x15"
       ],
@@ -654,7 +594,6 @@
     },
     "pextrd eax, xmm0, 00b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x16"
       ],
@@ -664,7 +603,6 @@
     },
     "pextrd eax, xmm0, 11b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x16"
       ],
@@ -674,7 +612,6 @@
     },
     "pextrq rax, xmm0, 0b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 REX.W 0x0f 0x3a 0x16"
       ],
@@ -684,7 +621,6 @@
     },
     "pextrq rax, xmm0, 1b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 REX.W 0x0f 0x3a 0x16"
       ],
@@ -694,7 +630,6 @@
     },
     "pextrb [rax], xmm0, 0000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x14"
       ],
@@ -704,7 +639,6 @@
     },
     "pextrb [rax], xmm0, 1111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x14"
       ],
@@ -714,7 +648,6 @@
     },
     "pextrw [rax], xmm0, 000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x15"
       ],
@@ -724,7 +657,6 @@
     },
     "pextrw [rax], xmm0, 111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x15"
       ],
@@ -734,7 +666,6 @@
     },
     "pextrd [rax], xmm0, 00b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x16"
       ],
@@ -744,7 +675,6 @@
     },
     "pextrd [rax], xmm0, 11b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x16"
       ],
@@ -754,7 +684,6 @@
     },
     "pextrq [rax], xmm0, 0b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 REX.W 0x0f 0x3a 0x16"
       ],
@@ -764,7 +693,6 @@
     },
     "pextrq [rax], xmm0, 1b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 REX.W 0x0f 0x3a 0x16"
       ],
@@ -774,7 +702,6 @@
     },
     "extractps eax, xmm0, 00b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x17"
       ],
@@ -784,7 +711,6 @@
     },
     "extractps eax, xmm0, 11b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x17"
       ],
@@ -794,7 +720,6 @@
     },
     "pinsrb xmm0, eax, 0000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
@@ -804,7 +729,6 @@
     },
     "pinsrb xmm0, eax, 0001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
@@ -814,7 +738,6 @@
     },
     "pinsrb xmm0, eax, 1111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
@@ -824,7 +747,6 @@
     },
     "pinsrb xmm0, [rax], 0000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
@@ -834,7 +756,6 @@
     },
     "pinsrb xmm0, [rax], 0001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
@@ -844,7 +765,6 @@
     },
     "pinsrb xmm0, [rax], 1111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x20"
       ],
@@ -854,7 +774,6 @@
     },
     "insertps xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x21"
       ],
@@ -864,7 +783,6 @@
     },
     "insertps xmm0, xmm1, 00001111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x21"
       ],
@@ -874,7 +792,6 @@
     },
     "insertps xmm0, xmm1, 00010000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x21"
       ],
@@ -884,7 +801,6 @@
     },
     "pinsrd xmm0, eax, 00b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
@@ -894,7 +810,6 @@
     },
     "pinsrd xmm0, eax, 01b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
@@ -904,7 +819,6 @@
     },
     "pinsrd xmm0, eax, 11b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
@@ -914,7 +828,6 @@
     },
     "pinsrq xmm0, rax, 0b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 REX.W 0x0f 0x3a 0x22"
       ],
@@ -924,7 +837,6 @@
     },
     "pinsrq xmm0, rax, 1b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 REX.W 0x0f 0x3a 0x22"
       ],
@@ -934,7 +846,6 @@
     },
     "pinsrd xmm0, [rax], 00b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
@@ -944,7 +855,6 @@
     },
     "pinsrd xmm0, [rax], 01b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
@@ -954,7 +864,6 @@
     },
     "pinsrd xmm0, [rax], 11b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x22"
       ],
@@ -964,7 +873,6 @@
     },
     "pinsrq xmm0, [rax], 0b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 REX.W 0x0f 0x3a 0x22"
       ],
@@ -974,7 +882,6 @@
     },
     "pinsrq xmm0, [rax], 1b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 REX.W 0x0f 0x3a 0x22"
       ],
@@ -984,7 +891,6 @@
     },
     "dpps xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -994,7 +900,6 @@
     },
     "dpps xmm0, xmm1, 00001111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1004,7 +909,6 @@
     },
     "dpps xmm0, xmm1, 11110000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1014,7 +918,6 @@
     },
     "dpps xmm0, xmm1, 11110001b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1028,7 +931,6 @@
     },
     "dpps xmm0, xmm1, 11110010b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1042,7 +944,6 @@
     },
     "dpps xmm0, xmm1, 11110011b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1055,7 +956,6 @@
     },
     "dpps xmm0, xmm1, 11110100b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1069,7 +969,6 @@
     },
     "dpps xmm0, xmm1, 11110101b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1082,7 +981,6 @@
     },
     "dpps xmm0, xmm1, 11110110b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1098,7 +996,6 @@
     },
     "dpps xmm0, xmm1, 11110111b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1114,7 +1011,6 @@
     },
     "dpps xmm0, xmm1, 11111000b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1128,7 +1024,6 @@
     },
     "dpps xmm0, xmm1, 11111001b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1144,7 +1039,6 @@
     },
     "dpps xmm0, xmm1, 11111010b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1159,7 +1053,6 @@
     },
     "dpps xmm0, xmm1, 11111011b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1175,7 +1068,6 @@
     },
     "dpps xmm0, xmm1, 11111100b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1190,7 +1082,6 @@
     },
     "dpps xmm0, xmm1, 11111101b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1206,7 +1097,6 @@
     },
     "dpps xmm0, xmm1, 11111110b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1222,7 +1112,6 @@
     },
     "dpps xmm0, xmm1, 11111111b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -1235,7 +1124,6 @@
     },
     "dppd xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x41"
       ],
@@ -1245,7 +1133,6 @@
     },
     "dppd xmm0, xmm1, 00001111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x41"
       ],
@@ -1255,7 +1142,6 @@
     },
     "dppd xmm0, xmm1, 11110000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x41"
       ],
@@ -1265,7 +1151,6 @@
     },
     "dppd xmm0, xmm1, 11111111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x41"
       ],
@@ -1277,7 +1162,6 @@
     },
     "mpsadbw xmm0, xmm1, 000b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x42"
       ],
@@ -1300,7 +1184,6 @@
     },
     "mpsadbw xmm0, xmm1, 001b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x42"
       ],
@@ -1323,7 +1206,6 @@
     },
     "mpsadbw xmm0, xmm1, 010b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x42"
       ],
@@ -1346,7 +1228,6 @@
     },
     "mpsadbw xmm0, xmm1, 011b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x42"
       ],
@@ -1369,7 +1250,6 @@
     },
     "mpsadbw xmm0, xmm1, 100b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x42"
       ],
@@ -1392,7 +1272,6 @@
     },
     "mpsadbw xmm0, xmm1, 101b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x42"
       ],
@@ -1415,7 +1294,6 @@
     },
     "mpsadbw xmm0, xmm1, 110b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x42"
       ],
@@ -1438,7 +1316,6 @@
     },
     "mpsadbw xmm0, xmm1, 111b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x42"
       ],
@@ -1461,7 +1338,6 @@
     },
     "pclmulqdq xmm0, xmm1, 00000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x44"
       ],
@@ -1471,7 +1347,6 @@
     },
     "pclmulqdq xmm0, xmm1, 00001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x44"
       ],
@@ -1482,7 +1357,6 @@
     },
     "pclmulqdq xmm0, xmm1, 10000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x44"
       ],
@@ -1493,7 +1367,6 @@
     },
     "pclmulqdq xmm0, xmm1, 10001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x44"
       ],
@@ -1503,7 +1376,6 @@
     },
     "sha1rnds4 xmm0, xmm1, 00b": {
       "ExpectedInstructionCount": 59,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0xcc"
       ],
@@ -1571,7 +1443,6 @@
     },
     "sha1rnds4 xmm0, xmm1, 01b": {
       "ExpectedInstructionCount": 55,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0xcc"
       ],
@@ -1635,7 +1506,6 @@
     },
     "sha1rnds4 xmm0, xmm1, 10b": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0xcc"
       ],
@@ -1711,7 +1581,6 @@
     },
     "sha1rnds4 xmm0, xmm1, 11b": {
       "ExpectedInstructionCount": 55,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0xcc"
       ],
@@ -1775,7 +1644,6 @@
     },
     "aeskeygenassist xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0xdf"
       ],
@@ -1789,7 +1657,6 @@
     },
     "aeskeygenassist xmm0, xmm1, 0xFF": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0xdf"
       ],

--- a/unittests/InstructionCountCI/H0F3A_SVE128.json
+++ b/unittests/InstructionCountCI/H0F3A_SVE128.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "dpps xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -22,7 +21,6 @@
     },
     "dpps xmm0, xmm1, 00001111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -32,7 +30,6 @@
     },
     "dpps xmm0, xmm1, 11110000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -42,7 +39,6 @@
     },
     "dpps xmm0, xmm1, 11110001b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -55,7 +51,6 @@
     },
     "dpps xmm0, xmm1, 11110010b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -68,7 +63,6 @@
     },
     "dpps xmm0, xmm1, 11110011b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -80,7 +74,6 @@
     },
     "dpps xmm0, xmm1, 11110100b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -93,7 +86,6 @@
     },
     "dpps xmm0, xmm1, 11110101b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -105,7 +97,6 @@
     },
     "dpps xmm0, xmm1, 11110110b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -120,7 +111,6 @@
     },
     "dpps xmm0, xmm1, 11110111b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -135,7 +125,6 @@
     },
     "dpps xmm0, xmm1, 11111000b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -148,7 +137,6 @@
     },
     "dpps xmm0, xmm1, 11111001b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -163,7 +151,6 @@
     },
     "dpps xmm0, xmm1, 11111010b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -177,7 +164,6 @@
     },
     "dpps xmm0, xmm1, 11111011b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -192,7 +178,6 @@
     },
     "dpps xmm0, xmm1, 11111100b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -206,7 +191,6 @@
     },
     "dpps xmm0, xmm1, 11111101b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -221,7 +205,6 @@
     },
     "dpps xmm0, xmm1, 11111110b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -236,7 +219,6 @@
     },
     "dpps xmm0, xmm1, 11111111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x40"
       ],
@@ -248,7 +230,6 @@
     },
     "dppd xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x41"
       ],
@@ -258,7 +239,6 @@
     },
     "dppd xmm0, xmm1, 00001111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x41"
       ],
@@ -268,7 +248,6 @@
     },
     "dppd xmm0, xmm1, 11110000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x41"
       ],
@@ -278,7 +257,6 @@
     },
     "dppd xmm0, xmm1, 11111111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x66 0x0f 0x3a 0x41"
       ],

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "add bl, cl": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0x00",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -36,7 +35,6 @@
     },
     "add bx, cx": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -60,7 +58,6 @@
     },
     "add ebx, ecx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -73,7 +70,6 @@
     },
     "add rbx, rcx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x01",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -86,7 +82,6 @@
     },
     "db 0x02, 0xcb": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "0x02",
         "add bl, cl but modrm.rm as source"
@@ -113,7 +108,6 @@
     },
     "db 0x66, 0x03, 0xcb": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "0x03",
         "add bx, cx but modrm.rm as source"
@@ -140,7 +134,6 @@
     },
     "db 0x03, 0xcb": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x03",
         "add ebx, ecx but modrm.rm as source"
@@ -156,7 +149,6 @@
     },
     "db 0x48, 0x03, 0xcb": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0x03",
         "add rbx, rcx but modrm.rm as source"
@@ -172,7 +164,6 @@
     },
     "add al, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x04",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -192,7 +183,6 @@
     },
     "add ax, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -212,7 +202,6 @@
     },
     "add eax, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -224,7 +213,6 @@
     },
     "add rax, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -236,7 +224,6 @@
     },
     "add al, -1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x04",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -257,7 +244,6 @@
     },
     "add ax, -1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -279,7 +265,6 @@
     },
     "add eax, -1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -293,7 +278,6 @@
     },
     "add rax, -1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -307,7 +291,6 @@
     },
     "or bl, bh": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "",
       "ExpectedArm64ASM": [
         "lsr w20, w7, #8",
@@ -319,7 +302,6 @@
     },
     "or bl, cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x08",
       "ExpectedArm64ASM": [
         "orr w20, w7, w5",
@@ -330,7 +312,6 @@
     },
     "or bx, cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "orr w20, w7, w5",
@@ -341,7 +322,6 @@
     },
     "or ebx, ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "orr w7, w7, w5",
@@ -351,7 +331,6 @@
     },
     "or rbx, rcx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "orr x7, x7, x5",
@@ -361,7 +340,6 @@
     },
     "db 0x0A, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x0A",
         "or bl, cl but modrm.rm as source"
@@ -375,7 +353,6 @@
     },
     "db 0x66, 0x0B, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x0B",
         "or bx, cx but modrm.rm as source"
@@ -389,7 +366,6 @@
     },
     "db 0x0B, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x0B",
         "or ebx, ecx but modrm.rm as source"
@@ -402,7 +378,6 @@
     },
     "db 0x48, 0x0B, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x0B",
         "or rbx, rcx but modrm.rm as source"
@@ -415,7 +390,6 @@
     },
     "or al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0C",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0x1",
@@ -426,7 +400,6 @@
     },
     "or ax, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0x1",
@@ -437,7 +410,6 @@
     },
     "or eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x1",
@@ -447,7 +419,6 @@
     },
     "or rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x1",
@@ -457,7 +428,6 @@
     },
     "or al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0C",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0xff",
@@ -468,7 +438,6 @@
     },
     "or ax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0xffff",
@@ -479,7 +448,6 @@
     },
     "or eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -490,7 +458,6 @@
     },
     "or rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -501,7 +468,6 @@
     },
     "adc bl, cl": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "0x10",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -533,7 +499,6 @@
     },
     "adc bx, cx": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -565,7 +530,6 @@
     },
     "adc ebx, ecx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -581,7 +545,6 @@
     },
     "adc rbx, rcx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x11",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -596,7 +559,6 @@
     },
     "db 0x12, 0xcb": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": [
         "0x12",
         "adc bl, cl but modrm.rm as source"
@@ -631,7 +593,6 @@
     },
     "db 0x66, 0x13, 0xcb": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": [
         "0x13",
         "adc bx, cx but modrm.rm as source"
@@ -666,7 +627,6 @@
     },
     "db 0x13, 0xcb": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0x13",
         "adc ebx, ecx but modrm.rm as source"
@@ -685,7 +645,6 @@
     },
     "db 0x48, 0x13, 0xcb": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0x13",
         "adc rbx, rcx but modrm.rm as source"
@@ -703,7 +662,6 @@
     },
     "adc al, 1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x14",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -732,7 +690,6 @@
     },
     "adc ax, 1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -761,7 +718,6 @@
     },
     "adc eax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -776,7 +732,6 @@
     },
     "adc rax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -791,7 +746,6 @@
     },
     "adc al, -1": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "0x14",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -821,7 +775,6 @@
     },
     "adc ax, -1": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -851,7 +804,6 @@
     },
     "adc eax, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -867,7 +819,6 @@
     },
     "adc rax, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x15",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -883,7 +834,6 @@
     },
     "sbb bl, cl": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "0x18",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -915,7 +865,6 @@
     },
     "sbb bx, cx": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -947,7 +896,6 @@
     },
     "sbb ebx, ecx": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -969,7 +917,6 @@
     },
     "sbb rbx, rcx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x19",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -990,7 +937,6 @@
     },
     "db 0x1A, 0xcb": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": [
         "0x1A",
         "sbb bl, cl but modrm.rm as source"
@@ -1025,7 +971,6 @@
     },
     "db 0x66, 0x1B, 0xcb": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": [
         "0x1B",
         "sbb bx, cx but modrm.rm as source"
@@ -1060,7 +1005,6 @@
     },
     "db 0x1B, 0xcb": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0x1B",
         "sbb ebx, ecx but modrm.rm as source"
@@ -1085,7 +1029,6 @@
     },
     "db 0x48, 0x1B, 0xcb": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0x1B",
         "sbb rbx, rcx but modrm.rm as source"
@@ -1109,7 +1052,6 @@
     },
     "sbb al, 1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x1C",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1138,7 +1080,6 @@
     },
     "sbb ax, 1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1167,7 +1108,6 @@
     },
     "sbb eax, 1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1188,7 +1128,6 @@
     },
     "sbb rax, 1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1209,7 +1148,6 @@
     },
     "sbb al, -1": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "0x1C",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -1239,7 +1177,6 @@
     },
     "sbb ax, -1": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1269,7 +1206,6 @@
     },
     "sbb eax, -1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1291,7 +1227,6 @@
     },
     "sbb rax, -1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0x1D",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1313,7 +1248,6 @@
     },
     "and bl, cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x20",
       "ExpectedArm64ASM": [
         "and w20, w7, w5",
@@ -1324,7 +1258,6 @@
     },
     "and bx, cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
         "and w20, w7, w5",
@@ -1335,7 +1268,6 @@
     },
     "and ebx, ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
         "and w7, w7, w5",
@@ -1345,7 +1277,6 @@
     },
     "and rbx, rcx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x21",
       "ExpectedArm64ASM": [
         "and x7, x7, x5",
@@ -1355,7 +1286,6 @@
     },
     "db 0x22, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x22",
         "and bl, cl but modrm.rm as source"
@@ -1369,7 +1299,6 @@
     },
     "db 0x66, 0x23, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x23",
         "and bx, cx but modrm.rm as source"
@@ -1383,7 +1312,6 @@
     },
     "db 0x23, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x23",
         "and ebx, ecx but modrm.rm as source"
@@ -1396,7 +1324,6 @@
     },
     "db 0x48, 0x23, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x23",
         "and rbx, rcx but modrm.rm as source"
@@ -1409,7 +1336,6 @@
     },
     "and al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x24",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -1420,7 +1346,6 @@
     },
     "and ax, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -1431,7 +1356,6 @@
     },
     "and eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "and w4, w4, #0x1",
@@ -1441,7 +1365,6 @@
     },
     "and rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "and x4, x4, #0x1",
@@ -1451,7 +1374,6 @@
     },
     "and al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x24",
       "ExpectedArm64ASM": [
         "and w20, w4, #0xff",
@@ -1462,7 +1384,6 @@
     },
     "and ax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "and w20, w4, #0xffff",
@@ -1473,7 +1394,6 @@
     },
     "and eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1484,7 +1404,6 @@
     },
     "and rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x25",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1495,7 +1414,6 @@
     },
     "sub bl, cl": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0x28",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -1519,7 +1437,6 @@
     },
     "sub bx, cx": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -1543,7 +1460,6 @@
     },
     "sub ebx, ecx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -1559,7 +1475,6 @@
     },
     "sub rbx, rcx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x29",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -1575,7 +1490,6 @@
     },
     "db 0x2A, 0xcb": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "0x2A",
         "sub bl, cl but modrm.rm as source"
@@ -1602,7 +1516,6 @@
     },
     "db 0x66, 0x2B, 0xcb": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "0x2B",
         "sub bx, cx but modrm.rm as source"
@@ -1629,7 +1542,6 @@
     },
     "db 0x2B, 0xcb": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0x2B",
         "sub ebx, ecx but modrm.rm as source"
@@ -1648,7 +1560,6 @@
     },
     "db 0x48, 0x2B, 0xcb": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0x2B",
         "sub rbx, rcx but modrm.rm as source"
@@ -1667,7 +1578,6 @@
     },
     "sub al, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x2C",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1687,7 +1597,6 @@
     },
     "sub ax, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1707,7 +1616,6 @@
     },
     "sub eax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1722,7 +1630,6 @@
     },
     "sub rax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1737,7 +1644,6 @@
     },
     "sub al, -1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x2C",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1758,7 +1664,6 @@
     },
     "sub ax, -1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1780,7 +1685,6 @@
     },
     "sub eax, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1797,7 +1701,6 @@
     },
     "sub rax, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1814,7 +1717,6 @@
     },
     "xor bl, cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x30",
       "ExpectedArm64ASM": [
         "eor w20, w7, w5",
@@ -1825,7 +1727,6 @@
     },
     "xor bx, cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "eor w20, w7, w5",
@@ -1836,7 +1737,6 @@
     },
     "xor ebx, ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "eor w7, w7, w5",
@@ -1846,7 +1746,6 @@
     },
     "xor rbx, rcx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "eor x7, x7, x5",
@@ -1856,7 +1755,6 @@
     },
     "db 0x32, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x32",
         "xor bl, cl but modrm.rm as source"
@@ -1870,7 +1768,6 @@
     },
     "db 0x66, 0x33, 0xcb": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0x33",
         "xor bx, cx but modrm.rm as source"
@@ -1884,7 +1781,6 @@
     },
     "db 0x33, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x33",
         "xor ebx, ecx but modrm.rm as source"
@@ -1897,7 +1793,6 @@
     },
     "db 0x48, 0x33, 0xcb": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "0x33",
         "xor rbx, rcx but modrm.rm as source"
@@ -1910,7 +1805,6 @@
     },
     "xor al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x34",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0x1",
@@ -1921,7 +1815,6 @@
     },
     "xor ax, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0x1",
@@ -1932,7 +1825,6 @@
     },
     "xor eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x1",
@@ -1942,7 +1834,6 @@
     },
     "xor rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x1",
@@ -1952,7 +1843,6 @@
     },
     "cmp bl, cl": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0x38",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -1975,7 +1865,6 @@
     },
     "xor al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x34",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0xff",
@@ -1986,7 +1875,6 @@
     },
     "xor ax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0xffff",
@@ -1997,7 +1885,6 @@
     },
     "xor eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -2008,7 +1895,6 @@
     },
     "xor rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -2019,7 +1905,6 @@
     },
     "cmp bx, cx": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "0x39",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -2042,7 +1927,6 @@
     },
     "cmp ebx, ecx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x39",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -2059,7 +1943,6 @@
     },
     "cmp rbx, rcx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "0x39",
       "ExpectedArm64ASM": [
         "sub x20, x7, x5",
@@ -2074,7 +1957,6 @@
     },
     "db 0x3A, 0xcb": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0x3A",
         "cmp bl, cl but modrm.rm as source"
@@ -2100,7 +1982,6 @@
     },
     "db 0x66, 0x3B, 0xcb": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0x3B",
         "cmp bx, cx but modrm.rm as source"
@@ -2126,7 +2007,6 @@
     },
     "db 0x3B, 0xcb": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0x3B",
         "cmp ebx, ecx but modrm.rm as source"
@@ -2146,7 +2026,6 @@
     },
     "db 0x48, 0x3B, 0xcb": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": [
         "0x3B",
         "cmp rbx, rcx but modrm.rm as source"
@@ -2164,7 +2043,6 @@
     },
     "cmp al, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x3C",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2183,7 +2061,6 @@
     },
     "cmp ax, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2202,7 +2079,6 @@
     },
     "cmp eax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2217,7 +2093,6 @@
     },
     "cmp rax, 1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "sub x20, x4, #0x1 (1)",
@@ -2231,7 +2106,6 @@
     },
     "cmp al, -1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x3C",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2251,7 +2125,6 @@
     },
     "cmp ax, -1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -2272,7 +2145,6 @@
     },
     "cmp eax, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -2289,7 +2161,6 @@
     },
     "cmp rax, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Yes",
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -2305,7 +2176,6 @@
     },
     "push ax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x50",
       "ExpectedArm64ASM": [
         "strh w4, [x8, #-2]!"
@@ -2313,7 +2183,6 @@
     },
     "push rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x50",
       "ExpectedArm64ASM": [
         "str x4, [x8, #-8]!"
@@ -2321,7 +2190,6 @@
     },
     "pop ax": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x8f",
       "ExpectedArm64ASM": [
         "ldrh w20, [x8]",
@@ -2331,7 +2199,6 @@
     },
     "pop rax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x8f",
       "ExpectedArm64ASM": [
         "ldr x4, [x8]",
@@ -2340,7 +2207,6 @@
     },
     "movsxd rax, ebx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x63",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2349,7 +2215,6 @@
     },
     "push word 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x68",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -2358,7 +2223,6 @@
     },
     "push qword 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x68",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -2367,7 +2231,6 @@
     },
     "imul ax, bx, 257": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x69",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2386,7 +2249,6 @@
     },
     "imul eax, ebx, 257": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x69",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2405,7 +2267,6 @@
     },
     "imul rax, rbx, 257": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x69",
       "ExpectedArm64ASM": [
         "mov w20, #0x101",
@@ -2421,7 +2282,6 @@
     },
     "push word -1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x6a",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -2430,7 +2290,6 @@
     },
     "push dword -1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x6a",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -2439,7 +2298,6 @@
     },
     "push qword -1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x6a",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -2448,7 +2306,6 @@
     },
     "imul ax, bx, 3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x6b",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2467,7 +2324,6 @@
     },
     "imul eax, ebx, 3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x6b",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2486,7 +2342,6 @@
     },
     "imul rax, rbx, 3": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x6b",
       "ExpectedArm64ASM": [
         "mov w20, #0x3",
@@ -2502,7 +2357,6 @@
     },
     "test al, bl": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x84",
       "ExpectedArm64ASM": [
         "and w20, w4, w7",
@@ -2512,7 +2366,6 @@
     },
     "test ax, bx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x84",
       "ExpectedArm64ASM": [
         "and w20, w4, w7",
@@ -2522,7 +2375,6 @@
     },
     "test eax, ebx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x84",
       "ExpectedArm64ASM": [
         "and w20, w4, w7",
@@ -2532,7 +2384,6 @@
     },
     "test rax, rbx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x84",
       "ExpectedArm64ASM": [
         "and x20, x4, x7",
@@ -2542,7 +2393,6 @@
     },
     "xchg bl, cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x86",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2553,7 +2403,6 @@
     },
     "xchg [rax], cl": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x86",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -2564,7 +2413,6 @@
     },
     "xchg bx, cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2575,7 +2423,6 @@
     },
     "xchg [rax], cx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -2586,7 +2433,6 @@
     },
     "xchg ebx, ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2596,7 +2442,6 @@
     },
     "xchg [rax], ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -2606,7 +2451,6 @@
     },
     "xchg rbx, rcx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -2616,7 +2460,6 @@
     },
     "xchg [rax], rcx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x87",
       "ExpectedArm64ASM": [
         "mov x1, x5",
@@ -2625,7 +2468,6 @@
     },
     "mov [rax], bl": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x88",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2634,7 +2476,6 @@
     },
     "mov [rax], bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x89",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2643,7 +2484,6 @@
     },
     "mov [rax], ebx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x89",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2652,7 +2492,6 @@
     },
     "mov [rax], rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x89",
       "ExpectedArm64ASM": [
         "str x7, [x4]"
@@ -2660,7 +2499,6 @@
     },
     "mov bl, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x8a",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -2669,7 +2507,6 @@
     },
     "mov bx, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x8b",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
@@ -2678,7 +2515,6 @@
     },
     "mov ebx, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8b",
       "ExpectedArm64ASM": [
         "ldr w7, [x4]"
@@ -2686,7 +2522,6 @@
     },
     "mov rbx, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8b",
       "ExpectedArm64ASM": [
         "ldr x7, [x4]"
@@ -2694,7 +2529,6 @@
     },
     "mov ax, cs": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #138]",
@@ -2703,7 +2537,6 @@
     },
     "mov eax, cs": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w4, [x28, #138]"
@@ -2711,7 +2544,6 @@
     },
     "mov rax, cs": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w4, [x28, #138]"
@@ -2719,7 +2551,6 @@
     },
     "mov ax, es": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #136]",
@@ -2728,7 +2559,6 @@
     },
     "mov eax, es": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w4, [x28, #136]"
@@ -2736,7 +2566,6 @@
     },
     "mov rax, es": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w4, [x28, #136]"
@@ -2744,7 +2573,6 @@
     },
     "mov ax, ss": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #140]",
@@ -2753,7 +2581,6 @@
     },
     "mov eax, ss": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w4, [x28, #140]"
@@ -2761,7 +2588,6 @@
     },
     "mov rax, ss": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w4, [x28, #140]"
@@ -2769,7 +2595,6 @@
     },
     "mov ax, ds": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #142]",
@@ -2778,7 +2603,6 @@
     },
     "mov eax, ds": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w4, [x28, #142]"
@@ -2786,7 +2610,6 @@
     },
     "mov rax, ds": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "ldrh w4, [x28, #142]"
@@ -2794,7 +2617,6 @@
     },
     "mov ax, gs": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "and x4, x4, #0xffffffffffff0000"
@@ -2802,7 +2624,6 @@
     },
     "mov eax, gs": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "mov w4, #0x0"
@@ -2810,7 +2631,6 @@
     },
     "mov rax, gs": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "mov w4, #0x0"
@@ -2818,7 +2638,6 @@
     },
     "mov ax, fs": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "and x4, x4, #0xffffffffffff0000"
@@ -2826,7 +2645,6 @@
     },
     "mov eax, fs": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "mov w4, #0x0"
@@ -2834,7 +2652,6 @@
     },
     "mov rax, fs": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8c",
       "ExpectedArm64ASM": [
         "mov w4, #0x0"
@@ -2842,7 +2659,6 @@
     },
     "lea ax, [rbx+rcx*1 + 0]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "add x20, x5, x7",
@@ -2851,7 +2667,6 @@
     },
     "lea eax, [rbx+rcx*1 + 0]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "add x20, x5, x7",
@@ -2861,7 +2676,6 @@
     },
     "lea rax, [rbx+rcx*1 + 0]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "add x4, x5, x7"
@@ -2869,7 +2683,6 @@
     },
     "lea ax, [rbx+rcx*2 + 0]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "lsl x20, x5, #1",
@@ -2879,7 +2692,6 @@
     },
     "lea eax, [rbx+rcx*2 + 0]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "lsl x20, x5, #1",
@@ -2890,7 +2702,6 @@
     },
     "lea rax, [rbx+rcx*2 + 0]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "lsl x20, x5, #1",
@@ -2899,7 +2710,6 @@
     },
     "lea ax, [rbx+rcx*4 + 0]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "lsl x20, x5, #2",
@@ -2909,7 +2719,6 @@
     },
     "lea eax, [rbx+rcx*4 + 0]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "lsl x20, x5, #2",
@@ -2920,7 +2729,6 @@
     },
     "lea rax, [rbx+rcx*4 + 0]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "lsl x20, x5, #2",
@@ -2929,7 +2737,6 @@
     },
     "lea ax, [rbx+rcx*8 + 0]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "lsl x20, x5, #3",
@@ -2939,7 +2746,6 @@
     },
     "lea eax, [rbx+rcx*8 + 0]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "lsl x20, x5, #3",
@@ -2950,7 +2756,6 @@
     },
     "lea rax, [rbx+rcx*8 + 0]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
         "lsl x20, x5, #3",
@@ -2959,13 +2764,11 @@
     },
     "mov cs, ax": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": "0x8e"
     },
     "mov es, ax": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x8e",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2978,7 +2781,6 @@
     },
     "mov ss, ax": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x8e",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2991,7 +2793,6 @@
     },
     "mov ds, ax": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x8e",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3004,19 +2805,16 @@
     },
     "mov gs, ax": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": "0x8e"
     },
     "mov fs, ax": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": "0x8e"
     },
     "pop word [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x8f",
       "ExpectedArm64ASM": [
         "ldrh w20, [x8]",
@@ -3026,7 +2824,6 @@
     },
     "pop qword [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x8f",
       "ExpectedArm64ASM": [
         "ldr x20, [x8]",
@@ -3036,7 +2833,6 @@
     },
     "xchg ax, bx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x90",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3047,7 +2843,6 @@
     },
     "xchg eax, ebx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x90",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3057,7 +2852,6 @@
     },
     "xchg rax, rbx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x90",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3067,13 +2861,11 @@
     },
     "nop": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x90",
       "ExpectedArm64ASM": []
     },
     "cbw": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x98",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3083,7 +2875,6 @@
     },
     "cwde": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x98",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3093,7 +2884,6 @@
     },
     "cdqe": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x98",
       "ExpectedArm64ASM": [
         "sxtw x4, w4"
@@ -3101,7 +2891,6 @@
     },
     "cwd": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x98",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3111,7 +2900,6 @@
     },
     "cdq": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x98",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3121,7 +2909,6 @@
     },
     "cqo": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x98",
       "ExpectedArm64ASM": [
         "asr x6, x4, #63"
@@ -3129,13 +2916,11 @@
     },
     "fwait": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x9b",
       "ExpectedArm64ASM": []
     },
     "pushf": {
       "ExpectedInstructionCount": 41,
-      "Optimal": "No",
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -3183,7 +2968,6 @@
     },
     "pushfq": {
       "ExpectedInstructionCount": 41,
-      "Optimal": "No",
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -3231,7 +3015,6 @@
     },
     "popf": {
       "ExpectedInstructionCount": 39,
-      "Optimal": "No",
       "Comment": "0x9d",
       "ExpectedArm64ASM": [
         "ldr x20, [x8]",
@@ -3277,7 +3060,6 @@
     },
     "sahf": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0x9e",
       "ExpectedArm64ASM": [
         "ubfx w20, w4, #8, #8",
@@ -3304,7 +3086,6 @@
     },
     "lahf": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "Yes",
       "Comment": "0x9f",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -3328,7 +3109,6 @@
     },
     "db 0x48, 0xa1; dq 0x00000000e0000008": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "mov rax, [0xe0000008]",
         "0xa1"
@@ -3343,7 +3123,6 @@
     },
     "db 0x67, 0xa1; dd 0xe0000000": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "mov eax, [0xe0000000]",
         "0xa1"
@@ -3356,7 +3135,6 @@
     },
     "db 0x48, 0xa3; dq 0x00000000e0000008": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "mov [0xe0000008], rax",
         "0xa3"
@@ -3371,7 +3149,6 @@
     },
     "db 0x67, 0xa3; dd 0xe0000000": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "mov [0xe0000000], eax",
         "0xa3"
@@ -3385,7 +3162,6 @@
     },
     "movsb": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xa4"
       ],
@@ -3401,7 +3177,6 @@
     },
     "movsw": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xa5"
       ],
@@ -3417,7 +3192,6 @@
     },
     "movsd": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xa5"
       ],
@@ -3433,7 +3207,6 @@
     },
     "movsq": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xa5"
       ],
@@ -3449,7 +3222,6 @@
     },
     "rep movsb": {
       "ExpectedInstructionCount": 29,
-      "Optimal": "No",
       "Comment": "0xa4",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3485,7 +3257,6 @@
     },
     "rep movsw": {
       "ExpectedInstructionCount": 29,
-      "Optimal": "No",
       "Comment": "0xa5",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3521,7 +3292,6 @@
     },
     "rep movsd": {
       "ExpectedInstructionCount": 29,
-      "Optimal": "No",
       "Comment": "0xa5",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3557,7 +3327,6 @@
     },
     "rep movsq": {
       "ExpectedInstructionCount": 29,
-      "Optimal": "No",
       "Comment": "0xa5",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3593,7 +3362,6 @@
     },
     "cmpsb": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": [
         "0xa6"
       ],
@@ -3623,7 +3391,6 @@
     },
     "cmpsw": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": [
         "0xa7"
       ],
@@ -3653,7 +3420,6 @@
     },
     "cmpsd": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xa7"
       ],
@@ -3677,7 +3443,6 @@
     },
     "cmpsq": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xa7"
       ],
@@ -3701,7 +3466,6 @@
     },
     "repz cmpsb": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "0xa6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3733,7 +3497,6 @@
     },
     "repz cmpsw": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3765,7 +3528,6 @@
     },
     "repz cmpsd": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3791,7 +3553,6 @@
     },
     "repz cmpsq": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3817,7 +3578,6 @@
     },
     "repnz cmpsb": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "0xa6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3849,7 +3609,6 @@
     },
     "repnz cmpsw": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3881,7 +3640,6 @@
     },
     "repnz cmpsd": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3907,7 +3665,6 @@
     },
     "repnz cmpsq": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -3933,7 +3690,6 @@
     },
     "test al, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa8",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -3943,7 +3699,6 @@
     },
     "test ax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -3953,7 +3708,6 @@
     },
     "test eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -3963,7 +3717,6 @@
     },
     "test rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "and x20, x4, #0x1",
@@ -3973,7 +3726,6 @@
     },
     "test al, -1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa8",
       "ExpectedArm64ASM": [
         "and w20, w4, #0xff",
@@ -3983,7 +3735,6 @@
     },
     "test ax, -1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "and w20, w4, #0xffff",
@@ -3993,7 +3744,6 @@
     },
     "test eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -4004,7 +3754,6 @@
     },
     "test rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0xa9",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -4015,7 +3764,6 @@
     },
     "stosb": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0xaa",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -4028,7 +3776,6 @@
     },
     "stosw": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0xab",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -4041,7 +3788,6 @@
     },
     "stosd": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0xab",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -4054,7 +3800,6 @@
     },
     "stosq": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0xab",
       "ExpectedArm64ASM": [
         "str x4, [x11]",
@@ -4066,7 +3811,6 @@
     },
     "rep stosb": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0xaa",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -4090,7 +3834,6 @@
     },
     "rep stosw": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0xab",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -4114,7 +3857,6 @@
     },
     "rep stosd": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0xab",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -4138,7 +3880,6 @@
     },
     "rep stosq": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "Yes",
       "Comment": [
         "Unrolling the loop for faster memset can be done.",
         "Taking advantage of ARM MOPs instructions can be done",
@@ -4165,7 +3906,6 @@
     },
     "lodsb": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0xac",
       "ExpectedArm64ASM": [
         "ldrb w20, [x10]",
@@ -4178,7 +3918,6 @@
     },
     "lodsw": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0xad",
       "ExpectedArm64ASM": [
         "ldrh w20, [x10]",
@@ -4191,7 +3930,6 @@
     },
     "lodsd": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0xad",
       "ExpectedArm64ASM": [
         "ldr w4, [x10]",
@@ -4203,7 +3941,6 @@
     },
     "lodsq": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0xad",
       "ExpectedArm64ASM": [
         "ldr x4, [x10]",
@@ -4215,7 +3952,6 @@
     },
     "rep lodsb": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0xac",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4231,7 +3967,6 @@
     },
     "rep lodsw": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0xad",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4247,7 +3982,6 @@
     },
     "rep lodsd": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0xad",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4262,7 +3996,6 @@
     },
     "rep lodsq": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0xad",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4277,7 +4010,6 @@
     },
     "scasb": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -4304,7 +4036,6 @@
     },
     "scasw": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -4331,7 +4062,6 @@
     },
     "scasd": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -4352,7 +4082,6 @@
     },
     "scasq": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldr x20, [x11]",
@@ -4372,7 +4101,6 @@
     },
     "repz scasb": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4403,7 +4131,6 @@
     },
     "repz scasw": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4434,7 +4161,6 @@
     },
     "repz scasd": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4459,7 +4185,6 @@
     },
     "repz scasq": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4483,7 +4208,6 @@
     },
     "repnz scasb": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4514,7 +4238,6 @@
     },
     "repnz scasw": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4545,7 +4268,6 @@
     },
     "repnz scasd": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4570,7 +4292,6 @@
     },
     "repnz scasq": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
@@ -4594,7 +4315,6 @@
     },
     "mov al, 0xff": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0xb0",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0xff"
@@ -4602,7 +4322,6 @@
     },
     "mov al, 0x82": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xb0",
       "ExpectedArm64ASM": [
         "mov w20, #0x82",
@@ -4611,7 +4330,6 @@
     },
     "mov ax, 0xffff": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0xb8",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0xffff"
@@ -4619,7 +4337,6 @@
     },
     "mov ax, 0x4243": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xb8",
       "ExpectedArm64ASM": [
         "mov w20, #0x4243",
@@ -4628,7 +4345,6 @@
     },
     "mov eax, 0xffffffff": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": [
         "movz+movk doesn't turn in to bitfield move",
         "0xb8"
@@ -4639,7 +4355,6 @@
     },
     "mov eax, 0x44454647": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xb8",
       "ExpectedArm64ASM": [
         "mov w4, #0x4647",
@@ -4648,7 +4363,6 @@
     },
     "mov rax, 0xffffffffffffffff": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xb8",
       "ExpectedArm64ASM": [
         "mov x4, #0xffffffffffffffff"
@@ -4656,7 +4370,6 @@
     },
     "mov rax, 0x5152535455565758": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0xb8",
       "ExpectedArm64ASM": [
         "mov x4, #0x5758",
@@ -4667,7 +4380,6 @@
     },
     "xlat": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xd7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -4677,7 +4389,6 @@
     },
     "cmc": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xf5",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -4687,7 +4398,6 @@
     },
     "clc": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xf8",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -4697,7 +4407,6 @@
     },
     "stc": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0xf9",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -4707,19 +4416,16 @@
     },
     "cli": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Skip": "Yes",
       "Comment": "0xfa"
     },
     "sti": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Skip": "Yes",
       "Comment": "0xfb"
     },
     "cld": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0xfc",
       "ExpectedArm64ASM": [
         "mov w20, #0x0",
@@ -4728,7 +4434,6 @@
     },
     "std": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xfd",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -16,7 +16,6 @@
   "Instructions": {
     "add al, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -36,7 +35,6 @@
     },
     "or al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /1",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0x1",
@@ -47,7 +45,6 @@
     },
     "adc al, 1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -76,7 +73,6 @@
     },
     "sbb al, 1": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -105,7 +101,6 @@
     },
     "and al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /4",
       "ExpectedArm64ASM": [
         "and w20, w4, #0x1",
@@ -116,7 +111,6 @@
     },
     "sub al, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -136,7 +130,6 @@
     },
     "xor al, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /6",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0x1",
@@ -147,7 +140,6 @@
     },
     "cmp al, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -166,7 +158,6 @@
     },
     "add al, -1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -187,7 +178,6 @@
     },
     "or al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /1",
       "ExpectedArm64ASM": [
         "orr w20, w4, #0xff",
@@ -198,7 +188,6 @@
     },
     "adc al, -1": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -228,7 +217,6 @@
     },
     "sbb al, -1": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -258,7 +246,6 @@
     },
     "and al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /4",
       "ExpectedArm64ASM": [
         "and w20, w4, #0xff",
@@ -269,7 +256,6 @@
     },
     "sub al, -1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -290,7 +276,6 @@
     },
     "xor al, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /6",
       "ExpectedArm64ASM": [
         "eor w20, w4, #0xff",
@@ -301,7 +286,6 @@
     },
     "cmp al, -1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP1 0x80 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -321,7 +305,6 @@
     },
     "add ax, 256": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -341,7 +324,6 @@
     },
     "add eax, 256": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -353,7 +335,6 @@
     },
     "add rax, 256": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -365,7 +346,6 @@
     },
     "or eax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x100",
@@ -375,7 +355,6 @@
     },
     "or rax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x100",
@@ -385,7 +364,6 @@
     },
     "adc eax, 256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -400,7 +378,6 @@
     },
     "adc rax, 256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -415,7 +392,6 @@
     },
     "sbb eax, 256": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -436,7 +412,6 @@
     },
     "sbb rax, 256": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
@@ -457,7 +432,6 @@
     },
     "and eax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "and w4, w4, #0x100",
@@ -467,7 +441,6 @@
     },
     "and rax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "and x4, x4, #0x100",
@@ -477,7 +450,6 @@
     },
     "sub eax, 256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -492,7 +464,6 @@
     },
     "sub rax, 256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -507,7 +478,6 @@
     },
     "xor eax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x100",
@@ -517,7 +487,6 @@
     },
     "xor rax, 256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x100",
@@ -527,7 +496,6 @@
     },
     "cmp eax, 256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -542,7 +510,6 @@
     },
     "cmp rax, 256": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
         "sub x20, x4, #0x100 (256)",
@@ -556,7 +523,6 @@
     },
     "add ax, -256": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xff00",
@@ -577,7 +543,6 @@
     },
     "add eax, -256": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffff00",
@@ -590,7 +555,6 @@
     },
     "add rax, -256": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffff00",
@@ -603,7 +567,6 @@
     },
     "or eax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0xffffff00",
@@ -613,7 +576,6 @@
     },
     "or rax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0xffffffffffffff00",
@@ -623,7 +585,6 @@
     },
     "adc eax, -256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffff00",
@@ -638,7 +599,6 @@
     },
     "adc rax, -256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /2",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffff00",
@@ -653,7 +613,6 @@
     },
     "sbb eax, -256": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffff00",
@@ -674,7 +633,6 @@
     },
     "sbb rax, -256": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /3",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffff00",
@@ -695,7 +653,6 @@
     },
     "and eax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "and w4, w4, #0xffffff00",
@@ -705,7 +662,6 @@
     },
     "and rax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /4",
       "ExpectedArm64ASM": [
         "and x4, x4, #0xffffffffffffff00",
@@ -715,7 +671,6 @@
     },
     "sub eax, -256": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffff00",
@@ -731,7 +686,6 @@
     },
     "sub rax, -256": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffff00",
@@ -747,7 +701,6 @@
     },
     "xor eax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0xffffff00",
@@ -757,7 +710,6 @@
     },
     "xor rax, -256": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0xffffffffffffff00",
@@ -767,7 +719,6 @@
     },
     "cmp eax, -256": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffff00",
@@ -783,7 +734,6 @@
     },
     "cmp rax, -256": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x81 /7",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffff00",
@@ -798,7 +748,6 @@
     },
     "add ax, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -818,7 +767,6 @@
     },
     "add eax, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -830,7 +778,6 @@
     },
     "add rax, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -842,7 +789,6 @@
     },
     "or eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x1",
@@ -852,7 +798,6 @@
     },
     "or rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x1",
@@ -862,7 +807,6 @@
     },
     "adc eax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -877,7 +821,6 @@
     },
     "adc rax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -892,7 +835,6 @@
     },
     "sbb eax, 1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -913,7 +855,6 @@
     },
     "sbb rax, 1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -934,7 +875,6 @@
     },
     "and eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "and w4, w4, #0x1",
@@ -944,7 +884,6 @@
     },
     "and rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "and x4, x4, #0x1",
@@ -954,7 +893,6 @@
     },
     "sub eax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -969,7 +907,6 @@
     },
     "sub rax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -984,7 +921,6 @@
     },
     "xor eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x1",
@@ -994,7 +930,6 @@
     },
     "xor rax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x1",
@@ -1004,7 +939,6 @@
     },
     "cmp eax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1019,7 +953,6 @@
     },
     "cmp rax, 1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
         "sub x20, x4, #0x1 (1)",
@@ -1033,7 +966,6 @@
     },
     "add ax, -1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1055,7 +987,6 @@
     },
     "add eax, -1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1069,7 +1000,6 @@
     },
     "add rax, -1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1083,7 +1013,6 @@
     },
     "or eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /-1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1094,7 +1023,6 @@
     },
     "or rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /-1",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1105,7 +1033,6 @@
     },
     "adc eax, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1121,7 +1048,6 @@
     },
     "adc rax, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /2",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1137,7 +1063,6 @@
     },
     "sbb eax, -1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1159,7 +1084,6 @@
     },
     "sbb rax, -1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /3",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1181,7 +1105,6 @@
     },
     "and eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1192,7 +1115,6 @@
     },
     "and rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /4",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1203,7 +1125,6 @@
     },
     "sub eax, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1220,7 +1141,6 @@
     },
     "sub rax, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1237,7 +1157,6 @@
     },
     "xor eax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1248,7 +1167,6 @@
     },
     "xor rax, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1259,7 +1177,6 @@
     },
     "cmp eax, -1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1276,7 +1193,6 @@
     },
     "cmp rax, -1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP1 0x83 /7",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1292,7 +1208,6 @@
     },
     "rol al, 2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1309,7 +1224,6 @@
     },
     "ror al, 2": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /1",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1325,7 +1239,6 @@
     },
     "rcl al, 2": {
       "ExpectedInstructionCount": 33,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /2",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1365,7 +1278,6 @@
     },
     "rcr al, 2": {
       "ExpectedInstructionCount": 22,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /3",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1394,7 +1306,6 @@
     },
     "shl al, 2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /4",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1411,7 +1322,6 @@
     },
     "shr al, 2": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1429,7 +1339,6 @@
     },
     "sar al, 2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC0 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1446,7 +1355,6 @@
     },
     "rol ax, 2": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1462,7 +1370,6 @@
     },
     "rol eax, 2": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1476,7 +1383,6 @@
     },
     "rol rax, 2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xC1 /0",
       "ExpectedArm64ASM": [
         "ror x4, x4, #62",
@@ -1489,7 +1395,6 @@
     },
     "ror ax, 2": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1505,7 +1410,6 @@
     },
     "ror eax, 2": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1519,7 +1423,6 @@
     },
     "ror rax, 2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xC1 /1",
       "ExpectedArm64ASM": [
         "ror x4, x4, #2",
@@ -1532,7 +1435,6 @@
     },
     "rcl ax, 2": {
       "ExpectedInstructionCount": 29,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1568,7 +1470,6 @@
     },
     "rcl eax, 2": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x2",
@@ -1600,7 +1501,6 @@
     },
     "rcl rax, 2": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /2",
       "ExpectedArm64ASM": [
         "mov w20, #0x2",
@@ -1632,7 +1532,6 @@
     },
     "rcr ax, 2": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /3",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1660,7 +1559,6 @@
     },
     "rcr eax, 2": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x2",
@@ -1693,7 +1591,6 @@
     },
     "rcr rax, 2": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x2",
@@ -1726,7 +1623,6 @@
     },
     "shl ax, 2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /4",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1743,7 +1639,6 @@
     },
     "shl eax, 2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /4",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1758,7 +1653,6 @@
     },
     "shl rax, 2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xC1 /4",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1773,7 +1667,6 @@
     },
     "shr ax, 2": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /5",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1791,7 +1684,6 @@
     },
     "shr eax, 2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /5",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1808,7 +1700,6 @@
     },
     "shr rax, 2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xC1 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1825,7 +1716,6 @@
     },
     "sar ax, 2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /7",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1842,7 +1732,6 @@
     },
     "sar eax, 2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xC1 /7",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1857,7 +1746,6 @@
     },
     "sar rax, 2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xC1 /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1872,7 +1760,6 @@
     },
     "rol al, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1892,7 +1779,6 @@
     },
     "ror al, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /1",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1911,7 +1797,6 @@
     },
     "rcl al, 1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /2",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1932,7 +1817,6 @@
     },
     "rcr al, 1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /3",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1954,7 +1838,6 @@
     },
     "shl al, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /4",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1974,7 +1857,6 @@
     },
     "shr al, 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1992,7 +1874,6 @@
     },
     "sar al, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd0 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2009,7 +1890,6 @@
     },
     "rol ax, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2028,7 +1908,6 @@
     },
     "rol eax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2045,7 +1924,6 @@
     },
     "rol rax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd1 /0",
       "ExpectedArm64ASM": [
         "ror x4, x4, #63",
@@ -2061,7 +1939,6 @@
     },
     "ror ax, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2080,7 +1957,6 @@
     },
     "ror eax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2097,7 +1973,6 @@
     },
     "ror rax, 1": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd1 /1",
       "ExpectedArm64ASM": [
         "ror x4, x4, #1",
@@ -2113,7 +1988,6 @@
     },
     "rcl ax, 1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2134,7 +2008,6 @@
     },
     "rcl eax, 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2152,7 +2025,6 @@
     },
     "rcl rax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -2169,7 +2041,6 @@
     },
     "rcr ax, 1": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /3",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2192,7 +2063,6 @@
     },
     "rcr eax, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /3",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2212,7 +2082,6 @@
     },
     "rcr rax, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /3",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2232,7 +2101,6 @@
     },
     "shl ax, 1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /4",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2252,7 +2120,6 @@
     },
     "shl eax, 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /4",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2270,7 +2137,6 @@
     },
     "shl rax, 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd1 /4",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2288,7 +2154,6 @@
     },
     "shr ax, 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /5",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2306,7 +2171,6 @@
     },
     "shr eax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /5",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2323,7 +2187,6 @@
     },
     "shr rax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd1 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2340,7 +2203,6 @@
     },
     "sar ax, 1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /7",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2357,7 +2219,6 @@
     },
     "sar eax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd1 /7",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2372,7 +2233,6 @@
     },
     "sar rax, 1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd1 /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2387,7 +2247,6 @@
     },
     "rol al, cl": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2413,7 +2272,6 @@
     },
     "ror al, cl": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /1",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2437,7 +2295,6 @@
     },
     "rcl al, cl": {
       "ExpectedInstructionCount": 41,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /2",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -2485,7 +2342,6 @@
     },
     "rcr al, cl": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /3",
       "ExpectedArm64ASM": [
         "uxtb w20, w5",
@@ -2516,7 +2372,6 @@
     },
     "shl al, cl": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /4",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2546,7 +2401,6 @@
     },
     "shr al, cl": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2574,7 +2428,6 @@
     },
     "sar al, cl": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd2 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2600,7 +2453,6 @@
     },
     "rol ax, cl": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2625,7 +2477,6 @@
     },
     "rol eax, cl": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2648,7 +2499,6 @@
     },
     "rol rax, cl": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /0",
       "ExpectedArm64ASM": [
         "and x20, x5, #0x3f",
@@ -2669,7 +2519,6 @@
     },
     "ror ax, cl": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2692,7 +2541,6 @@
     },
     "ror eax, cl": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2713,7 +2561,6 @@
     },
     "ror rax, cl": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /1",
       "ExpectedArm64ASM": [
         "and x20, x5, #0x3f",
@@ -2732,7 +2579,6 @@
     },
     "rcl ax, cl": {
       "ExpectedInstructionCount": 37,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -2776,7 +2622,6 @@
     },
     "rcl eax, cl": {
       "ExpectedInstructionCount": 35,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -2818,7 +2663,6 @@
     },
     "rcl rax, cl": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2859,7 +2703,6 @@
     },
     "rcr ax, cl": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
         "uxth w20, w5",
@@ -2889,7 +2732,6 @@
     },
     "rcr eax, cl": {
       "ExpectedInstructionCount": 36,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
         "mov w20, w5",
@@ -2932,7 +2774,6 @@
     },
     "rcr rax, cl": {
       "ExpectedInstructionCount": 33,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2972,7 +2813,6 @@
     },
     "shl ax, cl": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /4",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3002,7 +2842,6 @@
     },
     "shl eax, cl": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /4",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3030,7 +2869,6 @@
     },
     "shl rax, cl": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd3 /4",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3057,7 +2895,6 @@
     },
     "shr ax, cl": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /5",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3085,7 +2922,6 @@
     },
     "shr eax, cl": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /5",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3112,7 +2948,6 @@
     },
     "shr rax, cl": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd3 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3138,7 +2973,6 @@
     },
     "sar ax, cl": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /7",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3164,7 +2998,6 @@
     },
     "sar eax, cl": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "GROUP2 0xd3 /7",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3188,7 +3021,6 @@
     },
     "sar rax, cl": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xd3 /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3211,7 +3043,6 @@
     },
     "test bl, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /0",
       "ExpectedArm64ASM": [
         "and w20, w7, #0x1",
@@ -3221,7 +3052,6 @@
     },
     "not bl": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xf6 /2",
       "ExpectedArm64ASM": [
         "eor x7, x7, #0xff"
@@ -3229,7 +3059,6 @@
     },
     "not bh": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xf6 /2",
       "ExpectedArm64ASM": [
         "eor x7, x7, #0xff00"
@@ -3237,7 +3066,6 @@
     },
     "neg bl": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /3",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3257,7 +3085,6 @@
     },
     "mul bl": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /4",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3274,7 +3101,6 @@
     },
     "imul bl": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /5",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3293,7 +3119,6 @@
     },
     "div bl": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /6",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3313,7 +3138,6 @@
     },
     "idiv bl": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf6 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3331,7 +3155,6 @@
     },
     "test bx, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "and w20, w7, #0x1",
@@ -3341,7 +3164,6 @@
     },
     "test ebx, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "and w20, w7, #0x1",
@@ -3351,7 +3173,6 @@
     },
     "test rbx, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "and x20, x7, #0x1",
@@ -3361,7 +3182,6 @@
     },
     "test bx, -1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "and w20, w7, #0xffff",
@@ -3371,7 +3191,6 @@
     },
     "test ebx, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -3382,7 +3201,6 @@
     },
     "test rbx, -1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /0",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -3393,7 +3211,6 @@
     },
     "not bx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xf7 /1",
       "ExpectedArm64ASM": [
         "eor x7, x7, #0xffff"
@@ -3401,7 +3218,6 @@
     },
     "not ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xf7 /1",
       "ExpectedArm64ASM": [
         "mvn w7, w7"
@@ -3409,7 +3225,6 @@
     },
     "not rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP2 0xf7 /1",
       "ExpectedArm64ASM": [
         "mvn x7, x7"
@@ -3417,7 +3232,6 @@
     },
     "neg bx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -3437,7 +3251,6 @@
     },
     "neg ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -3452,7 +3265,6 @@
     },
     "neg rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -3467,7 +3279,6 @@
     },
     "mul bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -3485,7 +3296,6 @@
     },
     "mul ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -3502,7 +3312,6 @@
     },
     "mul rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3517,7 +3326,6 @@
     },
     "imul bx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /5",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -3537,7 +3345,6 @@
     },
     "imul ebx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /5",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -3558,7 +3365,6 @@
     },
     "imul rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3574,7 +3380,6 @@
     },
     "div bx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /6",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -3593,7 +3398,6 @@
     },
     "div ebx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /6",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -3612,7 +3416,6 @@
     },
     "div rbx": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /6",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3643,7 +3446,6 @@
     },
     "idiv bx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /7",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -3664,7 +3466,6 @@
     },
     "idiv ebx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /7",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -3685,7 +3486,6 @@
     },
     "idiv rbx": {
       "ExpectedInstructionCount": 28,
-      "Optimal": "No",
       "Comment": "GROUP2 0xf7 /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3720,7 +3520,6 @@
     },
     "inc al": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP3 0xfe /0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -3740,7 +3539,6 @@
     },
     "dec al": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -3760,7 +3558,6 @@
     },
     "inc ax": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3780,7 +3577,6 @@
     },
     "inc eax": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3796,7 +3592,6 @@
     },
     "inc rax": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3812,7 +3607,6 @@
     },
     "dec ax": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3832,7 +3626,6 @@
     },
     "dec eax": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3848,7 +3641,6 @@
     },
     "dec rax": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3864,7 +3656,6 @@
     },
     "push ax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xff /6",
       "ExpectedArm64ASM": [
         "strh w4, [x8, #-2]!"
@@ -3872,7 +3663,6 @@
     },
     "push rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP4 0xff /6",
       "ExpectedArm64ASM": [
         "str x4, [x8, #-8]!"
@@ -3880,7 +3670,6 @@
     },
     "mov byte [rax], 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP11 0xc6 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x0",
@@ -3889,7 +3678,6 @@
     },
     "mov word [rax], 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP11 0xc7 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x0",
@@ -3898,7 +3686,6 @@
     },
     "mov dword [rax], 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP11 0xc7 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x0",
@@ -3907,7 +3694,6 @@
     },
     "mov qword [rax], 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "GROUP11 0xc7 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x0",
@@ -3916,7 +3702,6 @@
     },
     "mov byte [rax], 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP11 0xc6 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -3925,7 +3710,6 @@
     },
     "mov word [rax], 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP11 0xc7 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -3934,7 +3718,6 @@
     },
     "mov dword [rax], 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP11 0xc7 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -3943,7 +3726,6 @@
     },
     "mov qword [rax], 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP11 0xc7 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -3952,7 +3734,6 @@
     },
     "mov byte [rax], -1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP11 0xc6 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
@@ -3961,7 +3742,6 @@
     },
     "mov word [rax], -1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP11 0xc7 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -3970,7 +3750,6 @@
     },
     "mov dword [rax], -1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP11 0xc7 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -3979,7 +3758,6 @@
     },
     "mov qword [rax], -1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP11 0xc7 /0",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "push es": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x06",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #136]",
@@ -21,7 +20,6 @@
     },
     "pop es": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x07",
       "ExpectedArm64ASM": [
         "ldr w20, [x8]",
@@ -35,7 +33,6 @@
     },
     "push cs": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0e",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #138]",
@@ -44,7 +41,6 @@
     },
     "push ss": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x16",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #140]",
@@ -53,7 +49,6 @@
     },
     "pop ss": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x17",
       "ExpectedArm64ASM": [
         "ldr w20, [x8]",
@@ -67,7 +62,6 @@
     },
     "push ds": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x1e",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #142]",
@@ -76,7 +70,6 @@
     },
     "pop ds": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x1f",
       "ExpectedArm64ASM": [
         "ldr w20, [x8]",
@@ -90,7 +83,6 @@
     },
     "daa": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": "0x27",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -160,7 +152,6 @@
     },
     "das": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": "0x2f",
       "ExpectedArm64ASM": [
         "cset w20, hs",
@@ -230,7 +221,6 @@
     },
     "aaa": {
       "ExpectedInstructionCount": 28,
-      "Optimal": "No",
       "Comment": "0x37",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #708]",
@@ -265,7 +255,6 @@
     },
     "aas": {
       "ExpectedInstructionCount": 29,
-      "Optimal": "No",
       "Comment": "0x3f",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #708]",
@@ -301,7 +290,6 @@
     },
     "inc ax": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x40",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -321,7 +309,6 @@
     },
     "inc eax": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x40",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -337,7 +324,6 @@
     },
     "dec ax": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x48",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -357,7 +343,6 @@
     },
     "push ax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x50",
       "ExpectedArm64ASM": [
         "strh w4, [x8, #-2]!"
@@ -365,7 +350,6 @@
     },
     "push eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x50",
       "ExpectedArm64ASM": [
         "str w4, [x8, #-4]!"
@@ -373,7 +357,6 @@
     },
     "dec eax": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x48",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -389,7 +372,6 @@
     },
     "pusha": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "Yes",
       "Comment": "0x60",
       "ExpectedArm64ASM": [
         "mov w20, w8",
@@ -406,7 +388,6 @@
     },
     "pushad": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "Yes",
       "Comment": "0x60",
       "ExpectedArm64ASM": [
         "mov w20, w8",
@@ -423,7 +404,6 @@
     },
     "popa": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x61",
       "ExpectedArm64ASM": [
         "ldr w11, [x8]",
@@ -444,7 +424,6 @@
     },
     "popad": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x61",
       "ExpectedArm64ASM": [
         "ldr w11, [x8]",
@@ -465,7 +444,6 @@
     },
     "aam": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0xd4",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -483,7 +461,6 @@
     },
     "aad": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0xd5",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -501,7 +478,6 @@
     },
     "db 0xd4, 0x40": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "aam with a different immediate byte base",
         "0xd4"
@@ -522,7 +498,6 @@
     },
     "db 0xd5, 0x40": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "aad with a different immediate byte base",
         "0xd5"
@@ -542,7 +517,6 @@
     },
     "salc": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0xd6",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "pfrcpv mm0, mm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x86"
       ],
@@ -24,7 +23,6 @@
     },
     "pfrsqrtv mm0, mm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x87"
       ],
@@ -36,7 +34,6 @@
     },
     "pfrcp mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x96"
       ],
@@ -49,7 +46,6 @@
     },
     "pfrsqrt mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x0f 0x97"
       ],

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "rsqrtps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x52"
       ],
@@ -22,7 +21,6 @@
     },
     "rcpps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x53"
       ],

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP.json
@@ -13,7 +13,6 @@
   "Instructions": {
     "rsqrtss xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "AFP can make this more optimal",
         "0xf3 0x0f 0x52"
@@ -25,7 +24,6 @@
     },
     "rcpss xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "AFP can make this more optimal",
         "0xf3 0x0f 0x53"

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -13,7 +13,6 @@
   "Instructions": {
     "rsqrtss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "AFP can make this more optimal",
         "0xf3 0x0f 0x52"
@@ -24,7 +23,6 @@
     },
     "rcpss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "AFP can make this more optimal",
         "0xf3 0x0f 0x53"

--- a/unittests/InstructionCountCI/RPRES/VEX_map1.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1.json
@@ -13,7 +13,6 @@
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x52 128-bit"
       ],
@@ -23,7 +22,6 @@
     },
     "vrsqrtps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x52 256-bit"
       ],
@@ -33,7 +31,6 @@
     },
     "vrsqrtss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "AFP can make this more optimal",
         "Map 1 0b10 0x52 128-bit"
@@ -46,7 +43,6 @@
     },
     "vrcpps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x53 128-bit"
       ],
@@ -56,7 +52,6 @@
     },
     "vrcpps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x53 256-bit"
       ],
@@ -66,7 +61,6 @@
     },
     "vrcpss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x53 128-bit"
       ],

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x52 128-bit"
       ],
@@ -22,7 +21,6 @@
     },
     "vrsqrtps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x52 256-bit"
       ],
@@ -32,7 +30,6 @@
     },
     "vrsqrtss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "AFP can make this more optimal",
         "Map 1 0b10 0x52 128-bit"
@@ -44,7 +41,6 @@
     },
     "vrcpps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x53 128-bit"
       ],
@@ -54,7 +50,6 @@
     },
     "vrcpps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x53 256-bit"
       ],
@@ -64,7 +59,6 @@
     },
     "vrcpss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x53 128-bit"
       ],

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -20,7 +20,6 @@
   "Instructions": {
     "femms": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x0b",
       "ExpectedArm64ASM": [
         "mov w20, #0x0",
@@ -29,13 +28,11 @@
     },
     "movups xmm0, xmm0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x10",
       "ExpectedArm64ASM": []
     },
     "movups xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x10",
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b"
@@ -43,7 +40,6 @@
     },
     "movups xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x10",
       "ExpectedArm64ASM": [
         "ldr q16, [x4]"
@@ -51,7 +47,6 @@
     },
     "movups [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x11",
       "ExpectedArm64ASM": [
         "str q16, [x4]"
@@ -59,7 +54,6 @@
     },
     "movlps xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x12",
       "ExpectedArm64ASM": [
         "ld1 {v16.d}[0], [x4]"
@@ -67,7 +61,6 @@
     },
     "movlps [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x13",
       "ExpectedArm64ASM": [
         "str d16, [x4]"
@@ -75,7 +68,6 @@
     },
     "movhlps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x12",
       "ExpectedArm64ASM": [
         "mov v16.d[0], v17.d[1]"
@@ -83,7 +75,6 @@
     },
     "unpcklps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x14",
       "ExpectedArm64ASM": [
         "zip1 v16.4s, v16.4s, v17.4s"
@@ -91,7 +82,6 @@
     },
     "unpckhps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x15",
       "ExpectedArm64ASM": [
         "zip2 v16.4s, v16.4s, v17.4s"
@@ -99,7 +89,6 @@
     },
     "movhps xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x16",
       "ExpectedArm64ASM": [
         "ld1 {v16.d}[1], [x4]"
@@ -107,7 +96,6 @@
     },
     "movlhps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x16",
       "ExpectedArm64ASM": [
         "mov v16.d[1], v17.d[0]"
@@ -115,7 +103,6 @@
     },
     "movhps [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x17",
       "ExpectedArm64ASM": [
         "st1 {v16.d}[1], [x4]"
@@ -123,19 +110,16 @@
     },
     "nop": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x19",
       "ExpectedArm64ASM": []
     },
     "movaps xmm0, xmm0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x28",
       "ExpectedArm64ASM": []
     },
     "movaps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x28",
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b"
@@ -143,7 +127,6 @@
     },
     "movaps xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x28",
       "ExpectedArm64ASM": [
         "ldr q16, [x4]"
@@ -151,7 +134,6 @@
     },
     "movaps [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x29",
       "ExpectedArm64ASM": [
         "str q16, [x4]"
@@ -159,7 +141,6 @@
     },
     "cvtpi2ps xmm0, [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x2a"
       ],
@@ -171,7 +152,6 @@
     },
     "cvtpi2ps xmm0, mm0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x2a"
       ],
@@ -183,7 +163,6 @@
     },
     "movntps [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x2b",
       "ExpectedArm64ASM": [
         "str q16, [x4]"
@@ -191,7 +170,6 @@
     },
     "cvttps2pi mm0, [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x2c",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -201,7 +179,6 @@
     },
     "cvttps2pi mm0, xmm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x2c",
       "ExpectedArm64ASM": [
         "fcvtzs v2.2s, v16.2s",
@@ -210,7 +187,6 @@
     },
     "cvtps2pi mm0, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x2d",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -221,7 +197,6 @@
     },
     "cvtps2pi mm0, xmm0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x2d",
       "ExpectedArm64ASM": [
         "frinti v2.2s, v16.2s",
@@ -231,7 +206,6 @@
     },
     "ucomiss xmm0, xmm1": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0x0f 0x2e",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -258,7 +232,6 @@
     },
     "comiss xmm0, xmm1": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0x0f 0x2f",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -285,7 +258,6 @@
     },
     "rdtsc": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x31",
       "ExpectedArm64ASM": [
         "mrs x20, S3_3_c14_c0_2",
@@ -295,7 +267,6 @@
     },
     "cmovo ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x40",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, vs",
@@ -304,7 +275,6 @@
     },
     "cmovo eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x40",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, vs"
@@ -312,7 +282,6 @@
     },
     "cmovo rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x40",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, vs"
@@ -320,7 +289,6 @@
     },
     "cmovno ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x41",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, vc",
@@ -329,7 +297,6 @@
     },
     "cmovno eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x41",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, vc"
@@ -337,7 +304,6 @@
     },
     "cmovno rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x41",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, vc"
@@ -345,7 +311,6 @@
     },
     "cmovb ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x42",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, hs",
@@ -354,7 +319,6 @@
     },
     "cmovb eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x42",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, hs"
@@ -362,7 +326,6 @@
     },
     "cmovb rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x42",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, hs"
@@ -370,7 +333,6 @@
     },
     "cmovnb ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x43",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, lo",
@@ -379,7 +341,6 @@
     },
     "cmovnb eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x43",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, lo"
@@ -387,7 +348,6 @@
     },
     "cmovnb rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x43",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, lo"
@@ -395,7 +355,6 @@
     },
     "cmovz ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x44",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, eq",
@@ -404,7 +363,6 @@
     },
     "cmovz eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x44",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, eq"
@@ -412,7 +370,6 @@
     },
     "cmovz rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x44",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, eq"
@@ -420,7 +377,6 @@
     },
     "cmovnz ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x45",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, ne",
@@ -429,7 +385,6 @@
     },
     "cmovnz eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x45",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, ne"
@@ -437,7 +392,6 @@
     },
     "cmovnz rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x45",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, ne"
@@ -445,7 +399,6 @@
     },
     "cmovbe ax, bx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0x46",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, hs",
@@ -455,7 +408,6 @@
     },
     "cmovbe eax, ebx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x46",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, hs",
@@ -464,7 +416,6 @@
     },
     "cmovbe rax, rbx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x46",
       "ExpectedArm64ASM": [
         "csel x20, x7, x4, hs",
@@ -473,7 +424,6 @@
     },
     "cmovnbe ax, bx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0x47",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, lo",
@@ -483,7 +433,6 @@
     },
     "cmovnbe eax, ebx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x47",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, lo",
@@ -492,7 +441,6 @@
     },
     "cmovnbe rax, rbx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x47",
       "ExpectedArm64ASM": [
         "csel x20, x7, x4, lo",
@@ -501,7 +449,6 @@
     },
     "cmovs ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x48",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, mi",
@@ -510,7 +457,6 @@
     },
     "cmovs eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x48",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, mi"
@@ -518,7 +464,6 @@
     },
     "cmovs rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x48",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, mi"
@@ -526,7 +471,6 @@
     },
     "cmovns ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x49",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, pl",
@@ -535,7 +479,6 @@
     },
     "cmovns eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x49",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, pl"
@@ -543,7 +486,6 @@
     },
     "cmovns rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x49",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, pl"
@@ -551,7 +493,6 @@
     },
     "cmovpe ax, bx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0x4a",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -567,7 +508,6 @@
     },
     "cmovpe eax, ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0x4a",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -582,7 +522,6 @@
     },
     "cmovpe rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0x4a",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -597,7 +536,6 @@
     },
     "cmovnp ax, bx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0x4b",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -613,7 +551,6 @@
     },
     "cmovnp eax, ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0x4b",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -628,7 +565,6 @@
     },
     "cmovnp rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0x4b",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -643,7 +579,6 @@
     },
     "cmovl ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x4c",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, lt",
@@ -652,7 +587,6 @@
     },
     "cmovl eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4c",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, lt"
@@ -660,7 +594,6 @@
     },
     "cmovl rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x4c",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, lt"
@@ -668,7 +601,6 @@
     },
     "cmovnl ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x4d",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, ge",
@@ -677,7 +609,6 @@
     },
     "cmovnl eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4d",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, ge"
@@ -685,7 +616,6 @@
     },
     "cmovnl rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x4d",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, ge"
@@ -693,7 +623,6 @@
     },
     "cmovle ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x4e",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, le",
@@ -702,7 +631,6 @@
     },
     "cmovle eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4e",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, le"
@@ -710,7 +638,6 @@
     },
     "cmovle rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4e",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, le"
@@ -718,7 +645,6 @@
     },
     "cmovnle ax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x4f",
       "ExpectedArm64ASM": [
         "csel w20, w7, w4, gt",
@@ -727,7 +653,6 @@
     },
     "cmovnle eax, ebx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4f",
       "ExpectedArm64ASM": [
         "csel w4, w7, w4, gt"
@@ -735,7 +660,6 @@
     },
     "cmovnle rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": "0x0f 0x4f",
       "ExpectedArm64ASM": [
         "csel x4, x7, x4, gt"
@@ -743,7 +667,6 @@
     },
     "movmskps eax, xmm0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x50",
       "ExpectedArm64ASM": [
         "ushr v2.4s, v16.4s, #31",
@@ -755,7 +678,6 @@
     },
     "movmskps rax, xmm0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x50",
       "ExpectedArm64ASM": [
         "ushr v2.4s, v16.4s, #31",
@@ -767,7 +689,6 @@
     },
     "sqrtps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x51",
       "ExpectedArm64ASM": [
         "fsqrt v16.4s, v17.4s"
@@ -775,7 +696,6 @@
     },
     "rsqrtps xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x52"
       ],
@@ -787,7 +707,6 @@
     },
     "rcpps xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0x0f 0x53"
       ],
@@ -798,7 +717,6 @@
     },
     "andps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x54",
       "ExpectedArm64ASM": [
         "and v16.16b, v16.16b, v17.16b"
@@ -806,7 +724,6 @@
     },
     "andnps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x55",
       "ExpectedArm64ASM": [
         "bic v16.16b, v17.16b, v16.16b"
@@ -814,7 +731,6 @@
     },
     "orps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x56",
       "ExpectedArm64ASM": [
         "orr v16.16b, v16.16b, v17.16b"
@@ -822,7 +738,6 @@
     },
     "xorps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x57",
       "ExpectedArm64ASM": [
         "eor v16.16b, v16.16b, v17.16b"
@@ -830,7 +745,6 @@
     },
     "addps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x58",
       "ExpectedArm64ASM": [
         "fadd v16.4s, v16.4s, v17.4s"
@@ -838,7 +752,6 @@
     },
     "mulps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x59",
       "ExpectedArm64ASM": [
         "fmul v16.4s, v16.4s, v17.4s"
@@ -846,7 +759,6 @@
     },
     "cvtps2pd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x5a",
       "ExpectedArm64ASM": [
         "fcvtl v16.2d, v17.2s"
@@ -854,7 +766,6 @@
     },
     "cvtps2pd xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x5a",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -863,7 +774,6 @@
     },
     "cvtdq2ps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x5b",
       "ExpectedArm64ASM": [
         "scvtf v16.4s, v17.4s"
@@ -871,7 +781,6 @@
     },
     "subps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x5c",
       "ExpectedArm64ASM": [
         "fsub v16.4s, v16.4s, v17.4s"
@@ -879,7 +788,6 @@
     },
     "minps xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x5d",
       "ExpectedArm64ASM": [
         "fcmgt v0.4s, v17.4s, v16.4s",
@@ -888,7 +796,6 @@
     },
     "divps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x5e",
       "ExpectedArm64ASM": [
         "fdiv v16.4s, v16.4s, v17.4s"
@@ -896,7 +803,6 @@
     },
     "maxps xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x5f",
       "ExpectedArm64ASM": [
         "fcmgt v0.4s, v17.4s, v16.4s",
@@ -905,7 +811,6 @@
     },
     "punpcklbw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x60",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -916,7 +821,6 @@
     },
     "punpcklbw mm0, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x60",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -927,7 +831,6 @@
     },
     "punpcklwd mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x61",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -938,7 +841,6 @@
     },
     "punpcklwd mm0, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x61",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -949,7 +851,6 @@
     },
     "punpckldq mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x62",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -960,7 +861,6 @@
     },
     "punpckldq mm0, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x62",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -971,7 +871,6 @@
     },
     "packsswb mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x63",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -983,7 +882,6 @@
     },
     "packsswb mm0, [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x63",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -995,7 +893,6 @@
     },
     "packsswb mm0, mm0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x63",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1006,7 +903,6 @@
     },
     "pcmpgtb mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x64",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -1017,7 +913,6 @@
     },
     "pcmpgtw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x65",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -1028,7 +923,6 @@
     },
     "pcmpgtd mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x66",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -1039,7 +933,6 @@
     },
     "punpckhbw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x68",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1050,7 +943,6 @@
     },
     "punpckhbw mm0, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x68",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1061,7 +953,6 @@
     },
     "punpckhwd mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x69",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1072,7 +963,6 @@
     },
     "punpckhwd mm0, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x69",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1083,7 +973,6 @@
     },
     "punpckhdq mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x6a",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1094,7 +983,6 @@
     },
     "punpckhdq mm0, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x6a",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1105,7 +993,6 @@
     },
     "packssdw mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x6b",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1117,7 +1004,6 @@
     },
     "movd mm0, eax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x6e",
       "ExpectedArm64ASM": [
         "fmov s2, w4",
@@ -1126,7 +1012,6 @@
     },
     "movd mm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x6e",
       "ExpectedArm64ASM": [
         "ldr s2, [x4]",
@@ -1135,7 +1020,6 @@
     },
     "movq mm0, mm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x6f",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1144,7 +1028,6 @@
     },
     "movq mm0, mm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x6f",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -1153,7 +1036,6 @@
     },
     "movq mm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x6f",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -1162,7 +1044,6 @@
     },
     "pshufw mm0, mm1, 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x70",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -1172,7 +1053,6 @@
     },
     "pshufw mm0, [rax], 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x70",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -1182,7 +1062,6 @@
     },
     "pshufw mm0, mm1, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x70",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -1194,7 +1073,6 @@
     },
     "pshufw mm0, [rax], 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x70",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -1206,7 +1084,6 @@
     },
     "pshufw mm0, mm1, 0xff": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x70",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -1216,7 +1093,6 @@
     },
     "pshufw mm0, [rax], 0xff": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x70",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -1226,7 +1102,6 @@
     },
     "pcmpeqb mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x74",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -1237,7 +1112,6 @@
     },
     "pcmpeqw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x75",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -1248,7 +1122,6 @@
     },
     "pcmpeqd mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x76",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -1259,7 +1132,6 @@
     },
     "emms": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x77",
       "ExpectedArm64ASM": [
         "mov w20, #0x0",
@@ -1268,7 +1140,6 @@
     },
     "movd eax, mm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x7e",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1277,7 +1148,6 @@
     },
     "movd [rax], mm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x7e",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1286,7 +1156,6 @@
     },
     "db 0x0f, 0x7f, 0xc1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "movq mm0, mm1",
         "Manual encoded since nasm would encode 0x6f version",
@@ -1299,7 +1168,6 @@
     },
     "movq [rax], mm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x7f",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1308,7 +1176,6 @@
     },
     "seto al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x90",
       "ExpectedArm64ASM": [
         "cset x20, vs",
@@ -1317,7 +1184,6 @@
     },
     "setno al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x91",
       "ExpectedArm64ASM": [
         "cset x20, vc",
@@ -1326,7 +1192,6 @@
     },
     "setb al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x92",
       "ExpectedArm64ASM": [
         "cset x20, hs",
@@ -1335,7 +1200,6 @@
     },
     "setnb al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x93",
       "ExpectedArm64ASM": [
         "cset x20, lo",
@@ -1344,7 +1208,6 @@
     },
     "setz al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x94",
       "ExpectedArm64ASM": [
         "cset x20, eq",
@@ -1353,7 +1216,6 @@
     },
     "setnz al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x95",
       "ExpectedArm64ASM": [
         "cset x20, ne",
@@ -1362,7 +1224,6 @@
     },
     "setbe al": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0f 0x96",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1373,7 +1234,6 @@
     },
     "setnbe al": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0x97",
       "ExpectedArm64ASM": [
         "cset x20, lo",
@@ -1383,7 +1243,6 @@
     },
     "sets al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x98",
       "ExpectedArm64ASM": [
         "cset x20, mi",
@@ -1392,7 +1251,6 @@
     },
     "setns al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x99",
       "ExpectedArm64ASM": [
         "cset x20, pl",
@@ -1401,7 +1259,6 @@
     },
     "setpe al": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x9a",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -1415,7 +1272,6 @@
     },
     "setnp al": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x9b",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #706]",
@@ -1428,7 +1284,6 @@
     },
     "setl al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x9c",
       "ExpectedArm64ASM": [
         "cset x20, lt",
@@ -1437,7 +1292,6 @@
     },
     "setnl al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x9d",
       "ExpectedArm64ASM": [
         "cset x20, ge",
@@ -1446,7 +1300,6 @@
     },
     "setle al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x9e",
       "ExpectedArm64ASM": [
         "cset x20, le",
@@ -1455,7 +1308,6 @@
     },
     "setnle al": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0x9f",
       "ExpectedArm64ASM": [
         "cset x20, gt",
@@ -1464,7 +1316,6 @@
     },
     "push fs": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xa0",
       "ExpectedArm64ASM": [
         "ldr x20, [x28, #176]",
@@ -1473,7 +1324,6 @@
     },
     "pop fs": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xa1",
       "ExpectedArm64ASM": [
         "ldr x20, [x8]",
@@ -1487,7 +1337,6 @@
     },
     "bt ax, bx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1500,7 +1349,6 @@
     },
     "bt [rax], bx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1515,7 +1363,6 @@
     },
     "bt eax, ebx": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1528,7 +1375,6 @@
     },
     "bt [rax], ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1543,7 +1389,6 @@
     },
     "bt rax, rbx": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "and x20, x7, #0x3f",
@@ -1555,7 +1400,6 @@
     },
     "bt [rax], rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xa3",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -1569,13 +1413,11 @@
     },
     "shld ax, bx, 0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": []
     },
     "shld ax, bx, 1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1597,7 +1439,6 @@
     },
     "shld ax, bx, 15": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1616,7 +1457,6 @@
     },
     "shld ax, bx, 16": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1634,7 +1474,6 @@
     },
     "shld ax, bx, 31": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1653,7 +1492,6 @@
     },
     "shld eax, ebx, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov w4, w4"
@@ -1661,7 +1499,6 @@
     },
     "shld eax, ebx, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1680,7 +1517,6 @@
     },
     "shld eax, ebx, 15": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1696,7 +1532,6 @@
     },
     "shld eax, ebx, 16": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1712,7 +1547,6 @@
     },
     "shld eax, ebx, 31": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1728,13 +1562,11 @@
     },
     "shld rax, rbx, 0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": []
     },
     "shld rax, rbx, 1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1752,7 +1584,6 @@
     },
     "shld rax, rbx, 15": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1767,7 +1598,6 @@
     },
     "shld rax, rbx, 32": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1782,7 +1612,6 @@
     },
     "shld rax, rbx, 63": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xac",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1797,7 +1626,6 @@
     },
     "shld ax, bx, cl": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": "0x0f 0xad",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1836,7 +1664,6 @@
     },
     "shld eax, ebx, cl": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": "0x0f 0xad",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1875,7 +1702,6 @@
     },
     "shld rax, rbx, cl": {
       "ExpectedInstructionCount": 29,
-      "Optimal": "No",
       "Comment": "0x0f 0xad",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1911,7 +1737,6 @@
     },
     "push gs": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xa8",
       "ExpectedArm64ASM": [
         "ldr x20, [x28, #168]",
@@ -1920,7 +1745,6 @@
     },
     "pop gs": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xa9",
       "ExpectedArm64ASM": [
         "ldr x20, [x8]",
@@ -1934,7 +1758,6 @@
     },
     "bts ax, bx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1951,7 +1774,6 @@
     },
     "bts [rax], bx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1970,7 +1792,6 @@
     },
     "bts eax, ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -1987,7 +1808,6 @@
     },
     "bts [rax], ebx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2006,7 +1826,6 @@
     },
     "bts rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "and x20, x7, #0x3f",
@@ -2021,7 +1840,6 @@
     },
     "bts [rax], rbx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xab",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -2039,7 +1857,6 @@
     },
     "lock bts [rax], bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2057,7 +1874,6 @@
     },
     "lock bts [rax], ebx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2075,7 +1891,6 @@
     },
     "lock bts [rax], rbx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -2092,7 +1907,6 @@
     },
     "imul ax, bx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x0f 0xaf",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2112,7 +1926,6 @@
     },
     "imul eax, ebx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0x0f 0xaf",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -2132,7 +1945,6 @@
     },
     "imul rax, rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xaf",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2148,7 +1960,6 @@
     },
     "cmpxchg al, bl": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "0x0f 0xb0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2178,7 +1989,6 @@
     },
     "cmpxchg [rax], bl": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0x0f 0xb0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2205,7 +2015,6 @@
     },
     "cmpxchg ax, bx": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2235,7 +2044,6 @@
     },
     "cmpxchg [rax], bx": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2262,7 +2070,6 @@
     },
     "cmpxchg eax, ebx": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2288,7 +2095,6 @@
     },
     "cmpxchg [rax], ebx": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2310,7 +2116,6 @@
     },
     "cmpxchg rax, rbx": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2332,7 +2137,6 @@
     },
     "cmpxchg [rax], rbx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -2351,7 +2155,6 @@
     },
     "btr ax, bx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2368,7 +2171,6 @@
     },
     "btr [rax], bx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2387,7 +2189,6 @@
     },
     "btr eax, ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2404,7 +2205,6 @@
     },
     "btr [rax], ebx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2423,7 +2223,6 @@
     },
     "btr rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "and x20, x7, #0x3f",
@@ -2438,7 +2237,6 @@
     },
     "btr [rax], rbx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -2456,7 +2254,6 @@
     },
     "movzx ax, bl": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xb6",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2465,7 +2262,6 @@
     },
     "lock btr [rax], bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2483,7 +2279,6 @@
     },
     "lock btr [rax], ebx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2501,7 +2296,6 @@
     },
     "lock btr [rax], rbx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -2518,7 +2312,6 @@
     },
     "movzx ax, byte [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xb6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -2527,7 +2320,6 @@
     },
     "movzx eax, bl": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xb6",
       "ExpectedArm64ASM": [
         "uxtb w4, w7"
@@ -2535,7 +2327,6 @@
     },
     "movzx eax, byte [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xb6",
       "ExpectedArm64ASM": [
         "ldrb w4, [x4]"
@@ -2543,7 +2334,6 @@
     },
     "movzx rax, bl": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xb6",
       "ExpectedArm64ASM": [
         "uxtb w4, w7"
@@ -2551,7 +2341,6 @@
     },
     "movzx rax, byte [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xb6",
       "ExpectedArm64ASM": [
         "ldrb w4, [x4]"
@@ -2559,7 +2348,6 @@
     },
     "movzx eax, bx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xb7",
       "ExpectedArm64ASM": [
         "uxth w4, w7"
@@ -2567,7 +2355,6 @@
     },
     "movzx eax, word [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xb7",
       "ExpectedArm64ASM": [
         "ldrh w4, [x4]"
@@ -2575,7 +2362,6 @@
     },
     "movzx rax, bx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xb7",
       "ExpectedArm64ASM": [
         "uxth w4, w7"
@@ -2583,7 +2369,6 @@
     },
     "movzx rax, word [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xb7",
       "ExpectedArm64ASM": [
         "ldrh w4, [x4]"
@@ -2591,7 +2376,6 @@
     },
     "btc ax, bx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2608,7 +2392,6 @@
     },
     "btc [rax], bx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2627,7 +2410,6 @@
     },
     "btc eax, ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2644,7 +2426,6 @@
     },
     "btc [rax], ebx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2663,7 +2444,6 @@
     },
     "btc rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "and x20, x7, #0x3f",
@@ -2678,7 +2458,6 @@
     },
     "btc [rax], rbx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xbb",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -2696,7 +2475,6 @@
     },
     "lock btc [rax], bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2714,7 +2492,6 @@
     },
     "lock btc [rax], ebx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2732,7 +2509,6 @@
     },
     "lock btc [rax], rbx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xb3",
       "ExpectedArm64ASM": [
         "ubfx x20, x7, #0, #3",
@@ -2749,7 +2525,6 @@
     },
     "bsf ax, bx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x0f 0xbc",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2770,7 +2545,6 @@
     },
     "bsf eax, ebx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0x0f 0xbc",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2789,7 +2563,6 @@
     },
     "bsf rax, rbx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xbc",
       "ExpectedArm64ASM": [
         "rbit x0, x7",
@@ -2806,7 +2579,6 @@
     },
     "bsr ax, bx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0x0f 0xbd",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2827,7 +2599,6 @@
     },
     "bsr eax, ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "0x0f 0xbd",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -2844,7 +2615,6 @@
     },
     "bsr rax, rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0x0f 0xbd",
       "ExpectedArm64ASM": [
         "mov x0, #0x3f",
@@ -2860,7 +2630,6 @@
     },
     "movsx ax, bl": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xbe",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2870,7 +2639,6 @@
     },
     "movsx ax, byte [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xbe",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -2880,7 +2648,6 @@
     },
     "movsx eax, bl": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xbe",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2890,7 +2657,6 @@
     },
     "movsx eax, byte [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xbe",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -2900,7 +2666,6 @@
     },
     "movsx rax, bl": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0xbe",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2909,7 +2674,6 @@
     },
     "movsx rax, byte [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xbe",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -2918,7 +2682,6 @@
     },
     "movsx eax, bx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xbf",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2928,7 +2691,6 @@
     },
     "movsx eax, word [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xbf",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
@@ -2938,7 +2700,6 @@
     },
     "movsx rax, bx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0xbf",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2947,7 +2708,6 @@
     },
     "movsx rax, word [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xbf",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
@@ -2956,7 +2716,6 @@
     },
     "xadd al, bl": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2981,7 +2740,6 @@
     },
     "xadd [rax], bl": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -3005,7 +2763,6 @@
     },
     "xadd ax, bx": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3030,7 +2787,6 @@
     },
     "xadd [rax], bx": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -3054,7 +2810,6 @@
     },
     "xadd eax, ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -3069,7 +2824,6 @@
     },
     "xadd [rax], ebx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -3083,7 +2837,6 @@
     },
     "xadd rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -3098,7 +2851,6 @@
     },
     "xadd [rax], rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "mov x20, x7",
@@ -3112,7 +2864,6 @@
     },
     "cmpps xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmeq v16.4s, v16.4s, v17.4s"
@@ -3120,7 +2871,6 @@
     },
     "cmpps xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmgt v16.4s, v17.4s, v16.4s"
@@ -3128,7 +2878,6 @@
     },
     "cmpps xmm0, xmm1, 2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmge v16.4s, v17.4s, v16.4s"
@@ -3136,7 +2885,6 @@
     },
     "cmpps xmm0, xmm1, 3": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmge v0.4s, v16.4s, v17.4s",
@@ -3147,7 +2895,6 @@
     },
     "cmpps xmm0, xmm1, 4": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmeq v16.4s, v16.4s, v17.4s",
@@ -3156,7 +2903,6 @@
     },
     "cmpps xmm0, xmm1, 5": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmgt v2.4s, v17.4s, v16.4s",
@@ -3165,7 +2911,6 @@
     },
     "cmpps xmm0, xmm1, 6": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmge v2.4s, v17.4s, v16.4s",
@@ -3174,7 +2919,6 @@
     },
     "cmpps xmm0, xmm1, 7": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmge v0.4s, v16.4s, v17.4s",
@@ -3184,7 +2928,6 @@
     },
     "movnti [rax], ebx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": "0x0f 0xc3",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -3193,7 +2936,6 @@
     },
     "movnti [rax], rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc3",
       "ExpectedArm64ASM": [
         "str x7, [x4]"
@@ -3201,7 +2943,6 @@
     },
     "pinsrw mm0, eax, 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3211,7 +2952,6 @@
     },
     "pinsrw mm0, eax, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3221,7 +2961,6 @@
     },
     "pinsrw mm0, eax, 2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3231,7 +2970,6 @@
     },
     "pinsrw mm0, eax, 3": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3241,7 +2979,6 @@
     },
     "pinsrw mm0, eax, 4": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3251,7 +2988,6 @@
     },
     "pinsrw mm0, [rax], 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3261,7 +2997,6 @@
     },
     "pinsrw mm0, [rax], 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3271,7 +3006,6 @@
     },
     "pinsrw mm0, [rax], 2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3281,7 +3015,6 @@
     },
     "pinsrw mm0, [rax], 3": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3291,7 +3024,6 @@
     },
     "pinsrw mm0, [rax], 4": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3301,7 +3033,6 @@
     },
     "pextrw eax, mm0, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc5",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3310,7 +3041,6 @@
     },
     "pextrw eax, mm0, 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc5",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3319,7 +3049,6 @@
     },
     "pextrw eax, mm0, 2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc5",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3328,7 +3057,6 @@
     },
     "pextrw eax, mm0, 3": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc5",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3337,7 +3065,6 @@
     },
     "pextrw eax, mm0, 4": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc5",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3346,7 +3073,6 @@
     },
     "shufps xmm0, xmm1, 01000100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Dst[63:0]    = Src1[63:0]",
         "Dest[127:64] = Src2[63:0]",
@@ -3358,7 +3084,6 @@
     },
     "shufps xmm0, xmm1, 11101110b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Dst[63:0]    = Src1[127:64]",
         "Dest[127:64] = Src2[127:64]",
@@ -3370,7 +3095,6 @@
     },
     "shufps xmm0, xmm1, 11100100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Dst[63:0]    = Src1[63:0]",
         "Dest[127:64] = Src2[127:64]",
@@ -3382,7 +3106,6 @@
     },
     "shufps xmm0, xmm1, 01001110b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Dst[63:0]    = Src1[63:0]",
         "Dest[127:64] = Src2[127:64]",
@@ -3394,7 +3117,6 @@
     },
     "shufps xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3407,7 +3129,6 @@
     },
     "shufps xmm0, xmm1, 00000101b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3420,7 +3141,6 @@
     },
     "shufps xmm0, xmm1, 00001010b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3433,7 +3153,6 @@
     },
     "shufps xmm0, xmm1, 00001111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3446,7 +3165,6 @@
     },
     "shufps xmm0, xmm1, 01010000b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3459,7 +3177,6 @@
     },
     "shufps xmm0, xmm1, 01010101b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3472,7 +3189,6 @@
     },
     "shufps xmm0, xmm1, 01011010b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3485,7 +3201,6 @@
     },
     "shufps xmm0, xmm1, 01011111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3498,7 +3213,6 @@
     },
     "shufps xmm0, xmm1, 10100000b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3511,7 +3225,6 @@
     },
     "shufps xmm0, xmm1, 10100101b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3524,7 +3237,6 @@
     },
     "shufps xmm0, xmm1, 10101010b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3537,7 +3249,6 @@
     },
     "shufps xmm0, xmm1, 10101111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3550,7 +3261,6 @@
     },
     "shufps xmm0, xmm1, 11110000b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3563,7 +3273,6 @@
     },
     "shufps xmm0, xmm1, 11110101b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3576,7 +3285,6 @@
     },
     "shufps xmm0, xmm1, 11111010b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3589,7 +3297,6 @@
     },
     "shufps xmm0, xmm1, 11100000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Bottom elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3601,7 +3308,6 @@
     },
     "shufps xmm0, xmm1, 11100101b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Bottom elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3613,7 +3319,6 @@
     },
     "shufps xmm0, xmm1, 11101010b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Bottom elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3625,7 +3330,6 @@
     },
     "shufps xmm0, xmm1, 11101111b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Bottom elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3637,7 +3341,6 @@
     },
     "shufps xmm0, xmm1, 01000000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Bottom elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3649,7 +3352,6 @@
     },
     "shufps xmm0, xmm1, 01000101b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Bottom elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3661,7 +3363,6 @@
     },
     "shufps xmm0, xmm1, 01001010b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Bottom elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3673,7 +3374,6 @@
     },
     "shufps xmm0, xmm1, 01001111b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Bottom elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3685,7 +3385,6 @@
     },
     "shufps xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Top elements duplicated, Bottom 64-bits inserted",
         "0x0f 0xc6"
@@ -3697,7 +3396,6 @@
     },
     "shufps xmm0, xmm1, 01010100b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Top elements duplicated, Bottom 64-bits inserted",
         "0x0f 0xc6"
@@ -3709,7 +3407,6 @@
     },
     "shufps xmm0, xmm1, 10100100b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Top elements duplicated, Bottom 64-bits inserted",
         "0x0f 0xc6"
@@ -3721,7 +3418,6 @@
     },
     "shufps xmm0, xmm1, 11110100b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Top elements duplicated, Bottom 64-bits inserted",
         "0x0f 0xc6"
@@ -3733,7 +3429,6 @@
     },
     "shufps xmm0, xmm1, 00001110b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Top elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3745,7 +3440,6 @@
     },
     "shufps xmm0, xmm1, 01011110b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Top elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3757,7 +3451,6 @@
     },
     "shufps xmm0, xmm1, 10101110b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Top elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3769,7 +3462,6 @@
     },
     "shufps xmm0, xmm1, 11111110b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Top elements duplicated, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3781,7 +3473,6 @@
     },
     "shufps xmm0, xmm1, 01000111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "odd elements inverted, Low 64-bits inserted",
         "SRA quirks with RA fail to understand that v16 is dead",
@@ -3796,7 +3487,6 @@
     },
     "shufps xmm0, xmm1, 11100111b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "odd elements inverted, Top 64-bits inserted",
         "SRA quirks with RA fail to understand that v16 is dead",
@@ -3812,7 +3502,6 @@
     },
     "shufps xmm0, xmm1, 11100001b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Lower 32-bit elements inverted, Top 64-bits inserted",
         "0x0f 0xc6"
@@ -3825,7 +3514,6 @@
     },
     "shufps xmm0, xmm1, 01000001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Lower 32-bit elements inverted, Low 64-bits inserted",
         "0x0f 0xc6"
@@ -3837,7 +3525,6 @@
     },
     "shufps xmm0, xmm1, 11111111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Duplicate selected element between each 64-bit segment",
         "0x0f 0xc6"
@@ -3850,7 +3537,6 @@
     },
     "shufps xmm0, [rax], 0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0f 0xc6",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -3861,7 +3547,6 @@
     },
     "shufps xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "0x0f 0xc6",
       "ExpectedArm64ASM": [
         "ldr x0, [x28, #1680]",
@@ -3871,7 +3556,6 @@
     },
     "shufps xmm1, xmm0, 1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "0x0f 0xc6",
       "ExpectedArm64ASM": [
         "ldr x0, [x28, #1680]",
@@ -3883,7 +3567,6 @@
     },
     "shufps xmm0, [rax], 1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "0x0f 0xc6",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -3896,7 +3579,6 @@
     },
     "shufps xmm0, [rax], 0xFF": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "0x0f 0xc6",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -3907,7 +3589,6 @@
     },
     "bswap eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc8",
       "ExpectedArm64ASM": [
         "rev w4, w4"
@@ -3915,7 +3596,6 @@
     },
     "bswap rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xc8",
       "ExpectedArm64ASM": [
         "rev x4, x4"
@@ -3923,7 +3603,6 @@
     },
     "psrlw mm0, mm1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd1",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3938,7 +3617,6 @@
     },
     "psrld mm0, mm1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3953,7 +3631,6 @@
     },
     "psrlq mm0, mm1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -3968,7 +3645,6 @@
     },
     "paddq mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -3979,7 +3655,6 @@
     },
     "pmullw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd5",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -3990,7 +3665,6 @@
     },
     "pmovmskb eax, mm0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd7",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4009,7 +3683,6 @@
     },
     "psubusb mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd8",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4020,7 +3693,6 @@
     },
     "psubusw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd9",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4031,7 +3703,6 @@
     },
     "pminub mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xda",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4042,7 +3713,6 @@
     },
     "pand mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xdb",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4053,7 +3723,6 @@
     },
     "paddusb mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xdc",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4064,7 +3733,6 @@
     },
     "paddusw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xdd",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4075,7 +3743,6 @@
     },
     "pmaxub mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xde",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4086,7 +3753,6 @@
     },
     "pandn mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xdf",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4097,7 +3763,6 @@
     },
     "pavgb mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe0",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4108,7 +3773,6 @@
     },
     "psraw mm0, mm1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe1",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4123,7 +3787,6 @@
     },
     "psrad mm0, mm1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4138,7 +3801,6 @@
     },
     "pavgw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4149,7 +3811,6 @@
     },
     "pmulhuw mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4161,7 +3822,6 @@
     },
     "pmulhw mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe5",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4173,7 +3833,6 @@
     },
     "movntq [rax], mm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe7",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4182,7 +3841,6 @@
     },
     "psubsb mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe8",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4193,7 +3851,6 @@
     },
     "psubsw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe9",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4204,7 +3861,6 @@
     },
     "pminsw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xea",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4215,7 +3871,6 @@
     },
     "por mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xeb",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4226,7 +3881,6 @@
     },
     "paddsb mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xec",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4237,7 +3891,6 @@
     },
     "paddsw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xed",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4248,7 +3901,6 @@
     },
     "pmaxsw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xee",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4259,7 +3911,6 @@
     },
     "pxor mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xef",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4270,7 +3921,6 @@
     },
     "psllw mm0, mm1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf1",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4284,7 +3934,6 @@
     },
     "pslld mm0, mm1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4298,7 +3947,6 @@
     },
     "psllq mm0, mm1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4312,7 +3960,6 @@
     },
     "pmuludq mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf4",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4323,7 +3970,6 @@
     },
     "pmaddwd mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf5",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4335,7 +3981,6 @@
     },
     "psadbw mm0, mm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -4347,7 +3992,6 @@
     },
     "maskmovq mm0, mm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf7",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4360,7 +4004,6 @@
     },
     "psubb mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf8",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4371,7 +4014,6 @@
     },
     "psubw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf9",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4382,7 +4024,6 @@
     },
     "psubd mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xfa",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4393,7 +4034,6 @@
     },
     "psubq mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xfb",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4404,7 +4044,6 @@
     },
     "paddb mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xfc",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4415,7 +4054,6 @@
     },
     "paddw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xfd",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",
@@ -4426,7 +4064,6 @@
     },
     "paddd mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xfe",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #768]",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -14,7 +14,6 @@
   "Instructions": {
     "sgdt [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP7 0x0F 0x1 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x0",
@@ -25,7 +24,6 @@
     },
     "bt ax, 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #1",
@@ -35,7 +33,6 @@
     },
     "bt eax, 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #1",
@@ -45,7 +42,6 @@
     },
     "bt rax, 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #1",
@@ -55,7 +51,6 @@
     },
     "bt ax, 15": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #15",
@@ -66,7 +61,6 @@
     },
     "bt eax, 31": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
@@ -77,7 +71,6 @@
     },
     "bt rax, 63": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /4",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #63",
@@ -88,7 +81,6 @@
     },
     "bt word [rax], 0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -99,7 +91,6 @@
     },
     "bt dword [rax], 0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -110,7 +101,6 @@
     },
     "bt qword [rax], 0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -121,7 +111,6 @@
     },
     "bt word [rax], 15": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #1]",
@@ -133,7 +122,6 @@
     },
     "bt dword [rax], 31": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #3]",
@@ -145,7 +133,6 @@
     },
     "bt qword [rax], 63": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #7]",
@@ -157,7 +144,6 @@
     },
     "bts ax, 0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -171,7 +157,6 @@
     },
     "bts eax, 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -184,7 +169,6 @@
     },
     "bts rax, 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -196,7 +180,6 @@
     },
     "bts ax, 15": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #15",
@@ -209,7 +192,6 @@
     },
     "bts eax, 31": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
@@ -222,7 +204,6 @@
     },
     "bts rax, 63": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /5",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #63",
@@ -234,7 +215,6 @@
     },
     "bts word [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -247,7 +227,6 @@
     },
     "bts dword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -260,7 +239,6 @@
     },
     "bts qword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -273,7 +251,6 @@
     },
     "bts word [rax], 15": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #1]",
@@ -287,7 +264,6 @@
     },
     "bts dword [rax], 31": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #3]",
@@ -301,7 +277,6 @@
     },
     "bts qword [rax], 63": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #7]",
@@ -315,7 +290,6 @@
     },
     "lock bts word [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -328,7 +302,6 @@
     },
     "lock bts dword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -341,7 +314,6 @@
     },
     "lock bts qword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -354,7 +326,6 @@
     },
     "lock bts word [rax], 15": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x1 (1)",
@@ -368,7 +339,6 @@
     },
     "lock bts dword [rax], 31": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x3 (3)",
@@ -382,7 +352,6 @@
     },
     "lock bts qword [rax], 63": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x7 (7)",
@@ -396,7 +365,6 @@
     },
     "btr ax, 0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -410,7 +378,6 @@
     },
     "btr eax, 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -423,7 +390,6 @@
     },
     "btr rax, 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -435,7 +401,6 @@
     },
     "btr ax, 15": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #15",
@@ -448,7 +413,6 @@
     },
     "btr eax, 31": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
@@ -461,7 +425,6 @@
     },
     "btr rax, 63": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #63",
@@ -473,7 +436,6 @@
     },
     "btr word [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -486,7 +448,6 @@
     },
     "btr dword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -499,7 +460,6 @@
     },
     "btr qword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -512,7 +472,6 @@
     },
     "btr word [rax], 15": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #1]",
@@ -526,7 +485,6 @@
     },
     "btr dword [rax], 31": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #3]",
@@ -540,7 +498,6 @@
     },
     "btr qword [rax], 63": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #7]",
@@ -554,7 +511,6 @@
     },
     "lock btr word [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -567,7 +523,6 @@
     },
     "lock btr dword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -580,7 +535,6 @@
     },
     "lock btr qword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -593,7 +547,6 @@
     },
     "lock btr word [rax], 15": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x1 (1)",
@@ -607,7 +560,6 @@
     },
     "lock btr dword [rax], 31": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x3 (3)",
@@ -621,7 +573,6 @@
     },
     "lock btr qword [rax], 63": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x7 (7)",
@@ -635,7 +586,6 @@
     },
     "btc ax, 0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -649,7 +599,6 @@
     },
     "btc eax, 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -662,7 +611,6 @@
     },
     "btc rax, 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -674,7 +622,6 @@
     },
     "btc ax, 15": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #15",
@@ -687,7 +634,6 @@
     },
     "btc eax, 31": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #31",
@@ -700,7 +646,6 @@
     },
     "btc rax, 63": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /7",
       "ExpectedArm64ASM": [
         "lsr x20, x4, #63",
@@ -712,7 +657,6 @@
     },
     "btc word [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -725,7 +669,6 @@
     },
     "btc dword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -738,7 +681,6 @@
     },
     "btc qword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4]",
@@ -751,7 +693,6 @@
     },
     "btc word [rax], 15": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #1]",
@@ -765,7 +706,6 @@
     },
     "btc dword [rax], 31": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #3]",
@@ -779,7 +719,6 @@
     },
     "btc qword [rax], 63": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x4, #7]",
@@ -793,7 +732,6 @@
     },
     "lock btc word [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -806,7 +744,6 @@
     },
     "lock btc dword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -819,7 +756,6 @@
     },
     "lock btc qword [rax], 0": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x0 (0)",
@@ -832,7 +768,6 @@
     },
     "lock btc word [rax], 15": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x1 (1)",
@@ -846,7 +781,6 @@
     },
     "lock btc dword [rax], 31": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x3 (3)",
@@ -860,7 +794,6 @@
     },
     "lock btc qword [rax], 63": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP8 0x0F 0xBA /6",
       "ExpectedArm64ASM": [
         "add x20, x4, #0x7 (7)",
@@ -874,7 +807,6 @@
     },
     "cmpxchg8b [rbp]": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /1",
       "ExpectedArm64ASM": [
         "add x20, x9, #0x0 (0)",
@@ -906,7 +838,6 @@
     },
     "cmpxchg16b [rbp]": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /1",
       "ExpectedArm64ASM": [
         "add x20, x9, #0x0 (0)",
@@ -934,7 +865,6 @@
     },
     "rdrand ax": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "mrs x20, rndr",
@@ -952,7 +882,6 @@
     },
     "rdrand eax": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "mrs x20, rndr",
@@ -970,7 +899,6 @@
     },
     "rdrand rax": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "mrs x20, rndr",
@@ -987,7 +915,6 @@
     },
     "rdseed ax": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /7",
       "ExpectedArm64ASM": [
         "mrs x20, rndrrs",
@@ -1005,7 +932,6 @@
     },
     "rdseed eax": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /7",
       "ExpectedArm64ASM": [
         "mrs x20, rndrrs",
@@ -1023,7 +949,6 @@
     },
     "rdseed rax": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": "GROUP9 0x0F 0xC7 /7",
       "ExpectedArm64ASM": [
         "mrs x20, rndrrs",
@@ -1041,14 +966,12 @@
     "psrlw mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrlw mm0, 15": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1059,7 +982,6 @@
     "psrlw mm0, 16": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1070,14 +992,12 @@
     "psrlw xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrlw xmm0, 15": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ushr v16.8h, v16.8h, #15"
@@ -1086,7 +1006,6 @@
     "psrlw xmm0, 16": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1095,14 +1014,12 @@
     "psraw mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": []
     },
     "psraw mm0, 15": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1113,7 +1030,6 @@
     "psraw mm0, 16": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1124,14 +1040,12 @@
     "psraw xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": []
     },
     "psraw xmm0, 15": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "sshr v16.8h, v16.8h, #15"
@@ -1140,7 +1054,6 @@
     "psraw xmm0, 16": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "sshr v16.8h, v16.8h, #15"
@@ -1149,14 +1062,12 @@
     "psllw mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "psllw mm0, 15": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1167,7 +1078,6 @@
     "psllw mm0, 16": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1178,14 +1088,12 @@
     "psllw xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "psllw xmm0, 15": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "shl v16.8h, v16.8h, #15"
@@ -1194,7 +1102,6 @@
     "psllw xmm0, 16": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP12 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1203,14 +1110,12 @@
     "psrld mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrld mm0, 31": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1221,7 +1126,6 @@
     "psrld mm0, 32": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1232,14 +1136,12 @@
     "psrld xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrld xmm0, 31": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ushr v16.4s, v16.4s, #31"
@@ -1248,7 +1150,6 @@
     "psrld xmm0, 32": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1257,14 +1158,12 @@
     "psrad mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": []
     },
     "psrad mm0, 31": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1275,7 +1174,6 @@
     "psrad mm0, 32": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1286,14 +1184,12 @@
     "psrad xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": []
     },
     "psrad xmm0, 31": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "sshr v16.4s, v16.4s, #31"
@@ -1302,7 +1198,6 @@
     "psrad xmm0, 32": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "sshr v16.4s, v16.4s, #31"
@@ -1311,14 +1206,12 @@
     "pslld mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "pslld mm0, 31": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1329,7 +1222,6 @@
     "pslld mm0, 32": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1340,14 +1232,12 @@
     "pslld xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "pslld xmm0, 31": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "shl v16.4s, v16.4s, #31"
@@ -1356,7 +1246,6 @@
     "pslld xmm0, 32": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP13 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1365,14 +1254,12 @@
     "psrlq mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrlq mm0, 63": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1383,7 +1270,6 @@
     "psrlq mm0, 64": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1394,14 +1280,12 @@
     "psrlq xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": []
     },
     "psrlq xmm0, 63": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "ushr v16.2d, v16.2d, #63"
@@ -1410,7 +1294,6 @@
     "psrlq xmm0, 64": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /2",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1419,14 +1302,12 @@
     "psrldq xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /3",
       "ExpectedArm64ASM": []
     },
     "psrldq xmm0, 15": {
       "ExpectedInstructionCount": 2,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
@@ -1436,7 +1317,6 @@
     "psrldq xmm0, 16": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /3",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1445,14 +1325,12 @@
     "psllq mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "psllq mm0, 63": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1463,7 +1341,6 @@
     "psllq mm0, 64": {
       "ExpectedInstructionCount": 3,
       "Type": "MMX",
-      "Optimal": "No",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -1474,14 +1351,12 @@
     "psllq xmm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": []
     },
     "psllq xmm0, 63": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "shl v16.2d, v16.2d, #63"
@@ -1490,7 +1365,6 @@
     "psllq xmm0, 64": {
       "ExpectedInstructionCount": 1,
       "Type": "SSE",
-      "Optimal": "Yes",
       "Comment": "GROUP14 0x0F 0xC7 /6",
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0"
@@ -1498,7 +1372,6 @@
     },
     "fxsave [rax]": {
       "ExpectedInstructionCount": 58,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /0",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #1008]",
@@ -1563,7 +1436,6 @@
     },
     "rdfsbase eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /0",
       "ExpectedArm64ASM": [
         "ldr w4, [x28, #176]"
@@ -1571,7 +1443,6 @@
     },
     "rdfsbase rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /0",
       "ExpectedArm64ASM": [
         "ldr x4, [x28, #176]"
@@ -1579,7 +1450,6 @@
     },
     "fxrstor [rax]": {
       "ExpectedInstructionCount": 56,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /1",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
@@ -1642,7 +1512,6 @@
     },
     "rdgsbase eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /1",
       "ExpectedArm64ASM": [
         "ldr w4, [x28, #168]"
@@ -1650,7 +1519,6 @@
     },
     "rdgsbase rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /1",
       "ExpectedArm64ASM": [
         "ldr x4, [x28, #168]"
@@ -1658,7 +1526,6 @@
     },
     "ldmxcsr [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /2",
       "ExpectedArm64ASM": [
         "ldr w20, [x4]",
@@ -1674,7 +1541,6 @@
     },
     "wrfsbase eax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /2",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1683,7 +1549,6 @@
     },
     "wrfsbase rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /2",
       "ExpectedArm64ASM": [
         "str x4, [x28, #176]"
@@ -1691,7 +1556,6 @@
     },
     "stmxcsr [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /3",
       "ExpectedArm64ASM": [
         "mov w20, #0x1f80",
@@ -1705,7 +1569,6 @@
     },
     "wrgsbase eax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /3",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1714,7 +1577,6 @@
     },
     "wrgsbase rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /3",
       "ExpectedArm64ASM": [
         "str x4, [x28, #168]"
@@ -1722,7 +1584,6 @@
     },
     "xsave [rax]": {
       "ExpectedInstructionCount": 71,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /4",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1800,7 +1661,6 @@
     },
     "lfence": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /5",
       "ExpectedArm64ASM": [
         "dmb ld"
@@ -1808,7 +1668,6 @@
     },
     "xrstor [rax]": {
       "ExpectedInstructionCount": 104,
-      "Optimal": "No",
       "Comment": "GROUP15 0x0F 0xAE /5",
       "ExpectedArm64ASM": [
         "mov x20, x4",
@@ -1919,7 +1778,6 @@
     },
     "mfence": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /6",
       "ExpectedArm64ASM": [
         "dmb sy"
@@ -1927,7 +1785,6 @@
     },
     "clwb [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /6",
       "ExpectedArm64ASM": [
         "dc cvac, x4"
@@ -1935,7 +1792,6 @@
     },
     "sfence": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /7",
       "ExpectedArm64ASM": [
         "dmb st"
@@ -1943,7 +1799,6 @@
     },
     "clflush [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /7",
       "ExpectedArm64ASM": [
         "dc civac, x4",
@@ -1952,7 +1807,6 @@
     },
     "clflushopt [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "GROUP15 0x0F 0xAE /7",
       "ExpectedArm64ASM": [
         "dc civac, x4"
@@ -1960,7 +1814,6 @@
     },
     "prefetchnta [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUP16 0x0F 0x18 /0",
         "NOP implementation"
@@ -1969,7 +1822,6 @@
     },
     "prefetcht0 [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUP16 0x0F 0x18 /1",
         "NOP implementation"
@@ -1978,7 +1830,6 @@
     },
     "prefetcht1 [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUP16 0x0F 0x18 /2",
         "NOP implementation"
@@ -1987,7 +1838,6 @@
     },
     "prefetcht2 [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUP16 0x0F 0x18 /3",
         "NOP implementation"
@@ -1996,7 +1846,6 @@
     },
     "db 0x0f, 0x18, 0x20;": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUP16 0x0F 0x18 /4",
         "nop dword [rax]",
@@ -2006,7 +1855,6 @@
     },
     "db 0x0f, 0x0d, 0x00": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUPP 0x0F 0x0D /0",
         "prefetch_exclusive [rax]",
@@ -2016,7 +1864,6 @@
     },
     "prefetchw [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUPP 0x0F 0x0D /1",
         "NOP implementation"
@@ -2025,7 +1872,6 @@
     },
     "prefetchwt1 [rax]": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "GROUPP 0x0F 0x0D /2",
         "NOP implementation"

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -15,7 +15,6 @@
   "Instructions": {
     "xgetbv": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": "0xF 0x01 /2 RM-0",
       "ExpectedArm64ASM": [
         "sub sp, sp, #0xf0 (240)",
@@ -72,7 +71,6 @@
     },
     "rdtscp": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": "0xF 0x01 /7 RM-1",
       "ExpectedArm64ASM": [
         "dmb ld",
@@ -100,7 +98,6 @@
     },
     "clzero rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xF 0x01 /7 RM-4",
       "ExpectedArm64ASM": [
         "dc zva, x4"

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -10,7 +10,6 @@
   "Instructions": {
     "push fs": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xa0",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #146]",
@@ -19,7 +18,6 @@
     },
     "pop fs": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xa1",
       "ExpectedArm64ASM": [
         "ldr w20, [x8]",
@@ -33,7 +31,6 @@
     },
     "push gs": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xa8",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #144]",
@@ -42,7 +39,6 @@
     },
     "pop gs": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0x0f 0xa9",
       "ExpectedArm64ASM": [
         "ldr w20, [x8]",

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -13,13 +13,11 @@
   "Instructions": {
     "movupd xmm0, xmm0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x10",
       "ExpectedArm64ASM": []
     },
     "movupd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x10",
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b"
@@ -27,7 +25,6 @@
     },
     "movupd xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x10",
       "ExpectedArm64ASM": [
         "ldr q16, [x4]"
@@ -35,7 +32,6 @@
     },
     "movupd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x11",
       "ExpectedArm64ASM": [
         "str q16, [x4]"
@@ -43,7 +39,6 @@
     },
     "movlpd xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x12",
       "ExpectedArm64ASM": [
         "ld1 {v16.d}[0], [x4]"
@@ -51,7 +46,6 @@
     },
     "movlpd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x13",
       "ExpectedArm64ASM": [
         "str d16, [x4]"
@@ -59,7 +53,6 @@
     },
     "unpcklpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x14",
       "ExpectedArm64ASM": [
         "zip1 v16.2d, v16.2d, v17.2d"
@@ -67,7 +60,6 @@
     },
     "unpckhpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x15",
       "ExpectedArm64ASM": [
         "zip2 v16.2d, v16.2d, v17.2d"
@@ -75,7 +67,6 @@
     },
     "movhpd xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x16",
       "ExpectedArm64ASM": [
         "ld1 {v16.d}[1], [x4]"
@@ -83,7 +74,6 @@
     },
     "movhpd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x17",
       "ExpectedArm64ASM": [
         "st1 {v16.d}[1], [x4]"
@@ -91,13 +81,11 @@
     },
     "movapd xmm0, xmm0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x28",
       "ExpectedArm64ASM": []
     },
     "movapd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x28",
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b"
@@ -105,7 +93,6 @@
     },
     "movapd xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x28",
       "ExpectedArm64ASM": [
         "ldr q16, [x4]"
@@ -113,7 +100,6 @@
     },
     "movapd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x29",
       "ExpectedArm64ASM": [
         "str q16, [x4]"
@@ -121,7 +107,6 @@
     },
     "cvtpi2pd xmm0, mm0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x2a",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -131,7 +116,6 @@
     },
     "movntpd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x2b",
       "ExpectedArm64ASM": [
         "str q16, [x4]"
@@ -139,7 +123,6 @@
     },
     "cvttpd2pi mm0, xmm0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "fcvtn v2.2s, v16.2d",
@@ -149,7 +132,6 @@
     },
     "cvtpd2pi mm0, xmm0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "fcvtn v2.2s, v16.2d",
@@ -160,7 +142,6 @@
     },
     "ucomisd xmm0, xmm1": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0x66 0x0f 0x2e",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -187,7 +168,6 @@
     },
     "comisd xmm0, xmm1": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": "0x66 0x0f 0x2f",
       "ExpectedArm64ASM": [
         "mrs x20, nzcv",
@@ -214,7 +194,6 @@
     },
     "movmskpd eax, xmm0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x50",
       "ExpectedArm64ASM": [
         "uzp2 v2.4s, v16.4s, v16.4s",
@@ -225,7 +204,6 @@
     },
     "sqrtpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x51",
       "ExpectedArm64ASM": [
         "fsqrt v16.2d, v17.2d"
@@ -233,7 +211,6 @@
     },
     "addpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x58",
       "ExpectedArm64ASM": [
         "fadd v16.2d, v16.2d, v17.2d"
@@ -241,7 +218,6 @@
     },
     "mulpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x59",
       "ExpectedArm64ASM": [
         "fmul v16.2d, v16.2d, v17.2d"
@@ -249,7 +225,6 @@
     },
     "cvtpd2ps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x5a",
       "ExpectedArm64ASM": [
         "fcvtn v16.2s, v17.2d"
@@ -257,7 +232,6 @@
     },
     "cvtpd2ps xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x5a",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -266,7 +240,6 @@
     },
     "cvtps2dq xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x5b",
       "ExpectedArm64ASM": [
         "frinti v16.4s, v17.4s",
@@ -275,7 +248,6 @@
     },
     "cvtps2dq xmm0, [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x5b",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -285,7 +257,6 @@
     },
     "subpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x5c",
       "ExpectedArm64ASM": [
         "fsub v16.2d, v16.2d, v17.2d"
@@ -293,7 +264,6 @@
     },
     "minpd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x5d",
       "ExpectedArm64ASM": [
         "fcmgt v0.2d, v17.2d, v16.2d",
@@ -302,7 +272,6 @@
     },
     "divpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x5e",
       "ExpectedArm64ASM": [
         "fdiv v16.2d, v16.2d, v17.2d"
@@ -310,7 +279,6 @@
     },
     "maxpd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x5f",
       "ExpectedArm64ASM": [
         "fcmgt v0.2d, v17.2d, v16.2d",
@@ -319,7 +287,6 @@
     },
     "punpcklbw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x60",
       "ExpectedArm64ASM": [
         "zip1 v16.16b, v16.16b, v17.16b"
@@ -327,7 +294,6 @@
     },
     "punpcklbw xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x60",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -336,7 +302,6 @@
     },
     "punpcklwd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x61",
       "ExpectedArm64ASM": [
         "zip1 v16.8h, v16.8h, v17.8h"
@@ -344,7 +309,6 @@
     },
     "punpcklwd xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x61",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -353,7 +317,6 @@
     },
     "punpckldq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x62",
       "ExpectedArm64ASM": [
         "zip1 v16.4s, v16.4s, v17.4s"
@@ -361,7 +324,6 @@
     },
     "punpckldq xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x62",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -370,7 +332,6 @@
     },
     "packsswb xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x63",
       "ExpectedArm64ASM": [
         "sqxtn v16.8b, v16.8h",
@@ -379,7 +340,6 @@
     },
     "packsswb xmm0, [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x63",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -389,7 +349,6 @@
     },
     "packsswb xmm0, xmm0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x63",
       "ExpectedArm64ASM": [
         "mov v0.16b, v16.16b",
@@ -399,7 +358,6 @@
     },
     "pcmpgtb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x64",
       "ExpectedArm64ASM": [
         "cmgt v16.16b, v16.16b, v17.16b"
@@ -407,7 +365,6 @@
     },
     "pcmpgtw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x65",
       "ExpectedArm64ASM": [
         "cmgt v16.8h, v16.8h, v17.8h"
@@ -415,7 +372,6 @@
     },
     "pcmpgtd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x66",
       "ExpectedArm64ASM": [
         "cmgt v16.4s, v16.4s, v17.4s"
@@ -423,7 +379,6 @@
     },
     "punpckhbw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x68",
       "ExpectedArm64ASM": [
         "zip2 v16.16b, v16.16b, v17.16b"
@@ -431,7 +386,6 @@
     },
     "punpckhbw xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x68",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -440,7 +394,6 @@
     },
     "punpckhwd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x69",
       "ExpectedArm64ASM": [
         "zip2 v16.8h, v16.8h, v17.8h"
@@ -448,7 +401,6 @@
     },
     "punpckhwd xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x69",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -457,7 +409,6 @@
     },
     "punpckhdq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6a",
       "ExpectedArm64ASM": [
         "zip2 v16.4s, v16.4s, v17.4s"
@@ -465,7 +416,6 @@
     },
     "punpckhdq xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6a",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -474,7 +424,6 @@
     },
     "packssdw xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6b",
       "ExpectedArm64ASM": [
         "sqxtn v16.4h, v16.4s",
@@ -483,7 +432,6 @@
     },
     "punpcklqdq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6c",
       "ExpectedArm64ASM": [
         "zip1 v16.2d, v16.2d, v17.2d"
@@ -491,7 +439,6 @@
     },
     "punpckhqdq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6d",
       "ExpectedArm64ASM": [
         "zip2 v16.2d, v16.2d, v17.2d"
@@ -499,7 +446,6 @@
     },
     "movd xmm0, dword [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6e",
       "ExpectedArm64ASM": [
         "ldr s16, [x4]"
@@ -507,7 +453,6 @@
     },
     "movd xmm0, eax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6e",
       "ExpectedArm64ASM": [
         "fmov s16, w4"
@@ -515,7 +460,6 @@
     },
     "movq xmm0, qword [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6e",
       "ExpectedArm64ASM": [
         "ldr d16, [x4]"
@@ -523,7 +467,6 @@
     },
     "movq xmm0, rax": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6e",
       "ExpectedArm64ASM": [
         "fmov d16, x4"
@@ -531,13 +474,11 @@
     },
     "movdqa xmm0, xmm0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6f",
       "ExpectedArm64ASM": []
     },
     "movdqa xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6f",
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b"
@@ -545,7 +486,6 @@
     },
     "movdqa xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x6f",
       "ExpectedArm64ASM": [
         "ldr q16, [x4]"
@@ -553,7 +493,6 @@
     },
     "pshufd xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast element 0",
         "0x66 0x0f 0x70"
@@ -564,7 +503,6 @@
     },
     "pshufd xmm0, xmm1, 11100100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Identity copy",
         "0x66 0x0f 0x70"
@@ -575,7 +513,6 @@
     },
     "pshufd xmm0, xmm1, 01010000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Zip with self",
         "0x66 0x0f 0x70"
@@ -586,7 +523,6 @@
     },
     "pshufd xmm0, [rax], 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast element 0 from memory",
         "0x66 0x0f 0x70"
@@ -598,7 +534,6 @@
     },
     "pshufd xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast element 0",
         "Element 0 becomes element 1",
@@ -612,7 +547,6 @@
     },
     "pshufd xmm0, [rax], 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast element 0 from Memory",
         "Element 0 becomes element 1",
@@ -627,7 +561,6 @@
     },
     "pshufd xmm0, xmm1, 0xff": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast element 3",
         "0x66 0x0f 0x70"
@@ -638,7 +571,6 @@
     },
     "pshufd xmm0, [rax], 0xff": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast element 3 from memory",
         "0x66 0x0f 0x70"
@@ -650,7 +582,6 @@
     },
     "pcmpeqb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x74",
       "ExpectedArm64ASM": [
         "cmeq v16.16b, v16.16b, v17.16b"
@@ -658,7 +589,6 @@
     },
     "pcmpeqw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x75",
       "ExpectedArm64ASM": [
         "cmeq v16.8h, v16.8h, v17.8h"
@@ -666,7 +596,6 @@
     },
     "pcmpeqd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x76",
       "ExpectedArm64ASM": [
         "cmeq v16.4s, v16.4s, v17.4s"
@@ -674,7 +603,6 @@
     },
     "extrq xmm0, 64, 0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "SSE4a",
@@ -683,7 +611,6 @@
     },
     "extrq xmm0, 32, 32": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "SSE4a",
@@ -692,7 +619,6 @@
     },
     "extrq xmm0, 0, 0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "SSE4a",
@@ -701,7 +627,6 @@
     },
     "extrq xmm0, xmm1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "SSE4a",
@@ -710,7 +635,6 @@
     },
     "haddpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x7c",
       "ExpectedArm64ASM": [
         "faddp v16.2d, v16.2d, v17.2d"
@@ -718,7 +642,6 @@
     },
     "hsubpd xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x7c",
       "ExpectedArm64ASM": [
         "uzp1 v2.2d, v16.2d, v17.2d",
@@ -728,7 +651,6 @@
     },
     "movd eax, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x7e",
       "ExpectedArm64ASM": [
         "mov w4, v16.s[0]"
@@ -736,7 +658,6 @@
     },
     "movq rax, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x7e",
       "ExpectedArm64ASM": [
         "mov x4, v16.d[0]"
@@ -744,7 +665,6 @@
     },
     "movd dword [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x7e",
       "ExpectedArm64ASM": [
         "str s16, [x4]"
@@ -752,7 +672,6 @@
     },
     "movq qword [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x7e",
       "ExpectedArm64ASM": [
         "str d16, [x4]"
@@ -760,7 +679,6 @@
     },
     "movdqa [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0x7f",
       "ExpectedArm64ASM": [
         "str q16, [x4]"
@@ -768,7 +686,6 @@
     },
     "cmppd xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmeq v16.2d, v16.2d, v17.2d"
@@ -776,7 +693,6 @@
     },
     "cmppd xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmgt v16.2d, v17.2d, v16.2d"
@@ -784,7 +700,6 @@
     },
     "cmppd xmm0, xmm1, 2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmge v16.2d, v17.2d, v16.2d"
@@ -792,7 +707,6 @@
     },
     "cmppd xmm0, xmm1, 3": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmge v0.2d, v16.2d, v17.2d",
@@ -803,7 +717,6 @@
     },
     "cmppd xmm0, xmm1, 4": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmeq v16.2d, v16.2d, v17.2d",
@@ -812,7 +725,6 @@
     },
     "cmppd xmm0, xmm1, 5": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmgt v2.2d, v17.2d, v16.2d",
@@ -821,7 +733,6 @@
     },
     "cmppd xmm0, xmm1, 6": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmge v2.2d, v17.2d, v16.2d",
@@ -830,7 +741,6 @@
     },
     "cmppd xmm0, xmm1, 7": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc2",
       "ExpectedArm64ASM": [
         "fcmge v0.2d, v16.2d, v17.2d",
@@ -840,7 +750,6 @@
     },
     "pinsrw xmm0, eax, 000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "mov v16.h[0], w4"
@@ -848,7 +757,6 @@
     },
     "pinsrw xmm0, eax, 001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "mov v16.h[1], w4"
@@ -856,7 +764,6 @@
     },
     "pinsrw xmm0, eax, 010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "mov v16.h[2], w4"
@@ -864,7 +771,6 @@
     },
     "pinsrw xmm0, eax, 011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "mov v16.h[3], w4"
@@ -872,7 +778,6 @@
     },
     "pinsrw xmm0, eax, 100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "mov v16.h[4], w4"
@@ -880,7 +785,6 @@
     },
     "pinsrw xmm0, eax, 101b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "mov v16.h[5], w4"
@@ -888,7 +792,6 @@
     },
     "pinsrw xmm0, eax, 110b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "mov v16.h[6], w4"
@@ -896,7 +799,6 @@
     },
     "pinsrw xmm0, eax, 111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "mov v16.h[7], w4"
@@ -904,7 +806,6 @@
     },
     "pinsrw xmm0, [rax], 000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ld1 {v16.h}[0], [x4]"
@@ -912,7 +813,6 @@
     },
     "pinsrw xmm0, [rax], 001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ld1 {v16.h}[1], [x4]"
@@ -920,7 +820,6 @@
     },
     "pinsrw xmm0, [rax], 010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ld1 {v16.h}[2], [x4]"
@@ -928,7 +827,6 @@
     },
     "pinsrw xmm0, [rax], 011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ld1 {v16.h}[3], [x4]"
@@ -936,7 +834,6 @@
     },
     "pinsrw xmm0, [rax], 100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ld1 {v16.h}[4], [x4]"
@@ -944,7 +841,6 @@
     },
     "pinsrw xmm0, [rax], 101b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ld1 {v16.h}[5], [x4]"
@@ -952,7 +848,6 @@
     },
     "pinsrw xmm0, [rax], 110b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ld1 {v16.h}[6], [x4]"
@@ -960,7 +855,6 @@
     },
     "pinsrw xmm0, [rax], 111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc4",
       "ExpectedArm64ASM": [
         "ld1 {v16.h}[7], [x4]"
@@ -968,7 +862,6 @@
     },
     "pextrw eax, xmm0, 000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "umov w4, v16.h[0]"
@@ -976,7 +869,6 @@
     },
     "pextrw eax, xmm0, 001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "umov w4, v16.h[1]"
@@ -984,7 +876,6 @@
     },
     "pextrw eax, xmm0, 010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "umov w4, v16.h[2]"
@@ -992,7 +883,6 @@
     },
     "pextrw eax, xmm0, 011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "umov w4, v16.h[3]"
@@ -1000,7 +890,6 @@
     },
     "pextrw eax, xmm0, 100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "umov w4, v16.h[4]"
@@ -1008,7 +897,6 @@
     },
     "pextrw eax, xmm0, 101b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "umov w4, v16.h[5]"
@@ -1016,7 +904,6 @@
     },
     "pextrw eax, xmm0, 110b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "umov w4, v16.h[6]"
@@ -1024,7 +911,6 @@
     },
     "pextrw eax, xmm0, 111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "umov w4, v16.h[7]"
@@ -1032,7 +918,6 @@
     },
     "pextrw [rax], xmm0, 000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "st1 {v16.h}[0], [x4]"
@@ -1040,7 +925,6 @@
     },
     "pextrw [rax], xmm0, 001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "st1 {v16.h}[1], [x4]"
@@ -1048,7 +932,6 @@
     },
     "pextrw [rax], xmm0, 010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "st1 {v16.h}[2], [x4]"
@@ -1056,7 +939,6 @@
     },
     "pextrw [rax], xmm0, 011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "st1 {v16.h}[3], [x4]"
@@ -1064,7 +946,6 @@
     },
     "pextrw [rax], xmm0, 100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "st1 {v16.h}[4], [x4]"
@@ -1072,7 +953,6 @@
     },
     "pextrw [rax], xmm0, 101b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "st1 {v16.h}[5], [x4]"
@@ -1080,7 +960,6 @@
     },
     "pextrw [rax], xmm0, 110b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "st1 {v16.h}[6], [x4]"
@@ -1088,7 +967,6 @@
     },
     "pextrw [rax], xmm0, 111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc5",
       "ExpectedArm64ASM": [
         "st1 {v16.h}[7], [x4]"
@@ -1096,7 +974,6 @@
     },
     "shufpd xmm0, xmm1, 00b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc6",
       "ExpectedArm64ASM": [
         "zip1 v16.2d, v16.2d, v17.2d"
@@ -1104,7 +981,6 @@
     },
     "shufpd xmm0, xmm1, 01b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc6",
       "ExpectedArm64ASM": [
         "ext v16.16b, v16.16b, v17.16b, #8"
@@ -1112,7 +988,6 @@
     },
     "shufpd xmm0, xmm1, 10b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc6",
       "ExpectedArm64ASM": [
         "mov v16.d[1], v17.d[1]"
@@ -1120,7 +995,6 @@
     },
     "shufpd xmm0, xmm1, 11b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc6",
       "ExpectedArm64ASM": [
         "zip2 v16.2d, v16.2d, v17.2d"
@@ -1128,7 +1002,6 @@
     },
     "shufpd xmm1, xmm0, 00b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc6",
       "ExpectedArm64ASM": [
         "zip1 v17.2d, v17.2d, v16.2d"
@@ -1136,7 +1009,6 @@
     },
     "shufpd xmm1, xmm0, 01b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc6",
       "ExpectedArm64ASM": [
         "ext v17.16b, v17.16b, v16.16b, #8"
@@ -1144,7 +1016,6 @@
     },
     "shufpd xmm1, xmm0, 10b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc6",
       "ExpectedArm64ASM": [
         "mov v17.d[1], v16.d[1]"
@@ -1152,7 +1023,6 @@
     },
     "shufpd xmm1, xmm0, 11b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xc6",
       "ExpectedArm64ASM": [
         "zip2 v17.2d, v17.2d, v16.2d"
@@ -1160,7 +1030,6 @@
     },
     "addsubpd xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd0",
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2016]",
@@ -1170,7 +1039,6 @@
     },
     "psrlw xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd1",
       "ExpectedArm64ASM": [
         "uqshl d0, d17, #57",
@@ -1182,7 +1050,6 @@
     },
     "psrld xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd2",
       "ExpectedArm64ASM": [
         "uqshl d0, d17, #57",
@@ -1194,7 +1061,6 @@
     },
     "psrlq xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd3",
       "ExpectedArm64ASM": [
         "uqshl d0, d17, #57",
@@ -1206,7 +1072,6 @@
     },
     "paddq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd4",
       "ExpectedArm64ASM": [
         "add v16.2d, v16.2d, v17.2d"
@@ -1214,7 +1079,6 @@
     },
     "pmullw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd3",
       "ExpectedArm64ASM": [
         "mul v16.8h, v16.8h, v17.8h"
@@ -1222,7 +1086,6 @@
     },
     "pmovmskb eax, xmm0": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd7",
       "ExpectedArm64ASM": [
         "mov x20, #0x201",
@@ -1240,7 +1103,6 @@
     },
     "psubusb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd8",
       "ExpectedArm64ASM": [
         "uqsub v16.16b, v16.16b, v17.16b"
@@ -1248,7 +1110,6 @@
     },
     "psubusw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd9",
       "ExpectedArm64ASM": [
         "uqsub v16.8h, v16.8h, v17.8h"
@@ -1256,7 +1117,6 @@
     },
     "pminub xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xda",
       "ExpectedArm64ASM": [
         "umin v16.16b, v16.16b, v17.16b"
@@ -1264,7 +1124,6 @@
     },
     "pand xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xdb",
       "ExpectedArm64ASM": [
         "and v16.16b, v16.16b, v17.16b"
@@ -1272,7 +1131,6 @@
     },
     "paddusb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xdc",
       "ExpectedArm64ASM": [
         "uqadd v16.16b, v16.16b, v17.16b"
@@ -1280,7 +1138,6 @@
     },
     "paddusw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xdd",
       "ExpectedArm64ASM": [
         "uqadd v16.8h, v16.8h, v17.8h"
@@ -1288,7 +1145,6 @@
     },
     "pmaxub xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xde",
       "ExpectedArm64ASM": [
         "umax v16.16b, v16.16b, v17.16b"
@@ -1296,7 +1152,6 @@
     },
     "pandn xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xdf",
       "ExpectedArm64ASM": [
         "bic v16.16b, v17.16b, v16.16b"
@@ -1304,7 +1159,6 @@
     },
     "pavgb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe0",
       "ExpectedArm64ASM": [
         "urhadd v16.16b, v16.16b, v17.16b"
@@ -1312,7 +1166,6 @@
     },
     "psraw xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe1",
       "ExpectedArm64ASM": [
         "uqshl d0, d17, #57",
@@ -1324,7 +1177,6 @@
     },
     "psrad xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe2",
       "ExpectedArm64ASM": [
         "uqshl d0, d17, #57",
@@ -1336,7 +1188,6 @@
     },
     "pavgw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe3",
       "ExpectedArm64ASM": [
         "urhadd v16.8h, v16.8h, v17.8h"
@@ -1344,7 +1195,6 @@
     },
     "pmulhuw xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe4",
       "ExpectedArm64ASM": [
         "umull2 v0.4s, v16.8h, v17.8h",
@@ -1354,7 +1204,6 @@
     },
     "pmulhw xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe5",
       "ExpectedArm64ASM": [
         "smull2 v0.4s, v16.8h, v17.8h",
@@ -1364,7 +1213,6 @@
     },
     "cvttpd2dq xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe6",
       "ExpectedArm64ASM": [
         "fcvtn v2.2s, v17.2d",
@@ -1373,7 +1221,6 @@
     },
     "movntdq [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe7",
       "ExpectedArm64ASM": [
         "str q16, [x4]"
@@ -1381,7 +1228,6 @@
     },
     "psubsb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe8",
       "ExpectedArm64ASM": [
         "sqsub v16.16b, v16.16b, v17.16b"
@@ -1389,7 +1235,6 @@
     },
     "psubsw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe9",
       "ExpectedArm64ASM": [
         "sqsub v16.8h, v16.8h, v17.8h"
@@ -1397,7 +1242,6 @@
     },
     "pminsw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xea",
       "ExpectedArm64ASM": [
         "smin v16.8h, v16.8h, v17.8h"
@@ -1405,7 +1249,6 @@
     },
     "por xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xeb",
       "ExpectedArm64ASM": [
         "orr v16.16b, v16.16b, v17.16b"
@@ -1413,7 +1256,6 @@
     },
     "paddsb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xec",
       "ExpectedArm64ASM": [
         "sqadd v16.16b, v16.16b, v17.16b"
@@ -1421,7 +1263,6 @@
     },
     "paddsw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xed",
       "ExpectedArm64ASM": [
         "sqadd v16.8h, v16.8h, v17.8h"
@@ -1429,7 +1270,6 @@
     },
     "pmaxsw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xee",
       "ExpectedArm64ASM": [
         "smax v16.8h, v16.8h, v17.8h"
@@ -1437,7 +1277,6 @@
     },
     "pxor xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xef",
       "ExpectedArm64ASM": [
         "eor v16.16b, v16.16b, v17.16b"
@@ -1445,7 +1284,6 @@
     },
     "psllw xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf1",
       "ExpectedArm64ASM": [
         "uqshl d0, d17, #57",
@@ -1456,7 +1294,6 @@
     },
     "pslld xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf2",
       "ExpectedArm64ASM": [
         "uqshl d0, d17, #57",
@@ -1467,7 +1304,6 @@
     },
     "psllq xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf3",
       "ExpectedArm64ASM": [
         "uqshl d0, d17, #57",
@@ -1478,7 +1314,6 @@
     },
     "pmuludq xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf4",
       "ExpectedArm64ASM": [
         "uzp1 v2.4s, v16.4s, v16.4s",
@@ -1488,7 +1323,6 @@
     },
     "pmaddwd xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf5",
       "ExpectedArm64ASM": [
         "smull v2.4s, v16.4h, v17.4h",
@@ -1498,7 +1332,6 @@
     },
     "psadbw xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf6",
       "ExpectedArm64ASM": [
         "uabdl v2.8h, v16.8b, v17.8b",
@@ -1510,7 +1343,6 @@
     },
     "maskmovdqu xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf7",
       "ExpectedArm64ASM": [
         "cmlt v2.16b, v17.16b, #0",
@@ -1521,7 +1353,6 @@
     },
     "psubb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf8",
       "ExpectedArm64ASM": [
         "sub v16.16b, v16.16b, v17.16b"
@@ -1529,7 +1360,6 @@
     },
     "psubw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf9",
       "ExpectedArm64ASM": [
         "sub v16.8h, v16.8h, v17.8h"
@@ -1537,7 +1367,6 @@
     },
     "psubd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xfa",
       "ExpectedArm64ASM": [
         "sub v16.4s, v16.4s, v17.4s"
@@ -1545,7 +1374,6 @@
     },
     "psubq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xfb",
       "ExpectedArm64ASM": [
         "sub v16.2d, v16.2d, v17.2d"
@@ -1553,7 +1381,6 @@
     },
     "paddb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xfc",
       "ExpectedArm64ASM": [
         "add v16.16b, v16.16b, v17.16b"
@@ -1561,7 +1388,6 @@
     },
     "paddw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xfd",
       "ExpectedArm64ASM": [
         "add v16.8h, v16.8h, v17.8h"
@@ -1569,7 +1395,6 @@
     },
     "paddd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xfe",
       "ExpectedArm64ASM": [
         "add v16.4s, v16.4s, v17.4s"

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "addsubpd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd0",
       "ExpectedArm64ASM": [
         "ext v2.16b, v17.16b, v17.16b, #8",

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -11,7 +11,6 @@
   "Instructions": {
     "psrlw xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd1",
       "ExpectedArm64ASM": [
         "mov z0.d, d17",
@@ -20,7 +19,6 @@
     },
     "psrld xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd2",
       "ExpectedArm64ASM": [
         "mov z0.d, d17",
@@ -29,7 +27,6 @@
     },
     "psrlq xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xd3",
       "ExpectedArm64ASM": [
         "mov z0.d, d17",
@@ -38,7 +35,6 @@
     },
     "psraw xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe1",
       "ExpectedArm64ASM": [
         "mov z0.d, d17",
@@ -47,7 +43,6 @@
     },
     "psrad xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe2",
       "ExpectedArm64ASM": [
         "mov z0.d, d17",
@@ -56,7 +51,6 @@
     },
     "pmulhuw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe4",
       "ExpectedArm64ASM": [
         "umulh z16.h, z16.h, z17.h"
@@ -64,7 +58,6 @@
     },
     "pmulhw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xe5",
       "ExpectedArm64ASM": [
         "smulh z16.h, z16.h, z17.h"
@@ -72,7 +65,6 @@
     },
     "psllw xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf1",
       "ExpectedArm64ASM": [
         "mov z0.d, d17",
@@ -81,7 +73,6 @@
     },
     "pslld xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf2",
       "ExpectedArm64ASM": [
         "mov z0.d, d17",
@@ -90,7 +81,6 @@
     },
     "psllq xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0x66 0x0f 0xf3",
       "ExpectedArm64ASM": [
         "mov z0.d, d17",

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -10,7 +10,6 @@
   "Instructions": {
     "pmulhuw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "SVE-256bit changes behaviour slightly",
         "0x66 0x0f 0xe4"
@@ -21,7 +20,6 @@
     },
     "pmulhw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "SVE-256bit changes behaviour slightly",
         "0x66 0x0f 0xe5"

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -14,7 +14,6 @@
   "Instructions": {
     "movss xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x10",
       "ExpectedArm64ASM": [
         "mov v16.s[0], v17.s[0]"
@@ -22,7 +21,6 @@
     },
     "movss xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x10",
       "ExpectedArm64ASM": [
         "ldr s16, [x4]"
@@ -30,7 +28,6 @@
     },
     "movss [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x11",
       "ExpectedArm64ASM": [
         "str s16, [x4]"
@@ -38,7 +35,6 @@
     },
     "movsldup xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x12",
       "ExpectedArm64ASM": [
         "trn1 v16.4s, v17.4s, v17.4s"
@@ -46,7 +42,6 @@
     },
     "movsldup xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x12",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -55,7 +50,6 @@
     },
     "movshdup xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x16",
       "ExpectedArm64ASM": [
         "trn2 v16.4s, v17.4s, v17.4s"
@@ -63,7 +57,6 @@
     },
     "movshdup xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x16",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
@@ -72,7 +65,6 @@
     },
     "cvtsi2ss xmm0, eax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x2a"
       ],
@@ -83,7 +75,6 @@
     },
     "cvtsi2ss xmm0, dword [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x2a"
       ],
@@ -95,7 +86,6 @@
     },
     "cvtsi2ss xmm0, rax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2a",
       "ExpectedArm64ASM": [
         "scvtf s0, x4",
@@ -104,7 +94,6 @@
     },
     "cvtsi2ss xmm0, qword [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x2a"
       ],
@@ -116,7 +105,6 @@
     },
     "movntss [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2b",
       "ExpectedArm64ASM": [
         "str s16, [x4]"
@@ -124,7 +112,6 @@
     },
     "cvttss2si eax, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "fcvtzs w4, s16"
@@ -132,7 +119,6 @@
     },
     "cvttss2si eax, dword [rbx]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "ldr s2, [x7]",
@@ -141,7 +127,6 @@
     },
     "cvttss2si rax, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "fcvtzs x4, s16"
@@ -149,7 +134,6 @@
     },
     "cvttss2si rax, dword [rbx]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "ldr d2, [x7]",
@@ -158,7 +142,6 @@
     },
     "cvtss2si eax, xmm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "frinti s0, s16",
@@ -167,7 +150,6 @@
     },
     "cvtss2si eax, dword [rbx]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "ldr s2, [x7]",
@@ -177,7 +159,6 @@
     },
     "cvtss2si rax, xmm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "frinti s0, s16",
@@ -186,7 +167,6 @@
     },
     "cvtss2si rax, dword [rbx]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "ldr d2, [x7]",
@@ -196,7 +176,6 @@
     },
     "sqrtss xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x51",
       "ExpectedArm64ASM": [
         "fsqrt s0, s17",
@@ -205,7 +184,6 @@
     },
     "rsqrtss xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x52"
       ],
@@ -218,7 +196,6 @@
     },
     "rcpss xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x53"
       ],
@@ -230,7 +207,6 @@
     },
     "addss xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x58"
       ],
@@ -241,7 +217,6 @@
     },
     "mulss xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x59"
       ],
@@ -252,7 +227,6 @@
     },
     "cvtss2sd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x5a",
       "ExpectedArm64ASM": [
         "fcvt d0, s17",
@@ -261,7 +235,6 @@
     },
     "cvtss2sd xmm0, [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x5a",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -271,7 +244,6 @@
     },
     "cvttps2dq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x5b",
       "ExpectedArm64ASM": [
         "fcvtzs v16.4s, v17.4s"
@@ -279,7 +251,6 @@
     },
     "subss xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5c"
       ],
@@ -290,7 +261,6 @@
     },
     "minss xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5d"
       ],
@@ -304,7 +274,6 @@
     },
     "divss xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5e"
       ],
@@ -315,7 +284,6 @@
     },
     "maxss xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0x5f"
       ],
@@ -329,13 +297,11 @@
     },
     "movdqu xmm0, xmm0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x6f",
       "ExpectedArm64ASM": []
     },
     "movdqu xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x6f",
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b"
@@ -343,7 +309,6 @@
     },
     "movdqu xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x6f",
       "ExpectedArm64ASM": [
         "ldr q16, [x4]"
@@ -351,7 +316,6 @@
     },
     "pshufhw xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast upper-half element 0",
         "0xf3 0x0f 0x70"
@@ -363,7 +327,6 @@
     },
     "pshufhw xmm0, xmm1, 11100100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Identity copy",
         "0xf3 0x0f 0x70"
@@ -374,7 +337,6 @@
     },
     "pshufhw xmm0, xmm1, 01010000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Upper elements Self-zip",
         "0xf3 0x0f 0x70"
@@ -386,7 +348,6 @@
     },
     "pshufhw xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast element 0 in the upper-half",
         "Upper-half Element 0 gets turned in to element 1",
@@ -400,7 +361,6 @@
     },
     "pshufhw xmm0, xmm1, 0xff": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast upper-half Element 3",
         "0xf3 0x0f 0x70"
@@ -412,7 +372,6 @@
     },
     "movq xmm0, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x7e",
       "ExpectedArm64ASM": [
         "mov v16.8b, v16.8b"
@@ -420,7 +379,6 @@
     },
     "movq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x7e",
       "ExpectedArm64ASM": [
         "mov v16.8b, v17.8b"
@@ -428,7 +386,6 @@
     },
     "movq xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x7e",
       "ExpectedArm64ASM": [
         "ldr d16, [x4]"
@@ -436,7 +393,6 @@
     },
     "movdqu [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0x7f",
       "ExpectedArm64ASM": [
         "str q16, [x4]"
@@ -444,7 +400,6 @@
     },
     "popcnt ax, bx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xb8",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -465,7 +420,6 @@
     },
     "popcnt eax, ebx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xb8",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -485,7 +439,6 @@
     },
     "popcnt rax, rbx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xb8",
       "ExpectedArm64ASM": [
         "fmov d0, x7",
@@ -504,7 +457,6 @@
     },
     "tzcnt ax, bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbc",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -522,7 +474,6 @@
     },
     "tzcnt eax, ebx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbc",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -538,7 +489,6 @@
     },
     "tzcnt rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0xbc",
       "ExpectedArm64ASM": [
         "rbit x4, x7",
@@ -553,7 +503,6 @@
     },
     "lzcnt ax, bx": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbd",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -571,7 +520,6 @@
     },
     "lzcnt eax, ebx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbd",
       "ExpectedArm64ASM": [
         "mov w20, w7",
@@ -586,7 +534,6 @@
     },
     "lzcnt rax, rbx": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": "0xf3 0x0f 0xbd",
       "ExpectedArm64ASM": [
         "clz x4, x7",
@@ -600,7 +547,6 @@
     },
     "cmpss xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -611,7 +557,6 @@
     },
     "cmpss xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -622,7 +567,6 @@
     },
     "cmpss xmm0, xmm1, 2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -633,7 +577,6 @@
     },
     "cmpss xmm0, xmm1, 3": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -647,7 +590,6 @@
     },
     "cmpss xmm0, xmm1, 4": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -659,7 +601,6 @@
     },
     "cmpss xmm0, xmm1, 5": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -671,7 +612,6 @@
     },
     "cmpss xmm0, xmm1, 6": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -683,7 +623,6 @@
     },
     "cmpss xmm0, xmm1, 7": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -696,7 +635,6 @@
     },
     "movq2dq xmm0, mm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0xd6",
       "ExpectedArm64ASM": [
         "ldr d16, [x28, #752]"
@@ -704,7 +642,6 @@
     },
     "cvtdq2pd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0xe6",
       "ExpectedArm64ASM": [
         "sxtl v2.2d, v17.2s",
@@ -713,7 +650,6 @@
     },
     "cvtdq2pd xmm0, [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xf3 0x0f 0xe6",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "movsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x10",
       "ExpectedArm64ASM": [
         "mov v16.d[0], v17.d[0]"
@@ -20,7 +19,6 @@
     },
     "movsd xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x10",
       "ExpectedArm64ASM": [
         "ldr d16, [x4]"
@@ -28,7 +26,6 @@
     },
     "movsd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x11",
       "ExpectedArm64ASM": [
         "str d16, [x4]"
@@ -36,7 +33,6 @@
     },
     "movddup xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x12",
       "ExpectedArm64ASM": [
         "dup v16.2d, v17.d[0]"
@@ -44,7 +40,6 @@
     },
     "movddup xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x12",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
@@ -53,7 +48,6 @@
     },
     "cvtsi2sd xmm0, eax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -64,7 +58,6 @@
     },
     "cvtsi2sd xmm0, dword [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -76,7 +69,6 @@
     },
     "cvtsi2sd xmm0, rax": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -87,7 +79,6 @@
     },
     "cvtsi2sd xmm0, qword [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x2a"
       ],
@@ -99,7 +90,6 @@
     },
     "movntsd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2b",
       "ExpectedArm64ASM": [
         "str d16, [x4]"
@@ -107,7 +97,6 @@
     },
     "cvttsd2si eax, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "fcvtzs w4, d16"
@@ -115,7 +104,6 @@
     },
     "cvttsd2si eax, qword [rbx]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "ldr d2, [x7]",
@@ -124,7 +112,6 @@
     },
     "cvttsd2si rax, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "fcvtzs x4, d16"
@@ -132,7 +119,6 @@
     },
     "cvttsd2si rax, qword [rbx]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "ldr d2, [x7]",
@@ -141,7 +127,6 @@
     },
     "cvtsd2si eax, xmm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "frinti d0, d16",
@@ -150,7 +135,6 @@
     },
     "cvtsd2si eax, qword [rbx]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "ldr d2, [x7]",
@@ -160,7 +144,6 @@
     },
     "cvtsd2si rax, xmm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "frinti d0, d16",
@@ -169,7 +152,6 @@
     },
     "cvtsd2si rax, qword [rbx]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "ldr d2, [x7]",
@@ -179,7 +161,6 @@
     },
     "sqrtsd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x51"
       ],
@@ -190,7 +171,6 @@
     },
     "addsd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x58"
       ],
@@ -201,7 +181,6 @@
     },
     "mulsd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x59"
       ],
@@ -212,7 +191,6 @@
     },
     "cvtsd2ss xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5a"
       ],
@@ -223,7 +201,6 @@
     },
     "cvtsd2ss xmm0, [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5a"
       ],
@@ -235,7 +212,6 @@
     },
     "subsd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5c"
       ],
@@ -246,7 +222,6 @@
     },
     "minsd xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5d"
       ],
@@ -260,7 +235,6 @@
     },
     "divsd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5e"
       ],
@@ -271,7 +245,6 @@
     },
     "maxsd xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0x5f"
       ],
@@ -285,7 +258,6 @@
     },
     "pshuflw xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast element 0",
         "0xf2 0x0f 0x70"
@@ -297,7 +269,6 @@
     },
     "pshuflw xmm0, xmm1, 11100100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Identity copy",
         "0xf2 0x0f 0x70"
@@ -308,7 +279,6 @@
     },
     "pshuflw xmm0, xmm1, 01010000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Lower elements Self-zip",
         "0xf2 0x0f 0x70"
@@ -320,7 +290,6 @@
     },
     "pshuflw xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast first element in to Elements 1,2,3",
         "Element 0 gets turned in to element 1",
@@ -334,7 +303,6 @@
     },
     "pshuflw xmm0, xmm1, 0xff": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Broadcast Element 3",
         "0xf2 0x0f 0x70"
@@ -346,7 +314,6 @@
     },
     "insertq xmm0, xmm1, 0, 0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "SSE4a",
@@ -355,7 +322,6 @@
     },
     "insertq xmm0, xmm1, 64, 0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "SSE4a",
@@ -364,7 +330,6 @@
     },
     "insertq xmm0, xmm1, 32, 32": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "SSE4a",
@@ -373,7 +338,6 @@
     },
     "insertq xmm0, xmm1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "SSE4a",
@@ -382,7 +346,6 @@
     },
     "haddps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x7c",
       "ExpectedArm64ASM": [
         "faddp v16.4s, v16.4s, v17.4s"
@@ -390,7 +353,6 @@
     },
     "hsubps xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0x7d",
       "ExpectedArm64ASM": [
         "uzp1 v2.4s, v16.4s, v17.4s",
@@ -400,7 +362,6 @@
     },
     "cmpsd xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -411,7 +372,6 @@
     },
     "cmpsd xmm0, xmm1, 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -422,7 +382,6 @@
     },
     "cmpsd xmm0, xmm1, 2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -433,7 +392,6 @@
     },
     "cmpsd xmm0, xmm1, 3": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -447,7 +405,6 @@
     },
     "cmpsd xmm0, xmm1, 4": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -459,7 +416,6 @@
     },
     "cmpsd xmm0, xmm1, 5": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -471,7 +427,6 @@
     },
     "cmpsd xmm0, xmm1, 6": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -483,7 +438,6 @@
     },
     "cmpsd xmm0, xmm1, 7": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -496,7 +450,6 @@
     },
     "addsubps xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0xd0",
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #1984]",
@@ -506,7 +459,6 @@
     },
     "movdq2q mm0, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0xd6",
       "ExpectedArm64ASM": [
         "str d16, [x28, #752]"
@@ -514,7 +466,6 @@
     },
     "cvtpd2dq xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0xe6",
       "ExpectedArm64ASM": [
         "fcvtn v2.2s, v17.2d",
@@ -524,7 +475,6 @@
     },
     "lddqu xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0xf0",
       "ExpectedArm64ASM": [
         "ldr q16, [x4]"

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "addsubps xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": "0xf2 0x0f 0xd0",
       "ExpectedArm64ASM": [
         "rev64 v2.4s, v17.4s",

--- a/unittests/InstructionCountCI/Secondary_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_SVE128.json
@@ -11,7 +11,6 @@
   "Instructions": {
     "movmskps eax, xmm0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x50",
       "ExpectedArm64ASM": [
         "ushr v2.4s, v16.4s, #31",
@@ -23,7 +22,6 @@
     },
     "movmskps rax, xmm0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": "0x0f 0x50",
       "ExpectedArm64ASM": [
         "ushr v2.4s, v16.4s, #31",
@@ -35,7 +33,6 @@
     },
     "psrlw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd1",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -46,7 +43,6 @@
     },
     "psrld mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -57,7 +53,6 @@
     },
     "psrlq mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xd3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -68,7 +63,6 @@
     },
     "psraw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe1",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -79,7 +73,6 @@
     },
     "psrad mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xe2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -90,7 +83,6 @@
     },
     "psllw mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf1",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -101,7 +93,6 @@
     },
     "pslld mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf2",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",
@@ -112,7 +103,6 @@
     },
     "psllq mm0, mm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": "0x0f 0xf3",
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #752]",

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -16,7 +16,6 @@
   "Instructions": {
     "vmovups xmm0, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x10 128-bit"
       ],
@@ -26,7 +25,6 @@
     },
     "vmovups xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "SVE 128-bit load already zero's the upper bits",
         "Map 1 0b00 0x10 128-bit"
@@ -37,7 +35,6 @@
     },
     "vmovups ymm0, ymm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Spurious moves",
         "Map 1 0b00 0x10 256-bit"
@@ -49,7 +46,6 @@
     },
     "vmovups ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x10 256-bit"
       ],
@@ -59,7 +55,6 @@
     },
     "vmovupd xmm0, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x10 128-bit"
       ],
@@ -69,7 +64,6 @@
     },
     "vmovupd xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "SVE 128-bit load already zero's the upper bits",
         "Map 1 0b01 0x10 128-bit"
@@ -80,7 +74,6 @@
     },
     "vmovupd ymm0, ymm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Spurious moves",
         "Map 1 0b01 0x10 256-bit"
@@ -92,7 +85,6 @@
     },
     "vmovupd ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x10 256-bit"
       ],
@@ -102,7 +94,6 @@
     },
     "vmovss xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "32-bit vector load already zero's the upper bits",
         "Map 1 0b10 0x10 128-bit"
@@ -113,7 +104,6 @@
     },
     "vmovss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b10 0x10 128-bit"
@@ -125,7 +115,6 @@
     },
     "vmovsd xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "32-bit vector load already zero's the upper bits",
         "Map 1 0b11 0x10 128-bit"
@@ -136,7 +125,6 @@
     },
     "vmovsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b11 0x10 128-bit"
@@ -148,7 +136,6 @@
     },
     "vmovups [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x11 128-bit"
       ],
@@ -158,7 +145,6 @@
     },
     "vmovups [rax], ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x11 256-bit"
       ],
@@ -168,7 +154,6 @@
     },
     "vmovupd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x11 128-bit"
       ],
@@ -178,7 +163,6 @@
     },
     "vmovupd [rax], ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x11 256-bit"
       ],
@@ -188,7 +172,6 @@
     },
     "vmovss [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x11 128-bit"
       ],
@@ -198,7 +181,6 @@
     },
     "db 0xc5, 0xf2, 0x11, 0xc2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "vmovss xmm2, xmm1, xmm0",
         "Need to manually encode since nasm won't encode this",
@@ -212,7 +194,6 @@
     },
     "vmovsd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x11 128-bit"
       ],
@@ -222,7 +203,6 @@
     },
     "db 0xc5, 0xf3, 0x11, 0xc2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "vmovsd xmm2, xmm1, xmm0",
         "Need to manually encode since nasm won't encode this",
@@ -236,7 +216,6 @@
     },
     "vmovlps xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b00 0x12 128-bit"
@@ -249,7 +228,6 @@
     },
     "vmovlpd xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b01 0x12 128-bit"
@@ -262,7 +240,6 @@
     },
     "vmovsldup xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x12 128-bit"
       ],
@@ -273,7 +250,6 @@
     },
     "vmovsldup ymm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Could potentially be considered optimal.",
         "Ideally the load happens directly in the destination register",
@@ -288,7 +264,6 @@
     },
     "vmovddup xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x12 128-bit"
       ],
@@ -299,7 +274,6 @@
     },
     "vmovddup ymm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Could potentially be considered optimal.",
         "Ideally the load happens directly in the destination register",
@@ -314,7 +288,6 @@
     },
     "vmovlps [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x13 128-bit"
       ],
@@ -324,7 +297,6 @@
     },
     "vmovlpd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x13 128-bit"
       ],
@@ -334,7 +306,6 @@
     },
     "vunpcklps xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x14 128-bit"
       ],
@@ -345,7 +316,6 @@
     },
     "vunpcklps ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x14 256-bit"
       ],
@@ -361,7 +331,6 @@
     },
     "vunpcklpd xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x14 128-bit"
       ],
@@ -372,7 +341,6 @@
     },
     "vunpcklpd ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x14 256-bit"
       ],
@@ -388,7 +356,6 @@
     },
     "vunpckhps xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x15 128-bit"
       ],
@@ -399,7 +366,6 @@
     },
     "vunpckhps ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x15 256-bit"
       ],
@@ -414,7 +380,6 @@
     },
     "vunpckhpd xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x15 128-bit"
       ],
@@ -425,7 +390,6 @@
     },
     "vunpckhpd ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x15 256-bit"
       ],
@@ -440,7 +404,6 @@
     },
     "vmovhps xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x16 128-bit"
       ],
@@ -453,7 +416,6 @@
     },
     "vmovhpd xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x16 128-bit"
       ],
@@ -466,7 +428,6 @@
     },
     "vmovshdup xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x16 128-bit"
       ],
@@ -477,7 +438,6 @@
     },
     "vmovshdup ymm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x16 256-bit"
       ],
@@ -488,7 +448,6 @@
     },
     "vmovhps [rax], xmm0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x17 128-bit"
       ],
@@ -500,7 +459,6 @@
     },
     "vmovhpd [rax], xmm0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x17 128-bit"
       ],
@@ -512,7 +470,6 @@
     },
     "vmovmskps rax, xmm0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x50 128-bit"
       ],
@@ -526,7 +483,6 @@
     },
     "vmovmskps rax, ymm0": {
       "ExpectedInstructionCount": 41,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x50 256-bit"
       ],
@@ -576,7 +532,6 @@
     },
     "vmovmskpd rax, xmm0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x50 128-bit"
       ],
@@ -589,7 +544,6 @@
     },
     "vmovmskpd rax, ymm0": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x50 256-bit"
       ],
@@ -619,7 +573,6 @@
     },
     "vsqrtps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x51 128-bit"
       ],
@@ -629,7 +582,6 @@
     },
     "vsqrtps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x51 256-bit"
       ],
@@ -639,7 +591,6 @@
     },
     "vsqrtpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x51 128-bit"
       ],
@@ -649,7 +600,6 @@
     },
     "vsqrtpd ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x51 256-bit"
       ],
@@ -659,7 +609,6 @@
     },
     "vsqrtss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x51 128-bit"
       ],
@@ -671,7 +620,6 @@
     },
     "vsqrtsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x51 128-bit"
       ],
@@ -683,7 +631,6 @@
     },
     "vrsqrtps xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x52 128-bit"
       ],
@@ -695,7 +642,6 @@
     },
     "vrsqrtps ymm0, ymm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x52 256-bit"
       ],
@@ -707,7 +653,6 @@
     },
     "vrsqrtss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x52 128-bit"
       ],
@@ -721,7 +666,6 @@
     },
     "vrcpps xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x53 128-bit"
       ],
@@ -732,7 +676,6 @@
     },
     "vrcpps ymm0, ymm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x53 256-bit"
       ],
@@ -744,7 +687,6 @@
     },
     "vrcpss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x53 128-bit"
       ],
@@ -757,7 +699,6 @@
     },
     "vandps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x54 128-bit"
       ],
@@ -767,7 +708,6 @@
     },
     "vandps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x54 256-bit"
       ],
@@ -777,7 +717,6 @@
     },
     "vandpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x54 128-bit"
       ],
@@ -787,7 +726,6 @@
     },
     "vandpd ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x54 256-bit"
       ],
@@ -797,7 +735,6 @@
     },
     "vandnps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x55 128-bit"
       ],
@@ -807,7 +744,6 @@
     },
     "vandnps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x55 256-bit"
       ],
@@ -817,7 +753,6 @@
     },
     "vandnpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x55 128-bit"
       ],
@@ -827,7 +762,6 @@
     },
     "vandnpd ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x55 256-bit"
       ],
@@ -837,7 +771,6 @@
     },
     "vorps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x56 128-bit"
       ],
@@ -847,7 +780,6 @@
     },
     "vorps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x56 256-bit"
       ],
@@ -857,7 +789,6 @@
     },
     "vorpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x56 128-bit"
       ],
@@ -867,7 +798,6 @@
     },
     "vorpd ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x56 256-bit"
       ],
@@ -877,7 +807,6 @@
     },
     "vxorps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x57 128-bit"
       ],
@@ -887,7 +816,6 @@
     },
     "vxorps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x57 256-bit"
       ],
@@ -897,7 +825,6 @@
     },
     "vxorpd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x57 128-bit"
       ],
@@ -907,7 +834,6 @@
     },
     "vxorpd ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x57 256-bit"
       ],
@@ -917,7 +843,6 @@
     },
     "vpunpcklbw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x60 128-bit"
       ],
@@ -927,7 +852,6 @@
     },
     "vpunpcklbw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x60 256-bit"
       ],
@@ -942,7 +866,6 @@
     },
     "vpunpcklwd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x61 128-bit"
       ],
@@ -952,7 +875,6 @@
     },
     "vpunpcklwd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x61 256-bit"
       ],
@@ -967,7 +889,6 @@
     },
     "vpunpckldq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x62 128-bit"
       ],
@@ -977,7 +898,6 @@
     },
     "vpunpckldq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x62 256-bit"
       ],
@@ -992,7 +912,6 @@
     },
     "vpacksswb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x63 128-bit"
       ],
@@ -1003,7 +922,6 @@
     },
     "vpacksswb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x63 256-bit"
       ],
@@ -1031,7 +949,6 @@
     },
     "vpcmpgtb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x64 128-bit"
       ],
@@ -1041,7 +958,6 @@
     },
     "vpcmpgtb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x64 256-bit"
       ],
@@ -1056,7 +972,6 @@
     },
     "vpcmpgtw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x65 128-bit"
       ],
@@ -1066,7 +981,6 @@
     },
     "vpcmpgtw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x65 256-bit"
       ],
@@ -1081,7 +995,6 @@
     },
     "vpcmpgtd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x66 128-bit"
       ],
@@ -1091,7 +1004,6 @@
     },
     "vpcmpgtd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x66 256-bit"
       ],
@@ -1106,7 +1018,6 @@
     },
     "vpackuswb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x67 128-bit"
       ],
@@ -1117,7 +1028,6 @@
     },
     "vpackuswb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x67 256-bit"
       ],
@@ -1145,7 +1055,6 @@
     },
     "vpshufd xmm0, xmm1, 00b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
@@ -1160,7 +1069,6 @@
     },
     "vpshufd xmm0, xmm1, 01b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
@@ -1175,7 +1083,6 @@
     },
     "vpshufd xmm0, xmm1, 10b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
@@ -1190,7 +1097,6 @@
     },
     "vpshufd xmm0, xmm1, 11b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
@@ -1205,7 +1111,6 @@
     },
     "vpshufd ymm0, ymm1, 00b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 256-bit"
       ],
@@ -1264,7 +1169,6 @@
     },
     "vpshufd ymm0, ymm1, 01b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 256-bit"
       ],
@@ -1323,7 +1227,6 @@
     },
     "vpshufd ymm0, ymm1, 10b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 256-bit"
       ],
@@ -1382,7 +1285,6 @@
     },
     "vpshufd ymm0, ymm1, 11b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x70 256-bit"
       ],
@@ -1441,7 +1343,6 @@
     },
     "vpshufhw xmm0, xmm1, 00b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
@@ -1456,7 +1357,6 @@
     },
     "vpshufhw xmm0, xmm1, 01b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
@@ -1471,7 +1371,6 @@
     },
     "vpshufhw xmm0, xmm1, 10b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
@@ -1486,7 +1385,6 @@
     },
     "vpshufhw xmm0, xmm1, 11b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
@@ -1501,7 +1399,6 @@
     },
     "vpshufhw ymm0, ymm1, 00b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
@@ -1560,7 +1457,6 @@
     },
     "vpshufhw ymm0, ymm1, 01b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
@@ -1619,7 +1515,6 @@
     },
     "vpshufhw ymm0, ymm1, 10b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
@@ -1678,7 +1573,6 @@
     },
     "vpshufhw ymm0, ymm1, 11b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
@@ -1737,7 +1631,6 @@
     },
     "vpshuflw xmm0, xmm1, 00b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
@@ -1752,7 +1645,6 @@
     },
     "vpshuflw xmm0, xmm1, 01b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
@@ -1767,7 +1659,6 @@
     },
     "vpshuflw xmm0, xmm1, 10b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
@@ -1782,7 +1673,6 @@
     },
     "vpshuflw xmm0, xmm1, 11b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
@@ -1797,7 +1687,6 @@
     },
     "vpshuflw ymm0, ymm1, 00b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
@@ -1856,7 +1745,6 @@
     },
     "vpshuflw ymm0, ymm1, 01b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
@@ -1915,7 +1803,6 @@
     },
     "vpshuflw ymm0, ymm1, 10b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
@@ -1974,7 +1861,6 @@
     },
     "vpshuflw ymm0, ymm1, 11b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
@@ -2033,7 +1919,6 @@
     },
     "vpcmpeqb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x74 128-bit"
       ],
@@ -2043,7 +1928,6 @@
     },
     "vpcmpeqb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x74 256-bit"
       ],
@@ -2058,7 +1942,6 @@
     },
     "vpcmpeqw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x75 128-bit"
       ],
@@ -2068,7 +1951,6 @@
     },
     "vpcmpeqw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x75 256-bit"
       ],
@@ -2083,7 +1965,6 @@
     },
     "vpcmpeqd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x76 128-bit"
       ],
@@ -2093,7 +1974,6 @@
     },
     "vpcmpeqd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x76 256-bit"
       ],
@@ -2108,7 +1988,6 @@
     },
     "vzeroupper": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "Yes",
       "Comment": [
         "Might need to revisit this if move renaming ends up slower than some other clearing",
         "Map 1 0b01 0x77 L=0"
@@ -2134,7 +2013,6 @@
     },
     "vzeroall": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x77 L=1"
       ],
@@ -2159,7 +2037,6 @@
     },
     "vcmpps xmm0, xmm1, xmm2, 0x00": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
@@ -2169,7 +2046,6 @@
     },
     "vcmpps ymm0, ymm1, ymm2, 0x00": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
@@ -2182,7 +2058,6 @@
     },
     "vcmpps xmm0, xmm1, xmm2, 0x01": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
@@ -2192,7 +2067,6 @@
     },
     "vcmpps ymm0, ymm1, ymm2, 0x01": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
@@ -2205,7 +2079,6 @@
     },
     "vcmpps xmm0, xmm1, xmm2, 0x02": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
@@ -2215,7 +2088,6 @@
     },
     "vcmpps ymm0, ymm1, ymm2, 0x02": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
@@ -2228,7 +2100,6 @@
     },
     "vcmpps xmm0, xmm1, xmm2, 0x03": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
@@ -2241,7 +2112,6 @@
     },
     "vcmpps ymm0, ymm1, ymm2, 0x03": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
@@ -2254,7 +2124,6 @@
     },
     "vcmpps xmm0, xmm1, xmm2, 0x04": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
@@ -2265,7 +2134,6 @@
     },
     "vcmpps ymm0, ymm1, ymm2, 0x04": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
@@ -2278,7 +2146,6 @@
     },
     "vcmpps xmm0, xmm1, xmm2, 0x05": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
@@ -2289,7 +2156,6 @@
     },
     "vcmpps ymm0, ymm1, ymm2, 0x05": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
@@ -2303,7 +2169,6 @@
     },
     "vcmpps xmm0, xmm1, xmm2, 0x06": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
@@ -2314,7 +2179,6 @@
     },
     "vcmpps ymm0, ymm1, ymm2, 0x06": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
@@ -2328,7 +2192,6 @@
     },
     "vcmpps xmm0, xmm1, xmm2, 0x07": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
@@ -2340,7 +2203,6 @@
     },
     "vcmpps ymm0, ymm1, ymm2, 0x07": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC2 256-bit"
       ],
@@ -2354,7 +2216,6 @@
     },
     "vcmppd xmm0, xmm1, xmm2, 0x00": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
@@ -2364,7 +2225,6 @@
     },
     "vcmppd ymm0, ymm1, ymm2, 0x00": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
@@ -2377,7 +2237,6 @@
     },
     "vcmppd xmm0, xmm1, xmm2, 0x01": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
@@ -2387,7 +2246,6 @@
     },
     "vcmppd ymm0, ymm1, ymm2, 0x01": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
@@ -2400,7 +2258,6 @@
     },
     "vcmppd xmm0, xmm1, xmm2, 0x02": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
@@ -2410,7 +2267,6 @@
     },
     "vcmppd ymm0, ymm1, ymm2, 0x02": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
@@ -2423,7 +2279,6 @@
     },
     "vcmppd xmm0, xmm1, xmm2, 0x03": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
@@ -2436,7 +2291,6 @@
     },
     "vcmppd ymm0, ymm1, ymm2, 0x03": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
@@ -2449,7 +2303,6 @@
     },
     "vcmppd xmm0, xmm1, xmm2, 0x04": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
@@ -2460,7 +2313,6 @@
     },
     "vcmppd ymm0, ymm1, ymm2, 0x04": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
@@ -2473,7 +2325,6 @@
     },
     "vcmppd xmm0, xmm1, xmm2, 0x05": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
@@ -2484,7 +2335,6 @@
     },
     "vcmppd ymm0, ymm1, ymm2, 0x05": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
@@ -2498,7 +2348,6 @@
     },
     "vcmppd xmm0, xmm1, xmm2, 0x06": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
@@ -2509,7 +2358,6 @@
     },
     "vcmppd ymm0, ymm1, ymm2, 0x06": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
@@ -2523,7 +2371,6 @@
     },
     "vcmppd xmm0, xmm1, xmm2, 0x07": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
@@ -2535,7 +2382,6 @@
     },
     "vcmppd ymm0, ymm1, ymm2, 0x07": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC2 256-bit"
       ],
@@ -2549,7 +2395,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x00": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2561,7 +2406,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x01": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2573,7 +2417,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x02": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2585,7 +2428,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x03": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2600,7 +2442,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x04": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2613,7 +2454,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x05": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2626,7 +2466,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x06": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2639,7 +2478,6 @@
     },
     "vcmpss xmm0, xmm1, xmm2, 0x07": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2653,7 +2491,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x00": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2665,7 +2502,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x01": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2677,7 +2513,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x02": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2689,7 +2524,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x03": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2704,7 +2538,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x04": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2717,7 +2550,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x05": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2730,7 +2562,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x06": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2743,7 +2574,6 @@
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x07": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2757,7 +2587,6 @@
     },
     "vpinsrw xmm0, xmm0, eax, 000b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
@@ -2769,7 +2598,6 @@
     },
     "vpinsrw xmm0, xmm1, eax, 000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
@@ -2780,7 +2608,6 @@
     },
     "vpinsrw xmm0, xmm1, eax, 001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
@@ -2791,7 +2618,6 @@
     },
     "vpinsrw xmm0, xmm1, eax, 111b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
@@ -2802,7 +2628,6 @@
     },
     "vpextrw eax, xmm0, 000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
@@ -2812,7 +2637,6 @@
     },
     "vpextrw eax, xmm0, 001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
@@ -2822,7 +2646,6 @@
     },
     "vpextrw eax, xmm0, 111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
@@ -2832,7 +2655,6 @@
     },
     "vpextrw [rax], xmm0, 000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
@@ -2842,7 +2664,6 @@
     },
     "vpextrw [rax], xmm0, 001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
@@ -2852,7 +2673,6 @@
     },
     "vpextrw [rax], xmm0, 111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC5 128-bit"
       ],
@@ -2862,7 +2682,6 @@
     },
     "vshufps xmm0, xmm1, xmm2, 00b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
@@ -2874,7 +2693,6 @@
     },
     "vshufps ymm0, ymm1, ymm2, 00b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 256-bit"
       ],
@@ -2933,7 +2751,6 @@
     },
     "vshufps xmm0, xmm1, xmm2, 01b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
@@ -2945,7 +2762,6 @@
     },
     "vshufps ymm0, ymm1, ymm2, 01b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 256-bit"
       ],
@@ -3004,7 +2820,6 @@
     },
     "vshufps xmm0, xmm1, xmm2, 10b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
@@ -3016,7 +2831,6 @@
     },
     "vshufps ymm0, ymm1, ymm2, 10b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 256-bit"
       ],
@@ -3075,7 +2889,6 @@
     },
     "vshufps xmm0, xmm1, xmm2, 11b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
@@ -3087,7 +2900,6 @@
     },
     "vshufps ymm0, ymm1, ymm2, 11b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0xC6 256-bit"
       ],
@@ -3146,7 +2958,6 @@
     },
     "vshufpd xmm0, xmm1, xmm2, 0b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC6 128-bit"
       ],
@@ -3156,7 +2967,6 @@
     },
     "vshufpd ymm0, ymm1, ymm2, 0b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC6 256-bit"
       ],
@@ -3191,7 +3001,6 @@
     },
     "vshufpd xmm0, xmm1, xmm2, 1b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xC6 128-bit"
       ],
@@ -3201,7 +3010,6 @@
     },
     "vshufpd ymm0, ymm1, ymm2, 1b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xC6 256-bit"
       ],
@@ -3236,7 +3044,6 @@
     },
     "vmovaps xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x28 128-bit"
       ],
@@ -3246,7 +3053,6 @@
     },
     "vmovaps ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x28 256-bit"
       ],
@@ -3256,7 +3062,6 @@
     },
     "vmovaps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x29 128-bit"
       ],
@@ -3266,7 +3071,6 @@
     },
     "vmovaps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x29 256-bit"
       ],
@@ -3276,7 +3080,6 @@
     },
     "vmovapd xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x28 128-bit"
       ],
@@ -3286,7 +3089,6 @@
     },
     "vmovapd ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x28 256-bit"
       ],
@@ -3296,7 +3098,6 @@
     },
     "vmovapd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x29 128-bit"
       ],
@@ -3306,7 +3107,6 @@
     },
     "vmovapd ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x29 256-bit"
       ],
@@ -3316,7 +3116,6 @@
     },
     "vmovaps [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x29 128-bit"
       ],
@@ -3326,7 +3125,6 @@
     },
     "vmovaps [rax], ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x29 256-bit"
       ],
@@ -3336,7 +3134,6 @@
     },
     "vmovapd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x29 128-bit"
       ],
@@ -3346,7 +3143,6 @@
     },
     "vmovapd [rax], ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x29 256-bit"
       ],
@@ -3356,7 +3152,6 @@
     },
     "vcvtsi2ss xmm0, xmm1, eax": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2A 128-bit"
       ],
@@ -3368,7 +3163,6 @@
     },
     "vcvtsi2ss xmm0, xmm1, rax": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2A 128-bit"
       ],
@@ -3380,7 +3174,6 @@
     },
     "vcvtsi2sd xmm0, xmm1, eax": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2A 128-bit"
       ],
@@ -3392,7 +3185,6 @@
     },
     "vcvtsi2sd xmm0, xmm1, rax": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2A 128-bit"
       ],
@@ -3404,7 +3196,6 @@
     },
     "vmovntps [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x2B 128-bit"
       ],
@@ -3414,7 +3205,6 @@
     },
     "vmovntps [rax], ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x2B 256-bit"
       ],
@@ -3424,7 +3214,6 @@
     },
     "vmovntpd [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x2B 128-bit"
       ],
@@ -3434,7 +3223,6 @@
     },
     "vmovntpd [rax], ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x2B 256-bit"
       ],
@@ -3444,7 +3232,6 @@
     },
     "vcvttss2si eax, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2c 128-bit"
       ],
@@ -3454,7 +3241,6 @@
     },
     "vcvttss2si rax, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2c 128-bit"
       ],
@@ -3464,7 +3250,6 @@
     },
     "vcvttsd2si eax, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2c 128-bit"
       ],
@@ -3474,7 +3259,6 @@
     },
     "vcvttsd2si rax, xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2c 128-bit"
       ],
@@ -3484,7 +3268,6 @@
     },
     "vcvtss2si eax, xmm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2d 128-bit"
       ],
@@ -3495,7 +3278,6 @@
     },
     "vcvtss2si rax, xmm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x2d 128-bit"
       ],
@@ -3506,7 +3288,6 @@
     },
     "vcvtsd2si eax, xmm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2d 128-bit"
       ],
@@ -3517,7 +3298,6 @@
     },
     "vcvtsd2si rax, xmm0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x2d 128-bit"
       ],
@@ -3528,7 +3308,6 @@
     },
     "vucomiss xmm0, xmm1": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x2e 128-bit"
       ],
@@ -3557,7 +3336,6 @@
     },
     "vucomisd xmm0, xmm1": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x2e 128-bit"
       ],
@@ -3586,7 +3364,6 @@
     },
     "vcomiss xmm0, xmm1": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x2f 128-bit"
       ],
@@ -3615,7 +3392,6 @@
     },
     "vcomisd xmm0, xmm1": {
       "ExpectedInstructionCount": 20,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x2f 128-bit"
       ],
@@ -3644,7 +3420,6 @@
     },
     "vaddps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x58 128-bit"
       ],
@@ -3654,7 +3429,6 @@
     },
     "vaddps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x58 256-bit"
       ],
@@ -3664,7 +3438,6 @@
     },
     "vaddpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x58 128-bit"
       ],
@@ -3674,7 +3447,6 @@
     },
     "vaddpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x58 256-bit"
       ],
@@ -3684,7 +3456,6 @@
     },
     "vaddss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x58 128-bit"
       ],
@@ -3696,7 +3467,6 @@
     },
     "vaddsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x58 128-bit"
       ],
@@ -3708,7 +3478,6 @@
     },
     "vmulps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x59 128-bit"
       ],
@@ -3718,7 +3487,6 @@
     },
     "vmulps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x59 256-bit"
       ],
@@ -3728,7 +3496,6 @@
     },
     "vmulpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x59 128-bit"
       ],
@@ -3738,7 +3505,6 @@
     },
     "vmulpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x59 256-bit"
       ],
@@ -3748,7 +3514,6 @@
     },
     "vmulss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x59 128-bit"
       ],
@@ -3760,7 +3525,6 @@
     },
     "vmulsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x59 128-bit"
       ],
@@ -3772,7 +3536,6 @@
     },
     "vcvtps2pd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5a 128-bit"
       ],
@@ -3783,7 +3546,6 @@
     },
     "vcvtpd2ps xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5a 128-bit"
       ],
@@ -3794,7 +3556,6 @@
     },
     "vcvtpd2ps xmm0, yword [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5a 128-bit"
       ],
@@ -3807,7 +3568,6 @@
     },
     "vcvtpd2ps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5a 128-bit"
       ],
@@ -3817,7 +3577,6 @@
     },
     "vcvtss2sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5a 128-bit"
       ],
@@ -3829,7 +3588,6 @@
     },
     "vcvtsd2ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x5a 128-bit"
       ],
@@ -3841,7 +3599,6 @@
     },
     "vcvtdq2ps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5b 128-bit"
       ],
@@ -3851,7 +3608,6 @@
     },
     "vcvtdq2ps ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5b 256-bit"
       ],
@@ -3861,7 +3617,6 @@
     },
     "vcvtps2dq xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5b 128-bit"
       ],
@@ -3872,7 +3627,6 @@
     },
     "vcvtps2dq ymm0, ymm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5b 256-bit"
       ],
@@ -3883,7 +3637,6 @@
     },
     "vcvttps2dq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5b 128-bit"
       ],
@@ -3893,7 +3646,6 @@
     },
     "vcvttps2dq ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5b 256-bit"
       ],
@@ -3903,7 +3655,6 @@
     },
     "vsubps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5c 128-bit"
       ],
@@ -3913,7 +3664,6 @@
     },
     "vsubps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5c 256-bit"
       ],
@@ -3923,7 +3673,6 @@
     },
     "vsubpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5c 128-bit"
       ],
@@ -3933,7 +3682,6 @@
     },
     "vsubpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5c 256-bit"
       ],
@@ -3943,7 +3691,6 @@
     },
     "vsubss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5c 128-bit"
       ],
@@ -3955,7 +3702,6 @@
     },
     "vsubsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x5c 128-bit"
       ],
@@ -3967,7 +3713,6 @@
     },
     "vminps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5d 128-bit"
       ],
@@ -3979,7 +3724,6 @@
     },
     "vminps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5d 256-bit"
       ],
@@ -3993,7 +3737,6 @@
     },
     "vminpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5d 128-bit"
       ],
@@ -4005,7 +3748,6 @@
     },
     "vminpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5d 256-bit"
       ],
@@ -4019,7 +3761,6 @@
     },
     "vminss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5d 128-bit"
       ],
@@ -4034,7 +3775,6 @@
     },
     "vminsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x5d 128-bit"
       ],
@@ -4049,7 +3789,6 @@
     },
     "vdivps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5e 128-bit"
       ],
@@ -4059,7 +3798,6 @@
     },
     "vdivps ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b00 0x5e 256-bit"
@@ -4070,7 +3808,6 @@
     },
     "vdivps ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b00 0x5e 256-bit"
@@ -4083,7 +3820,6 @@
     },
     "vdivps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b00 0x5e 256-bit"
       ],
@@ -4094,7 +3830,6 @@
     },
     "vdivpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5e 128-bit"
       ],
@@ -4104,7 +3839,6 @@
     },
     "vdivpd ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0x5e 256-bit"
@@ -4117,7 +3851,6 @@
     },
     "vdivpd ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0x5e 256-bit"
@@ -4128,7 +3861,6 @@
     },
     "vdivpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x5e 256-bit"
       ],
@@ -4139,7 +3871,6 @@
     },
     "vdivss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5e 128-bit"
       ],
@@ -4151,7 +3882,6 @@
     },
     "vdivsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x5e 128-bit"
       ],
@@ -4163,7 +3893,6 @@
     },
     "vmaxps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5f 128-bit"
       ],
@@ -4175,7 +3904,6 @@
     },
     "vmaxps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b00 0x5f 256-bit"
       ],
@@ -4188,7 +3916,6 @@
     },
     "vmaxpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5f 128-bit"
       ],
@@ -4200,7 +3927,6 @@
     },
     "vmaxpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x5f 256-bit"
       ],
@@ -4213,7 +3939,6 @@
     },
     "vmaxss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x5f 128-bit"
       ],
@@ -4228,7 +3953,6 @@
     },
     "vmaxsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x5f 128-bit"
       ],
@@ -4243,7 +3967,6 @@
     },
     "vpunpckhbw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x68 128-bit"
       ],
@@ -4253,7 +3976,6 @@
     },
     "vpunpckhbw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x68 256-bit"
       ],
@@ -4267,7 +3989,6 @@
     },
     "vpunpckhwd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x69 128-bit"
       ],
@@ -4277,7 +3998,6 @@
     },
     "vpunpckhwd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x69 256-bit"
       ],
@@ -4291,7 +4011,6 @@
     },
     "vpunpckhdq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6a 128-bit"
       ],
@@ -4301,7 +4020,6 @@
     },
     "vpunpckhdq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6a 256-bit"
       ],
@@ -4315,7 +4033,6 @@
     },
     "vpackssdw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6b 128-bit"
       ],
@@ -4326,7 +4043,6 @@
     },
     "vpackssdw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6b 256-bit"
       ],
@@ -4354,7 +4070,6 @@
     },
     "vpunpcklqdq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6c 128-bit"
       ],
@@ -4364,7 +4079,6 @@
     },
     "vpunpcklqdq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6c 256-bit"
       ],
@@ -4379,7 +4093,6 @@
     },
     "vpunpckhqdq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6d 128-bit"
       ],
@@ -4389,7 +4102,6 @@
     },
     "vpunpckhqdq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x6d 256-bit"
       ],
@@ -4403,7 +4115,6 @@
     },
     "vmovd xmm0, dword [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6e 128-bit"
       ],
@@ -4413,7 +4124,6 @@
     },
     "vmovq xmm0, qword [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6e 128-bit"
       ],
@@ -4423,7 +4133,6 @@
     },
     "vmovdqa xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6f 128-bit"
       ],
@@ -4433,7 +4142,6 @@
     },
     "vmovdqa [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x6f 128-bit"
       ],
@@ -4443,7 +4151,6 @@
     },
     "vmovdqu xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x6f 128-bit"
       ],
@@ -4453,7 +4160,6 @@
     },
     "vmovdqu [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x6f 128-bit"
       ],
@@ -4463,7 +4169,6 @@
     },
     "vhaddpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x7c 128-bit"
       ],
@@ -4473,7 +4178,6 @@
     },
     "vhaddpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7c 256-bit"
       ],
@@ -4501,7 +4205,6 @@
     },
     "vhaddps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0x7c 128-bit"
       ],
@@ -4511,7 +4214,6 @@
     },
     "vhaddps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x7c 256-bit"
       ],
@@ -4539,7 +4241,6 @@
     },
     "vhsubpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7d 128-bit"
       ],
@@ -4551,7 +4252,6 @@
     },
     "vhsubpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7d 256-bit"
       ],
@@ -4577,7 +4277,6 @@
     },
     "vhsubps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x7d 128-bit"
       ],
@@ -4589,7 +4288,6 @@
     },
     "vhsubps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0x7d 256-bit"
       ],
@@ -4615,7 +4313,6 @@
     },
     "vmovd dword [rax], xmm0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0x7e 128-bit"
       ],
@@ -4628,7 +4325,6 @@
     },
     "vmovq qword [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x7e 128-bit"
       ],
@@ -4638,7 +4334,6 @@
     },
     "vmovdqa ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x7f 128-bit"
       ],
@@ -4648,7 +4343,6 @@
     },
     "vmovdqa [rax], ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0x7f 128-bit"
       ],
@@ -4658,7 +4352,6 @@
     },
     "vmovdqu ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x7f 128-bit"
       ],
@@ -4668,7 +4361,6 @@
     },
     "vmovdqu [rax], ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0x7f 128-bit"
       ],
@@ -4678,7 +4370,6 @@
     },
     "vaddsubpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd0 128-bit"
       ],
@@ -4690,7 +4381,6 @@
     },
     "vaddsubpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd0 256-bit"
       ],
@@ -4703,7 +4393,6 @@
     },
     "vaddsubps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xd0 128-bit"
       ],
@@ -4715,7 +4404,6 @@
     },
     "vaddsubps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xd0 256-bit"
       ],
@@ -4728,7 +4416,6 @@
     },
     "vpsrlw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd1 128-bit"
       ],
@@ -4741,7 +4428,6 @@
     },
     "vpsrlw ymm0, ymm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd1 256-bit"
       ],
@@ -4753,7 +4439,6 @@
     },
     "vpsrld xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd2 128-bit"
       ],
@@ -4766,7 +4451,6 @@
     },
     "vpsrld ymm0, ymm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd2 256-bit"
       ],
@@ -4778,7 +4462,6 @@
     },
     "vpsrlq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd3 128-bit"
       ],
@@ -4791,7 +4474,6 @@
     },
     "vpsrlq ymm0, ymm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd3 256-bit"
       ],
@@ -4803,7 +4485,6 @@
     },
     "vpaddq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd4 128-bit"
       ],
@@ -4813,7 +4494,6 @@
     },
     "vpaddq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd4 256-bit"
       ],
@@ -4823,7 +4503,6 @@
     },
     "vpmullw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd5 128-bit"
       ],
@@ -4833,7 +4512,6 @@
     },
     "vpmullw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd4 256-bit"
       ],
@@ -4843,7 +4521,6 @@
     },
     "vmovq [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd6 256-bit"
       ],
@@ -4853,7 +4530,6 @@
     },
     "vpmovmskb rax, xmm0": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd7 256-bit"
       ],
@@ -4873,7 +4549,6 @@
     },
     "vpmovmskb rax, ymm0": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd7 256-bit"
       ],
@@ -4903,7 +4578,6 @@
     },
     "vpsubusb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd8 128-bit"
       ],
@@ -4913,7 +4587,6 @@
     },
     "vpsubusb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd8 256-bit"
       ],
@@ -4923,7 +4596,6 @@
     },
     "vpsubusw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd9 128-bit"
       ],
@@ -4933,7 +4605,6 @@
     },
     "vpsubusw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd9 256-bit"
       ],
@@ -4943,7 +4614,6 @@
     },
     "vpminub xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xda 128-bit"
       ],
@@ -4953,7 +4623,6 @@
     },
     "vpminub ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xda 256-bit"
@@ -4964,7 +4633,6 @@
     },
     "vpminub ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xda 256-bit"
@@ -4975,7 +4643,6 @@
     },
     "vpminub ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xda 256-bit"
       ],
@@ -4986,7 +4653,6 @@
     },
     "vpand xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdb 128-bit"
       ],
@@ -4996,7 +4662,6 @@
     },
     "vpand ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdb 256-bit"
       ],
@@ -5006,7 +4671,6 @@
     },
     "vpaddusb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdc 128-bit"
       ],
@@ -5016,7 +4680,6 @@
     },
     "vpaddusb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdc 256-bit"
       ],
@@ -5026,7 +4689,6 @@
     },
     "vpaddusw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdd 128-bit"
       ],
@@ -5036,7 +4698,6 @@
     },
     "vpaddusw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdd 256-bit"
       ],
@@ -5046,7 +4707,6 @@
     },
     "vpmaxub xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xdd 128-bit"
@@ -5057,7 +4717,6 @@
     },
     "vpmaxub ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xde 256-bit"
@@ -5068,7 +4727,6 @@
     },
     "vpmaxub ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xde 256-bit"
@@ -5079,7 +4737,6 @@
     },
     "vpmaxub ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xde 256-bit"
       ],
@@ -5090,7 +4747,6 @@
     },
     "vpandn xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdf 128-bit"
       ],
@@ -5100,7 +4756,6 @@
     },
     "vpandn ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xdf 256-bit"
       ],
@@ -5110,7 +4765,6 @@
     },
     "vpavgb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe0 128-bit"
       ],
@@ -5120,7 +4774,6 @@
     },
     "vpavgb ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xe0 256-bit"
@@ -5131,7 +4784,6 @@
     },
     "vpavgb ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xe0 256-bit"
@@ -5142,7 +4794,6 @@
     },
     "vpavgb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe0 256-bit"
       ],
@@ -5153,7 +4804,6 @@
     },
     "vpsraw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe1 128-bit"
       ],
@@ -5166,7 +4816,6 @@
     },
     "vpsraw ymm0, ymm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe1 256-bit"
       ],
@@ -5178,7 +4827,6 @@
     },
     "vpsrad xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe2 128-bit"
       ],
@@ -5191,7 +4839,6 @@
     },
     "vpsrad ymm0, ymm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe2 256-bit"
       ],
@@ -5203,7 +4850,6 @@
     },
     "vpavgw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe3 128-bit"
       ],
@@ -5213,7 +4859,6 @@
     },
     "vpavgw ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xe3 256-bit"
@@ -5224,7 +4869,6 @@
     },
     "vpavgw ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xe3 256-bit"
@@ -5235,7 +4879,6 @@
     },
     "vpavgw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe3 256-bit"
       ],
@@ -5246,7 +4889,6 @@
     },
     "vpmulhuw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe4 128-bit"
       ],
@@ -5258,7 +4900,6 @@
     },
     "vpmulhuw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe4 256-bit"
       ],
@@ -5268,7 +4909,6 @@
     },
     "vpmulhw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe5 128-bit"
       ],
@@ -5280,7 +4920,6 @@
     },
     "vpmulhw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe5 256-bit"
       ],
@@ -5290,7 +4929,6 @@
     },
     "vcvttpd2dq xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe6 128-bit"
       ],
@@ -5302,7 +4940,6 @@
     },
     "vcvttpd2dq xmm0, ymm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xe6 256-bit"
       ],
@@ -5315,7 +4952,6 @@
     },
     "vcvtdq2pd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xe6 128-bit"
       ],
@@ -5326,7 +4962,6 @@
     },
     "vcvtdq2pd ymm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b10 0xe6 256-bit"
       ],
@@ -5337,7 +4972,6 @@
     },
     "vcvtpd2dq xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xe6 128-bit"
       ],
@@ -5350,7 +4984,6 @@
     },
     "vcvtpd2dq xmm0, ymm1": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xe6 256-bit"
       ],
@@ -5364,7 +4997,6 @@
     },
     "vmovntdq [rax], xmm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe7 128-bit"
       ],
@@ -5374,7 +5006,6 @@
     },
     "vmovntdq [rax], ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe7 256-bit"
       ],
@@ -5384,7 +5015,6 @@
     },
     "vpsubsb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe8 128-bit"
       ],
@@ -5394,7 +5024,6 @@
     },
     "vpsubsb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe8 256-bit"
       ],
@@ -5404,7 +5033,6 @@
     },
     "vpsubsw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe9 128-bit"
       ],
@@ -5414,7 +5042,6 @@
     },
     "vpsubsw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xe9 256-bit"
       ],
@@ -5424,7 +5051,6 @@
     },
     "vpminsw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xea 128-bit"
       ],
@@ -5434,7 +5060,6 @@
     },
     "vpminsw ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xea 256-bit"
@@ -5445,7 +5070,6 @@
     },
     "vpminsw ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xea 256-bit"
@@ -5456,7 +5080,6 @@
     },
     "vpminsw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xea 256-bit"
       ],
@@ -5467,7 +5090,6 @@
     },
     "vpor xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xeb 128-bit"
       ],
@@ -5477,7 +5099,6 @@
     },
     "vpor ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xeb 256-bit"
       ],
@@ -5487,7 +5108,6 @@
     },
     "vpaddsb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xec 128-bit"
       ],
@@ -5497,7 +5117,6 @@
     },
     "vpaddsb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xec 256-bit"
       ],
@@ -5507,7 +5126,6 @@
     },
     "vpaddsw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xed 128-bit"
       ],
@@ -5517,7 +5135,6 @@
     },
     "vpaddsw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xed 256-bit"
       ],
@@ -5527,7 +5144,6 @@
     },
     "vpmaxsw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xee 128-bit"
       ],
@@ -5537,7 +5153,6 @@
     },
     "vpmaxsw ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xee 256-bit"
@@ -5548,7 +5163,6 @@
     },
     "vpmaxsw ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xee 256-bit"
@@ -5559,7 +5173,6 @@
     },
     "vpmaxsw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xee 256-bit"
       ],
@@ -5570,7 +5183,6 @@
     },
     "vpxor xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xef 128-bit"
       ],
@@ -5580,7 +5192,6 @@
     },
     "vpxor ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xef 256-bit"
       ],
@@ -5590,7 +5201,6 @@
     },
     "vlddqu xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xf0 128-bit"
       ],
@@ -5600,7 +5210,6 @@
     },
     "vlddqu ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b11 0xf0 256-bit"
       ],
@@ -5610,7 +5219,6 @@
     },
     "vpsllw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf1 128-bit"
       ],
@@ -5623,7 +5231,6 @@
     },
     "vpsllw ymm0, ymm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf1 256-bit"
       ],
@@ -5635,7 +5242,6 @@
     },
     "vpslld xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf2 128-bit"
       ],
@@ -5648,7 +5254,6 @@
     },
     "vpslld ymm0, ymm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf2 256-bit"
       ],
@@ -5660,7 +5265,6 @@
     },
     "vpsllq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf3 128-bit"
       ],
@@ -5673,7 +5277,6 @@
     },
     "vpsllq ymm0, ymm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf3 256-bit"
       ],
@@ -5685,7 +5288,6 @@
     },
     "vpmuludq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf4 128-bit"
       ],
@@ -5697,7 +5299,6 @@
     },
     "vpmuludq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf4 256-bit"
       ],
@@ -5711,7 +5312,6 @@
     },
     "vpmaddwd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf5 128-bit"
       ],
@@ -5723,7 +5323,6 @@
     },
     "vpmaddwd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf5 256-bit"
       ],
@@ -5743,7 +5342,6 @@
     },
     "vpsadbw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf6 128-bit"
       ],
@@ -5757,7 +5355,6 @@
     },
     "vpsadbw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 37,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xf6 256-bit"
       ],
@@ -5803,7 +5400,6 @@
     },
     "vmaskmovdqu xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf7 128-bit"
       ],
@@ -5816,7 +5412,6 @@
     },
     "vpsubb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf8 128-bit"
       ],
@@ -5826,7 +5421,6 @@
     },
     "vpsubb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf8 256-bit"
       ],
@@ -5836,7 +5430,6 @@
     },
     "vpsubw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf9 128-bit"
       ],
@@ -5846,7 +5439,6 @@
     },
     "vpsubw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xf9 256-bit"
       ],
@@ -5856,7 +5448,6 @@
     },
     "vpsubd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfa 128-bit"
       ],
@@ -5866,7 +5457,6 @@
     },
     "vpsubd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfa 256-bit"
       ],
@@ -5876,7 +5466,6 @@
     },
     "vpsubq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfb 128-bit"
       ],
@@ -5886,7 +5475,6 @@
     },
     "vpsubq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfb 256-bit"
       ],
@@ -5896,7 +5484,6 @@
     },
     "vpaddb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfc 128-bit"
       ],
@@ -5906,7 +5493,6 @@
     },
     "vpaddb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfc 256-bit"
       ],
@@ -5916,7 +5502,6 @@
     },
     "vpaddw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfd 128-bit"
       ],
@@ -5926,7 +5511,6 @@
     },
     "vpaddw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfd 256-bit"
       ],
@@ -5936,7 +5520,6 @@
     },
     "vpaddd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfe 128-bit"
       ],
@@ -5946,7 +5529,6 @@
     },
     "vpaddd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xfe 256-bit"
       ],

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -11,7 +11,6 @@
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 1 0b01 0xd0 128-bit"
       ],
@@ -22,7 +21,6 @@
     },
     "vaddsubpd ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xd0 256-bit"
@@ -35,7 +33,6 @@
     },
     "vaddsubpd ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xd0 256-bit"
@@ -49,7 +46,6 @@
     },
     "vaddsubpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b01 0xd0 256-bit"
       ],
@@ -62,7 +58,6 @@
     },
     "vaddsubps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xd0 128-bit"
       ],
@@ -73,7 +68,6 @@
     },
     "vaddsubps ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b11 0xd0 256-bit"
@@ -86,7 +80,6 @@
     },
     "vaddsubps ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b11 0xd0 256-bit"
@@ -98,7 +91,6 @@
     },
     "vaddsubps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 1 0b11 0xd0 256-bit"
       ],

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -13,7 +13,6 @@
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x00 128-bit"
       ],
@@ -25,7 +24,6 @@
     },
     "vpshufb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x00 256-bit"
       ],
@@ -45,7 +43,6 @@
     },
     "vphaddw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x01 128-bit"
       ],
@@ -55,7 +52,6 @@
     },
     "vphaddw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x01 256-bit"
       ],
@@ -83,7 +79,6 @@
     },
     "vphaddd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x02 128-bit"
       ],
@@ -93,7 +88,6 @@
     },
     "vphaddd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x02 256-bit"
       ],
@@ -121,7 +115,6 @@
     },
     "vphaddsw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x03 128-bit"
       ],
@@ -133,7 +126,6 @@
     },
     "vphaddsw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x03 256-bit"
       ],
@@ -159,7 +151,6 @@
     },
     "vpmaddubsw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x04 128-bit"
       ],
@@ -177,7 +168,6 @@
     },
     "vpmaddubsw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x04 256-bit"
       ],
@@ -195,7 +185,6 @@
     },
     "vphsubw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x05 128-bit"
       ],
@@ -207,7 +196,6 @@
     },
     "vphsubw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x05 256-bit"
       ],
@@ -233,7 +221,6 @@
     },
     "vphsubd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x06 128-bit"
       ],
@@ -245,7 +232,6 @@
     },
     "vphsubd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x06 256-bit"
       ],
@@ -271,7 +257,6 @@
     },
     "vphsubsw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x07 128-bit"
       ],
@@ -283,7 +268,6 @@
     },
     "vphsubsw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x07 256-bit"
       ],
@@ -309,7 +293,6 @@
     },
     "vpsignb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x08 128-bit"
       ],
@@ -321,7 +304,6 @@
     },
     "vpsignb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x08 256-bit"
       ],
@@ -334,7 +316,6 @@
     },
     "vpsignw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x09 128-bit"
       ],
@@ -346,7 +327,6 @@
     },
     "vpsignw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x09 256-bit"
       ],
@@ -359,7 +339,6 @@
     },
     "vpsignd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x0a 128-bit"
       ],
@@ -371,7 +350,6 @@
     },
     "vpsignd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x0a 256-bit"
       ],
@@ -384,7 +362,6 @@
     },
     "vpmulhrsw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0b 128-bit"
       ],
@@ -404,7 +381,6 @@
     },
     "vpmulhrsw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0b 256-bit"
       ],
@@ -430,7 +406,6 @@
     },
     "vpermilps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0c 128-bit"
       ],
@@ -449,7 +424,6 @@
     },
     "vpermilps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0c 256-bit"
       ],
@@ -474,7 +448,6 @@
     },
     "vpermilpd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0d 128-bit"
       ],
@@ -498,7 +471,6 @@
     },
     "vpermilpd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 21,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0d 256-bit"
       ],
@@ -528,7 +500,6 @@
     },
     "vtestps xmm0, xmm1": {
       "ExpectedInstructionCount": 28,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0e 128-bit"
       ],
@@ -565,7 +536,6 @@
     },
     "vtestps ymm0, ymm1": {
       "ExpectedInstructionCount": 36,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0e 256-bit"
       ],
@@ -610,7 +580,6 @@
     },
     "vtestpd xmm0, xmm1": {
       "ExpectedInstructionCount": 28,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0f 128-bit"
       ],
@@ -647,7 +616,6 @@
     },
     "vtestpd ymm0, ymm1": {
       "ExpectedInstructionCount": 36,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x0f 256-bit"
       ],
@@ -692,7 +660,6 @@
     },
     "vcvtph2ps xmm0, xmm1": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x13 128-bit"
@@ -700,7 +667,6 @@
     },
     "vcvtph2ps ymm0, xmm1": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x13 256-bit"
@@ -708,7 +674,6 @@
     },
     "vpermps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x16 256-bit"
       ],
@@ -727,7 +692,6 @@
     },
     "vptest xmm0, xmm1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x16 128-bit"
       ],
@@ -755,7 +719,6 @@
     },
     "vptest ymm0, ymm1": {
       "ExpectedInstructionCount": 27,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x16 256-bit"
       ],
@@ -791,7 +754,6 @@
     },
     "vbroadcastss xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x18 128-bit"
       ],
@@ -801,7 +763,6 @@
     },
     "vbroadcastss ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x18 256-bit"
       ],
@@ -811,7 +772,6 @@
     },
     "vbroadcastsd ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x19 256-bit"
       ],
@@ -821,7 +781,6 @@
     },
     "vbroadcastf128 ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1a 256-bit"
       ],
@@ -831,7 +790,6 @@
     },
     "vpabsb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1c 128-bit"
       ],
@@ -841,7 +799,6 @@
     },
     "vpabsb ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1c 256-bit"
       ],
@@ -851,7 +808,6 @@
     },
     "vpabsw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1d 128-bit"
       ],
@@ -861,7 +817,6 @@
     },
     "vpabsw ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1d 256-bit"
       ],
@@ -871,7 +826,6 @@
     },
     "vpabsd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1e 128-bit"
       ],
@@ -881,7 +835,6 @@
     },
     "vpabsd ymm0, ymm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x1e 256-bit"
       ],
@@ -891,7 +844,6 @@
     },
     "vpmovsxbw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x20 128-bit"
       ],
@@ -901,7 +853,6 @@
     },
     "vpmovsxbw ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x20 256-bit"
       ],
@@ -911,7 +862,6 @@
     },
     "vpmovsxbd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x21 128-bit"
       ],
@@ -922,7 +872,6 @@
     },
     "vpmovsxbd ymm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x21 256-bit"
       ],
@@ -933,7 +882,6 @@
     },
     "vpmovsxbq xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x22 128-bit"
       ],
@@ -945,7 +893,6 @@
     },
     "vpmovsxbq ymm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x22 256-bit"
       ],
@@ -957,7 +904,6 @@
     },
     "vpmovsxwd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x23 128-bit"
       ],
@@ -967,7 +913,6 @@
     },
     "vpmovsxwd ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x23 256-bit"
       ],
@@ -977,7 +922,6 @@
     },
     "vpmovsxwq xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x24 128-bit"
       ],
@@ -988,7 +932,6 @@
     },
     "vpmovsxwq ymm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x24 256-bit"
       ],
@@ -999,7 +942,6 @@
     },
     "vpmovsxdq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x25 128-bit"
       ],
@@ -1009,7 +951,6 @@
     },
     "vpmovsxdq ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x25 256-bit"
       ],
@@ -1019,7 +960,6 @@
     },
     "vpmuldq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x28 128-bit"
       ],
@@ -1031,7 +971,6 @@
     },
     "vpmuldq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x28 256-bit"
       ],
@@ -1045,7 +984,6 @@
     },
     "vpcmpeqq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x29 128-bit"
       ],
@@ -1055,7 +993,6 @@
     },
     "vpcmpeqq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x29 256-bit"
       ],
@@ -1070,7 +1007,6 @@
     },
     "vmovntdqa xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x2a 128-bit"
       ],
@@ -1080,7 +1016,6 @@
     },
     "vmovntdqa ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x2a 256-bit"
       ],
@@ -1090,7 +1025,6 @@
     },
     "vpackusdw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2b 128-bit"
       ],
@@ -1101,7 +1035,6 @@
     },
     "vpackusdw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2b 256-bit"
       ],
@@ -1129,7 +1062,6 @@
     },
     "vmaskmovps xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2c 128-bit"
       ],
@@ -1143,7 +1075,6 @@
     },
     "vmaskmovps ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2c 256-bit"
       ],
@@ -1156,7 +1087,6 @@
     },
     "vmaskmovpd xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2d 128-bit"
       ],
@@ -1170,7 +1100,6 @@
     },
     "vmaskmovpd ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2d 256-bit"
       ],
@@ -1183,7 +1112,6 @@
     },
     "vmaskmovps [rax], xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2e 128-bit"
       ],
@@ -1196,7 +1124,6 @@
     },
     "vmaskmovps [rax], ymm0, ymm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2e 256-bit"
       ],
@@ -1209,7 +1136,6 @@
     },
     "vmaskmovpd [rax], xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2f 128-bit"
       ],
@@ -1222,7 +1148,6 @@
     },
     "vmaskmovpd [rax], ymm0, ymm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x2f 256-bit"
       ],
@@ -1235,7 +1160,6 @@
     },
     "vpmovzxbw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x30 128-bit"
       ],
@@ -1245,7 +1169,6 @@
     },
     "vpmovzxbw ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x30 256-bit"
       ],
@@ -1255,7 +1178,6 @@
     },
     "vpmovzxbd xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x31 128-bit"
       ],
@@ -1266,7 +1188,6 @@
     },
     "vpmovzxbd ymm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x31 256-bit"
       ],
@@ -1277,7 +1198,6 @@
     },
     "vpmovzxbq xmm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x32 128-bit"
       ],
@@ -1289,7 +1209,6 @@
     },
     "vpmovzxbq ymm0, xmm1": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x32 256-bit"
       ],
@@ -1301,7 +1220,6 @@
     },
     "vpmovzxwd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x33 128-bit"
       ],
@@ -1311,7 +1229,6 @@
     },
     "vpmovzxwd ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x33 256-bit"
       ],
@@ -1321,7 +1238,6 @@
     },
     "vpmovzxwq xmm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x34 128-bit"
       ],
@@ -1332,7 +1248,6 @@
     },
     "vpmovzxwq ymm0, xmm1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x34 256-bit"
       ],
@@ -1343,7 +1258,6 @@
     },
     "vpmovzxdq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x35 128-bit"
       ],
@@ -1353,7 +1267,6 @@
     },
     "vpmovzxdq ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x35 256-bit"
       ],
@@ -1363,7 +1276,6 @@
     },
     "vpermd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x36 256-bit"
       ],
@@ -1382,7 +1294,6 @@
     },
     "vpcmpgtq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x37 128-bit"
       ],
@@ -1392,7 +1303,6 @@
     },
     "vpcmpgtq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x37 256-bit"
       ],
@@ -1407,7 +1317,6 @@
     },
     "vpminsb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x38 128-bit"
       ],
@@ -1417,7 +1326,6 @@
     },
     "vpminsb ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x38 256-bit"
@@ -1428,7 +1336,6 @@
     },
     "vpminsb ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x38 256-bit"
@@ -1439,7 +1346,6 @@
     },
     "vpminsb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x38 256-bit"
       ],
@@ -1450,7 +1356,6 @@
     },
     "vpminsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x39 128-bit"
       ],
@@ -1460,7 +1365,6 @@
     },
     "vpminsd ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x39 256-bit"
@@ -1471,7 +1375,6 @@
     },
     "vpminsd ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x39 256-bit"
@@ -1482,7 +1385,6 @@
     },
     "vpminsd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x39 256-bit"
       ],
@@ -1493,7 +1395,6 @@
     },
     "vpminuw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3a 128-bit"
       ],
@@ -1503,7 +1404,6 @@
     },
     "vpminuw ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x3a 256-bit"
@@ -1514,7 +1414,6 @@
     },
     "vpminuw ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x3a 256-bit"
@@ -1525,7 +1424,6 @@
     },
     "vpminuw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3a 256-bit"
       ],
@@ -1536,7 +1434,6 @@
     },
     "vpminud xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3b 128-bit"
       ],
@@ -1546,7 +1443,6 @@
     },
     "vpminud ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x3b 256-bit"
@@ -1557,7 +1453,6 @@
     },
     "vpminud ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x3b 256-bit"
@@ -1568,7 +1463,6 @@
     },
     "vpminud ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3b 256-bit"
       ],
@@ -1579,7 +1473,6 @@
     },
     "vpmaxsb xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3c 128-bit"
       ],
@@ -1589,7 +1482,6 @@
     },
     "vpmaxsb ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x3c 256-bit"
@@ -1600,7 +1492,6 @@
     },
     "vpmaxsb ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3c 256-bit"
       ],
@@ -1610,7 +1501,6 @@
     },
     "vpmaxsb ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3c 256-bit"
       ],
@@ -1621,7 +1511,6 @@
     },
     "vpmaxsd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3d 128-bit"
       ],
@@ -1631,7 +1520,6 @@
     },
     "vpmaxsd ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x3d 256-bit"
@@ -1642,7 +1530,6 @@
     },
     "vpmaxsd ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x3d 256-bit"
@@ -1653,7 +1540,6 @@
     },
     "vpmaxsd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3d 256-bit"
       ],
@@ -1664,7 +1550,6 @@
     },
     "vpmaxuw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3e 128-bit"
       ],
@@ -1674,7 +1559,6 @@
     },
     "vpmaxuw ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x3e 256-bit"
@@ -1685,7 +1569,6 @@
     },
     "vpmaxuw ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x3e 256-bit"
@@ -1696,7 +1579,6 @@
     },
     "vpmaxuw ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3e 256-bit"
       ],
@@ -1707,7 +1589,6 @@
     },
     "vpmaxud xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3f 128-bit"
       ],
@@ -1717,7 +1598,6 @@
     },
     "vpmaxud ymm0, ymm0, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Aliasing source and destination",
         "Map 2 0b01 0x3f 256-bit"
@@ -1728,7 +1608,6 @@
     },
     "vpmaxud ymm0, ymm1, ymm0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3f 256-bit"
       ],
@@ -1738,7 +1617,6 @@
     },
     "vpmaxud ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x3f 256-bit"
       ],
@@ -1749,7 +1627,6 @@
     },
     "vpmulld xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x40 128-bit"
       ],
@@ -1759,7 +1636,6 @@
     },
     "vpmulld ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x40 256-bit"
       ],
@@ -1769,7 +1645,6 @@
     },
     "vphminposuw xmm0, xmm1": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x41 256-bit"
       ],
@@ -1784,7 +1659,6 @@
     },
     "vpsrlvd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 128-bit"
       ],
@@ -1797,7 +1671,6 @@
     },
     "vpsrlvd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 256-bit"
       ],
@@ -1810,7 +1683,6 @@
     },
     "vpsrlvq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 128-bit"
       ],
@@ -1825,7 +1697,6 @@
     },
     "vpsrlvq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x45 256-bit"
       ],
@@ -1838,7 +1709,6 @@
     },
     "vpsravd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x46 128-bit"
       ],
@@ -1851,7 +1721,6 @@
     },
     "vpsravd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x46 256-bit"
       ],
@@ -1864,7 +1733,6 @@
     },
     "vpsllvd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 128-bit"
       ],
@@ -1876,7 +1744,6 @@
     },
     "vpsllvd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 256-bit"
       ],
@@ -1889,7 +1756,6 @@
     },
     "vpsllvq xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 128-bit"
       ],
@@ -1903,7 +1769,6 @@
     },
     "vpsllvq ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x47 256-bit"
       ],
@@ -1916,7 +1781,6 @@
     },
     "vpbroadcastd xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
       ],
@@ -1926,7 +1790,6 @@
     },
     "vpbroadcastd xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
       ],
@@ -1936,7 +1799,6 @@
     },
     "vpbroadcastd ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x58 256-bit"
       ],
@@ -1946,7 +1808,6 @@
     },
     "vpbroadcastd ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x58 256-bit"
       ],
@@ -1956,7 +1817,6 @@
     },
     "vpbroadcastq xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
       ],
@@ -1966,7 +1826,6 @@
     },
     "vpbroadcastq xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
       ],
@@ -1976,7 +1835,6 @@
     },
     "vpbroadcastq ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x59 256-bit"
       ],
@@ -1986,7 +1844,6 @@
     },
     "vpbroadcastq ymm0, [rax]": {
       "ExpectedInstructiqonCount": -1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x59 256-bit"
       ],
@@ -1997,7 +1854,6 @@
     },
     "vbroadcasti128 ymm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x5a 256-bit"
       ],
@@ -2007,7 +1863,6 @@
     },
     "vpbroadcastb xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
       ],
@@ -2017,7 +1872,6 @@
     },
     "vpbroadcastb xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
       ],
@@ -2027,7 +1881,6 @@
     },
     "vpbroadcastb ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x78 256-bit"
       ],
@@ -2037,7 +1890,6 @@
     },
     "vpbroadcastb ymm0, [rax]": {
       "ExpectedInstructiqonCount": -1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x78 256-bit"
       ],
@@ -2048,7 +1900,6 @@
     },
     "vpbroadcastw xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
       ],
@@ -2058,7 +1909,6 @@
     },
     "vpbroadcastw xmm0, [rax]": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
       ],
@@ -2068,7 +1918,6 @@
     },
     "vpbroadcastw ymm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x79 256-bit"
       ],
@@ -2078,7 +1927,6 @@
     },
     "vpbroadcastw ymm0, [rax]": {
       "ExpectedInstructiqonCount": -1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0x79 256-bit"
       ],
@@ -2089,7 +1937,6 @@
     },
     "vpmaskmovd xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 128-bit"
       ],
@@ -2103,7 +1950,6 @@
     },
     "vpmaskmovd ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 256-bit"
       ],
@@ -2116,7 +1962,6 @@
     },
     "vpmaskmovq xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 128-bit"
       ],
@@ -2130,7 +1975,6 @@
     },
     "vpmaskmovq ymm0, ymm1, [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8c 256-bit"
       ],
@@ -2143,7 +1987,6 @@
     },
     "vpmaskmovd [rax], xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 128-bit"
       ],
@@ -2156,7 +1999,6 @@
     },
     "vpmaskmovd [rax], ymm0, ymm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 256-bit"
       ],
@@ -2169,7 +2011,6 @@
     },
     "vpmaskmovq [rax], xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 128-bit"
       ],
@@ -2182,7 +2023,6 @@
     },
     "vpmaskmovq [rax], ymm0, ymm1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0x8e 256-bit"
       ],
@@ -2195,7 +2035,6 @@
     },
     "vpgatherdd xmm0, [xmm1*1 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 128-bit"
@@ -2203,7 +2042,6 @@
     },
     "vpgatherdd xmm0, [xmm1*2 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 128-bit"
@@ -2211,7 +2049,6 @@
     },
     "vpgatherdd xmm0, [xmm1*4 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 128-bit"
@@ -2219,7 +2056,6 @@
     },
     "vpgatherdd xmm0, [xmm1*8 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 128-bit"
@@ -2227,7 +2063,6 @@
     },
     "vpgatherdd ymm0, [ymm1*1 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 256-bit"
@@ -2235,7 +2070,6 @@
     },
     "vpgatherdd ymm0, [ymm1*2 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 256-bit"
@@ -2243,7 +2077,6 @@
     },
     "vpgatherdd ymm0, [ymm1*4 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 256-bit"
@@ -2251,7 +2084,6 @@
     },
     "vpgatherdd ymm0, [ymm1*8 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 256-bit"
@@ -2259,7 +2091,6 @@
     },
     "vpgatherdq xmm0, [xmm1*1 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 128-bit"
@@ -2267,7 +2098,6 @@
     },
     "vpgatherdq xmm0, [xmm1*2 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 128-bit"
@@ -2275,7 +2105,6 @@
     },
     "vpgatherdq xmm0, [xmm1*4 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 128-bit"
@@ -2283,7 +2112,6 @@
     },
     "vpgatherdq xmm0, [xmm1*8 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 128-bit"
@@ -2291,7 +2119,6 @@
     },
     "vpgatherdq ymm0, [xmm1*1 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 256-bit"
@@ -2299,7 +2126,6 @@
     },
     "vpgatherdq ymm0, [xmm1*2 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 256-bit"
@@ -2307,7 +2133,6 @@
     },
     "vpgatherdq ymm0, [xmm1*4 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 256-bit"
@@ -2315,7 +2140,6 @@
     },
     "vpgatherdq ymm0, [xmm1*8 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x90 256-bit"
@@ -2323,7 +2147,6 @@
     },
     "vpgatherqd xmm0, [xmm1*1 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 128-bit"
@@ -2331,7 +2154,6 @@
     },
     "vpgatherqd xmm0, [xmm1*2 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 128-bit"
@@ -2339,7 +2161,6 @@
     },
     "vpgatherqd xmm0, [xmm1*4 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 128-bit"
@@ -2347,7 +2168,6 @@
     },
     "vpgatherqd xmm0, [xmm1*8 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 128-bit"
@@ -2355,7 +2175,6 @@
     },
     "vpgatherqd xmm0, [ymm1*1 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 256-bit"
@@ -2363,7 +2182,6 @@
     },
     "vpgatherqd xmm0, [ymm1*2 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 256-bit"
@@ -2371,7 +2189,6 @@
     },
     "vpgatherqd xmm0, [ymm1*4 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 256-bit"
@@ -2379,7 +2196,6 @@
     },
     "vpgatherqd xmm0, [ymm1*8 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 256-bit"
@@ -2387,7 +2203,6 @@
     },
     "vpgatherqq xmm0, [xmm1*1 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 128-bit"
@@ -2395,7 +2210,6 @@
     },
     "vpgatherqq xmm0, [xmm1*2 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 128-bit"
@@ -2403,7 +2217,6 @@
     },
     "vpgatherqq xmm0, [xmm1*4 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 128-bit"
@@ -2411,7 +2224,6 @@
     },
     "vpgatherqq xmm0, [xmm1*8 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 128-bit"
@@ -2419,7 +2231,6 @@
     },
     "vpgatherqq ymm0, [ymm1*1 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 256-bit"
@@ -2427,7 +2238,6 @@
     },
     "vpgatherqq ymm0, [ymm1*2 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 256-bit"
@@ -2435,7 +2245,6 @@
     },
     "vpgatherqq ymm0, [ymm1*4 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 256-bit"
@@ -2443,7 +2252,6 @@
     },
     "vpgatherqq ymm0, [ymm1*8 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x91 256-bit"
@@ -2451,7 +2259,6 @@
     },
     "vgatherdps xmm0, [xmm1*1 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 128-bit"
@@ -2459,7 +2266,6 @@
     },
     "vgatherdps xmm0, [xmm1*2 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 128-bit"
@@ -2467,7 +2273,6 @@
     },
     "vgatherdps xmm0, [xmm1*4 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 128-bit"
@@ -2475,7 +2280,6 @@
     },
     "vgatherdps xmm0, [xmm1*8 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 128-bit"
@@ -2483,7 +2287,6 @@
     },
     "vgatherdps ymm0, [ymm1*1 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 256-bit"
@@ -2491,7 +2294,6 @@
     },
     "vgatherdps ymm0, [ymm1*2 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 256-bit"
@@ -2499,7 +2301,6 @@
     },
     "vgatherdps ymm0, [ymm1*4 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 256-bit"
@@ -2507,7 +2308,6 @@
     },
     "vgatherdps ymm0, [ymm1*8 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 256-bit"
@@ -2515,7 +2315,6 @@
     },
     "vgatherdpd xmm0, [xmm1*1 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 128-bit"
@@ -2523,7 +2322,6 @@
     },
     "vgatherdpd xmm0, [xmm1*2 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 128-bit"
@@ -2531,7 +2329,6 @@
     },
     "vgatherdpd xmm0, [xmm1*4 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 128-bit"
@@ -2539,7 +2336,6 @@
     },
     "vgatherdpd xmm0, [xmm1*8 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 128-bit"
@@ -2547,7 +2343,6 @@
     },
     "vgatherdpd ymm0, [xmm1*1 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 256-bit"
@@ -2555,7 +2350,6 @@
     },
     "vgatherdpd ymm0, [xmm1*2 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 256-bit"
@@ -2563,7 +2357,6 @@
     },
     "vgatherdpd ymm0, [xmm1*4 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 256-bit"
@@ -2571,7 +2364,6 @@
     },
     "vgatherdpd ymm0, [xmm1*8 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x92 256-bit"
@@ -2579,7 +2371,6 @@
     },
     "vgatherqps xmm0, [xmm1*1 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 128-bit"
@@ -2587,7 +2378,6 @@
     },
     "vgatherqps xmm0, [xmm1*2 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 128-bit"
@@ -2595,7 +2385,6 @@
     },
     "vgatherqps xmm0, [xmm1*4 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 128-bit"
@@ -2603,7 +2392,6 @@
     },
     "vgatherqps xmm0, [xmm1*8 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 128-bit"
@@ -2611,7 +2399,6 @@
     },
     "vgatherqps xmm0, [ymm1*1 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 256-bit"
@@ -2619,7 +2406,6 @@
     },
     "vgatherqps xmm0, [ymm1*2 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 256-bit"
@@ -2627,7 +2413,6 @@
     },
     "vgatherqps xmm0, [ymm1*4 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 256-bit"
@@ -2635,7 +2420,6 @@
     },
     "vgatherqps xmm0, [ymm1*8 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 256-bit"
@@ -2643,7 +2427,6 @@
     },
     "vgatherqpd xmm0, [xmm1*1 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 128-bit"
@@ -2651,7 +2434,6 @@
     },
     "vgatherqpd xmm0, [xmm1*2 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 128-bit"
@@ -2659,7 +2441,6 @@
     },
     "vgatherqpd xmm0, [xmm1*4 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 128-bit"
@@ -2667,7 +2448,6 @@
     },
     "vgatherqpd xmm0, [xmm1*8 + rax], xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 128-bit"
@@ -2675,7 +2455,6 @@
     },
     "vgatherqpd ymm0, [ymm1*1 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 256-bit"
@@ -2683,7 +2462,6 @@
     },
     "vgatherqpd ymm0, [ymm1*2 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 256-bit"
@@ -2691,7 +2469,6 @@
     },
     "vgatherqpd ymm0, [ymm1*4 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 256-bit"
@@ -2699,7 +2476,6 @@
     },
     "vgatherqpd ymm0, [ymm1*8 + rax], ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x93 256-bit"
@@ -2707,7 +2483,6 @@
     },
     "vfmaddsub132ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x96 128-bit"
@@ -2715,7 +2490,6 @@
     },
     "vfmaddsub132ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x96 256-bit"
@@ -2723,7 +2497,6 @@
     },
     "vfmaddsub132pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x96 128-bit"
@@ -2731,7 +2504,6 @@
     },
     "vfmaddsub132pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x96 256-bit"
@@ -2739,7 +2511,6 @@
     },
     "vfmsubadd132ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x97 128-bit"
@@ -2747,7 +2518,6 @@
     },
     "vfmsubadd132ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x97 256-bit"
@@ -2755,7 +2525,6 @@
     },
     "vfmsubadd132pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x97 128-bit"
@@ -2763,7 +2532,6 @@
     },
     "vfmsubadd132pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x97 256-bit"
@@ -2771,7 +2539,6 @@
     },
     "vfmadd132ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x98 128-bit"
@@ -2779,7 +2546,6 @@
     },
     "vfmadd132ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x98 256-bit"
@@ -2787,7 +2553,6 @@
     },
     "vfmadd132pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x98 128-bit"
@@ -2795,7 +2560,6 @@
     },
     "vfmadd132pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x98 256-bit"
@@ -2803,7 +2567,6 @@
     },
     "vfmadd132ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x99 128-bit"
@@ -2811,7 +2574,6 @@
     },
     "vfmadd132sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x99 128-bit"
@@ -2819,7 +2581,6 @@
     },
     "vfmsub132ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9a 128-bit"
@@ -2827,7 +2588,6 @@
     },
     "vfmsub132ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9a 256-bit"
@@ -2835,7 +2595,6 @@
     },
     "vfmsub132pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9a 128-bit"
@@ -2843,7 +2602,6 @@
     },
     "vfmsub132pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9a 256-bit"
@@ -2851,7 +2609,6 @@
     },
     "vfmsub132ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9b 128-bit"
@@ -2859,7 +2616,6 @@
     },
     "vfmsub132sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9b 128-bit"
@@ -2867,7 +2623,6 @@
     },
     "vfnmadd132ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9c 128-bit"
@@ -2875,7 +2630,6 @@
     },
     "vfnmadd132ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9c 256-bit"
@@ -2883,7 +2637,6 @@
     },
     "vfnmadd132pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9c 128-bit"
@@ -2891,7 +2644,6 @@
     },
     "vfnmadd132pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9c 256-bit"
@@ -2899,7 +2651,6 @@
     },
     "vfnmadd132ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9d 128-bit"
@@ -2907,7 +2658,6 @@
     },
     "vfnmadd132sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9d 128-bit"
@@ -2915,7 +2665,6 @@
     },
     "vfnmsub132ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9e 128-bit"
@@ -2923,7 +2672,6 @@
     },
     "vfnmsub132ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9e 256-bit"
@@ -2931,7 +2679,6 @@
     },
     "vfnmsub132pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9e 128-bit"
@@ -2939,7 +2686,6 @@
     },
     "vfnmsub132pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9e 256-bit"
@@ -2947,7 +2693,6 @@
     },
     "vfnmsub132ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9f 128-bit"
@@ -2955,7 +2700,6 @@
     },
     "vfnmsub132sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0x9f 128-bit"
@@ -2963,7 +2707,6 @@
     },
     "vfmadd213ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa8 128-bit"
@@ -2971,7 +2714,6 @@
     },
     "vfmadd213ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa8 256-bit"
@@ -2979,7 +2721,6 @@
     },
     "vfmadd213pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa8 128-bit"
@@ -2987,7 +2728,6 @@
     },
     "vfmadd213pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa8 256-bit"
@@ -2995,7 +2735,6 @@
     },
     "vfmadd213ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa9 128-bit"
@@ -3003,7 +2742,6 @@
     },
     "vfmadd213sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa9 128-bit"
@@ -3011,7 +2749,6 @@
     },
     "vfmsub213ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xaa 128-bit"
@@ -3019,7 +2756,6 @@
     },
     "vfmsub213ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xaa 256-bit"
@@ -3027,7 +2763,6 @@
     },
     "vfmsub213pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xaa 128-bit"
@@ -3035,7 +2770,6 @@
     },
     "vfmsub213pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xaa 256-bit"
@@ -3043,7 +2777,6 @@
     },
     "vfmsub213ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xab 128-bit"
@@ -3051,7 +2784,6 @@
     },
     "vfmsub213sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xab 128-bit"
@@ -3059,7 +2791,6 @@
     },
     "vfnmadd213ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xac 128-bit"
@@ -3067,7 +2798,6 @@
     },
     "vfnmadd213ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xac 256-bit"
@@ -3075,7 +2805,6 @@
     },
     "vfnmadd213pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xac 128-bit"
@@ -3083,7 +2812,6 @@
     },
     "vfnmadd213pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xac 256-bit"
@@ -3091,7 +2819,6 @@
     },
     "vfnmadd213ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xad 128-bit"
@@ -3099,7 +2826,6 @@
     },
     "vfnmadd213sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xad 128-bit"
@@ -3107,7 +2833,6 @@
     },
     "vfnmsub213ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xae 128-bit"
@@ -3115,7 +2840,6 @@
     },
     "vfnmsub213ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xae 256-bit"
@@ -3123,7 +2847,6 @@
     },
     "vfnmsub213pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xae 128-bit"
@@ -3131,7 +2854,6 @@
     },
     "vfnmsub213pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xae 256-bit"
@@ -3139,7 +2861,6 @@
     },
     "vfnmsub213ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xaf 128-bit"
@@ -3147,7 +2868,6 @@
     },
     "vfnmsub213sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xaf 128-bit"
@@ -3155,7 +2875,6 @@
     },
     "vfmadd231ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb8 128-bit"
@@ -3163,7 +2882,6 @@
     },
     "vfmadd231ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb8 256-bit"
@@ -3171,7 +2889,6 @@
     },
     "vfmadd231pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb8 128-bit"
@@ -3179,7 +2896,6 @@
     },
     "vfmadd231pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb8 256-bit"
@@ -3187,7 +2903,6 @@
     },
     "vfmadd231ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb9 128-bit"
@@ -3195,7 +2910,6 @@
     },
     "vfmadd231sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb9 128-bit"
@@ -3203,7 +2917,6 @@
     },
     "vfmsub231ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xba 128-bit"
@@ -3211,7 +2924,6 @@
     },
     "vfmsub231ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xba 256-bit"
@@ -3219,7 +2931,6 @@
     },
     "vfmsub231pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xba 128-bit"
@@ -3227,7 +2938,6 @@
     },
     "vfmsub231pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xba 256-bit"
@@ -3235,7 +2945,6 @@
     },
     "vfmsub231ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbb 128-bit"
@@ -3243,7 +2952,6 @@
     },
     "vfmsub231sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbb 128-bit"
@@ -3251,7 +2959,6 @@
     },
     "vfnmadd231ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbc 128-bit"
@@ -3259,7 +2966,6 @@
     },
     "vfnmadd231ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbc 256-bit"
@@ -3267,7 +2973,6 @@
     },
     "vfnmadd231pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbc 128-bit"
@@ -3275,7 +2980,6 @@
     },
     "vfnmadd231pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbc 256-bit"
@@ -3283,7 +2987,6 @@
     },
     "vfnmadd231ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbd 128-bit"
@@ -3291,7 +2994,6 @@
     },
     "vfnmadd231sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbd 128-bit"
@@ -3299,7 +3001,6 @@
     },
     "vfnmsub231ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbe 128-bit"
@@ -3307,7 +3008,6 @@
     },
     "vfnmsub231ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbe 256-bit"
@@ -3315,7 +3015,6 @@
     },
     "vfnmsub231pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbe 128-bit"
@@ -3323,7 +3022,6 @@
     },
     "vfnmsub231pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbe 256-bit"
@@ -3331,7 +3029,6 @@
     },
     "vfnmsub231ss xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbf 128-bit"
@@ -3339,7 +3036,6 @@
     },
     "vfnmsub231sd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xbf 128-bit"
@@ -3347,7 +3043,6 @@
     },
     "vfmaddsub213ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa6 128-bit"
@@ -3355,7 +3050,6 @@
     },
     "vfmaddsub213ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa6 256-bit"
@@ -3363,7 +3057,6 @@
     },
     "vfmaddsub213pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa6 128-bit"
@@ -3371,7 +3064,6 @@
     },
     "vfmaddsub213pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa6 256-bit"
@@ -3379,7 +3071,6 @@
     },
     "vfmsubadd213ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa7 128-bit"
@@ -3387,7 +3078,6 @@
     },
     "vfmsubadd213ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa7 256-bit"
@@ -3395,7 +3085,6 @@
     },
     "vfmsubadd213pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa7 128-bit"
@@ -3403,7 +3092,6 @@
     },
     "vfmsubadd213pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xa7 256-bit"
@@ -3411,7 +3099,6 @@
     },
     "vfmaddsub231ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb6 128-bit"
@@ -3419,7 +3106,6 @@
     },
     "vfmaddsub231ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb6 256-bit"
@@ -3427,7 +3113,6 @@
     },
     "vfmaddsub231pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb6 128-bit"
@@ -3435,7 +3120,6 @@
     },
     "vfmaddsub231pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb6 256-bit"
@@ -3443,7 +3127,6 @@
     },
     "vfmsubadd231ps xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb7 128-bit"
@@ -3451,7 +3134,6 @@
     },
     "vfmsubadd231ps ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb7 256-bit"
@@ -3459,7 +3141,6 @@
     },
     "vfmsubadd231pd xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb7 128-bit"
@@ -3467,7 +3148,6 @@
     },
     "vfmsubadd231pd ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xb7 256-bit"
@@ -3475,7 +3155,6 @@
     },
     "vaesimc xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0xdb 128-bit"
       ],
@@ -3485,7 +3164,6 @@
     },
     "vaesenc xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdc 128-bit"
       ],
@@ -3499,7 +3177,6 @@
     },
     "vaesenc ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xdc 256-bit"
@@ -3507,7 +3184,6 @@
     },
     "vaesenclast xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdd 128-bit"
       ],
@@ -3520,7 +3196,6 @@
     },
     "vaesenclast ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xdd 256-bit"
@@ -3528,7 +3203,6 @@
     },
     "vaesdec xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xde 128-bit"
       ],
@@ -3542,7 +3216,6 @@
     },
     "vaesdec ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xde 256-bit"
@@ -3550,7 +3223,6 @@
     },
     "vaesdeclast xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xdf 128-bit"
       ],
@@ -3563,7 +3235,6 @@
     },
     "vaesdeclast ymm0, ymm1, ymm2": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 2 0b01 0xdf 256-bit"
@@ -3571,7 +3242,6 @@
     },
     "andn eax, ebx, ecx": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf2 32-bit"
       ],
@@ -3585,7 +3255,6 @@
     },
     "andn rax, rbx, rcx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf2 64-bit"
       ],
@@ -3597,7 +3266,6 @@
     },
     "bzhi eax, ebx, ecx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf5 32-bit"
       ],
@@ -3616,7 +3284,6 @@
     },
     "bzhi rax, rbx, rcx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf5 64-bit"
       ],
@@ -3635,7 +3302,6 @@
     },
     "pext eax, ebx, ecx": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b10 0xf5 32-bit"
       ],
@@ -3658,7 +3324,6 @@
     },
     "pext rax, rbx, rcx": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b10 0xf5 64-bit"
       ],
@@ -3679,7 +3344,6 @@
     },
     "pdep eax, ebx, ecx": {
       "ExpectedInstructionCount": 29,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b11 0xf5 32-bit"
       ],
@@ -3717,7 +3381,6 @@
     },
     "pdep rax, rbx, rcx": {
       "ExpectedInstructionCount": 27,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b11 0xf5 64-bit"
       ],
@@ -3753,7 +3416,6 @@
     },
     "mulx eax, ebx, ecx": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b11 0xf6 32-bit"
       ],
@@ -3767,7 +3429,6 @@
     },
     "mulx eax, eax, ebx": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Same two destinations should only compute high part",
         "Map 2 0b11 0xf6 32-bit"
@@ -3781,7 +3442,6 @@
     },
     "mulx eax, ebx, [ecx]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b11 0xf6 32-bit"
       ],
@@ -3797,7 +3457,6 @@
     },
     "mulx rax, rbx, rcx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b11 0xf6 64-bit"
       ],
@@ -3808,7 +3467,6 @@
     },
     "mulx rax, rax, rbx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Same two destinations should only compute high part",
         "Map 2 0b11 0xf6 64-bit"
@@ -3819,7 +3477,6 @@
     },
     "mulx rax, rbx, [rcx]": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b11 0xf6 64-bit"
       ],
@@ -3831,7 +3488,6 @@
     },
     "bextr eax, ebx, ecx": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf7 32-bit"
       ],
@@ -3859,7 +3515,6 @@
     },
     "bextr rax, rbx, rcx": {
       "ExpectedInstructionCount": 17,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b00 0xf7 64-bit"
       ],
@@ -3885,7 +3540,6 @@
     },
     "shlx eax, ebx, ecx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0xf7 32-bit"
       ],
@@ -3895,7 +3549,6 @@
     },
     "shlx eax, [ebx], ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b01 0xf7 32-bit"
       ],
@@ -3907,7 +3560,6 @@
     },
     "shlx rax, rbx, rcx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0xf7 64-bit"
       ],
@@ -3917,7 +3569,6 @@
     },
     "shlx rax, [rbx], rcx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b01 0xf7 64-bit"
       ],
@@ -3928,7 +3579,6 @@
     },
     "sarx eax, ebx, ecx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b10 0xf7 32-bit"
       ],
@@ -3938,7 +3588,6 @@
     },
     "sarx eax, [ebx], ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b10 0xf7 32-bit"
       ],
@@ -3950,7 +3599,6 @@
     },
     "sarx rax, rbx, rcx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b10 0xf7 64-bit"
       ],
@@ -3960,7 +3608,6 @@
     },
     "sarx rax, [rbx], rcx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b10 0xf7 64-bit"
       ],
@@ -3971,7 +3618,6 @@
     },
     "shrx eax, ebx, ecx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b11 0xf7 32-bit"
       ],
@@ -3981,7 +3627,6 @@
     },
     "shrx eax, [ebx], ecx": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 2 0b11 0xf7 32-bit"
       ],
@@ -3993,7 +3638,6 @@
     },
     "shrx rax, rbx, rcx": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b11 0xf7 64-bit"
       ],
@@ -4003,7 +3647,6 @@
     },
     "shrx rax, [rbx], rcx": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 2 0b11 0xf7 64-bit"
       ],

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "vpermq ymm0, ymm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
@@ -22,7 +21,6 @@
     },
     "vpermq ymm0, ymm1, 01010101b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
@@ -32,7 +30,6 @@
     },
     "vpermq ymm0, ymm1, 10101010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
@@ -42,7 +39,6 @@
     },
     "vpermq ymm0, ymm1, 11111111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
@@ -52,7 +48,6 @@
     },
     "vpermpd ymm0, ymm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x01 256-bit"
       ],
@@ -62,7 +57,6 @@
     },
     "vpermpd ymm0, ymm1, 01010101b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x01 256-bit"
       ],
@@ -72,7 +66,6 @@
     },
     "vpermpd ymm0, ymm1, 10101010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x01 256-bit"
       ],
@@ -82,7 +75,6 @@
     },
     "vpermpd ymm0, ymm1, 11111111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x01 256-bit"
       ],
@@ -92,7 +84,6 @@
     },
     "vpblendd xmm0, xmm1, 0000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -102,7 +93,6 @@
     },
     "vpblendd xmm0, xmm1, 0001b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -117,7 +107,6 @@
     },
     "vpblendd xmm0, xmm1, 0010b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -132,7 +121,6 @@
     },
     "vpblendd xmm0, xmm1, 0011b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -147,7 +135,6 @@
     },
     "vpblendd xmm0, xmm1, 0100b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -162,7 +149,6 @@
     },
     "vpblendd xmm0, xmm1, 0101b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -177,7 +163,6 @@
     },
     "vpblendd xmm0, xmm1, 0110b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -192,7 +177,6 @@
     },
     "vpblendd xmm0, xmm1, 0111b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -207,7 +191,6 @@
     },
     "vpblendd xmm0, xmm1, 1000b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -222,7 +205,6 @@
     },
     "vpblendd xmm0, xmm1, 1001b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -237,7 +219,6 @@
     },
     "vpblendd xmm0, xmm1, 1010b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -252,7 +233,6 @@
     },
     "vpblendd xmm0, xmm1, 1011b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -267,7 +247,6 @@
     },
     "vpblendd xmm0, xmm1, 1100b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -282,7 +261,6 @@
     },
     "vpblendd xmm0, xmm1, 1101b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -297,7 +275,6 @@
     },
     "vpblendd xmm0, xmm1, 1110b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -312,7 +289,6 @@
     },
     "vpblendd xmm0, xmm1, 1111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
@@ -322,7 +298,6 @@
     },
     "vpblendd ymm0, ymm1, 00000000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 256-bit"
       ],
@@ -333,7 +308,6 @@
     },
     "vpblendd ymm0, ymm1, 01010101b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 256-bit"
       ],
@@ -392,7 +366,6 @@
     },
     "vpblendd ymm0, ymm1, 10101010b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x02 256-bit"
       ],
@@ -451,7 +424,6 @@
     },
     "vpblendd ymm0, ymm1, 11111111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x02 256-bit"
       ],
@@ -461,7 +433,6 @@
     },
     "vpermilps xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
@@ -476,7 +447,6 @@
     },
     "vpermilps xmm0, xmm1, 01010101b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
@@ -491,7 +461,6 @@
     },
     "vpermilps xmm0, xmm1, 10101010b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
@@ -506,7 +475,6 @@
     },
     "vpermilps xmm0, xmm1, 11111111b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
@@ -521,7 +489,6 @@
     },
     "vpermilps ymm0, ymm1, 00000000b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 256-bit"
       ],
@@ -580,7 +547,6 @@
     },
     "vpermilps ymm0, ymm1, 01010101b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 256-bit"
       ],
@@ -639,7 +605,6 @@
     },
     "vpermilps ymm0, ymm1, 10101010b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 256-bit"
       ],
@@ -698,7 +663,6 @@
     },
     "vpermilps ymm0, ymm1, 11111111b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x03 256-bit"
       ],
@@ -757,7 +721,6 @@
     },
     "vpermilpd xmm0, xmm1, 00b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
@@ -770,7 +733,6 @@
     },
     "vpermilpd xmm0, xmm1, 01b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
@@ -783,7 +745,6 @@
     },
     "vpermilpd xmm0, xmm1, 10b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
@@ -796,7 +757,6 @@
     },
     "vpermilpd xmm0, xmm1, 11b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
@@ -809,7 +769,6 @@
     },
     "vpermilpd ymm0, ymm1, 0000b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -844,7 +803,6 @@
     },
     "vpermilpd ymm0, ymm1, 0001b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -879,7 +837,6 @@
     },
     "vpermilpd ymm0, ymm1, 0010b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -914,7 +871,6 @@
     },
     "vpermilpd ymm0, ymm1, 0011b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -949,7 +905,6 @@
     },
     "vpermilpd ymm0, ymm1, 0100b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -984,7 +939,6 @@
     },
     "vpermilpd ymm0, ymm1, 0101b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1019,7 +973,6 @@
     },
     "vpermilpd ymm0, ymm1, 0110b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1054,7 +1007,6 @@
     },
     "vpermilpd ymm0, ymm1, 0111b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1089,7 +1041,6 @@
     },
     "vpermilpd ymm0, ymm1, 1000b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1124,7 +1075,6 @@
     },
     "vpermilpd ymm0, ymm1, 1001b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1159,7 +1109,6 @@
     },
     "vpermilpd ymm0, ymm1, 1010b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1194,7 +1143,6 @@
     },
     "vpermilpd ymm0, ymm1, 1011b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1229,7 +1177,6 @@
     },
     "vpermilpd ymm0, ymm1, 1100b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1264,7 +1211,6 @@
     },
     "vpermilpd ymm0, ymm1, 1101b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1299,7 +1245,6 @@
     },
     "vpermilpd ymm0, ymm1, 1110b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1334,7 +1279,6 @@
     },
     "vpermilpd ymm0, ymm1, 1111b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
@@ -1369,7 +1313,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00000000b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1385,7 +1328,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00000001b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1401,7 +1343,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00000010b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1417,7 +1358,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00000011b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1433,7 +1373,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00010000b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1449,7 +1388,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00010001b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1465,7 +1403,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00010010b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1481,7 +1418,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00010011b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1497,7 +1433,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00100000b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1513,7 +1448,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00100001b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1529,7 +1463,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00100010b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1545,7 +1478,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00100011b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1561,7 +1493,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00110000b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1577,7 +1508,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00110001b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1593,7 +1523,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00110010b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1609,7 +1538,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00110011b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1625,7 +1553,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00001000b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1639,7 +1566,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00011000b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1653,7 +1579,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00101000b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1667,7 +1592,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00111000b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1681,7 +1605,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10001000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1691,7 +1614,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000000b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1704,7 +1626,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000001b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1717,7 +1638,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000010b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1730,7 +1650,6 @@
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000011b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1743,7 +1662,6 @@
     },
     "vroundps xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x08 128-bit"
@@ -1754,7 +1672,6 @@
     },
     "vroundps xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x08 128-bit"
@@ -1765,7 +1682,6 @@
     },
     "vroundps xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x08 128-bit"
@@ -1776,7 +1692,6 @@
     },
     "vroundps xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x08 128-bit"
@@ -1787,7 +1702,6 @@
     },
     "vroundps xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x08 128-bit"
@@ -1798,7 +1712,6 @@
     },
     "vroundps ymm0, ymm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x08 256-bit"
@@ -1809,7 +1722,6 @@
     },
     "vroundps ymm0, ymm1, 00000001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x08 256-bit"
@@ -1820,7 +1732,6 @@
     },
     "vroundps ymm0, ymm1, 00000010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x08 256-bit"
@@ -1831,7 +1742,6 @@
     },
     "vroundps ymm0, ymm1, 00000011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x08 256-bit"
@@ -1842,7 +1752,6 @@
     },
     "vroundps ymm0, ymm1, 00000100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x08 256-bit"
@@ -1853,7 +1762,6 @@
     },
     "vroundpd xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x09 128-bit"
@@ -1864,7 +1772,6 @@
     },
     "vroundpd xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x09 128-bit"
@@ -1875,7 +1782,6 @@
     },
     "vroundpd xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x09 128-bit"
@@ -1886,7 +1792,6 @@
     },
     "vroundpd xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x09 128-bit"
@@ -1897,7 +1802,6 @@
     },
     "vroundpd xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x09 128-bit"
@@ -1908,7 +1812,6 @@
     },
     "vroundpd ymm0, ymm1, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x09 256-bit"
@@ -1919,7 +1822,6 @@
     },
     "vroundpd ymm0, ymm1, 00000001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x09 256-bit"
@@ -1930,7 +1832,6 @@
     },
     "vroundpd ymm0, ymm1, 00000010b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x09 256-bit"
@@ -1941,7 +1842,6 @@
     },
     "vroundpd ymm0, ymm1, 00000011b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x09 256-bit"
@@ -1952,7 +1852,6 @@
     },
     "vroundpd ymm0, ymm1, 00000100b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x09 256-bit"
@@ -1963,7 +1862,6 @@
     },
     "vroundss xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1976,7 +1874,6 @@
     },
     "vroundss xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1989,7 +1886,6 @@
     },
     "vroundss xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -2002,7 +1898,6 @@
     },
     "vroundss xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -2015,7 +1910,6 @@
     },
     "vroundss xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -2028,7 +1922,6 @@
     },
     "vroundsd xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -2041,7 +1934,6 @@
     },
     "vroundsd xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -2054,7 +1946,6 @@
     },
     "vroundsd xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -2067,7 +1958,6 @@
     },
     "vroundsd xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -2080,7 +1970,6 @@
     },
     "vroundsd xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "Yes",
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -2093,7 +1982,6 @@
     },
     "vblendps xmm0, xmm1, xmm2, 0000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
@@ -2103,7 +1991,6 @@
     },
     "vblendps xmm0, xmm1, xmm2, 0001b": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
@@ -2118,7 +2005,6 @@
     },
     "vblendps xmm0, xmm1, xmm2, 1111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
@@ -2128,7 +2014,6 @@
     },
     "vblendps ymm0, ymm1, ymm2, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0c 256-bit"
       ],
@@ -2138,7 +2023,6 @@
     },
     "vblendps ymm0, ymm1, ymm2, 10000001b": {
       "ExpectedInstructionCount": 50,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0c 256-bit"
       ],
@@ -2197,7 +2081,6 @@
     },
     "vblendps ymm0, ymm1, ymm2, 11111111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0c 256-bit"
       ],
@@ -2207,7 +2090,6 @@
     },
     "vblendpd xmm0, xmm1, xmm2, 00b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
@@ -2217,7 +2099,6 @@
     },
     "vblendpd xmm0, xmm1, xmm2, 01b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
@@ -2230,7 +2111,6 @@
     },
     "vblendpd xmm0, xmm1, xmm2, 10b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
@@ -2243,7 +2123,6 @@
     },
     "vblendpd xmm0, xmm1, xmm2, 11b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
@@ -2253,7 +2132,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 0000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2263,7 +2141,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 0001b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2298,7 +2175,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 0010b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2333,7 +2209,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 0011b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2368,7 +2243,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 0100b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2403,7 +2277,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 0101b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2438,7 +2311,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 0110b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2473,7 +2345,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 0111b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2508,7 +2379,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 1000b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2543,7 +2413,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 1001b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2578,7 +2447,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 1010b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2613,7 +2481,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 1011b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2648,7 +2515,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 1100b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2683,7 +2549,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 1101b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2718,7 +2583,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 1110b": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2753,7 +2617,6 @@
     },
     "vblendpd ymm0, ymm1, ymm2, 1111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0d 256-bit"
       ],
@@ -2763,7 +2626,6 @@
     },
     "vpblendw xmm0, xmm1, xmm2, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
@@ -2773,7 +2635,6 @@
     },
     "vpblendw xmm0, xmm1, xmm2, 00000001b": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
@@ -2792,7 +2653,6 @@
     },
     "vpblendw xmm0, xmm1, xmm2, 11111111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
@@ -2802,7 +2662,6 @@
     },
     "vpblendw ymm0, ymm1, ymm2, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
@@ -2812,7 +2671,6 @@
     },
     "vpblendw ymm0, ymm1, ymm2, 00000001b": {
       "ExpectedInstructionCount": 98,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
@@ -2919,7 +2777,6 @@
     },
     "vpblendw ymm0, ymm1, ymm2, 11111111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
@@ -2929,7 +2786,6 @@
     },
     "vpalignr xmm0, xmm1, xmm2, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
@@ -2939,7 +2795,6 @@
     },
     "vpalignr xmm0, xmm1, xmm2, 1": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
@@ -2949,7 +2804,6 @@
     },
     "vpalignr xmm0, xmm1, xmm2, 15": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
@@ -2959,7 +2813,6 @@
     },
     "vpalignr xmm0, xmm1, xmm2, 16": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
@@ -2970,7 +2823,6 @@
     },
     "vpalignr ymm0, ymm1, ymm2, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x0f 256-bit"
       ],
@@ -2980,7 +2832,6 @@
     },
     "vpalignr ymm0, ymm1, ymm2, 1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0f 256-bit"
       ],
@@ -3001,7 +2852,6 @@
     },
     "vpalignr ymm0, ymm1, ymm2, 15": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0f 256-bit"
       ],
@@ -3022,7 +2872,6 @@
     },
     "vpalignr ymm0, ymm1, ymm2, 16": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x0f 256-bit"
       ],
@@ -3045,7 +2894,6 @@
     },
     "vpextrb rax, xmm0, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x14 128-bit"
       ],
@@ -3055,7 +2903,6 @@
     },
     "vpextrb rax, xmm0, 15": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x14 128-bit"
       ],
@@ -3065,7 +2912,6 @@
     },
     "vpextrw rax, xmm0, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x15 128-bit"
       ],
@@ -3075,7 +2921,6 @@
     },
     "vpextrw rax, xmm0, 7": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x15 128-bit"
       ],
@@ -3085,7 +2930,6 @@
     },
     "vpextrd rax, xmm0, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x16 128-bit"
       ],
@@ -3095,7 +2939,6 @@
     },
     "vpextrd rax, xmm0, 3": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x16 128-bit"
       ],
@@ -3105,7 +2948,6 @@
     },
     "vpextrb [rax], xmm0, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x14 128-bit"
       ],
@@ -3115,7 +2957,6 @@
     },
     "vpextrb [rax], xmm0, 15": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x14 128-bit"
       ],
@@ -3125,7 +2966,6 @@
     },
     "vpextrw [rax], xmm0, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x15 128-bit"
       ],
@@ -3135,7 +2975,6 @@
     },
     "vpextrw [rax], xmm0, 7": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x15 128-bit"
       ],
@@ -3145,7 +2984,6 @@
     },
     "vpextrd [rax], xmm0, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x16 128-bit"
       ],
@@ -3155,7 +2993,6 @@
     },
     "vpextrd [rax], xmm0, 3": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x16 128-bit"
       ],
@@ -3165,7 +3002,6 @@
     },
     "vextractps eax, xmm0, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x17 128-bit"
       ],
@@ -3175,7 +3011,6 @@
     },
     "vextractps eax, xmm0, 3": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x17 128-bit"
       ],
@@ -3185,7 +3020,6 @@
     },
     "vinsertf128 ymm0, ymm1, xmm2, 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x18 256-bit"
       ],
@@ -3197,7 +3031,6 @@
     },
     "vinsertf128 ymm0, ymm1, xmm2, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x18 256-bit"
       ],
@@ -3210,7 +3043,6 @@
     },
     "vextractf128 xmm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x19 256-bit"
       ],
@@ -3220,7 +3052,6 @@
     },
     "vextractf128 xmm0, ymm1, 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x19 256-bit"
       ],
@@ -3231,7 +3062,6 @@
     },
     "vcvtps2ph xmm0, xmm1, 00000000b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "nearest rounding",
@@ -3240,7 +3070,6 @@
     },
     "vcvtps2ph xmm0, xmm1, 00000001b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "-inf rounding",
@@ -3249,7 +3078,6 @@
     },
     "vcvtps2ph xmm0, xmm1, 00000010b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "+inf rounding",
@@ -3258,7 +3086,6 @@
     },
     "vcvtps2ph xmm0, xmm1, 00000011b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "truncate rounding",
@@ -3267,7 +3094,6 @@
     },
     "vcvtps2ph xmm0, xmm1, 00000100b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "host mode rounding",
@@ -3276,7 +3102,6 @@
     },
     "vcvtps2ph xmm0, ymm1, 00000000b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "nearest rounding",
@@ -3285,7 +3110,6 @@
     },
     "vcvtps2ph xmm0, ymm1, 00000001b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "-inf rounding",
@@ -3294,7 +3118,6 @@
     },
     "vcvtps2ph xmm0, ymm1, 00000010b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "+inf rounding",
@@ -3303,7 +3126,6 @@
     },
     "vcvtps2ph xmm0, ymm1, 00000011b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "truncate rounding",
@@ -3312,7 +3134,6 @@
     },
     "vcvtps2ph xmm0, ymm1, 00000100b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "host mode rounding",
@@ -3321,7 +3142,6 @@
     },
     "vpinsrb xmm0, xmm0, eax, 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x20 128-bit"
       ],
@@ -3333,7 +3153,6 @@
     },
     "vpinsrb xmm0, xmm1, eax, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x20 128-bit"
       ],
@@ -3344,7 +3163,6 @@
     },
     "vpinsrb xmm0, xmm1, eax, 15": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x20 128-bit"
       ],
@@ -3355,7 +3173,6 @@
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b00 << 6) | (0b00 << 4) | (0b0000))": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x21 128-bit"
       ],
@@ -3366,7 +3183,6 @@
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b00 << 6) | (0b00 << 4) | (0b1111))": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x21 128-bit"
       ],
@@ -3376,7 +3192,6 @@
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b11 << 6) | (0b11 << 4) | (0b0000))": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x21 128-bit"
       ],
@@ -3387,7 +3202,6 @@
     },
     "vpinsrd xmm0, xmm0, eax, 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
@@ -3399,7 +3213,6 @@
     },
     "vpinsrd xmm0, xmm1, eax, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
@@ -3410,7 +3223,6 @@
     },
     "vpinsrd xmm0, xmm1, eax, 3": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
@@ -3421,7 +3233,6 @@
     },
     "vpinsrq xmm0, xmm0, rax, 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
@@ -3433,7 +3244,6 @@
     },
     "vpinsrq xmm0, xmm1, rax, 0": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
@@ -3444,7 +3254,6 @@
     },
     "vpinsrq xmm0, xmm1, rax, 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
@@ -3455,7 +3264,6 @@
     },
     "vinserti128 ymm0, ymm1, xmm2, 0": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x38 256-bit"
       ],
@@ -3467,7 +3275,6 @@
     },
     "vinserti128 ymm0, ymm1, xmm2, 1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x38 256-bit"
       ],
@@ -3480,7 +3287,6 @@
     },
     "vextracti128 xmm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x39 256-bit"
       ],
@@ -3490,7 +3296,6 @@
     },
     "vextracti128 xmm0, ymm1, 1": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x39 256-bit"
       ],
@@ -3501,7 +3306,6 @@
     },
     "vdpps xmm0, xmm1, xmm2, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
@@ -3511,7 +3315,6 @@
     },
     "vdpps xmm0, xmm1, xmm2, 00001111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
@@ -3521,7 +3324,6 @@
     },
     "vdpps xmm0, xmm1, xmm2, 11110000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
@@ -3531,7 +3333,6 @@
     },
     "vdpps xmm0, xmm1, xmm2, 11111111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
@@ -3543,7 +3344,6 @@
     },
     "vdpps ymm0, ymm1, ymm2, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
@@ -3553,7 +3353,6 @@
     },
     "vdpps ymm0, ymm1, ymm2, 00001111b": {
       "ExpectedInstructionCount": 109,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
@@ -3671,7 +3470,6 @@
     },
     "vdpps ymm0, ymm1, ymm2, 11110000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
@@ -3681,7 +3479,6 @@
     },
     "vdpps ymm0, ymm1, ymm2, 11111111b": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
@@ -3751,7 +3548,6 @@
     },
     "vdppd xmm0, xmm1, xmm2, 00000000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
       ],
@@ -3761,7 +3557,6 @@
     },
     "vdppd xmm0, xmm1, xmm2, 00001111b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
       ],
@@ -3771,7 +3566,6 @@
     },
     "vdppd xmm0, xmm1, xmm2, 11110000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
       ],
@@ -3781,7 +3575,6 @@
     },
     "vdppd xmm0, xmm1, xmm2, 11111111b": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
       ],
@@ -3793,7 +3586,6 @@
     },
     "vmpsadbw xmm0, xmm1, xmm2, 000b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
@@ -3816,7 +3608,6 @@
     },
     "vmpsadbw xmm0, xmm1, xmm2, 001b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
@@ -3839,7 +3630,6 @@
     },
     "vmpsadbw xmm0, xmm1, xmm2, 010b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
@@ -3862,7 +3652,6 @@
     },
     "vmpsadbw xmm0, xmm1, xmm2, 011b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
@@ -3885,7 +3674,6 @@
     },
     "vmpsadbw xmm0, xmm1, xmm2, 100b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
@@ -3908,7 +3696,6 @@
     },
     "vmpsadbw xmm0, xmm1, xmm2, 101b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
@@ -3931,7 +3718,6 @@
     },
     "vmpsadbw xmm0, xmm1, xmm2, 110b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
@@ -3954,7 +3740,6 @@
     },
     "vmpsadbw xmm0, xmm1, xmm2, 111b": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
@@ -3977,7 +3762,6 @@
     },
     "vmpsadbw ymm0, ymm1, ymm2, 000b": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
@@ -4020,7 +3804,6 @@
     },
     "vmpsadbw ymm0, ymm1, ymm2, 001b": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
@@ -4063,7 +3846,6 @@
     },
     "vmpsadbw ymm0, ymm1, ymm2, 010b": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
@@ -4106,7 +3888,6 @@
     },
     "vmpsadbw ymm0, ymm1, ymm2, 011b": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
@@ -4149,7 +3930,6 @@
     },
     "vmpsadbw ymm0, ymm1, ymm2, 100b": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
@@ -4192,7 +3972,6 @@
     },
     "vmpsadbw ymm0, ymm1, ymm2, 101b": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
@@ -4235,7 +4014,6 @@
     },
     "vmpsadbw ymm0, ymm1, ymm2, 110b": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
@@ -4278,7 +4056,6 @@
     },
     "vmpsadbw ymm0, ymm1, ymm2, 111b": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x42 256-bit"
       ],
@@ -4321,7 +4098,6 @@
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 00000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
@@ -4331,7 +4107,6 @@
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 00001b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
@@ -4342,7 +4117,6 @@
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 10000b": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
@@ -4353,7 +4127,6 @@
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 10001b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
@@ -4363,7 +4136,6 @@
     },
     "vpclmulqdq ymm0, ymm1, ymm2, 00000b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x44 256-bit"
@@ -4371,7 +4143,6 @@
     },
     "vpclmulqdq ymm0, ymm1, ymm2, 00001b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x44 256-bit"
@@ -4379,7 +4150,6 @@
     },
     "vpclmulqdq ymm0, ymm1, ymm2, 10000b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x44 256-bit"
@@ -4387,7 +4157,6 @@
     },
     "vpclmulqdq ymm0, ymm1, ymm2, 10001b": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x44 256-bit"
@@ -4395,7 +4164,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00000000b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4411,7 +4179,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00000001b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4427,7 +4194,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00000010b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4443,7 +4209,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00000011b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4459,7 +4224,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00010000b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4475,7 +4239,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00010001b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4491,7 +4254,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00010010b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4507,7 +4269,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00010011b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4523,7 +4284,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00100000b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4539,7 +4299,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00100001b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4555,7 +4314,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00100010b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4571,7 +4329,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00100011b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4587,7 +4344,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00110000b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4603,7 +4359,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00110001b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4619,7 +4374,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00110010b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4635,7 +4389,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00110011b": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4651,7 +4404,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00001000b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4665,7 +4417,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00011000b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4679,7 +4430,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00101000b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4693,7 +4443,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00111000b": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4707,7 +4456,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10001000b": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4717,7 +4465,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000000b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4730,7 +4477,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000001b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4743,7 +4489,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000010b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4756,7 +4501,6 @@
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000011b": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4769,7 +4513,6 @@
     },
     "vblendvps xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4a 128-bit"
       ],
@@ -4781,7 +4524,6 @@
     },
     "vblendvps ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4a 256-bit"
       ],
@@ -4795,7 +4537,6 @@
     },
     "vblendvpd xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4b 128-bit"
       ],
@@ -4807,7 +4548,6 @@
     },
     "vblendvpd ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4b 256-bit"
       ],
@@ -4821,7 +4561,6 @@
     },
     "vpblendvb xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": 3,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4c 128-bit"
       ],
@@ -4833,7 +4572,6 @@
     },
     "vpblendvb ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0x4c 256-bit"
       ],
@@ -4847,7 +4585,6 @@
     },
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x5c 128-bit"
@@ -4855,7 +4592,6 @@
     },
     "vfmaddsubps ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x5c 256-bit"
@@ -4863,7 +4599,6 @@
     },
     "vfmaddsubpd xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x5d 128-bit"
@@ -4871,7 +4606,6 @@
     },
     "vfmaddsubpd ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x5d 256-bit"
@@ -4879,7 +4613,6 @@
     },
     "vfmsubaddps xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x5e 128-bit"
@@ -4887,7 +4620,6 @@
     },
     "vfmsubaddps ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x5e 256-bit"
@@ -4895,7 +4627,6 @@
     },
     "vfmsubaddpd xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x5f 128-bit"
@@ -4903,7 +4634,6 @@
     },
     "vfmsubaddpd ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x5f 256-bit"
@@ -4911,7 +4641,6 @@
     },
     "vfmaddps xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x68 128-bit"
@@ -4919,7 +4648,6 @@
     },
     "vfmaddps ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x68 256-bit"
@@ -4927,7 +4655,6 @@
     },
     "vfmaddpd xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x69 128-bit"
@@ -4935,7 +4662,6 @@
     },
     "vfmaddpd ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x69 256-bit"
@@ -4943,7 +4669,6 @@
     },
     "vfmaddss xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x6a 128-bit"
@@ -4951,7 +4676,6 @@
     },
     "vfmaddsd xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x6b 128-bit"
@@ -4959,7 +4683,6 @@
     },
     "vfmsubps xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x6c 128-bit"
@@ -4967,7 +4690,6 @@
     },
     "vfmsubps ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x6c 256-bit"
@@ -4975,7 +4697,6 @@
     },
     "vfmsubpd xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x6d 128-bit"
@@ -4983,7 +4704,6 @@
     },
     "vfmsubpd ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x6d 256-bit"
@@ -4991,7 +4711,6 @@
     },
     "vfmsubss xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x6e 128-bit"
@@ -4999,7 +4718,6 @@
     },
     "vfmsubsd xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x6f 128-bit"
@@ -5007,7 +4725,6 @@
     },
     "vfnmaddps xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x78 128-bit"
@@ -5015,7 +4732,6 @@
     },
     "vfnmaddpd ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x78 256-bit"
@@ -5023,7 +4739,6 @@
     },
     "vfnmaddss xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x79 128-bit"
@@ -5031,7 +4746,6 @@
     },
     "vfnmaddsd xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x7a 128-bit"
@@ -5039,7 +4753,6 @@
     },
     "vfnmsubps xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x7c 128-bit"
@@ -5047,7 +4760,6 @@
     },
     "vfnmsubps ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x7c 256-bit"
@@ -5055,7 +4767,6 @@
     },
     "vfnmsubpd xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x7d 128-bit"
@@ -5063,7 +4774,6 @@
     },
     "vfnmsubpd ymm0, ymm1, ymm2, ymm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x7d 256-bit"
@@ -5071,7 +4781,6 @@
     },
     "vfnmsubss xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x7e 128-bit"
@@ -5079,7 +4788,6 @@
     },
     "vfnmsubsd xmm0, xmm1, xmm2, xmm3": {
       "ExpectedInstructionCount": -1,
-      "Optimal": "Unknown",
       "Skip": "Yes",
       "Comment": [
         "Map 3 0b01 0x7f 128-bit"
@@ -5087,7 +4795,6 @@
     },
     "vaeskeygenassist xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0xdf 128-bit"
       ],
@@ -5101,7 +4808,6 @@
     },
     "vaeskeygenassist xmm0, xmm1, 0xFF": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "Map 3 0b01 0xdf 128-bit"
       ],
@@ -5118,7 +4824,6 @@
     },
     "rorx eax, ebx, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 32-bit"
       ],
@@ -5128,7 +4833,6 @@
     },
     "rorx eax, eax, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 32-bit"
       ],
@@ -5138,7 +4842,6 @@
     },
     "rorx eax, ebx, 31": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 32-bit"
       ],
@@ -5148,7 +4851,6 @@
     },
     "rorx eax, ebx, 32": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 32-bit"
       ],
@@ -5158,7 +4860,6 @@
     },
     "rorx eax, eax, 32": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 32-bit"
       ],
@@ -5168,7 +4869,6 @@
     },
     "rorx rax, rbx, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 64-bit"
       ],
@@ -5178,7 +4878,6 @@
     },
     "rorx rax, rax, 0": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 64-bit"
       ],
@@ -5186,7 +4885,6 @@
     },
     "rorx rax, rbx, 63": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 64-bit"
       ],
@@ -5196,7 +4894,6 @@
     },
     "rorx rax, rbx, 64": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 64-bit"
       ],
@@ -5206,7 +4903,6 @@
     },
     "rorx rax, rax, 64": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "Map 3 0b11 0xf0 64-bit"
       ],

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -12,7 +12,6 @@
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
@@ -22,7 +21,6 @@
     },
     "vpsrlw xmm0, xmm1, 15": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
@@ -32,7 +30,6 @@
     },
     "vpsrlw xmm0, xmm1, 16": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
@@ -42,7 +39,6 @@
     },
     "vpsrlw ymm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 256-bit"
       ],
@@ -52,7 +48,6 @@
     },
     "vpsrlw ymm0, ymm1, 15": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 256-bit"
       ],
@@ -63,7 +58,6 @@
     },
     "vpsrlw ymm0, ymm1, 16": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b010 256-bit"
       ],
@@ -73,7 +67,6 @@
     },
     "vpsraw xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
@@ -83,7 +76,6 @@
     },
     "vpsraw xmm0, xmm1, 15": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
@@ -93,7 +85,6 @@
     },
     "vpsraw xmm0, xmm1, 16": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
@@ -103,7 +94,6 @@
     },
     "vpsraw ymm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 256-bit"
       ],
@@ -113,7 +103,6 @@
     },
     "vpsraw ymm0, ymm1, 15": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 256-bit"
       ],
@@ -124,7 +113,6 @@
     },
     "vpsraw ymm0, ymm1, 16": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b100 256-bit"
       ],
@@ -135,7 +123,6 @@
     },
     "vpsllw xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
@@ -145,7 +132,6 @@
     },
     "vpsllw xmm0, xmm1, 15": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
@@ -155,7 +141,6 @@
     },
     "vpsllw xmm0, xmm1, 16": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
@@ -165,7 +150,6 @@
     },
     "vpsllw ymm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 256-bit"
       ],
@@ -175,7 +159,6 @@
     },
     "vpsllw ymm0, ymm1, 15": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 256-bit"
       ],
@@ -186,7 +169,6 @@
     },
     "vpsllw ymm0, ymm1, 16": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 12 0b110 256-bit"
       ],
@@ -196,7 +178,6 @@
     },
     "vpsrld xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
@@ -206,7 +187,6 @@
     },
     "vpsrld xmm0, xmm1, 31": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
@@ -216,7 +196,6 @@
     },
     "vpsrld xmm0, xmm1, 32": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
@@ -226,7 +205,6 @@
     },
     "vpsrld ymm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 256-bit"
       ],
@@ -236,7 +214,6 @@
     },
     "vpsrld ymm0, ymm1, 31": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 256-bit"
       ],
@@ -247,7 +224,6 @@
     },
     "vpsrld ymm0, ymm1, 32": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b010 256-bit"
       ],
@@ -257,7 +233,6 @@
     },
     "vpsrad xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
@@ -267,7 +242,6 @@
     },
     "vpsrad xmm0, xmm1, 31": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
@@ -277,7 +251,6 @@
     },
     "vpsrad xmm0, xmm1, 32": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
@@ -287,7 +260,6 @@
     },
     "vpsrad ymm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 256-bit"
       ],
@@ -297,7 +269,6 @@
     },
     "vpsrad ymm0, ymm1, 31": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 256-bit"
       ],
@@ -308,7 +279,6 @@
     },
     "vpsrad ymm0, ymm1, 32": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b100 256-bit"
       ],
@@ -319,7 +289,6 @@
     },
     "vpslld xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
@@ -329,7 +298,6 @@
     },
     "vpslld xmm0, xmm1, 31": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
@@ -339,7 +307,6 @@
     },
     "vpslld xmm0, xmm1, 32": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
@@ -349,7 +316,6 @@
     },
     "vpslld ymm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 256-bit"
       ],
@@ -359,7 +325,6 @@
     },
     "vpslld ymm0, ymm1, 31": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 256-bit"
       ],
@@ -370,7 +335,6 @@
     },
     "vpslld ymm0, ymm1, 32": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 13 0b110 256-bit"
       ],
@@ -380,7 +344,6 @@
     },
     "vpsrlq xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
@@ -390,7 +353,6 @@
     },
     "vpsrlq xmm0, xmm1, 63": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
@@ -400,7 +362,6 @@
     },
     "vpsrlq xmm0, xmm1, 64": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
@@ -410,7 +371,6 @@
     },
     "vpsrlq ymm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 256-bit"
       ],
@@ -420,7 +380,6 @@
     },
     "vpsrlq ymm0, ymm1, 63": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 256-bit"
       ],
@@ -431,7 +390,6 @@
     },
     "vpsrlq ymm0, ymm1, 64": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b010 256-bit"
       ],
@@ -441,7 +399,6 @@
     },
     "vpsrldq xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b011 128-bit"
       ],
@@ -451,7 +408,6 @@
     },
     "vpsrldq xmm0, xmm1, 15": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map group 14 0b011 128-bit"
       ],
@@ -462,7 +418,6 @@
     },
     "vpsrldq xmm0, xmm1, 16": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b011 128-bit"
       ],
@@ -472,7 +427,6 @@
     },
     "vpsrldq ymm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b011 256-bit"
       ],
@@ -482,7 +436,6 @@
     },
     "vpsrldq ymm0, ymm1, 15": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "Map group 14 0b011 256-bit"
       ],
@@ -500,7 +453,6 @@
     },
     "vpsrldq ymm0, ymm1, 16": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b011 256-bit"
       ],
@@ -510,7 +462,6 @@
     },
     "vpsllq xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
@@ -520,7 +471,6 @@
     },
     "vpsllq xmm0, xmm1, 63": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
@@ -530,7 +480,6 @@
     },
     "vpsllq xmm0, xmm1, 64": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "No",
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
@@ -540,7 +489,6 @@
     },
     "vpsllq ymm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b110 256-bit"
       ],
@@ -550,7 +498,6 @@
     },
     "vpsllq ymm0, ymm1, 63": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b110 256-bit"
       ],
@@ -561,7 +508,6 @@
     },
     "vpsllq ymm0, ymm1, 64": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b110 256-bit"
       ],
@@ -571,7 +517,6 @@
     },
     "vpslldq xmm0, xmm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b111 128-bit"
       ],
@@ -581,7 +526,6 @@
     },
     "vpslldq xmm0, xmm1, 15": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "Map group 14 0b111 128-bit"
       ],
@@ -592,7 +536,6 @@
     },
     "vpslldq xmm0, xmm1, 16": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b111 128-bit"
       ],
@@ -602,7 +545,6 @@
     },
     "vpslldq ymm0, ymm1, 0": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b111 256-bit"
       ],
@@ -612,7 +554,6 @@
     },
     "vpslldq ymm0, ymm1, 15": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map group 14 0b111 256-bit"
       ],
@@ -628,7 +569,6 @@
     },
     "vpslldq ymm0, ymm1, 16": {
       "ExpectedInstructionCount": 1,
-      "Optimal": "Yes",
       "Comment": [
         "Map group 14 0b111 256-bit"
       ],
@@ -638,7 +578,6 @@
     },
     "vldmxcsr [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "Map group 15 0b010"
       ],
@@ -656,7 +595,6 @@
     },
     "vstmxcsr [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "Map group 15 0b011"
       ],
@@ -672,7 +610,6 @@
     },
     "blsr eax, ebx": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b001 32-bit"
       ],
@@ -691,7 +628,6 @@
     },
     "blsr rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b001 64-bit"
       ],
@@ -708,7 +644,6 @@
     },
     "blsmsk eax, ebx": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b010 32-bit"
       ],
@@ -730,7 +665,6 @@
     },
     "blsmsk rax, rbx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b010 64-bit"
       ],
@@ -748,7 +682,6 @@
     },
     "blsi eax, ebx": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b011 32-bit"
       ],
@@ -766,7 +699,6 @@
     },
     "blsi rax, rbx": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "Map group 17 0b011 64-bit"
       ],

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -14,7 +14,6 @@
   "Instructions": {
     "fadd dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /0"
       ],
@@ -130,7 +129,6 @@
     },
     "fmul dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /1"
       ],
@@ -246,7 +244,6 @@
     },
     "fcom dword [rax]": {
       "ExpectedInstructionCount": 113,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /2"
       ],
@@ -368,7 +365,6 @@
     },
     "fcomp dword [rax]": {
       "ExpectedInstructionCount": 121,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /3"
       ],
@@ -498,7 +494,6 @@
     },
     "fsub dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /4"
       ],
@@ -614,7 +609,6 @@
     },
     "fsubr dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /5"
       ],
@@ -730,7 +724,6 @@
     },
     "fdiv dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /6"
       ],
@@ -846,7 +839,6 @@
     },
     "fdivr dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /7"
       ],
@@ -962,7 +954,6 @@
     },
     "fadd st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc0 /0"
       ],
@@ -1032,7 +1023,6 @@
     },
     "fadd st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc1 /0"
       ],
@@ -1102,7 +1092,6 @@
     },
     "fadd st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc2 /0"
       ],
@@ -1172,7 +1161,6 @@
     },
     "fadd st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc3 /0"
       ],
@@ -1242,7 +1230,6 @@
     },
     "fadd st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc4 /0"
       ],
@@ -1312,7 +1299,6 @@
     },
     "fadd st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc5 /0"
       ],
@@ -1382,7 +1368,6 @@
     },
     "fadd st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc6 /0"
       ],
@@ -1452,7 +1437,6 @@
     },
     "fadd st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc7 /0"
       ],
@@ -1522,7 +1506,6 @@
     },
     "fmul st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc8 /1"
       ],
@@ -1592,7 +1575,6 @@
     },
     "fmul st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc9 /1"
       ],
@@ -1662,7 +1644,6 @@
     },
     "fmul st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xca /1"
       ],
@@ -1732,7 +1713,6 @@
     },
     "fmul st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcb /1"
       ],
@@ -1802,7 +1782,6 @@
     },
     "fmul st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcc /1"
       ],
@@ -1872,7 +1851,6 @@
     },
     "fmul st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcd /1"
       ],
@@ -1942,7 +1920,6 @@
     },
     "fmul st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xce /1"
       ],
@@ -2012,7 +1989,6 @@
     },
     "fmul st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcf /1"
       ],
@@ -2082,7 +2058,6 @@
     },
     "fcom st0, st0": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd0 /2"
       ],
@@ -2158,7 +2133,6 @@
     },
     "fcom st0, st1": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd1 /2"
       ],
@@ -2234,7 +2208,6 @@
     },
     "fcom st0, st2": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd2 /2"
       ],
@@ -2310,7 +2283,6 @@
     },
     "fcom st0, st3": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd3 /2"
       ],
@@ -2386,7 +2358,6 @@
     },
     "fcom st0, st4": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd4 /2"
       ],
@@ -2462,7 +2433,6 @@
     },
     "fcom st0, st5": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd5 /2"
       ],
@@ -2538,7 +2508,6 @@
     },
     "fcom st0, st6": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd6 /2"
       ],
@@ -2614,7 +2583,6 @@
     },
     "fcom st0, st7": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd7 /2"
       ],
@@ -2690,7 +2658,6 @@
     },
     "fcomp st0, st0": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd8 /3"
       ],
@@ -2774,7 +2741,6 @@
     },
     "fcomp st0, st1": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd9 /3"
       ],
@@ -2858,7 +2824,6 @@
     },
     "fcomp st0, st2": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xda /3"
       ],
@@ -2942,7 +2907,6 @@
     },
     "fcomp st0, st3": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdb /3"
       ],
@@ -3026,7 +2990,6 @@
     },
     "fcomp st0, st4": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdc /3"
       ],
@@ -3110,7 +3073,6 @@
     },
     "fcomp st0, st5": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdd /3"
       ],
@@ -3194,7 +3156,6 @@
     },
     "fcomp st0, st6": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xde /3"
       ],
@@ -3278,7 +3239,6 @@
     },
     "fcomp st0, st7": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdf /3"
       ],
@@ -3362,7 +3322,6 @@
     },
     "fsub st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe0 /4"
       ],
@@ -3432,7 +3391,6 @@
     },
     "fsub st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe1 /4"
       ],
@@ -3502,7 +3460,6 @@
     },
     "fsub st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe2 /4"
       ],
@@ -3572,7 +3529,6 @@
     },
     "fsub st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe3 /4"
       ],
@@ -3642,7 +3598,6 @@
     },
     "fsub st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe4 /4"
       ],
@@ -3712,7 +3667,6 @@
     },
     "fsub st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe5 /4"
       ],
@@ -3782,7 +3736,6 @@
     },
     "fsub st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe6 /4"
       ],
@@ -3852,7 +3805,6 @@
     },
     "fsub st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe7 /4"
       ],
@@ -3922,7 +3874,6 @@
     },
     "fsubr st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe8 /5"
       ],
@@ -3992,7 +3943,6 @@
     },
     "fsubr st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe9 /5"
       ],
@@ -4062,7 +4012,6 @@
     },
     "fsubr st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xea /5"
       ],
@@ -4132,7 +4081,6 @@
     },
     "fsubr st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xeb /5"
       ],
@@ -4202,7 +4150,6 @@
     },
     "fsubr st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xec /5"
       ],
@@ -4272,7 +4219,6 @@
     },
     "fsubr st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xed /5"
       ],
@@ -4342,7 +4288,6 @@
     },
     "fsubr st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xee /5"
       ],
@@ -4412,7 +4357,6 @@
     },
     "fsubr st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xef /5"
       ],
@@ -4482,7 +4426,6 @@
     },
     "fdiv st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf0 /6"
       ],
@@ -4552,7 +4495,6 @@
     },
     "fdiv st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf1 /6"
       ],
@@ -4622,7 +4564,6 @@
     },
     "fdiv st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf2 /6"
       ],
@@ -4692,7 +4633,6 @@
     },
     "fdiv st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf3 /6"
       ],
@@ -4762,7 +4702,6 @@
     },
     "fdiv st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf4 /6"
       ],
@@ -4832,7 +4771,6 @@
     },
     "fdiv st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf5 /6"
       ],
@@ -4902,7 +4840,6 @@
     },
     "fdiv st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf6 /6"
       ],
@@ -4972,7 +4909,6 @@
     },
     "fdiv st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf7 /6"
       ],
@@ -5042,7 +4978,6 @@
     },
     "fdivr st0, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf8 /7"
       ],
@@ -5112,7 +5047,6 @@
     },
     "fdivr st0, st1": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf9 /7"
       ],
@@ -5182,7 +5116,6 @@
     },
     "fdivr st0, st2": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfa /7"
       ],
@@ -5252,7 +5185,6 @@
     },
     "fdivr st0, st3": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfb /7"
       ],
@@ -5322,7 +5254,6 @@
     },
     "fdivr st0, st4": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfc /7"
       ],
@@ -5392,7 +5323,6 @@
     },
     "fdivr st0, st5": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfd /7"
       ],
@@ -5462,7 +5392,6 @@
     },
     "fdivr st0, st6": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfe /7"
       ],
@@ -5532,7 +5461,6 @@
     },
     "fdivr st0, st7": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xff /7"
       ],
@@ -5602,7 +5530,6 @@
     },
     "fld dword [rax]": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /0"
       ],
@@ -5672,7 +5599,6 @@
     },
     "fst dword [rax]": {
       "ExpectedInstructionCount": 52,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /2"
       ],
@@ -5733,7 +5659,6 @@
     },
     "fstp dword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /3"
       ],
@@ -5802,7 +5727,6 @@
     },
     "fldenv [rax]": {
       "ExpectedInstructionCount": 48,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /4"
       ],
@@ -5859,7 +5783,6 @@
     },
     "fldcw [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /5"
       ],
@@ -5870,7 +5793,6 @@
     },
     "fnstenv [rax]": {
       "ExpectedInstructionCount": 64,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /6"
       ],
@@ -5943,7 +5865,6 @@
     },
     "fnstcw [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 !11b /7"
       ],
@@ -5954,7 +5875,6 @@
     },
     "fld st0": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc0 /0"
       ],
@@ -5978,7 +5898,6 @@
     },
     "fld st1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc1 /0"
       ],
@@ -6002,7 +5921,6 @@
     },
     "fld st2": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc2 /0"
       ],
@@ -6026,7 +5944,6 @@
     },
     "fld st3": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc3 /0"
       ],
@@ -6050,7 +5967,6 @@
     },
     "fld st4": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc4 /0"
       ],
@@ -6074,7 +5990,6 @@
     },
     "fld st5": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc5 /0"
       ],
@@ -6098,7 +6013,6 @@
     },
     "fld st6": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc6 /0"
       ],
@@ -6122,7 +6036,6 @@
     },
     "fld st7": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc7 /0"
       ],
@@ -6146,7 +6059,6 @@
     },
     "fxch st0, st0": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc8 /1"
       ],
@@ -6166,7 +6078,6 @@
     },
     "fxch st0, st1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc9 /1"
       ],
@@ -6186,7 +6097,6 @@
     },
     "fxch st0, st2": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xca /1"
       ],
@@ -6206,7 +6116,6 @@
     },
     "fxch st0, st3": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcb /1"
       ],
@@ -6226,7 +6135,6 @@
     },
     "fxch st0, st4": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcc /1"
       ],
@@ -6246,7 +6154,6 @@
     },
     "fxch st0, st5": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcd /1"
       ],
@@ -6266,7 +6173,6 @@
     },
     "fxch st0, st6": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xce /1"
       ],
@@ -6286,7 +6192,6 @@
     },
     "fxch st0, st7": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcf /1"
       ],
@@ -6306,7 +6211,6 @@
     },
     "fnop": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xd0 /2"
       ],
@@ -6314,7 +6218,6 @@
     },
     "fchs": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe0 /4"
       ],
@@ -6333,7 +6236,6 @@
     },
     "fabs": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe1 /4"
       ],
@@ -6352,7 +6254,6 @@
     },
     "ftst": {
       "ExpectedInstructionCount": 64,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe4 /4"
       ],
@@ -6425,7 +6326,6 @@
     },
     "fxam": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe5 /4"
       ],
@@ -6450,7 +6350,6 @@
     },
     "fld1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe8 /5"
       ],
@@ -6474,7 +6373,6 @@
     },
     "fldl2t": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe9 /5"
       ],
@@ -6501,7 +6399,6 @@
     },
     "fldl2e": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xea /5"
       ],
@@ -6528,7 +6425,6 @@
     },
     "fldpi": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xeb /5"
       ],
@@ -6555,7 +6451,6 @@
     },
     "fldlg2": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xec /5"
       ],
@@ -6582,7 +6477,6 @@
     },
     "fldln2": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xed /5"
       ],
@@ -6609,7 +6503,6 @@
     },
     "fldz": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xee /5"
       ],
@@ -6632,7 +6525,6 @@
     },
     "f2xm1": {
       "ExpectedInstructionCount": 55,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf0 /6"
       ],
@@ -6696,7 +6588,6 @@
     },
     "fyl2x": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf1 /6"
       ],
@@ -6772,7 +6663,6 @@
     },
     "fptan": {
       "ExpectedInstructionCount": 71,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf2 /6"
       ],
@@ -6852,7 +6742,6 @@
     },
     "fpatan": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf3 /6"
       ],
@@ -6928,7 +6817,6 @@
     },
     "fxtract": {
       "ExpectedInstructionCount": 115,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf4 /6"
       ],
@@ -7052,7 +6940,6 @@
     },
     "fprem1": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf5 /6"
       ],
@@ -7124,7 +7011,6 @@
     },
     "fdecstp": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xf6 /6"
       ],
@@ -7137,7 +7023,6 @@
     },
     "fincstp": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xf7 /6"
       ],
@@ -7150,7 +7035,6 @@
     },
     "fprem": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf8 /7"
       ],
@@ -7222,7 +7106,6 @@
     },
     "fyl2xp1": {
       "ExpectedInstructionCount": 123,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf9 /7"
       ],
@@ -7354,7 +7237,6 @@
     },
     "fsqrt": {
       "ExpectedInstructionCount": 55,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfa /7"
       ],
@@ -7418,7 +7300,6 @@
     },
     "fsincos": {
       "ExpectedInstructionCount": 117,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfb /7"
       ],
@@ -7544,7 +7425,6 @@
     },
     "frndint": {
       "ExpectedInstructionCount": 55,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfc /7"
       ],
@@ -7608,7 +7488,6 @@
     },
     "fscale": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfd /7"
       ],
@@ -7678,7 +7557,6 @@
     },
     "fsin": {
       "ExpectedInstructionCount": 57,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfe /7"
       ],
@@ -7744,7 +7622,6 @@
     },
     "fcos": {
       "ExpectedInstructionCount": 57,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xff /7"
       ],
@@ -7810,7 +7687,6 @@
     },
     "fiadd dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /0"
       ],
@@ -7926,7 +7802,6 @@
     },
     "fimul dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /1"
       ],
@@ -8042,7 +7917,6 @@
     },
     "ficom dword [rax]": {
       "ExpectedInstructionCount": 113,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /2"
       ],
@@ -8164,7 +8038,6 @@
     },
     "ficomp dword [rax]": {
       "ExpectedInstructionCount": 121,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /3"
       ],
@@ -8294,7 +8167,6 @@
     },
     "fisub dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /4"
       ],
@@ -8410,7 +8282,6 @@
     },
     "fisubr dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /5"
       ],
@@ -8526,7 +8397,6 @@
     },
     "fidiv dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /6"
       ],
@@ -8642,7 +8512,6 @@
     },
     "fidivr dword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /7"
       ],
@@ -8758,7 +8627,6 @@
     },
     "fcmovb st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc0 /0"
       ],
@@ -8779,7 +8647,6 @@
     },
     "fcmovb st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc1 /0"
       ],
@@ -8800,7 +8667,6 @@
     },
     "fcmovb st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc2 /0"
       ],
@@ -8821,7 +8687,6 @@
     },
     "fcmovb st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc3 /0"
       ],
@@ -8842,7 +8707,6 @@
     },
     "fcmovb st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc4 /0"
       ],
@@ -8863,7 +8727,6 @@
     },
     "fcmovb st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc5 /0"
       ],
@@ -8884,7 +8747,6 @@
     },
     "fcmovb st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc6 /0"
       ],
@@ -8905,7 +8767,6 @@
     },
     "fcmovb st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc7 /0"
       ],
@@ -8926,7 +8787,6 @@
     },
     "fcmove st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc8 /1"
       ],
@@ -8947,7 +8807,6 @@
     },
     "fcmove st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc9 /1"
       ],
@@ -8968,7 +8827,6 @@
     },
     "fcmove st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xca /1"
       ],
@@ -8989,7 +8847,6 @@
     },
     "fcmove st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcb /1"
       ],
@@ -9010,7 +8867,6 @@
     },
     "fcmove st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcc /1"
       ],
@@ -9031,7 +8887,6 @@
     },
     "fcmove st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcd /1"
       ],
@@ -9052,7 +8907,6 @@
     },
     "fcmove st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xce /1"
       ],
@@ -9073,7 +8927,6 @@
     },
     "fcmove st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcf /1"
       ],
@@ -9094,7 +8947,6 @@
     },
     "fcmovbe st0, st0": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd0 /0"
       ],
@@ -9117,7 +8969,6 @@
     },
     "fcmovbe st0, st1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd1 /0"
       ],
@@ -9140,7 +8991,6 @@
     },
     "fcmovbe st0, st2": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd2 /0"
       ],
@@ -9163,7 +9013,6 @@
     },
     "fcmovbe st0, st3": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd3 /0"
       ],
@@ -9186,7 +9035,6 @@
     },
     "fcmovbe st0, st4": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd4 /0"
       ],
@@ -9209,7 +9057,6 @@
     },
     "fcmovbe st0, st5": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd5 /0"
       ],
@@ -9232,7 +9079,6 @@
     },
     "fcmovbe st0, st6": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd6 /0"
       ],
@@ -9255,7 +9101,6 @@
     },
     "fcmovbe st0, st7": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd7 /0"
       ],
@@ -9278,7 +9123,6 @@
     },
     "fcmovu st0, st0": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd8 /1"
       ],
@@ -9306,7 +9150,6 @@
     },
     "fcmovu st0, st1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd9 /1"
       ],
@@ -9334,7 +9177,6 @@
     },
     "fcmovu st0, st2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xda /1"
       ],
@@ -9362,7 +9204,6 @@
     },
     "fcmovu st0, st3": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdb /1"
       ],
@@ -9390,7 +9231,6 @@
     },
     "fcmovu st0, st4": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdc /1"
       ],
@@ -9418,7 +9258,6 @@
     },
     "fcmovu st0, st5": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdd /1"
       ],
@@ -9446,7 +9285,6 @@
     },
     "fcmovu st0, st6": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xde /1"
       ],
@@ -9474,7 +9312,6 @@
     },
     "fcmovu st0, st7": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdf /1"
       ],
@@ -9502,7 +9339,6 @@
     },
     "fucompp": {
       "ExpectedInstructionCount": 80,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xe9 /5"
       ],
@@ -9591,7 +9427,6 @@
     },
     "fild dword [rax]": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /5"
       ],
@@ -9634,7 +9469,6 @@
     },
     "fisttp dword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /1"
       ],
@@ -9703,7 +9537,6 @@
     },
     "fist dword [rax]": {
       "ExpectedInstructionCount": 52,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /2"
       ],
@@ -9764,7 +9597,6 @@
     },
     "fistp dword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /7"
       ],
@@ -9833,7 +9665,6 @@
     },
     "fld tword [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /5"
       ],
@@ -9854,7 +9685,6 @@
     },
     "fstp tword [rax]": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /7"
       ],
@@ -9877,7 +9707,6 @@
     },
     "fcmovnb st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc0 /0"
       ],
@@ -9898,7 +9727,6 @@
     },
     "fcmovnb st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc1 /0"
       ],
@@ -9919,7 +9747,6 @@
     },
     "fcmovnb st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc2 /0"
       ],
@@ -9940,7 +9767,6 @@
     },
     "fcmovnb st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc3 /0"
       ],
@@ -9961,7 +9787,6 @@
     },
     "fcmovnb st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc4 /0"
       ],
@@ -9982,7 +9807,6 @@
     },
     "fcmovnb st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc5 /0"
       ],
@@ -10003,7 +9827,6 @@
     },
     "fcmovnb st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc6 /0"
       ],
@@ -10024,7 +9847,6 @@
     },
     "fcmovnb st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc7 /0"
       ],
@@ -10045,7 +9867,6 @@
     },
     "fcmovne st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc8 /1"
       ],
@@ -10066,7 +9887,6 @@
     },
     "fcmovne st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc9 /1"
       ],
@@ -10087,7 +9907,6 @@
     },
     "fcmovne st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xca /1"
       ],
@@ -10108,7 +9927,6 @@
     },
     "fcmovne st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcb /1"
       ],
@@ -10129,7 +9947,6 @@
     },
     "fcmovne st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcc /1"
       ],
@@ -10150,7 +9967,6 @@
     },
     "fcmovne st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcd /1"
       ],
@@ -10171,7 +9987,6 @@
     },
     "fcmovne st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xce /1"
       ],
@@ -10192,7 +10007,6 @@
     },
     "fcmovne st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcf /1"
       ],
@@ -10213,7 +10027,6 @@
     },
     "fcmovnbe st0, st0": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd0 /2"
       ],
@@ -10235,7 +10048,6 @@
     },
     "fcmovnbe st0, st1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd1 /2"
       ],
@@ -10257,7 +10069,6 @@
     },
     "fcmovnbe st0, st2": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd2 /2"
       ],
@@ -10279,7 +10090,6 @@
     },
     "fcmovnbe st0, st3": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd3 /2"
       ],
@@ -10301,7 +10111,6 @@
     },
     "fcmovnbe st0, st4": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd4 /2"
       ],
@@ -10323,7 +10132,6 @@
     },
     "fcmovnbe st0, st5": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd5 /2"
       ],
@@ -10345,7 +10153,6 @@
     },
     "fcmovnbe st0, st6": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd6 /2"
       ],
@@ -10367,7 +10174,6 @@
     },
     "fcmovnbe st0, st7": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd7 /2"
       ],
@@ -10389,7 +10195,6 @@
     },
     "fcmovnu st0, st0": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd8 /3"
       ],
@@ -10417,7 +10222,6 @@
     },
     "fcmovnu st0, st1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd9 /3"
       ],
@@ -10445,7 +10249,6 @@
     },
     "fcmovnu st0, st2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xda /3"
       ],
@@ -10473,7 +10276,6 @@
     },
     "fcmovnu st0, st3": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdb /3"
       ],
@@ -10501,7 +10303,6 @@
     },
     "fcmovnu st0, st4": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdc /3"
       ],
@@ -10529,7 +10330,6 @@
     },
     "fcmovnu st0, st5": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdd /3"
       ],
@@ -10557,7 +10357,6 @@
     },
     "fcmovnu st0, st6": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xde /3"
       ],
@@ -10585,7 +10384,6 @@
     },
     "fcmovnu st0, st7": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdf /3"
       ],
@@ -10613,7 +10411,6 @@
     },
     "fnclex": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe2 /4"
       ],
@@ -10621,7 +10418,6 @@
     },
     "fninit": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe3 /4"
       ],
@@ -10639,7 +10435,6 @@
     },
     "fucomi st0, st0": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe8 /5"
       ],
@@ -10715,7 +10510,6 @@
     },
     "fucomi st0, st1": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe9 /5"
       ],
@@ -10791,7 +10585,6 @@
     },
     "fucomi st0, st2": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xea /5"
       ],
@@ -10867,7 +10660,6 @@
     },
     "fucomi st0, st3": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xeb /5"
       ],
@@ -10943,7 +10735,6 @@
     },
     "fucomi st0, st4": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xec /5"
       ],
@@ -11019,7 +10810,6 @@
     },
     "fucomi st0, st5": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xed /5"
       ],
@@ -11095,7 +10885,6 @@
     },
     "fucomi st0, st6": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xee /5"
       ],
@@ -11171,7 +10960,6 @@
     },
     "fucomi st0, st7": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xef /5"
       ],
@@ -11247,7 +11035,6 @@
     },
     "fcomi st0, st0": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf0 /6"
       ],
@@ -11323,7 +11110,6 @@
     },
     "fcomi st0, st1": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf1 /6"
       ],
@@ -11399,7 +11185,6 @@
     },
     "fcomi st0, st2": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf2 /6"
       ],
@@ -11475,7 +11260,6 @@
     },
     "fcomi st0, st3": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf3 /6"
       ],
@@ -11551,7 +11335,6 @@
     },
     "fcomi st0, st4": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf4 /6"
       ],
@@ -11627,7 +11410,6 @@
     },
     "fcomi st0, st5": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf5 /6"
       ],
@@ -11703,7 +11485,6 @@
     },
     "fcomi st0, st6": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf6 /6"
       ],
@@ -11779,7 +11560,6 @@
     },
     "fcomi st0, st7": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf7 /6"
       ],
@@ -11855,7 +11635,6 @@
     },
     "fadd qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /0"
       ],
@@ -11971,7 +11750,6 @@
     },
     "fmul qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /1"
       ],
@@ -12087,7 +11865,6 @@
     },
     "fcom qword [rax]": {
       "ExpectedInstructionCount": 113,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /2"
       ],
@@ -12209,7 +11986,6 @@
     },
     "fcomp qword [rax]": {
       "ExpectedInstructionCount": 121,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /3"
       ],
@@ -12339,7 +12115,6 @@
     },
     "fsub qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /4"
       ],
@@ -12455,7 +12230,6 @@
     },
     "fsubr qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /5"
       ],
@@ -12571,7 +12345,6 @@
     },
     "fdiv qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /6"
       ],
@@ -12687,7 +12460,6 @@
     },
     "fdivr qword [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /7"
       ],
@@ -12803,7 +12575,6 @@
     },
     "db 0xdc, 0xc0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fadd st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -12875,7 +12646,6 @@
     },
     "fadd st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc1 /0"
       ],
@@ -12945,7 +12715,6 @@
     },
     "fadd st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc2 /0"
       ],
@@ -13015,7 +12784,6 @@
     },
     "fadd st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc3 /0"
       ],
@@ -13085,7 +12853,6 @@
     },
     "fadd st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc4 /0"
       ],
@@ -13155,7 +12922,6 @@
     },
     "fadd st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc5 /0"
       ],
@@ -13225,7 +12991,6 @@
     },
     "fadd st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc6 /0"
       ],
@@ -13295,7 +13060,6 @@
     },
     "fadd st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc7 /0"
       ],
@@ -13365,7 +13129,6 @@
     },
     "db 0xdc, 0xc8": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fmul st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -13437,7 +13200,6 @@
     },
     "fmul st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc9 /1"
       ],
@@ -13507,7 +13269,6 @@
     },
     "fmul st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xca /1"
       ],
@@ -13577,7 +13338,6 @@
     },
     "fmul st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcb /1"
       ],
@@ -13647,7 +13407,6 @@
     },
     "fmul st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcc /1"
       ],
@@ -13717,7 +13476,6 @@
     },
     "fmul st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcd /1"
       ],
@@ -13787,7 +13545,6 @@
     },
     "fmul st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xce /1"
       ],
@@ -13857,7 +13614,6 @@
     },
     "fmul st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcf /1"
       ],
@@ -13927,7 +13683,6 @@
     },
     "db 0xdc, 0xe0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fsubr st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -13999,7 +13754,6 @@
     },
     "fsubr st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe1 /4"
       ],
@@ -14069,7 +13823,6 @@
     },
     "fsubr st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe2 /4"
       ],
@@ -14139,7 +13892,6 @@
     },
     "fsubr st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe3 /4"
       ],
@@ -14209,7 +13961,6 @@
     },
     "fsubr st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe4 /4"
       ],
@@ -14279,7 +14030,6 @@
     },
     "fsubr st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe5 /4"
       ],
@@ -14349,7 +14099,6 @@
     },
     "fsubr st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe6 /4"
       ],
@@ -14419,7 +14168,6 @@
     },
     "fsubr st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe7 /4"
       ],
@@ -14489,7 +14237,6 @@
     },
     "db 0xdc, 0xe8": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fsub st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -14561,7 +14308,6 @@
     },
     "fsub st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe9 /5"
       ],
@@ -14631,7 +14377,6 @@
     },
     "fsub st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xea /5"
       ],
@@ -14701,7 +14446,6 @@
     },
     "fsub st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xeb /5"
       ],
@@ -14771,7 +14515,6 @@
     },
     "fsub st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xec /5"
       ],
@@ -14841,7 +14584,6 @@
     },
     "fsub st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xed /5"
       ],
@@ -14911,7 +14653,6 @@
     },
     "fsub st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xee /5"
       ],
@@ -14981,7 +14722,6 @@
     },
     "fsub st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xef /5"
       ],
@@ -15051,7 +14791,6 @@
     },
     "db 0xdc, 0xf0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fdivr st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -15123,7 +14862,6 @@
     },
     "fdivr st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf1 /6"
       ],
@@ -15193,7 +14931,6 @@
     },
     "fdivr st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf2 /6"
       ],
@@ -15263,7 +15000,6 @@
     },
     "fdivr st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf3 /6"
       ],
@@ -15333,7 +15069,6 @@
     },
     "fdivr st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf4 /6"
       ],
@@ -15403,7 +15138,6 @@
     },
     "fdivr st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf5 /6"
       ],
@@ -15473,7 +15207,6 @@
     },
     "fdivr st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf6 /6"
       ],
@@ -15543,7 +15276,6 @@
     },
     "fdivr st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf7 /6"
       ],
@@ -15613,7 +15345,6 @@
     },
     "db 0xdc, 0xf8": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "fdiv st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -15685,7 +15416,6 @@
     },
     "fdiv st1, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf9 /7"
       ],
@@ -15755,7 +15485,6 @@
     },
     "fdiv st2, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfa /7"
       ],
@@ -15825,7 +15554,6 @@
     },
     "fdiv st3, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfb /7"
       ],
@@ -15895,7 +15623,6 @@
     },
     "fdiv st4, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfc /7"
       ],
@@ -15965,7 +15692,6 @@
     },
     "fdiv st5, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfd /7"
       ],
@@ -16035,7 +15761,6 @@
     },
     "fdiv st6, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfe /7"
       ],
@@ -16105,7 +15830,6 @@
     },
     "fdiv st7, st0": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xff /7"
       ],
@@ -16175,7 +15899,6 @@
     },
     "fld qword [rax]": {
       "ExpectedInstructionCount": 61,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /0"
       ],
@@ -16245,7 +15968,6 @@
     },
     "fisttp qword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /1"
       ],
@@ -16314,7 +16036,6 @@
     },
     "fst qword [rax]": {
       "ExpectedInstructionCount": 52,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /2"
       ],
@@ -16375,7 +16096,6 @@
     },
     "fstp qword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /3"
       ],
@@ -16444,7 +16164,6 @@
     },
     "frstor [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /4"
       ],
@@ -16560,7 +16279,6 @@
     },
     "fnsave [rax]": {
       "ExpectedInstructionCount": 119,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /6"
       ],
@@ -16688,7 +16406,6 @@
     },
     "fnstsw [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /7"
       ],
@@ -16709,7 +16426,6 @@
     },
     "ffree st0": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc0 /0"
       ],
@@ -16726,7 +16442,6 @@
     },
     "ffree st1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc1 /0"
       ],
@@ -16743,7 +16458,6 @@
     },
     "ffree st2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc2 /0"
       ],
@@ -16760,7 +16474,6 @@
     },
     "ffree st3": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc3 /0"
       ],
@@ -16777,7 +16490,6 @@
     },
     "ffree st4": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc4 /0"
       ],
@@ -16794,7 +16506,6 @@
     },
     "ffree st5": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc5 /0"
       ],
@@ -16811,7 +16522,6 @@
     },
     "ffree st6": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc6 /0"
       ],
@@ -16828,7 +16538,6 @@
     },
     "ffree st7": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc7 /0"
       ],
@@ -16845,7 +16554,6 @@
     },
     "fst st0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd0 /2"
       ],
@@ -16861,7 +16569,6 @@
     },
     "fst st1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd1 /2"
       ],
@@ -16877,7 +16584,6 @@
     },
     "fst st2": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd2 /2"
       ],
@@ -16893,7 +16599,6 @@
     },
     "fst st3": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd3 /2"
       ],
@@ -16909,7 +16614,6 @@
     },
     "fst st4": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd4 /2"
       ],
@@ -16925,7 +16629,6 @@
     },
     "fst st5": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd5 /2"
       ],
@@ -16941,7 +16644,6 @@
     },
     "fst st6": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd6 /2"
       ],
@@ -16957,7 +16659,6 @@
     },
     "fst st7": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd7 /2"
       ],
@@ -16973,7 +16674,6 @@
     },
     "fstp st0": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd8 /3"
       ],
@@ -16997,7 +16697,6 @@
     },
     "fstp st1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd9 /3"
       ],
@@ -17021,7 +16720,6 @@
     },
     "fstp st2": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xda /3"
       ],
@@ -17045,7 +16743,6 @@
     },
     "fstp st3": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdb /3"
       ],
@@ -17069,7 +16766,6 @@
     },
     "fstp st4": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdc /3"
       ],
@@ -17093,7 +16789,6 @@
     },
     "fstp st5": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdd /3"
       ],
@@ -17117,7 +16812,6 @@
     },
     "fstp st6": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xde /3"
       ],
@@ -17141,7 +16835,6 @@
     },
     "fstp st7": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdf /3"
       ],
@@ -17165,7 +16858,6 @@
     },
     "fucom st0": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe0 /4"
       ],
@@ -17241,7 +16933,6 @@
     },
     "fucom st1": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe1 /4"
       ],
@@ -17317,7 +17008,6 @@
     },
     "fucom st2": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe2 /4"
       ],
@@ -17393,7 +17083,6 @@
     },
     "fucom st3": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe3 /4"
       ],
@@ -17469,7 +17158,6 @@
     },
     "fucom st4": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe4 /4"
       ],
@@ -17545,7 +17233,6 @@
     },
     "fucom st5": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe5 /4"
       ],
@@ -17621,7 +17308,6 @@
     },
     "fucom st6": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe6 /4"
       ],
@@ -17697,7 +17383,6 @@
     },
     "fucom st7": {
       "ExpectedInstructionCount": 67,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe7 /4"
       ],
@@ -17773,7 +17458,6 @@
     },
     "fucomp st0": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe8 /5"
       ],
@@ -17857,7 +17541,6 @@
     },
     "fucomp st1": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe9 /5"
       ],
@@ -17941,7 +17624,6 @@
     },
     "fucomp st2": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xea /5"
       ],
@@ -18025,7 +17707,6 @@
     },
     "fucomp st3": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xeb /5"
       ],
@@ -18109,7 +17790,6 @@
     },
     "fucomp st4": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xec /5"
       ],
@@ -18193,7 +17873,6 @@
     },
     "fucomp st5": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xed /5"
       ],
@@ -18277,7 +17956,6 @@
     },
     "fucomp st6": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xee /5"
       ],
@@ -18361,7 +18039,6 @@
     },
     "fucomp st7": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xef /5"
       ],
@@ -18445,7 +18122,6 @@
     },
     "fiadd word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /0"
       ],
@@ -18561,7 +18237,6 @@
     },
     "fimul word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /1"
       ],
@@ -18677,7 +18352,6 @@
     },
     "ficom word [rax]": {
       "ExpectedInstructionCount": 113,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /2"
       ],
@@ -18799,7 +18473,6 @@
     },
     "ficomp word [rax]": {
       "ExpectedInstructionCount": 121,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /3"
       ],
@@ -18929,7 +18602,6 @@
     },
     "fisub word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /4"
       ],
@@ -19045,7 +18717,6 @@
     },
     "fisubr word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /5"
       ],
@@ -19161,7 +18832,6 @@
     },
     "fidiv word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /6"
       ],
@@ -19277,7 +18947,6 @@
     },
     "fidivr word [rax]": {
       "ExpectedInstructionCount": 107,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /7"
       ],
@@ -19393,7 +19062,6 @@
     },
     "faddp st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc0 /0"
       ],
@@ -19471,7 +19139,6 @@
     },
     "faddp st1": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc1 /0"
       ],
@@ -19549,7 +19216,6 @@
     },
     "faddp st2": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc2 /0"
       ],
@@ -19627,7 +19293,6 @@
     },
     "faddp st3": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc3 /0"
       ],
@@ -19705,7 +19370,6 @@
     },
     "faddp st4": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc4 /0"
       ],
@@ -19783,7 +19447,6 @@
     },
     "faddp st5": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc5 /0"
       ],
@@ -19861,7 +19524,6 @@
     },
     "faddp st6": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc6 /0"
       ],
@@ -19939,7 +19601,6 @@
     },
     "faddp st7": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc7 /0"
       ],
@@ -20017,7 +19678,6 @@
     },
     "fmulp st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc8 /1"
       ],
@@ -20095,7 +19755,6 @@
     },
     "fmulp st1": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc9 /1"
       ],
@@ -20173,7 +19832,6 @@
     },
     "fmulp st2": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xca /1"
       ],
@@ -20251,7 +19909,6 @@
     },
     "fmulp st3": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcb /1"
       ],
@@ -20329,7 +19986,6 @@
     },
     "fmulp st4": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcc /1"
       ],
@@ -20407,7 +20063,6 @@
     },
     "fmulp st5": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcd /1"
       ],
@@ -20485,7 +20140,6 @@
     },
     "fmulp st6": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xce /1"
       ],
@@ -20563,7 +20217,6 @@
     },
     "fmulp st7": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcf /1"
       ],
@@ -20641,7 +20294,6 @@
     },
     "fcompp": {
       "ExpectedInstructionCount": 80,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xd9 /3"
       ],
@@ -20730,7 +20382,6 @@
     },
     "db 0xde, 0xe0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "fsubrp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -20810,7 +20461,6 @@
     },
     "fsubrp st1, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe1 /4"
       ],
@@ -20888,7 +20538,6 @@
     },
     "fsubrp st2, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe2 /4"
       ],
@@ -20966,7 +20615,6 @@
     },
     "fsubrp st3, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe3 /4"
       ],
@@ -21044,7 +20692,6 @@
     },
     "fsubrp st4, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe4 /4"
       ],
@@ -21122,7 +20769,6 @@
     },
     "fsubrp st5, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe5 /4"
       ],
@@ -21200,7 +20846,6 @@
     },
     "fsubrp st6, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe6 /4"
       ],
@@ -21278,7 +20923,6 @@
     },
     "fsubrp st7, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe7 /4"
       ],
@@ -21356,7 +21000,6 @@
     },
     "db 0xde, 0xe8": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "fsubp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -21436,7 +21079,6 @@
     },
     "fsubp st1, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe9 /5"
       ],
@@ -21514,7 +21156,6 @@
     },
     "fsubp st2, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xea /5"
       ],
@@ -21592,7 +21233,6 @@
     },
     "fsubp st3, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xeb /5"
       ],
@@ -21670,7 +21310,6 @@
     },
     "fsubp st4, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xec /5"
       ],
@@ -21748,7 +21387,6 @@
     },
     "fsubp st5, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xed /5"
       ],
@@ -21826,7 +21464,6 @@
     },
     "fsubp st6, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xee /5"
       ],
@@ -21904,7 +21541,6 @@
     },
     "fsubp st7, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xef /5"
       ],
@@ -21982,7 +21618,6 @@
     },
     "db 0xde, 0xf0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "fdivrp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -22062,7 +21697,6 @@
     },
     "fdivrp st1, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf1 /6"
       ],
@@ -22140,7 +21774,6 @@
     },
     "fdivrp st2, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf2 /6"
       ],
@@ -22218,7 +21851,6 @@
     },
     "fdivrp st3, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf3 /6"
       ],
@@ -22296,7 +21928,6 @@
     },
     "fdivrp st4, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf4 /6"
       ],
@@ -22374,7 +22005,6 @@
     },
     "fdivrp st5, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf5 /6"
       ],
@@ -22452,7 +22082,6 @@
     },
     "fdivrp st6, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf6 /6"
       ],
@@ -22530,7 +22159,6 @@
     },
     "fdivrp st7, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf7 /6"
       ],
@@ -22608,7 +22236,6 @@
     },
     "db 0xde, 0xf8": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "fdivp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -22688,7 +22315,6 @@
     },
     "fdivp st1, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf9 /7"
       ],
@@ -22766,7 +22392,6 @@
     },
     "fdivp st2, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfa /7"
       ],
@@ -22844,7 +22469,6 @@
     },
     "fdivp st3, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfb /7"
       ],
@@ -22922,7 +22546,6 @@
     },
     "fdivp st4, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfc /7"
       ],
@@ -23000,7 +22623,6 @@
     },
     "fdivp st5, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfd /7"
       ],
@@ -23078,7 +22700,6 @@
     },
     "fdivp st6, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfe /7"
       ],
@@ -23156,7 +22777,6 @@
     },
     "fdivp st7, st0": {
       "ExpectedInstructionCount": 69,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xff /7"
       ],
@@ -23234,7 +22854,6 @@
     },
     "fild word [rax]": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /0"
       ],
@@ -23277,7 +22896,6 @@
     },
     "fisttp word [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /1"
       ],
@@ -23346,7 +22964,6 @@
     },
     "fist word [rax]": {
       "ExpectedInstructionCount": 52,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /2"
       ],
@@ -23407,7 +23024,6 @@
     },
     "fistp word [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /3"
       ],
@@ -23476,7 +23092,6 @@
     },
     "fbld tword [rax]": {
       "ExpectedInstructionCount": 62,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /4"
       ],
@@ -23547,7 +23162,6 @@
     },
     "fbstp tword [rax]": {
       "ExpectedInstructionCount": 64,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /6"
       ],
@@ -23620,7 +23234,6 @@
     },
     "ffreep st0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc0 /0"
       ],
@@ -23633,7 +23246,6 @@
     },
     "ffreep st1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc1 /0"
       ],
@@ -23646,7 +23258,6 @@
     },
     "ffreep st2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc2 /0"
       ],
@@ -23659,7 +23270,6 @@
     },
     "ffreep st3": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc3 /0"
       ],
@@ -23672,7 +23282,6 @@
     },
     "ffreep st4": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc4 /0"
       ],
@@ -23685,7 +23294,6 @@
     },
     "ffreep st5": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc5 /0"
       ],
@@ -23698,7 +23306,6 @@
     },
     "ffreep st6": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc6 /0"
       ],
@@ -23711,7 +23318,6 @@
     },
     "ffreep st7": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc7 /0"
       ],
@@ -23724,7 +23330,6 @@
     },
     "fnstsw ax": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe0 /4"
       ],
@@ -23745,7 +23350,6 @@
     },
     "fucomip st0": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe8 /5"
       ],
@@ -23829,7 +23433,6 @@
     },
     "fucomip st1": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe9 /5"
       ],
@@ -23913,7 +23516,6 @@
     },
     "fucomip st2": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xea /5"
       ],
@@ -23997,7 +23599,6 @@
     },
     "fucomip st3": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xeb /5"
       ],
@@ -24081,7 +23682,6 @@
     },
     "fucomip st4": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xec /5"
       ],
@@ -24165,7 +23765,6 @@
     },
     "fucomip st5": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xed /5"
       ],
@@ -24249,7 +23848,6 @@
     },
     "fucomip st6": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xee /5"
       ],
@@ -24333,7 +23931,6 @@
     },
     "fucomip st7": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xef /5"
       ],
@@ -24417,7 +24014,6 @@
     },
     "fcomip st0": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf0 /6"
       ],
@@ -24501,7 +24097,6 @@
     },
     "fcomip st1": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf1 /6"
       ],
@@ -24585,7 +24180,6 @@
     },
     "fcomip st2": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf2 /6"
       ],
@@ -24669,7 +24263,6 @@
     },
     "fcomip st3": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf3 /6"
       ],
@@ -24753,7 +24346,6 @@
     },
     "fcomip st4": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf4 /6"
       ],
@@ -24837,7 +24429,6 @@
     },
     "fcomip st5": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf5 /6"
       ],
@@ -24921,7 +24512,6 @@
     },
     "fcomip st6": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf6 /6"
       ],
@@ -25005,7 +24595,6 @@
     },
     "fcomip st7": {
       "ExpectedInstructionCount": 75,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf7 /6"
       ],

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -16,7 +16,6 @@
   "Instructions": {
     "fadd dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /0"
       ],
@@ -33,7 +32,6 @@
     },
     "fmul dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /1"
       ],
@@ -50,7 +48,6 @@
     },
     "fcom dword [rax]": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /2"
       ],
@@ -83,7 +80,6 @@
     },
     "fcomp dword [rax]": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /3"
       ],
@@ -124,7 +120,6 @@
     },
     "fsub dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /4"
       ],
@@ -141,7 +136,6 @@
     },
     "fsubr dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /5"
       ],
@@ -158,7 +152,6 @@
     },
     "fdiv dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /6"
       ],
@@ -175,7 +168,6 @@
     },
     "fdivr dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xd8 !11b /7"
       ],
@@ -192,7 +184,6 @@
     },
     "fadd st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc0 /0"
       ],
@@ -211,7 +202,6 @@
     },
     "fadd st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc1 /0"
       ],
@@ -230,7 +220,6 @@
     },
     "fadd st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc2 /0"
       ],
@@ -249,7 +238,6 @@
     },
     "fadd st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc3 /0"
       ],
@@ -268,7 +256,6 @@
     },
     "fadd st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc4 /0"
       ],
@@ -287,7 +274,6 @@
     },
     "fadd st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc5 /0"
       ],
@@ -306,7 +292,6 @@
     },
     "fadd st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc6 /0"
       ],
@@ -325,7 +310,6 @@
     },
     "fadd st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc7 /0"
       ],
@@ -344,7 +328,6 @@
     },
     "fmul st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc8 /1"
       ],
@@ -363,7 +346,6 @@
     },
     "fmul st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc9 /1"
       ],
@@ -382,7 +364,6 @@
     },
     "fmul st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xca /1"
       ],
@@ -401,7 +382,6 @@
     },
     "fmul st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcb /1"
       ],
@@ -420,7 +400,6 @@
     },
     "fmul st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcc /1"
       ],
@@ -439,7 +418,6 @@
     },
     "fmul st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcd /1"
       ],
@@ -458,7 +436,6 @@
     },
     "fmul st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xce /1"
       ],
@@ -477,7 +454,6 @@
     },
     "fmul st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xcf /1"
       ],
@@ -496,7 +472,6 @@
     },
     "fcom st0, st0": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd0 /2"
       ],
@@ -531,7 +506,6 @@
     },
     "fcom st0, st1": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd1 /2"
       ],
@@ -566,7 +540,6 @@
     },
     "fcom st0, st2": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd2 /2"
       ],
@@ -601,7 +574,6 @@
     },
     "fcom st0, st3": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd3 /2"
       ],
@@ -636,7 +608,6 @@
     },
     "fcom st0, st4": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd4 /2"
       ],
@@ -671,7 +642,6 @@
     },
     "fcom st0, st5": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd5 /2"
       ],
@@ -706,7 +676,6 @@
     },
     "fcom st0, st6": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd6 /2"
       ],
@@ -741,7 +710,6 @@
     },
     "fcom st0, st7": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd7 /2"
       ],
@@ -776,7 +744,6 @@
     },
     "fcomp st0, st0": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd8 /3"
       ],
@@ -819,7 +786,6 @@
     },
     "fcomp st0, st1": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xd9 /3"
       ],
@@ -862,7 +828,6 @@
     },
     "fcomp st0, st2": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xda /3"
       ],
@@ -905,7 +870,6 @@
     },
     "fcomp st0, st3": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdb /3"
       ],
@@ -948,7 +912,6 @@
     },
     "fcomp st0, st4": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdc /3"
       ],
@@ -991,7 +954,6 @@
     },
     "fcomp st0, st5": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdd /3"
       ],
@@ -1034,7 +996,6 @@
     },
     "fcomp st0, st6": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xde /3"
       ],
@@ -1077,7 +1038,6 @@
     },
     "fcomp st0, st7": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xdf /3"
       ],
@@ -1120,7 +1080,6 @@
     },
     "fsub st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe0 /4"
       ],
@@ -1139,7 +1098,6 @@
     },
     "fsub st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe1 /4"
       ],
@@ -1158,7 +1116,6 @@
     },
     "fsub st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe2 /4"
       ],
@@ -1177,7 +1134,6 @@
     },
     "fsub st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe3 /4"
       ],
@@ -1196,7 +1152,6 @@
     },
     "fsub st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe4 /4"
       ],
@@ -1215,7 +1170,6 @@
     },
     "fsub st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe5 /4"
       ],
@@ -1234,7 +1188,6 @@
     },
     "fsub st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe6 /4"
       ],
@@ -1253,7 +1206,6 @@
     },
     "fsub st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe7 /4"
       ],
@@ -1272,7 +1224,6 @@
     },
     "fsubr st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe8 /5"
       ],
@@ -1291,7 +1242,6 @@
     },
     "fsubr st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xe9 /5"
       ],
@@ -1310,7 +1260,6 @@
     },
     "fsubr st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xea /5"
       ],
@@ -1329,7 +1278,6 @@
     },
     "fsubr st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xeb /5"
       ],
@@ -1348,7 +1296,6 @@
     },
     "fsubr st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xec /5"
       ],
@@ -1367,7 +1314,6 @@
     },
     "fsubr st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xed /5"
       ],
@@ -1386,7 +1332,6 @@
     },
     "fsubr st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xee /5"
       ],
@@ -1405,7 +1350,6 @@
     },
     "fsubr st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xef /5"
       ],
@@ -1424,7 +1368,6 @@
     },
     "fdiv st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf0 /6"
       ],
@@ -1443,7 +1386,6 @@
     },
     "fdiv st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf1 /6"
       ],
@@ -1462,7 +1404,6 @@
     },
     "fdiv st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf2 /6"
       ],
@@ -1481,7 +1422,6 @@
     },
     "fdiv st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf3 /6"
       ],
@@ -1500,7 +1440,6 @@
     },
     "fdiv st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf4 /6"
       ],
@@ -1519,7 +1458,6 @@
     },
     "fdiv st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf5 /6"
       ],
@@ -1538,7 +1476,6 @@
     },
     "fdiv st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf6 /6"
       ],
@@ -1557,7 +1494,6 @@
     },
     "fdiv st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf7 /6"
       ],
@@ -1576,7 +1512,6 @@
     },
     "fdivr st0, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf8 /7"
       ],
@@ -1595,7 +1530,6 @@
     },
     "fdivr st0, st1": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xf9 /7"
       ],
@@ -1614,7 +1548,6 @@
     },
     "fdivr st0, st2": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfa /7"
       ],
@@ -1633,7 +1566,6 @@
     },
     "fdivr st0, st3": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfb /7"
       ],
@@ -1652,7 +1584,6 @@
     },
     "fdivr st0, st4": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfc /7"
       ],
@@ -1671,7 +1602,6 @@
     },
     "fdivr st0, st5": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfd /7"
       ],
@@ -1690,7 +1620,6 @@
     },
     "fdivr st0, st6": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xfe /7"
       ],
@@ -1709,7 +1638,6 @@
     },
     "fdivr st0, st7": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xff /7"
       ],
@@ -1728,7 +1656,6 @@
     },
     "fld dword [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /0"
       ],
@@ -1750,7 +1677,6 @@
     },
     "fst dword [rax]": {
       "ExpectedInstructionCount": 5,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /2"
       ],
@@ -1764,7 +1690,6 @@
     },
     "fstp dword [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /3"
       ],
@@ -1786,7 +1711,6 @@
     },
     "fldenv [rax]": {
       "ExpectedInstructionCount": 56,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /4"
       ],
@@ -1851,7 +1775,6 @@
     },
     "fldcw [rax]": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /5"
       ],
@@ -1870,7 +1793,6 @@
     },
     "fnstenv [rax]": {
       "ExpectedInstructionCount": 64,
-      "Optimal": "No",
       "Comment": [
         "0xd9 !11b /6"
       ],
@@ -1943,7 +1865,6 @@
     },
     "fnstcw [rax]": {
       "ExpectedInstructionCount": 2,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 !11b /7"
       ],
@@ -1954,7 +1875,6 @@
     },
     "fld st0": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc0 /0"
       ],
@@ -1978,7 +1898,6 @@
     },
     "fld st1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc1 /0"
       ],
@@ -2002,7 +1921,6 @@
     },
     "fld st2": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc2 /0"
       ],
@@ -2026,7 +1944,6 @@
     },
     "fld st3": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc3 /0"
       ],
@@ -2050,7 +1967,6 @@
     },
     "fld st4": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc4 /0"
       ],
@@ -2074,7 +1990,6 @@
     },
     "fld st5": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc5 /0"
       ],
@@ -2098,7 +2013,6 @@
     },
     "fld st6": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc6 /0"
       ],
@@ -2122,7 +2036,6 @@
     },
     "fld st7": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc7 /0"
       ],
@@ -2146,7 +2059,6 @@
     },
     "fxch st0, st0": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc8 /1"
       ],
@@ -2166,7 +2078,6 @@
     },
     "fxch st0, st1": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xc9 /1"
       ],
@@ -2186,7 +2097,6 @@
     },
     "fxch st0, st2": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xca /1"
       ],
@@ -2206,7 +2116,6 @@
     },
     "fxch st0, st3": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcb /1"
       ],
@@ -2226,7 +2135,6 @@
     },
     "fxch st0, st4": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcc /1"
       ],
@@ -2246,7 +2154,6 @@
     },
     "fxch st0, st5": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcd /1"
       ],
@@ -2266,7 +2173,6 @@
     },
     "fxch st0, st6": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xce /1"
       ],
@@ -2286,7 +2192,6 @@
     },
     "fxch st0, st7": {
       "ExpectedInstructionCount": 11,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xcf /1"
       ],
@@ -2306,7 +2211,6 @@
     },
     "fnop": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xd0 /2"
       ],
@@ -2314,7 +2218,6 @@
     },
     "fchs": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe0 /4"
       ],
@@ -2329,7 +2232,6 @@
     },
     "fabs": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe1 /4"
       ],
@@ -2344,7 +2246,6 @@
     },
     "ftst": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe4 /4"
       ],
@@ -2376,7 +2277,6 @@
     },
     "fxam": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe5 /4"
       ],
@@ -2403,7 +2303,6 @@
     },
     "fld1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe8 /5"
       ],
@@ -2425,7 +2324,6 @@
     },
     "fldl2t": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xe9 /5"
       ],
@@ -2450,7 +2348,6 @@
     },
     "fldl2e": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xea /5"
       ],
@@ -2475,7 +2372,6 @@
     },
     "fldpi": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xeb /5"
       ],
@@ -2500,7 +2396,6 @@
     },
     "fldlg2": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xec /5"
       ],
@@ -2525,7 +2420,6 @@
     },
     "fldln2": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xed /5"
       ],
@@ -2550,7 +2444,6 @@
     },
     "fldz": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xee /5"
       ],
@@ -2572,7 +2465,6 @@
     },
     "f2xm1": {
       "ExpectedInstructionCount": 52,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf0 /6"
       ],
@@ -2633,7 +2525,6 @@
     },
     "fyl2x": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf1 /6"
       ],
@@ -2705,7 +2596,6 @@
     },
     "fptan": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf2 /6"
       ],
@@ -2780,7 +2670,6 @@
     },
     "fpatan": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf3 /6"
       ],
@@ -2852,7 +2741,6 @@
     },
     "fxtract": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf4 /6"
       ],
@@ -2884,7 +2772,6 @@
     },
     "fprem1": {
       "ExpectedInstructionCount": 59,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf5 /6"
       ],
@@ -2952,7 +2839,6 @@
     },
     "fdecstp": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xf6 /6"
       ],
@@ -2965,7 +2851,6 @@
     },
     "fincstp": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xd9 11b 0xf7 /6"
       ],
@@ -2978,7 +2863,6 @@
     },
     "fprem": {
       "ExpectedInstructionCount": 59,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf8 /7"
       ],
@@ -3046,7 +2930,6 @@
     },
     "fyl2xp1": {
       "ExpectedInstructionCount": 66,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xf9 /7"
       ],
@@ -3121,7 +3004,6 @@
     },
     "fsqrt": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfa /7"
       ],
@@ -3136,7 +3018,6 @@
     },
     "fsincos": {
       "ExpectedInstructionCount": 111,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfb /7"
       ],
@@ -3256,7 +3137,6 @@
     },
     "frndint": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfc /7"
       ],
@@ -3271,7 +3151,6 @@
     },
     "fscale": {
       "ExpectedInstructionCount": 57,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfd /7"
       ],
@@ -3337,7 +3216,6 @@
     },
     "fsin": {
       "ExpectedInstructionCount": 54,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xfe /7"
       ],
@@ -3400,7 +3278,6 @@
     },
     "fcos": {
       "ExpectedInstructionCount": 54,
-      "Optimal": "No",
       "Comment": [
         "0xd9 11b 0xff /7"
       ],
@@ -3463,7 +3340,6 @@
     },
     "fiadd dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /0"
       ],
@@ -3480,7 +3356,6 @@
     },
     "fimul dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /1"
       ],
@@ -3497,7 +3372,6 @@
     },
     "ficom dword [rax]": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /2"
       ],
@@ -3530,7 +3404,6 @@
     },
     "ficomp dword [rax]": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /3"
       ],
@@ -3571,7 +3444,6 @@
     },
     "fisub dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /4"
       ],
@@ -3588,7 +3460,6 @@
     },
     "fisubr dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /5"
       ],
@@ -3605,7 +3476,6 @@
     },
     "fidiv dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /6"
       ],
@@ -3622,7 +3492,6 @@
     },
     "fidivr dword [rax]": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xda !11b /7"
       ],
@@ -3639,7 +3508,6 @@
     },
     "fcmovb st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc0 /0"
       ],
@@ -3660,7 +3528,6 @@
     },
     "fcmovb st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc1 /0"
       ],
@@ -3681,7 +3548,6 @@
     },
     "fcmovb st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc2 /0"
       ],
@@ -3702,7 +3568,6 @@
     },
     "fcmovb st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc3 /0"
       ],
@@ -3723,7 +3588,6 @@
     },
     "fcmovb st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc4 /0"
       ],
@@ -3744,7 +3608,6 @@
     },
     "fcmovb st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc5 /0"
       ],
@@ -3765,7 +3628,6 @@
     },
     "fcmovb st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc6 /0"
       ],
@@ -3786,7 +3648,6 @@
     },
     "fcmovb st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc7 /0"
       ],
@@ -3807,7 +3668,6 @@
     },
     "fcmove st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc8 /1"
       ],
@@ -3828,7 +3688,6 @@
     },
     "fcmove st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xc9 /1"
       ],
@@ -3849,7 +3708,6 @@
     },
     "fcmove st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xca /1"
       ],
@@ -3870,7 +3728,6 @@
     },
     "fcmove st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcb /1"
       ],
@@ -3891,7 +3748,6 @@
     },
     "fcmove st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcc /1"
       ],
@@ -3912,7 +3768,6 @@
     },
     "fcmove st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcd /1"
       ],
@@ -3933,7 +3788,6 @@
     },
     "fcmove st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xce /1"
       ],
@@ -3954,7 +3808,6 @@
     },
     "fcmove st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xcf /1"
       ],
@@ -3975,7 +3828,6 @@
     },
     "fcmovbe st0, st0": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd0 /0"
       ],
@@ -3998,7 +3850,6 @@
     },
     "fcmovbe st0, st1": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd1 /0"
       ],
@@ -4021,7 +3872,6 @@
     },
     "fcmovbe st0, st2": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd2 /0"
       ],
@@ -4044,7 +3894,6 @@
     },
     "fcmovbe st0, st3": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd3 /0"
       ],
@@ -4067,7 +3916,6 @@
     },
     "fcmovbe st0, st4": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd4 /0"
       ],
@@ -4090,7 +3938,6 @@
     },
     "fcmovbe st0, st5": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd5 /0"
       ],
@@ -4113,7 +3960,6 @@
     },
     "fcmovbe st0, st6": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd6 /0"
       ],
@@ -4136,7 +3982,6 @@
     },
     "fcmovbe st0, st7": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd7 /0"
       ],
@@ -4159,7 +4004,6 @@
     },
     "fcmovu st0, st0": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd8 /1"
       ],
@@ -4187,7 +4031,6 @@
     },
     "fcmovu st0, st1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xd9 /1"
       ],
@@ -4215,7 +4058,6 @@
     },
     "fcmovu st0, st2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xda /1"
       ],
@@ -4243,7 +4085,6 @@
     },
     "fcmovu st0, st3": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdb /1"
       ],
@@ -4271,7 +4112,6 @@
     },
     "fcmovu st0, st4": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdc /1"
       ],
@@ -4299,7 +4139,6 @@
     },
     "fcmovu st0, st5": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdd /1"
       ],
@@ -4327,7 +4166,6 @@
     },
     "fcmovu st0, st6": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xde /1"
       ],
@@ -4355,7 +4193,6 @@
     },
     "fcmovu st0, st7": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xdf /1"
       ],
@@ -4383,7 +4220,6 @@
     },
     "fucompp": {
       "ExpectedInstructionCount": 39,
-      "Optimal": "No",
       "Comment": [
         "0xda 11b 0xe9 /5"
       ],
@@ -4431,7 +4267,6 @@
     },
     "fild dword [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /5"
       ],
@@ -4453,7 +4288,6 @@
     },
     "fisttp dword [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /1"
       ],
@@ -4475,7 +4309,6 @@
     },
     "fist dword [rax]": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /2"
       ],
@@ -4490,7 +4323,6 @@
     },
     "fistp dword [rax]": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /7"
       ],
@@ -4513,7 +4345,6 @@
     },
     "fld tword [rax]": {
       "ExpectedInstructionCount": 60,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /5"
       ],
@@ -4582,7 +4413,6 @@
     },
     "fstp tword [rax]": {
       "ExpectedInstructionCount": 63,
-      "Optimal": "No",
       "Comment": [
         "0xdb !11b /7"
       ],
@@ -4654,7 +4484,6 @@
     },
     "fcmovnb st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc0 /0"
       ],
@@ -4675,7 +4504,6 @@
     },
     "fcmovnb st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc1 /0"
       ],
@@ -4696,7 +4524,6 @@
     },
     "fcmovnb st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc2 /0"
       ],
@@ -4717,7 +4544,6 @@
     },
     "fcmovnb st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc3 /0"
       ],
@@ -4738,7 +4564,6 @@
     },
     "fcmovnb st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc4 /0"
       ],
@@ -4759,7 +4584,6 @@
     },
     "fcmovnb st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc5 /0"
       ],
@@ -4780,7 +4604,6 @@
     },
     "fcmovnb st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc6 /0"
       ],
@@ -4801,7 +4624,6 @@
     },
     "fcmovnb st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc7 /0"
       ],
@@ -4822,7 +4644,6 @@
     },
     "fcmovne st0, st0": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc8 /1"
       ],
@@ -4843,7 +4664,6 @@
     },
     "fcmovne st0, st1": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xc9 /1"
       ],
@@ -4864,7 +4684,6 @@
     },
     "fcmovne st0, st2": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xca /1"
       ],
@@ -4885,7 +4704,6 @@
     },
     "fcmovne st0, st3": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcb /1"
       ],
@@ -4906,7 +4724,6 @@
     },
     "fcmovne st0, st4": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcc /1"
       ],
@@ -4927,7 +4744,6 @@
     },
     "fcmovne st0, st5": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcd /1"
       ],
@@ -4948,7 +4764,6 @@
     },
     "fcmovne st0, st6": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xce /1"
       ],
@@ -4969,7 +4784,6 @@
     },
     "fcmovne st0, st7": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xcf /1"
       ],
@@ -4990,7 +4804,6 @@
     },
     "fcmovnbe st0, st0": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd0 /2"
       ],
@@ -5012,7 +4825,6 @@
     },
     "fcmovnbe st0, st1": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd1 /2"
       ],
@@ -5034,7 +4846,6 @@
     },
     "fcmovnbe st0, st2": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd2 /2"
       ],
@@ -5056,7 +4867,6 @@
     },
     "fcmovnbe st0, st3": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd3 /2"
       ],
@@ -5078,7 +4888,6 @@
     },
     "fcmovnbe st0, st4": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd4 /2"
       ],
@@ -5100,7 +4909,6 @@
     },
     "fcmovnbe st0, st5": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd5 /2"
       ],
@@ -5122,7 +4930,6 @@
     },
     "fcmovnbe st0, st6": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd6 /2"
       ],
@@ -5144,7 +4951,6 @@
     },
     "fcmovnbe st0, st7": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd7 /2"
       ],
@@ -5166,7 +4972,6 @@
     },
     "fcmovnu st0, st0": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd8 /3"
       ],
@@ -5194,7 +4999,6 @@
     },
     "fcmovnu st0, st1": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xd9 /3"
       ],
@@ -5222,7 +5026,6 @@
     },
     "fcmovnu st0, st2": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xda /3"
       ],
@@ -5250,7 +5053,6 @@
     },
     "fcmovnu st0, st3": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdb /3"
       ],
@@ -5278,7 +5080,6 @@
     },
     "fcmovnu st0, st4": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdc /3"
       ],
@@ -5306,7 +5107,6 @@
     },
     "fcmovnu st0, st5": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdd /3"
       ],
@@ -5334,7 +5134,6 @@
     },
     "fcmovnu st0, st6": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xde /3"
       ],
@@ -5362,7 +5161,6 @@
     },
     "fcmovnu st0, st7": {
       "ExpectedInstructionCount": 19,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xdf /3"
       ],
@@ -5390,7 +5188,6 @@
     },
     "fnclex": {
       "ExpectedInstructionCount": 0,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe2 /4"
       ],
@@ -5398,7 +5195,6 @@
     },
     "fninit": {
       "ExpectedInstructionCount": 16,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe3 /4"
       ],
@@ -5423,7 +5219,6 @@
     },
     "fucomi st0, st0": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe8 /5"
       ],
@@ -5456,7 +5251,6 @@
     },
     "fucomi st0, st1": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xe9 /5"
       ],
@@ -5489,7 +5283,6 @@
     },
     "fucomi st0, st2": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xea /5"
       ],
@@ -5522,7 +5315,6 @@
     },
     "fucomi st0, st3": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xeb /5"
       ],
@@ -5555,7 +5347,6 @@
     },
     "fucomi st0, st4": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xec /5"
       ],
@@ -5588,7 +5379,6 @@
     },
     "fucomi st0, st5": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xed /5"
       ],
@@ -5621,7 +5411,6 @@
     },
     "fucomi st0, st6": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xee /5"
       ],
@@ -5654,7 +5443,6 @@
     },
     "fucomi st0, st7": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xef /5"
       ],
@@ -5687,7 +5475,6 @@
     },
     "fcomi st0, st0": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf0 /6"
       ],
@@ -5720,7 +5507,6 @@
     },
     "fcomi st0, st1": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf1 /6"
       ],
@@ -5753,7 +5539,6 @@
     },
     "fcomi st0, st2": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf2 /6"
       ],
@@ -5786,7 +5571,6 @@
     },
     "fcomi st0, st3": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf3 /6"
       ],
@@ -5819,7 +5603,6 @@
     },
     "fcomi st0, st4": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf4 /6"
       ],
@@ -5852,7 +5635,6 @@
     },
     "fcomi st0, st5": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf5 /6"
       ],
@@ -5885,7 +5667,6 @@
     },
     "fcomi st0, st6": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf6 /6"
       ],
@@ -5918,7 +5699,6 @@
     },
     "fcomi st0, st7": {
       "ExpectedInstructionCount": 24,
-      "Optimal": "No",
       "Comment": [
         "0xdb 11b 0xf7 /6"
       ],
@@ -5951,7 +5731,6 @@
     },
     "fadd qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /0"
       ],
@@ -5967,7 +5746,6 @@
     },
     "fmul qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /1"
       ],
@@ -5983,7 +5761,6 @@
     },
     "fcom qword [rax]": {
       "ExpectedInstructionCount": 23,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /2"
       ],
@@ -6015,7 +5792,6 @@
     },
     "fcomp qword [rax]": {
       "ExpectedInstructionCount": 31,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /3"
       ],
@@ -6055,7 +5831,6 @@
     },
     "fsub qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /4"
       ],
@@ -6071,7 +5846,6 @@
     },
     "fsubr qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /5"
       ],
@@ -6087,7 +5861,6 @@
     },
     "fdiv qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /6"
       ],
@@ -6103,7 +5876,6 @@
     },
     "fdivr qword [rax]": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdc !11b /7"
       ],
@@ -6119,7 +5891,6 @@
     },
     "db 0xdc, 0xc0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fadd st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6140,7 +5911,6 @@
     },
     "fadd st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc1 /0"
       ],
@@ -6159,7 +5929,6 @@
     },
     "fadd st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc2 /0"
       ],
@@ -6178,7 +5947,6 @@
     },
     "fadd st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc3 /0"
       ],
@@ -6197,7 +5965,6 @@
     },
     "fadd st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc4 /0"
       ],
@@ -6216,7 +5983,6 @@
     },
     "fadd st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc5 /0"
       ],
@@ -6235,7 +6001,6 @@
     },
     "fadd st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc6 /0"
       ],
@@ -6254,7 +6019,6 @@
     },
     "fadd st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc7 /0"
       ],
@@ -6273,7 +6037,6 @@
     },
     "db 0xdc, 0xc8": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fmul st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6294,7 +6057,6 @@
     },
     "fmul st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xc9 /1"
       ],
@@ -6313,7 +6075,6 @@
     },
     "fmul st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xca /1"
       ],
@@ -6332,7 +6093,6 @@
     },
     "fmul st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcb /1"
       ],
@@ -6351,7 +6111,6 @@
     },
     "fmul st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcc /1"
       ],
@@ -6370,7 +6129,6 @@
     },
     "fmul st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcd /1"
       ],
@@ -6389,7 +6147,6 @@
     },
     "fmul st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xce /1"
       ],
@@ -6408,7 +6165,6 @@
     },
     "fmul st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xcf /1"
       ],
@@ -6427,7 +6183,6 @@
     },
     "db 0xdc, 0xe0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fsubr st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6448,7 +6203,6 @@
     },
     "fsubr st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe1 /4"
       ],
@@ -6467,7 +6221,6 @@
     },
     "fsubr st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe2 /4"
       ],
@@ -6486,7 +6239,6 @@
     },
     "fsubr st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe3 /4"
       ],
@@ -6505,7 +6257,6 @@
     },
     "fsubr st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe4 /4"
       ],
@@ -6524,7 +6275,6 @@
     },
     "fsubr st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe5 /4"
       ],
@@ -6543,7 +6293,6 @@
     },
     "fsubr st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe6 /4"
       ],
@@ -6562,7 +6311,6 @@
     },
     "fsubr st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe7 /4"
       ],
@@ -6581,7 +6329,6 @@
     },
     "db 0xdc, 0xe8": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fsub st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6602,7 +6349,6 @@
     },
     "fsub st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xe9 /5"
       ],
@@ -6621,7 +6367,6 @@
     },
     "fsub st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xea /5"
       ],
@@ -6640,7 +6385,6 @@
     },
     "fsub st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xeb /5"
       ],
@@ -6659,7 +6403,6 @@
     },
     "fsub st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xec /5"
       ],
@@ -6678,7 +6421,6 @@
     },
     "fsub st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xed /5"
       ],
@@ -6697,7 +6439,6 @@
     },
     "fsub st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xee /5"
       ],
@@ -6716,7 +6457,6 @@
     },
     "fsub st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xef /5"
       ],
@@ -6735,7 +6475,6 @@
     },
     "db 0xdc, 0xf0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fdivr st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6756,7 +6495,6 @@
     },
     "fdivr st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf1 /6"
       ],
@@ -6775,7 +6513,6 @@
     },
     "fdivr st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf2 /6"
       ],
@@ -6794,7 +6531,6 @@
     },
     "fdivr st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf3 /6"
       ],
@@ -6813,7 +6549,6 @@
     },
     "fdivr st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf4 /6"
       ],
@@ -6832,7 +6567,6 @@
     },
     "fdivr st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf5 /6"
       ],
@@ -6851,7 +6585,6 @@
     },
     "fdivr st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf6 /6"
       ],
@@ -6870,7 +6603,6 @@
     },
     "fdivr st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf7 /6"
       ],
@@ -6889,7 +6621,6 @@
     },
     "db 0xdc, 0xf8": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "fdiv st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -6910,7 +6641,6 @@
     },
     "fdiv st1, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xf9 /7"
       ],
@@ -6929,7 +6659,6 @@
     },
     "fdiv st2, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfa /7"
       ],
@@ -6948,7 +6677,6 @@
     },
     "fdiv st3, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfb /7"
       ],
@@ -6967,7 +6695,6 @@
     },
     "fdiv st4, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfc /7"
       ],
@@ -6986,7 +6713,6 @@
     },
     "fdiv st5, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfd /7"
       ],
@@ -7005,7 +6731,6 @@
     },
     "fdiv st6, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xfe /7"
       ],
@@ -7024,7 +6749,6 @@
     },
     "fdiv st7, st0": {
       "ExpectedInstructionCount": 10,
-      "Optimal": "No",
       "Comment": [
         "0xdc 11b 0xff /7"
       ],
@@ -7043,7 +6767,6 @@
     },
     "fld qword [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /0"
       ],
@@ -7064,7 +6787,6 @@
     },
     "fisttp qword [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /1"
       ],
@@ -7086,7 +6808,6 @@
     },
     "fst qword [rax]": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /2"
       ],
@@ -7099,7 +6820,6 @@
     },
     "fstp qword [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /3"
       ],
@@ -7120,7 +6840,6 @@
     },
     "frstor [rax]": {
       "ExpectedInstructionCount": 501,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /4"
       ],
@@ -7630,7 +7349,6 @@
     },
     "fnsave [rax]": {
       "ExpectedInstructionCount": 511,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /6"
       ],
@@ -8150,7 +7868,6 @@
     },
     "fnstsw [rax]": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdd !11b /7"
       ],
@@ -8171,7 +7888,6 @@
     },
     "ffree st0": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc0 /0"
       ],
@@ -8188,7 +7904,6 @@
     },
     "ffree st1": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc1 /0"
       ],
@@ -8205,7 +7920,6 @@
     },
     "ffree st2": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc2 /0"
       ],
@@ -8222,7 +7936,6 @@
     },
     "ffree st3": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc3 /0"
       ],
@@ -8239,7 +7952,6 @@
     },
     "ffree st4": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc4 /0"
       ],
@@ -8256,7 +7968,6 @@
     },
     "ffree st5": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc5 /0"
       ],
@@ -8273,7 +7984,6 @@
     },
     "ffree st6": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc6 /0"
       ],
@@ -8290,7 +8000,6 @@
     },
     "ffree st7": {
       "ExpectedInstructionCount": 8,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xc7 /0"
       ],
@@ -8307,7 +8016,6 @@
     },
     "fst st0": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd0 /2"
       ],
@@ -8323,7 +8031,6 @@
     },
     "fst st1": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd1 /2"
       ],
@@ -8339,7 +8046,6 @@
     },
     "fst st2": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd2 /2"
       ],
@@ -8355,7 +8061,6 @@
     },
     "fst st3": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd3 /2"
       ],
@@ -8371,7 +8076,6 @@
     },
     "fst st4": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd4 /2"
       ],
@@ -8387,7 +8091,6 @@
     },
     "fst st5": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd5 /2"
       ],
@@ -8403,7 +8106,6 @@
     },
     "fst st6": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd6 /2"
       ],
@@ -8419,7 +8121,6 @@
     },
     "fst st7": {
       "ExpectedInstructionCount": 7,
-      "Optimal": "Yes",
       "Comment": [
         "0xdd 11b 0xd7 /2"
       ],
@@ -8435,7 +8136,6 @@
     },
     "fstp st0": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd8 /3"
       ],
@@ -8459,7 +8159,6 @@
     },
     "fstp st1": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xd9 /3"
       ],
@@ -8483,7 +8182,6 @@
     },
     "fstp st2": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xda /3"
       ],
@@ -8507,7 +8205,6 @@
     },
     "fstp st3": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdb /3"
       ],
@@ -8531,7 +8228,6 @@
     },
     "fstp st4": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdc /3"
       ],
@@ -8555,7 +8251,6 @@
     },
     "fstp st5": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdd /3"
       ],
@@ -8579,7 +8274,6 @@
     },
     "fstp st6": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xde /3"
       ],
@@ -8603,7 +8297,6 @@
     },
     "fstp st7": {
       "ExpectedInstructionCount": 15,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xdf /3"
       ],
@@ -8627,7 +8320,6 @@
     },
     "fucom st0": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe0 /4"
       ],
@@ -8662,7 +8354,6 @@
     },
     "fucom st1": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe1 /4"
       ],
@@ -8697,7 +8388,6 @@
     },
     "fucom st2": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe2 /4"
       ],
@@ -8732,7 +8422,6 @@
     },
     "fucom st3": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe3 /4"
       ],
@@ -8767,7 +8456,6 @@
     },
     "fucom st4": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe4 /4"
       ],
@@ -8802,7 +8490,6 @@
     },
     "fucom st5": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe5 /4"
       ],
@@ -8837,7 +8524,6 @@
     },
     "fucom st6": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe6 /4"
       ],
@@ -8872,7 +8558,6 @@
     },
     "fucom st7": {
       "ExpectedInstructionCount": 26,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe7 /4"
       ],
@@ -8907,7 +8592,6 @@
     },
     "fucomp st0": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe8 /5"
       ],
@@ -8950,7 +8634,6 @@
     },
     "fucomp st1": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xe9 /5"
       ],
@@ -8993,7 +8676,6 @@
     },
     "fucomp st2": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xea /5"
       ],
@@ -9036,7 +8718,6 @@
     },
     "fucomp st3": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xeb /5"
       ],
@@ -9079,7 +8760,6 @@
     },
     "fucomp st4": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xec /5"
       ],
@@ -9122,7 +8802,6 @@
     },
     "fucomp st5": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xed /5"
       ],
@@ -9165,7 +8844,6 @@
     },
     "fucomp st6": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xee /5"
       ],
@@ -9208,7 +8886,6 @@
     },
     "fucomp st7": {
       "ExpectedInstructionCount": 34,
-      "Optimal": "No",
       "Comment": [
         "0xdd 11b 0xef /5"
       ],
@@ -9251,7 +8928,6 @@
     },
     "fiadd word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /0"
       ],
@@ -9269,7 +8945,6 @@
     },
     "fimul word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /1"
       ],
@@ -9287,7 +8962,6 @@
     },
     "ficom word [rax]": {
       "ExpectedInstructionCount": 25,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /2"
       ],
@@ -9321,7 +8995,6 @@
     },
     "ficomp word [rax]": {
       "ExpectedInstructionCount": 33,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /3"
       ],
@@ -9363,7 +9036,6 @@
     },
     "fisub word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /4"
       ],
@@ -9381,7 +9053,6 @@
     },
     "fisubr word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /5"
       ],
@@ -9399,7 +9070,6 @@
     },
     "fidiv word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /6"
       ],
@@ -9417,7 +9087,6 @@
     },
     "fidivr word [rax]": {
       "ExpectedInstructionCount": 9,
-      "Optimal": "No",
       "Comment": [
         "0xde !11b /7"
       ],
@@ -9435,7 +9104,6 @@
     },
     "faddp st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xd8 11b 0xc0 /0"
       ],
@@ -9462,7 +9130,6 @@
     },
     "faddp st1": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc1 /0"
       ],
@@ -9489,7 +9156,6 @@
     },
     "faddp st2": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc2 /0"
       ],
@@ -9516,7 +9182,6 @@
     },
     "faddp st3": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc3 /0"
       ],
@@ -9543,7 +9208,6 @@
     },
     "faddp st4": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc4 /0"
       ],
@@ -9570,7 +9234,6 @@
     },
     "faddp st5": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc5 /0"
       ],
@@ -9597,7 +9260,6 @@
     },
     "faddp st6": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc6 /0"
       ],
@@ -9624,7 +9286,6 @@
     },
     "faddp st7": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc7 /0"
       ],
@@ -9651,7 +9312,6 @@
     },
     "fmulp st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc8 /1"
       ],
@@ -9678,7 +9338,6 @@
     },
     "fmulp st1": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xc9 /1"
       ],
@@ -9705,7 +9364,6 @@
     },
     "fmulp st2": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xca /1"
       ],
@@ -9732,7 +9390,6 @@
     },
     "fmulp st3": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcb /1"
       ],
@@ -9759,7 +9416,6 @@
     },
     "fmulp st4": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcc /1"
       ],
@@ -9786,7 +9442,6 @@
     },
     "fmulp st5": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcd /1"
       ],
@@ -9813,7 +9468,6 @@
     },
     "fmulp st6": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xce /1"
       ],
@@ -9840,7 +9494,6 @@
     },
     "fmulp st7": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xcf /1"
       ],
@@ -9867,7 +9520,6 @@
     },
     "fcompp": {
       "ExpectedInstructionCount": 39,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xd9 /3"
       ],
@@ -9915,7 +9567,6 @@
     },
     "db 0xde, 0xe0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "fsubrp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -9944,7 +9595,6 @@
     },
     "fsubrp st1, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe1 /4"
       ],
@@ -9971,7 +9621,6 @@
     },
     "fsubrp st2, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe2 /4"
       ],
@@ -9998,7 +9647,6 @@
     },
     "fsubrp st3, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe3 /4"
       ],
@@ -10025,7 +9673,6 @@
     },
     "fsubrp st4, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe4 /4"
       ],
@@ -10052,7 +9699,6 @@
     },
     "fsubrp st5, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe5 /4"
       ],
@@ -10079,7 +9725,6 @@
     },
     "fsubrp st6, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe6 /4"
       ],
@@ -10106,7 +9751,6 @@
     },
     "fsubrp st7, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe7 /4"
       ],
@@ -10133,7 +9777,6 @@
     },
     "db 0xde, 0xe8": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "fsubp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -10162,7 +9805,6 @@
     },
     "fsubp st1, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xe9 /5"
       ],
@@ -10189,7 +9831,6 @@
     },
     "fsubp st2, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xea /5"
       ],
@@ -10216,7 +9857,6 @@
     },
     "fsubp st3, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xeb /5"
       ],
@@ -10243,7 +9883,6 @@
     },
     "fsubp st4, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xec /5"
       ],
@@ -10270,7 +9909,6 @@
     },
     "fsubp st5, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xed /5"
       ],
@@ -10297,7 +9935,6 @@
     },
     "fsubp st6, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xee /5"
       ],
@@ -10324,7 +9961,6 @@
     },
     "fsubp st7, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xef /5"
       ],
@@ -10351,7 +9987,6 @@
     },
     "db 0xde, 0xf0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "fdivrp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -10380,7 +10015,6 @@
     },
     "fdivrp st1, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf1 /6"
       ],
@@ -10407,7 +10041,6 @@
     },
     "fdivrp st2, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf2 /6"
       ],
@@ -10434,7 +10067,6 @@
     },
     "fdivrp st3, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf3 /6"
       ],
@@ -10461,7 +10093,6 @@
     },
     "fdivrp st4, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf4 /6"
       ],
@@ -10488,7 +10119,6 @@
     },
     "fdivrp st5, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf5 /6"
       ],
@@ -10515,7 +10145,6 @@
     },
     "fdivrp st6, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf6 /6"
       ],
@@ -10542,7 +10171,6 @@
     },
     "fdivrp st7, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf7 /6"
       ],
@@ -10569,7 +10197,6 @@
     },
     "db 0xde, 0xf8": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "fdivp st0, st0",
         "Needs manual encoding since otherwise nasm will emit the 0xd8 variant.",
@@ -10598,7 +10225,6 @@
     },
     "fdivp st1, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xf9 /7"
       ],
@@ -10625,7 +10251,6 @@
     },
     "fdivp st2, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfa /7"
       ],
@@ -10652,7 +10277,6 @@
     },
     "fdivp st3, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfb /7"
       ],
@@ -10679,7 +10303,6 @@
     },
     "fdivp st4, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfc /7"
       ],
@@ -10706,7 +10329,6 @@
     },
     "fdivp st5, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfd /7"
       ],
@@ -10733,7 +10355,6 @@
     },
     "fdivp st6, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xfe /7"
       ],
@@ -10760,7 +10381,6 @@
     },
     "fdivp st7, st0": {
       "ExpectedInstructionCount": 18,
-      "Optimal": "No",
       "Comment": [
         "0xde 11b 0xff /7"
       ],
@@ -10787,7 +10407,6 @@
     },
     "fild word [rax]": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /0"
       ],
@@ -10810,7 +10429,6 @@
     },
     "fisttp word [rax]": {
       "ExpectedInstructionCount": 13,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /1"
       ],
@@ -10832,7 +10450,6 @@
     },
     "fist word [rax]": {
       "ExpectedInstructionCount": 6,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /2"
       ],
@@ -10847,7 +10464,6 @@
     },
     "fistp word [rax]": {
       "ExpectedInstructionCount": 14,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /3"
       ],
@@ -10870,7 +10486,6 @@
     },
     "fbld tword [rax]": {
       "ExpectedInstructionCount": 110,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /4"
       ],
@@ -10989,7 +10604,6 @@
     },
     "fbstp tword [rax]": {
       "ExpectedInstructionCount": 113,
-      "Optimal": "No",
       "Comment": [
         "0xdf !11b /6"
       ],
@@ -11111,7 +10725,6 @@
     },
     "ffreep st0": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc0 /0"
       ],
@@ -11124,7 +10737,6 @@
     },
     "ffreep st1": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc1 /0"
       ],
@@ -11137,7 +10749,6 @@
     },
     "ffreep st2": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc2 /0"
       ],
@@ -11150,7 +10761,6 @@
     },
     "ffreep st3": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc3 /0"
       ],
@@ -11163,7 +10773,6 @@
     },
     "ffreep st4": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc4 /0"
       ],
@@ -11176,7 +10785,6 @@
     },
     "ffreep st5": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc5 /0"
       ],
@@ -11189,7 +10797,6 @@
     },
     "ffreep st6": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc6 /0"
       ],
@@ -11202,7 +10809,6 @@
     },
     "ffreep st7": {
       "ExpectedInstructionCount": 4,
-      "Optimal": "Yes",
       "Comment": [
         "0xdf 11b 0xc7 /0"
       ],
@@ -11215,7 +10821,6 @@
     },
     "fnstsw ax": {
       "ExpectedInstructionCount": 12,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe0 /4"
       ],
@@ -11236,7 +10841,6 @@
     },
     "fucomip st0": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe8 /5"
       ],
@@ -11277,7 +10881,6 @@
     },
     "fucomip st1": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xe9 /5"
       ],
@@ -11318,7 +10921,6 @@
     },
     "fucomip st2": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xea /5"
       ],
@@ -11359,7 +10961,6 @@
     },
     "fucomip st3": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xeb /5"
       ],
@@ -11400,7 +11001,6 @@
     },
     "fucomip st4": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xec /5"
       ],
@@ -11441,7 +11041,6 @@
     },
     "fucomip st5": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xed /5"
       ],
@@ -11482,7 +11081,6 @@
     },
     "fucomip st6": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xee /5"
       ],
@@ -11523,7 +11121,6 @@
     },
     "fucomip st7": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xef /5"
       ],
@@ -11564,7 +11161,6 @@
     },
     "fcomip st0": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf0 /6"
       ],
@@ -11605,7 +11201,6 @@
     },
     "fcomip st1": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf1 /6"
       ],
@@ -11646,7 +11241,6 @@
     },
     "fcomip st2": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf2 /6"
       ],
@@ -11687,7 +11281,6 @@
     },
     "fcomip st3": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf3 /6"
       ],
@@ -11728,7 +11321,6 @@
     },
     "fcomip st4": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf4 /6"
       ],
@@ -11769,7 +11361,6 @@
     },
     "fcomip st5": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf5 /6"
       ],
@@ -11810,7 +11401,6 @@
     },
     "fcomip st6": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf6 /6"
       ],
@@ -11851,7 +11441,6 @@
     },
     "fcomip st7": {
       "ExpectedInstructionCount": 32,
-      "Optimal": "No",
       "Comment": [
         "0xdf 11b 0xf7 /6"
       ],


### PR DESCRIPTION
Instruction count CI has transformed the way we work on FEX… I love the system and want to make it better. there’s one part of instruction count CI that isn’t so lovable: the problematic “optimal” flag on instructions.

There are several issues with this flag, both philosophical and practical.

– it is tedious to update the optimal flag when making an implementation optimal. The effect of that is discouraging people from making instructions, optimal, or encouraging people to fail to update the flag, and dilute the value of it. Either way, since we care far more about optimal implementations, then we do about updating the flag, clearly we should prioritize the implementation and not the flag.  This issue was not obvious at the outset, when instruction count, CI was introduced, and still quite small. The problem magnified when we started duplicating instructions in bulk for different combinations of CPU features (flagm, AFP, etc.) that intern multiplies the manual work required to update the flags by the corresponding constant factor. if it comes down to a choice between removing this extra coverage and removing the flag, I think we all agree that removing the flag is the lesser evil.

– The definition of “optimal” is fundamentally problematic. I have often improved the instruction count of an instruction that was already “optimal”. This is all kinds of silly, and calls into question whether there’s any value whatsoever in the existing classifications of the flag. Furthermore, it is often unknowable, whether an implementation really is optimal. Is it possible to implement BZHI (with flag calculations) in fewer than eight instructions? We don’t know, and it’s silly to pretend that we do.

– as a consequence of the problematic definitions , there are so many errors in both directions that I don’t think there’s much value in preserving the existing classification at the expense of +progress. Being able to say “32% of instructions are translated optimally” is neat, but it really doesn’t tell us anything whatsoever when you dig a little deeper.

So, as the flag is misleading at best and perhaps harmful at worst, let’s remove it and make the instruction count CI, more useful overall. let’s let the expected count and the assembly speak for themselves, and cut away the chaff. if we want a meaningless number to report to management, we can instead calculate the average blowup factor ;-)