### PR TITLE
FEXCore: Work around broken preserve_all support in Windows clang

### DIFF
--- a/FEXCore/CMakeLists.txt
+++ b/FEXCore/CMakeLists.txt
@@ -38,7 +38,12 @@ check_cxx_source_compiles(
   HAS_CLANG_PRESERVE_ALL)
 unset(CMAKE_REQUIRED_FLAGS)
 if (HAS_CLANG_PRESERVE_ALL)
-  message(STATUS "Has clang::preserve_all")
+  if (MINGW_BUILD)
+    message(STATUS "Ignoring broken clang::preserve_all support")
+    set(HAS_CLANG_PRESERVE_ALL FALSE)
+  else()
+    message(STATUS "Has clang::preserve_all")
+  endif()
 endif ()
 
 if (EXISTS ${CMAKE_CURRENT_DIR}/External/vixl/)


### PR DESCRIPTION
While clang side code to support preserve_all on Windows is in place (and thus there are no errors for using it), there are still some parts missing on the [https://github.com/llvm/llvm-project/blob/2402b14046b9628b584c07789830d7ed481f7d74/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp#L88](LLVM side). I'll submit a patch to fix this upstream, but this works for now.

Thanks to @AndreRH for reporting this, glad I was finally able to reproduce it :)