### PR TITLE
FEXCore: Start changing how thread creation works

### DIFF
--- a/FEXCore/include/FEXCore/Core/CPUBackend.h
+++ b/FEXCore/include/FEXCore/Core/CPUBackend.h
@@ -156,13 +156,6 @@ namespace CPU {
     [[nodiscard]] virtual void *MapRegion(void *HostPtr, uint64_t GuestPtr, uint64_t Size) = 0;
 
     /**
-     * @brief This is post-setup initialization that is called just before code executino
-     *
-     * Guest memory is available at this point and ThreadState is valid
-     */
-    virtual void Initialize() {}
-
-    /**
      * @brief Lets FEXCore know if this CPUBackend needs IR and DebugData for CompileCode
      *
      * This is useful if the FEXCore Frontend hits an x86-64 instruction that isn't understood but can continue regardless

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -278,7 +278,19 @@ namespace FEXCore::Context {
       ///< Sets FEX's internal EFLAGS representation to the passed in compacted form.
       FEX_DEFAULT_VISIBILITY virtual void SetFlagsFromCompactedEFLAGS(FEXCore::Core::InternalThreadState *Thread, uint32_t EFLAGS) = 0;
 
-      FEX_DEFAULT_VISIBILITY virtual FEXCore::Core::InternalThreadState* CreateThread(FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID) = 0;
+      /**
+       * @brief Create a new thread object that doesn't inherit any state.
+       * Used to create FEX thread objects in preparation for creating a true OS thread.
+       *
+       * @param InitialRIP The starting RIP of this thread
+       * @param StackPointer The starting RSP of this thread
+       * @param NewThreadState The thread state to inherit from if not nullptr.
+       * @param ParentTID The thread ID that the parent is inheriting from
+       *
+       * @return A new InternalThreadState object for using with a new guest thread.
+       */
+      FEX_DEFAULT_VISIBILITY virtual FEXCore::Core::InternalThreadState* CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::Core::CPUState *NewThreadState = nullptr, uint64_t ParentTID = 0) = 0;
+
       FEX_DEFAULT_VISIBILITY virtual void ExecutionThread(FEXCore::Core::InternalThreadState *Thread) = 0;
       FEX_DEFAULT_VISIBILITY virtual void InitializeThread(FEXCore::Core::InternalThreadState *Thread) = 0;
       FEX_DEFAULT_VISIBILITY virtual void RunThread(FEXCore::Core::InternalThreadState *Thread) = 0;

--- a/Source/Tools/FEXLoader/AOT/AOTGenerator.cpp
+++ b/Source/Tools/FEXLoader/AOT/AOTGenerator.cpp
@@ -106,8 +106,7 @@ void AOTGenSection(FEXCore::Context::Context *CTX, ELFCodeLoader::LoadedSection 
       setpriority(PRIO_PROCESS, FHU::Syscalls::gettid(), 19);
 
       // Setup thread - Each compilation thread uses its own backing FEX thread
-      FEXCore::Core::CPUState state;
-      auto Thread = CTX->CreateThread(&state, FHU::Syscalls::gettid());
+      auto Thread = CTX->CreateThread(0, 0);
       fextl::set<uint64_t> ExternalBranchesLocal;
       CTX->ConfigureAOTGen(Thread, &ExternalBranchesLocal, SectionMaxAddress);
 

--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls/Thread.cpp
@@ -58,7 +58,7 @@ namespace FEX::HLE {
       NewThreadState.gregs[FEXCore::X86State::REG_RSP] = args->args.stack;
     }
 
-    auto NewThread = CTX->CreateThread(&NewThreadState, args->args.parent_tid);
+    auto NewThread = CTX->CreateThread(0, 0, &NewThreadState, args->args.parent_tid);
     CTX->InitializeThread(NewThread);
 
     if (FEX::HLE::_SyscallHandler->Is64BitMode()) {
@@ -131,7 +131,7 @@ namespace FEX::HLE {
       }
 
       // Overwrite thread
-      NewThread = CTX->CreateThread(&NewThreadState, GuestArgs->parent_tid);
+      NewThread = CTX->CreateThread(0, 0, &NewThreadState, GuestArgs->parent_tid);
 
       // CLONE_PARENT_SETTID, CLONE_CHILD_SETTID, CLONE_CHILD_CLEARTID, CLONE_PIDFD will be handled by kernel
       // Call execution thread directly since we already are on the new thread

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -555,7 +555,7 @@ void BTCpuProcessInit() {
 }
 
 NTSTATUS BTCpuThreadInit() {
-  GetTLS().ThreadState() = CTX->CreateThread(nullptr, 0);
+  GetTLS().ThreadState() = CTX->CreateThread(0, 0);
 
   std::scoped_lock Lock(ThreadSuspendLock);
   InitializedWOWThreads.emplace(GetCurrentThreadId());


### PR DESCRIPTION
First commit from #3282.

The frontend needs to be in control of how threads are created. This is inherent to the fact that OS threads are OS specific. We currently have this weird split that when initializing the FEXCore context, we create a parent thread at all times.

This does some initial cleanup that gets the core initialization nearly decoupled.