### PR TITLE
Start moving thread handling to frontend

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -52,20 +52,16 @@ namespace FEXCore::Context {
     CompileBlock(Thread->CurrentFrame, GuestRIP, MaxInst);
   }
 
-  FEXCore::Context::ExitReason FEXCore::Context::ContextImpl::GetExitReason() {
-    return ParentThread->ExitReason;
-  }
-
   bool FEXCore::Context::ContextImpl::IsDone() const {
     return IsPaused();
   }
 
-  void FEXCore::Context::ContextImpl::GetCPUState(FEXCore::Core::CPUState *State) const {
-    memcpy(State, ParentThread->CurrentFrame, sizeof(FEXCore::Core::CPUState));
+  void FEXCore::Context::ContextImpl::GetCPUState(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::CPUState *State) const {
+    memcpy(State, Thread->CurrentFrame, sizeof(FEXCore::Core::CPUState));
   }
 
-  void FEXCore::Context::ContextImpl::SetCPUState(const FEXCore::Core::CPUState *State) {
-    memcpy(ParentThread->CurrentFrame, State, sizeof(FEXCore::Core::CPUState));
+  void FEXCore::Context::ContextImpl::SetCPUState(FEXCore::Core::InternalThreadState *Thread, const FEXCore::Core::CPUState *State) {
+    memcpy(Thread->CurrentFrame, State, sizeof(FEXCore::Core::CPUState));
   }
 
   void FEXCore::Context::ContextImpl::SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) {

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -74,7 +74,7 @@ namespace FEXCore::Context {
       // Context base class implementation.
       bool InitializeContext() override;
 
-      FEXCore::Core::InternalThreadState* InitCore(uint64_t InitialRIP, uint64_t StackPointer) override;
+      bool InitCore() override;
 
       void SetExitHandler(ExitHandler handler) override;
       ExitHandler GetExitHandler() const override;
@@ -84,21 +84,17 @@ namespace FEXCore::Context {
       void Stop() override;
       void Step() override;
 
-      ExitReason RunUntilExit() override;
+      ExitReason RunUntilExit(FEXCore::Core::InternalThreadState *Thread) override;
 
       void ExecuteThread(FEXCore::Core::InternalThreadState *Thread) override;
 
       void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) override;
       void CompileRIPCount(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst) override;
 
-      int GetProgramStatus() const override;
-
-      ExitReason GetExitReason() override;
-
       bool IsDone() const override;
 
-      void GetCPUState(FEXCore::Core::CPUState *State) const override;
-      void SetCPUState(const FEXCore::Core::CPUState *State) override;
+      void GetCPUState(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::CPUState *State) const override;
+      void SetCPUState(FEXCore::Core::InternalThreadState *Thread, const FEXCore::Core::CPUState *State) override;
 
       void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) override;
 
@@ -256,7 +252,6 @@ namespace FEXCore::Context {
     FEXCore::HostFeatures HostFeatures;
 
     std::mutex ThreadCreationMutex;
-    FEXCore::Core::InternalThreadState* ParentThread{};
     fextl::vector<FEXCore::Core::InternalThreadState*> Threads;
     std::atomic_bool CoreShuttingDown{false};
     bool NeedToCheckXID{true};
@@ -403,7 +398,6 @@ namespace FEXCore::Context {
 
     ThreadsState GetThreads() override  {
       return ThreadsState {
-        .ParentThread = ParentThread,
         .Threads = &Threads,
       };
     }

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -113,25 +113,31 @@ namespace FEXCore::Context {
       /**
        * @brief Used to create FEX thread objects in preparation for creating a true OS thread. Does set a TID or PID.
        *
-       * @param NewThreadState The initial thread state to setup for our state
+       * @param InitialRIP The starting RIP of this thread
+       * @param StackPointer The starting RSP of this thread
+       * @param NewThreadState The initial thread state to setup for our state, if inheriting.
        * @param ParentTID The PID that was the parent thread that created this
        *
        * @return The InternalThreadState object that tracks all of the emulated thread's state
        *
        * Usecases:
+       *  Parent thread Creation:
+       *    - Thread = CreateThread(InitialRIP, InitialStack, nullptr, 0);
+       *    - CTX->RunUntilExit(Thread);
        *  OS thread Creation:
-       *    - Thread = CreateThread(NewState, PPID);
+       *    - Thread = CreateThread(0, 0, NewState, PPID);
        *    - InitializeThread(Thread);
        *  OS fork (New thread created with a clone of thread state):
        *    - clone{2, 3}
-       *    - Thread = CreateThread(CopyOfThreadState, PPID);
+       *    - Thread = CreateThread(0, 0, CopyOfThreadState, PPID);
        *    - ExecutionThread(Thread); // Starts executing without creating another host thread
        *  Thunk callback executing guest code from native host thread
-       *    - Thread = CreateThread(NewState, PPID);
+       *    - Thread = CreateThread(0, 0, NewState, PPID);
        *    - InitializeThreadTLSData(Thread);
        *    - HandleCallback(Thread, RIP);
        */
-      FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID) override;
+
+      FEXCore::Core::InternalThreadState* CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID) override;
 
       // Public for threading
       void ExecutionThread(FEXCore::Core::InternalThreadState *Thread) override;
@@ -419,15 +425,6 @@ namespace FEXCore::Context {
     }
 
   private:
-    /**
-     * @brief Does some final thread initialization
-     *
-     * @param Thread The internal FEX thread state object
-     *
-     * InitCore and CreateThread both call this to finish up thread object initialization
-     */
-    void InitializeThreadData(FEXCore::Core::InternalThreadState *Thread);
-
     /**
      * @brief Initializes the JIT compilers for the thread
      *

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -692,9 +692,13 @@ namespace FEXCore::Context {
       std::lock_guard lk(ThreadCreationMutex);
 
       auto It = std::find(Threads.begin(), Threads.end(), Thread);
-      LOGMAN_THROW_A_FMT(It != Threads.end(), "Thread wasn't in Threads");
+      // TODO: Some threads aren't currently tracked in FEXCore.
+      // Re-enable once tracking is in frontend.
+      //LOGMAN_THROW_A_FMT(It != Threads.end(), "Thread wasn't in Threads");
 
-      Threads.erase(It);
+      if (It != Threads.end()) {
+        Threads.erase(It);
+      }
     }
 
     if (Thread->ExecutionThread &&

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -387,18 +387,11 @@ namespace FEXCore::Context {
       StartPaused = true;
     }
 
-    using namespace FEXCore::Core;
-
-    FEXCore::Core::InternalThreadState *Thread = CreateThread(nullptr, 0);
+    FEXCore::Core::InternalThreadState *Thread = CreateThread(InitialRIP, StackPointer);
 
     // We are the parent thread
     ParentThread = Thread;
 
-    Thread->CurrentFrame->State.gregs[X86State::REG_RSP] = StackPointer;
-
-    Thread->CurrentFrame->State.rip = InitialRIP;
-
-    InitializeThreadData(Thread);
     return Thread;
   }
 
@@ -578,10 +571,6 @@ namespace FEXCore::Context {
     return ParentThread->StatusCode;
   }
 
-  void ContextImpl::InitializeThreadData(FEXCore::Core::InternalThreadState *Thread) {
-    Thread->CPUBackend->Initialize();
-  }
-
   struct ExecutionThreadHandler {
     ContextImpl *This;
     FEXCore::Core::InternalThreadState *Thread;
@@ -680,20 +669,23 @@ namespace FEXCore::Context {
     Thread->PassManager->Finalize();
   }
 
-  FEXCore::Core::InternalThreadState* ContextImpl::CreateThread(FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID) {
+  FEXCore::Core::InternalThreadState* ContextImpl::CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID) {
     FEXCore::Core::InternalThreadState *Thread = new FEXCore::Core::InternalThreadState{};
+
+    Thread->CurrentFrame->State.gregs[X86State::REG_RSP] = StackPointer;
+    Thread->CurrentFrame->State.rip = InitialRIP;
 
     // Copy over the new thread state to the new object
     if (NewThreadState) {
-      memcpy(Thread->CurrentFrame, NewThreadState, sizeof(FEXCore::Core::CPUState));
+      memcpy(&Thread->CurrentFrame->State, NewThreadState, sizeof(FEXCore::Core::CPUState));
+
+      // Set up the thread manager state
+      Thread->ThreadManager.parent_tid = ParentTID;
     }
+
     Thread->CurrentFrame->Thread = Thread;
 
-    // Set up the thread manager state
-    Thread->ThreadManager.parent_tid = ParentTID;
-
     InitializeCompiler(Thread);
-    InitializeThreadData(Thread);
 
     Thread->CurrentFrame->State.DeferredSignalRefCount.Store(0);
     Thread->CurrentFrame->State.DeferredSignalFaultAddress = reinterpret_cast<Core::NonAtomicRefCounter<uint64_t>*>(FEXCore::Allocator::VirtualAlloc(4096));
@@ -722,6 +714,13 @@ namespace FEXCore::Context {
         Thread->ExecutionThread->IsSelf()) {
       // To be able to delete a thread from itself, we need to detached the std::thread object
       Thread->ExecutionThread->detach();
+    }
+
+    if (Thread->DestroyedByParent) {
+#ifndef _WIN32
+      Alloc::OSAllocator::UninstallTLSData(Thread);
+#endif
+      SignalDelegation->UninstallTLSState(Thread);
     }
 
     FEXCore::Allocator::VirtualFree(reinterpret_cast<void*>(Thread->CurrentFrame->State.DeferredSignalFaultAddress), 4096);

--- a/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -156,13 +156,6 @@ namespace CPU {
     [[nodiscard]] virtual void *MapRegion(void *HostPtr, uint64_t GuestPtr, uint64_t Size) = 0;
 
     /**
-     * @brief This is post-setup initialization that is called just before code executino
-     *
-     * Guest memory is available at this point and ThreadState is valid
-     */
-    virtual void Initialize() {}
-
-    /**
      * @brief Lets FEXCore know if this CPUBackend needs IR and DebugData for CompileCode
      *
      * This is useful if the FEXCore Frontend hits an x86-64 instruction that isn't understood but can continue regardless

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -287,7 +287,19 @@ namespace FEXCore::Context {
       ///< Sets FEX's internal EFLAGS representation to the passed in compacted form.
       FEX_DEFAULT_VISIBILITY virtual void SetFlagsFromCompactedEFLAGS(FEXCore::Core::InternalThreadState *Thread, uint32_t EFLAGS) = 0;
 
-      FEX_DEFAULT_VISIBILITY virtual FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID) = 0;
+      /**
+       * @brief Create a new thread object that doesn't inherit any state.
+       * Used to create FEX thread objects in preparation for creating a true OS thread.
+       *
+       * @param InitialRIP The starting RIP of this thread
+       * @param StackPointer The starting RSP of this thread
+       * @param NewThreadState The thread state to inherit from if not nullptr.
+       * @param ParentTID The thread ID that the parent is inheriting from
+       *
+       * @return A new InternalThreadState object for using with a new guest thread.
+       */
+      FEX_DEFAULT_VISIBILITY virtual FEXCore::Core::InternalThreadState* CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::Core::CPUState *NewThreadState = nullptr, uint64_t ParentTID = 0) = 0;
+
       FEX_DEFAULT_VISIBILITY virtual void ExecutionThread(FEXCore::Core::InternalThreadState *Thread) = 0;
       FEX_DEFAULT_VISIBILITY virtual void InitializeThread(FEXCore::Core::InternalThreadState *Thread) = 0;
       FEX_DEFAULT_VISIBILITY virtual void RunThread(FEXCore::Core::InternalThreadState *Thread) = 0;

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -88,7 +88,6 @@ namespace FEXCore::Context {
   };
 
   struct ThreadsState {
-    FEXCore::Core::InternalThreadState* ParentThread;
     fextl::vector<FEXCore::Core::InternalThreadState*>* Threads;
   };
 
@@ -129,12 +128,9 @@ namespace FEXCore::Context {
       /**
        * @brief Allows setting up in memory code and other things prior to launchign code execution
        *
-       * @param CTX The context that we created
-       * @param Loader The loader that will be doing all the code loading
-       *
-       * @return true if we loaded code
+       * @return true if we initialized the core
        */
-      FEX_DEFAULT_VISIBILITY virtual FEXCore::Core::InternalThreadState* InitCore(uint64_t InitialRIP, uint64_t StackPointer) = 0;
+      FEX_DEFAULT_VISIBILITY virtual bool InitCore() = 0;
 
       FEX_DEFAULT_VISIBILITY virtual void SetExitHandler(ExitHandler handler) = 0;
       FEX_DEFAULT_VISIBILITY virtual ExitHandler GetExitHandler() const = 0;
@@ -191,7 +187,7 @@ namespace FEXCore::Context {
        *
        * @return The ExitReason for the parentthread.
        */
-      FEX_DEFAULT_VISIBILITY virtual ExitReason RunUntilExit() = 0;
+      FEX_DEFAULT_VISIBILITY virtual ExitReason RunUntilExit(FEXCore::Core::InternalThreadState *Thread) = 0;
 
       /**
        * @brief Executes the supplied thread context on the current thread until a return is requested
@@ -200,25 +196,6 @@ namespace FEXCore::Context {
 
       FEX_DEFAULT_VISIBILITY virtual void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) = 0;
       FEX_DEFAULT_VISIBILITY virtual void CompileRIPCount(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst) = 0;
-
-      /**
-       * @brief Gets the program exit status
-       *
-       *
-       * @param CTX The context that we created
-       *
-       * @return The program exit status
-       */
-      FEX_DEFAULT_VISIBILITY virtual int GetProgramStatus() const = 0;
-
-      /**
-       * @brief [[threadsafe]] Returns the ExitReason of the parent thread. Typically used for async result status
-       *
-       * @param CTX The context that we created
-       *
-       * @return The ExitReason for the parentthread
-       */
-      FEX_DEFAULT_VISIBILITY virtual ExitReason GetExitReason() = 0;
 
       /**
        * @brief [[theadsafe]] Checks if the Context is either done working or paused(in the case of single stepping)
@@ -232,20 +209,20 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual bool IsDone() const = 0;
 
       /**
-       * @brief Gets a copy the CPUState of the parent thread
+       * @brief Gets a copy the CPUState of the thread passed in
        *
        * @param CTX The context that we created
        * @param State The state object to populate
        */
-      FEX_DEFAULT_VISIBILITY virtual void GetCPUState(FEXCore::Core::CPUState *State) const = 0;
+      FEX_DEFAULT_VISIBILITY virtual void GetCPUState(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::CPUState *State) const = 0;
 
       /**
-       * @brief Copies the CPUState provided to the parent thread
+       * @brief Copies the CPUState provided to the thread passed in
        *
        * @param CTX The context that we created
        * @param State The satate object to copy from
        */
-      FEX_DEFAULT_VISIBILITY virtual void SetCPUState(const FEXCore::Core::CPUState *State) = 0;
+      FEX_DEFAULT_VISIBILITY virtual void SetCPUState(FEXCore::Core::InternalThreadState *Thread, const FEXCore::Core::CPUState *State) = 0;
 
       /**
        * @brief Allows the frontend to pass in a custom CPUBackend creation factory

--- a/Source/Tools/FEXLoader/AOT/AOTGenerator.cpp
+++ b/Source/Tools/FEXLoader/AOT/AOTGenerator.cpp
@@ -106,8 +106,7 @@ void AOTGenSection(FEXCore::Context::Context *CTX, ELFCodeLoader::LoadedSection 
       setpriority(PRIO_PROCESS, FHU::Syscalls::gettid(), 19);
 
       // Setup thread - Each compilation thread uses its own backing FEX thread
-      FEXCore::Core::CPUState state;
-      auto Thread = CTX->CreateThread(&state, FHU::Syscalls::gettid());
+      auto Thread = CTX->CreateThread(0, 0);
       fextl::set<uint64_t> ExternalBranchesLocal;
       CTX->ConfigureAOTGen(Thread, &ExternalBranchesLocal, SectionMaxAddress);
 

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -488,6 +488,7 @@ int main(int argc, char **argv, char **const envp) {
   auto ParentThread = CTX->CreateThread(Loader.DefaultRIP(), Loader.GetStackPointer());
   ParentThread->DestroyedByParent = true;
 
+  SyscallHandler->SetParentThread(ParentThread);
   if (GdbServer) {
     DebugServer->SetParentThread(ParentThread);
   }
@@ -567,8 +568,6 @@ int main(int argc, char **argv, char **const envp) {
   }
 
   auto ProgramStatus = ParentThread->StatusCode;
-
-  CTX->DestroyThread(ParentThread);
 
   DebugServer.reset();
   SyscallHandler.reset();

--- a/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.cpp
@@ -284,7 +284,7 @@ fextl::string GdbServer::readRegs() {
   FEXCore::Core::CPUState state{};
 
   auto Threads = CTX->GetThreads();
-  FEXCore::Core::InternalThreadState *CurrentThread { Threads.ParentThread };
+  FEXCore::Core::InternalThreadState *CurrentThread { ParentThread };
   bool Found = false;
 
   for (auto &Thread : *Threads.Threads) {
@@ -299,7 +299,7 @@ fextl::string GdbServer::readRegs() {
 
   if (!Found) {
     // If set to an invalid thread then just get the parent thread ID
-    memcpy(&state, Threads.ParentThread->CurrentFrame, sizeof(state));
+    memcpy(&state, ParentThread->CurrentFrame, sizeof(state));
   }
 
   // Encode the GDB context definition
@@ -335,7 +335,7 @@ GdbServer::HandledPacketType GdbServer::readReg(const fextl::string& packet) {
   FEXCore::Core::CPUState state{};
 
   auto Threads = CTX->GetThreads();
-  FEXCore::Core::InternalThreadState *CurrentThread { Threads.ParentThread };
+  FEXCore::Core::InternalThreadState *CurrentThread { ParentThread };
   bool Found = false;
 
   for (auto &Thread : *Threads.Threads) {
@@ -350,7 +350,7 @@ GdbServer::HandledPacketType GdbServer::readReg(const fextl::string& packet) {
 
   if (!Found) {
     // If set to an invalid thread then just get the parent thread ID
-    memcpy(&state, Threads.ParentThread->CurrentFrame, sizeof(state));
+    memcpy(&state, ParentThread->CurrentFrame, sizeof(state));
   }
 
 
@@ -954,7 +954,7 @@ GdbServer::HandledPacketType GdbServer::handleQuery(const fextl::string &packet)
   if (match("qC")) {
     // Returns the current Thread ID
     fextl::ostringstream ss;
-    ss << "m" <<  std::hex << CTX->GetThreads().ParentThread->ThreadManager.TID;
+    ss << "m" <<  std::hex << ParentThread->ThreadManager.TID;
     return {ss.str(), HandledPacketType::TYPE_ACK};
   }
   if (match("QStartNoAckMode")) {

--- a/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
@@ -33,7 +33,18 @@ public:
       LibraryMapChanged = true;
     }
 
+    /**
+     * @brief Sets the parent thread object.
+     * TODO: Temporary until the frontend does all the guest thread tracking.
+     *
+     * @param Thread
+     */
+    void SetParentThread(FEXCore::Core::InternalThreadState *Thread) {
+      ParentThread = Thread;
+    }
+
 private:
+    FEXCore::Core::InternalThreadState *ParentThread;
     void Break(int signal);
 
     void OpenListenSocket();

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.cpp
@@ -755,6 +755,8 @@ SyscallHandler::SyscallHandler(FEXCore::Context::Context *_CTX, FEX::HLE::Signal
 
 SyscallHandler::~SyscallHandler() {
   FEXCore::Allocator::munmap(reinterpret_cast<void*>(DataSpace), DataSpaceMaxSize);
+
+  CTX->DestroyThread(ParentThread);
 }
 
 uint32_t SyscallHandler::CalculateHostKernelVersion() {

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.h
@@ -226,6 +226,10 @@ public:
 
   SourcecodeResolver *GetSourcecodeResolver() override { return this; }
 
+  void SetParentThread(FEXCore::Core::InternalThreadState *Thread) {
+    ParentThread = Thread;
+  }
+
 protected:
   SyscallHandler(FEXCore::Context::Context *_CTX, FEX::HLE::SignalDelegator *_SignalDelegation);
 
@@ -245,6 +249,9 @@ protected:
   FEXCore::Context::Context *CTX;
 
 private:
+
+  // Thread tracking.
+  FEXCore::Core::InternalThreadState* ParentThread{};
 
   FEX::HLE::SignalDelegator *SignalDelegation;
 

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/Thread.cpp
@@ -58,7 +58,7 @@ namespace FEX::HLE {
       NewThreadState.gregs[FEXCore::X86State::REG_RSP] = args->args.stack;
     }
 
-    auto NewThread = CTX->CreateThread(&NewThreadState, args->args.parent_tid);
+    auto NewThread = CTX->CreateThread(0, 0, &NewThreadState, args->args.parent_tid);
     CTX->InitializeThread(NewThread);
 
     if (FEX::HLE::_SyscallHandler->Is64BitMode()) {
@@ -131,7 +131,7 @@ namespace FEX::HLE {
       }
 
       // Overwrite thread
-      NewThread = CTX->CreateThread(&NewThreadState, GuestArgs->parent_tid);
+      NewThread = CTX->CreateThread(0, 0, &NewThreadState, GuestArgs->parent_tid);
 
       // CLONE_PARENT_SETTID, CLONE_CHILD_SETTID, CLONE_CHILD_CLEARTID, CLONE_PIDFD will be handled by kernel
       // Call execution thread directly since we already are on the new thread

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -518,7 +518,7 @@ void BTCpuProcessInit() {
   CTX->InitializeContext();
   CTX->SetSignalDelegator(SignalDelegator.get());
   CTX->SetSyscallHandler(SyscallHandler.get());
-  CTX->InitCore(0, 0);
+  CTX->InitCore();
 
   CpuInfo.ProcessorArchitecture = PROCESSOR_ARCHITECTURE_INTEL;
 
@@ -555,7 +555,7 @@ void BTCpuProcessInit() {
 }
 
 NTSTATUS BTCpuThreadInit() {
-  GetTLS().ThreadState() = CTX->CreateThread(nullptr, 0);
+  GetTLS().ThreadState() = CTX->CreateThread(0, 0);
 
   std::scoped_lock Lock(ThreadSuspendLock);
   InitializedWOWThreads.emplace(GetCurrentThreadId());


### PR DESCRIPTION
The frontend needs to be in control of how threads are created. This is
inherent to the fact that OS threads are OS specific. We currently have
this weird split that when initializing the FEXCore context, we create a
parent thread at all times.

This does some initial cleanup that gets the core initialization nearly
decoupled.

We hand over the parent thread ownership to the frontend, which then gets managed by our syscall handler (Since it handles OS thread creation). Children thread are not yet decoupled from FEXCore since there are non-trivial changes that need to be done there to get them moved over.