### PR TITLE
FEXCore: Removes FEX_PACKED from CPUState

### DIFF
--- a/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/FEXCore/include/FEXCore/Core/CoreState.h
@@ -72,7 +72,7 @@ namespace FEXCore::Core {
   static_assert(std::is_trivially_copyable_v<NonAtomicRefCounter<uint64_t>>, "needs to be trivially copyable");
   static_assert(sizeof(NonAtomicRefCounter<uint64_t>) == sizeof(uint64_t), "Needs to be correct size");
 
-  struct FEX_PACKED CPUState {
+  struct CPUState {
     // Allows more efficient handling of the register
     // file in the event AVX is not supported.
     union XMMRegs {


### PR DESCRIPTION
Removes new warning from clang:
```
FEXCore/include/FEXCore/Core/CoreState.h:119:35: warning: not packing field 'DeferredSignalRefCount' as it is non-POD for the purposes of layout [-Wpacked-non-pod]
  119 |     NonAtomicRefCounter<uint64_t> DeferredSignalRefCount;
      |                                   ^
```

We already ensure sane data layout that this is unnecessary anyway.