### PR TITLE
FEXCore: Changes ParentThread ownership from the CTX to the frontend 

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -74,7 +74,7 @@ namespace FEXCore::Context {
       // Context base class implementation.
       bool InitializeContext() override;
 
-      FEXCore::Core::InternalThreadState* InitCore(uint64_t InitialRIP, uint64_t StackPointer) override;
+      bool InitCore() override;
 
       void SetExitHandler(ExitHandler handler) override;
       ExitHandler GetExitHandler() const override;
@@ -84,14 +84,12 @@ namespace FEXCore::Context {
       void Stop() override;
       void Step() override;
 
-      ExitReason RunUntilExit() override;
+      ExitReason RunUntilExit(FEXCore::Core::InternalThreadState *Thread) override;
 
       void ExecuteThread(FEXCore::Core::InternalThreadState *Thread) override;
 
       void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) override;
       void CompileRIPCount(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst) override;
-
-      int GetProgramStatus() const override;
 
       bool IsDone() const override;
 
@@ -251,7 +249,6 @@ namespace FEXCore::Context {
     FEXCore::HostFeatures HostFeatures;
 
     std::mutex ThreadCreationMutex;
-    FEXCore::Core::InternalThreadState* ParentThread{};
     fextl::vector<FEXCore::Core::InternalThreadState*> Threads;
     std::atomic_bool CoreShuttingDown{false};
     bool NeedToCheckXID{true};
@@ -398,7 +395,6 @@ namespace FEXCore::Context {
 
     ThreadsState GetThreads() override  {
       return ThreadsState {
-        .ParentThread = ParentThread,
         .Threads = &Threads,
       };
     }

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -88,7 +88,6 @@ namespace FEXCore::Context {
   };
 
   struct ThreadsState {
-    FEXCore::Core::InternalThreadState* ParentThread;
     fextl::vector<FEXCore::Core::InternalThreadState*>* Threads;
   };
 
@@ -129,12 +128,9 @@ namespace FEXCore::Context {
       /**
        * @brief Allows setting up in memory code and other things prior to launchign code execution
        *
-       * @param CTX The context that we created
-       * @param Loader The loader that will be doing all the code loading
-       *
-       * @return true if we loaded code
+       * @return true if we initialized the core
        */
-      FEX_DEFAULT_VISIBILITY virtual FEXCore::Core::InternalThreadState* InitCore(uint64_t InitialRIP, uint64_t StackPointer) = 0;
+      FEX_DEFAULT_VISIBILITY virtual bool InitCore() = 0;
 
       FEX_DEFAULT_VISIBILITY virtual void SetExitHandler(ExitHandler handler) = 0;
       FEX_DEFAULT_VISIBILITY virtual ExitHandler GetExitHandler() const = 0;
@@ -191,7 +187,7 @@ namespace FEXCore::Context {
        *
        * @return The ExitReason for the parentthread.
        */
-      FEX_DEFAULT_VISIBILITY virtual ExitReason RunUntilExit() = 0;
+      FEX_DEFAULT_VISIBILITY virtual ExitReason RunUntilExit(FEXCore::Core::InternalThreadState *Thread) = 0;
 
       /**
        * @brief Executes the supplied thread context on the current thread until a return is requested
@@ -200,16 +196,6 @@ namespace FEXCore::Context {
 
       FEX_DEFAULT_VISIBILITY virtual void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) = 0;
       FEX_DEFAULT_VISIBILITY virtual void CompileRIPCount(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst) = 0;
-
-      /**
-       * @brief Gets the program exit status
-       *
-       *
-       * @param CTX The context that we created
-       *
-       * @return The program exit status
-       */
-      FEX_DEFAULT_VISIBILITY virtual int GetProgramStatus() const = 0;
 
       /**
        * @brief [[theadsafe]] Checks if the Context is either done working or paused(in the case of single stepping)

--- a/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.cpp
@@ -336,7 +336,7 @@ fextl::string GdbServer::readRegs() {
   FEXCore::Core::CPUState state{};
 
   auto Threads = CTX->GetThreads();
-  FEXCore::Core::InternalThreadState *CurrentThread { Threads.ParentThread };
+  FEXCore::Core::InternalThreadState *CurrentThread { ParentThread };
   bool Found = false;
 
   for (auto &Thread : *Threads.Threads) {
@@ -351,7 +351,7 @@ fextl::string GdbServer::readRegs() {
 
   if (!Found) {
     // If set to an invalid thread then just get the parent thread ID
-    memcpy(&state, Threads.ParentThread->CurrentFrame, sizeof(state));
+    memcpy(&state, ParentThread->CurrentFrame, sizeof(state));
   }
 
   // Encode the GDB context definition
@@ -387,7 +387,7 @@ GdbServer::HandledPacketType GdbServer::readReg(const fextl::string& packet) {
   FEXCore::Core::CPUState state{};
 
   auto Threads = CTX->GetThreads();
-  FEXCore::Core::InternalThreadState *CurrentThread { Threads.ParentThread };
+  FEXCore::Core::InternalThreadState *CurrentThread { ParentThread };
   bool Found = false;
 
   for (auto &Thread : *Threads.Threads) {
@@ -402,7 +402,7 @@ GdbServer::HandledPacketType GdbServer::readReg(const fextl::string& packet) {
 
   if (!Found) {
     // If set to an invalid thread then just get the parent thread ID
-    memcpy(&state, Threads.ParentThread->CurrentFrame, sizeof(state));
+    memcpy(&state, ParentThread->CurrentFrame, sizeof(state));
   }
 
 
@@ -1006,7 +1006,7 @@ GdbServer::HandledPacketType GdbServer::handleQuery(const fextl::string &packet)
   if (match("qC")) {
     // Returns the current Thread ID
     fextl::ostringstream ss;
-    ss << "m" <<  std::hex << CTX->GetThreads().ParentThread->ThreadManager.TID;
+    ss << "m" <<  std::hex << ParentThread->ThreadManager.TID;
     return {ss.str(), HandledPacketType::TYPE_ACK};
   }
   if (match("QStartNoAckMode")) {

--- a/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
@@ -35,7 +35,18 @@ public:
       LibraryMapChanged = true;
     }
 
+    /**
+     * @brief Sets the parent thread object.
+     * TODO: Temporary until the frontend does all the guest thread tracking.
+     *
+     * @param Thread
+     */
+    void SetParentThread(FEXCore::Core::InternalThreadState *Thread) {
+      ParentThread = Thread;
+    }
+
 private:
+    FEXCore::Core::InternalThreadState *ParentThread;
     void Break(int signal);
 
     void OpenListenSocket();

--- a/Source/Tools/FEXLoader/TestHarnessRunner.cpp
+++ b/Source/Tools/FEXLoader/TestHarnessRunner.cpp
@@ -303,7 +303,14 @@ int main(int argc, char **argv, char **const envp) {
     CTX->SetSignalDelegator(SignalDelegation.get());
     CTX->SetSyscallHandler(SyscallHandler.get());
 
-    auto ParentThread = CTX->InitCore(Loader.DefaultRIP(), Loader.GetStackPointer());
+    bool Result1 = CTX->InitCore();
+
+    if (!Result1) {
+      return 1;
+    }
+
+    auto ParentThread = CTX->CreateThread(Loader.DefaultRIP(), Loader.GetStackPointer());
+    ParentThread->DestroyedByParent = true;
 
     if (!ParentThread) {
       return 1;
@@ -311,13 +318,14 @@ int main(int argc, char **argv, char **const envp) {
 
     int LongJumpVal = setjmp(LongJumpHandler::LongJump);
     if (!LongJumpVal) {
-      CTX->RunUntilExit();
+      CTX->RunUntilExit(ParentThread);
     }
 
     // Just re-use compare state. It also checks against the expected values in config.
     memcpy(&State, &ParentThread->CurrentFrame->State, sizeof(State));
 
     SyscallHandler.reset();
+    CTX->DestroyThread(ParentThread);
   }
 #ifndef _WIN32
   else {

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -518,7 +518,7 @@ void BTCpuProcessInit() {
   CTX->InitializeContext();
   CTX->SetSignalDelegator(SignalDelegator.get());
   CTX->SetSyscallHandler(SyscallHandler.get());
-  CTX->InitCore(0, 0);
+  CTX->InitCore();
 
   CpuInfo.ProcessorArchitecture = PROCESSOR_ARCHITECTURE_INTEL;
 


### PR DESCRIPTION
Second commit from #3282.

This is the minimal amount of changes to move the ownership from FEXCore
to the frontend. Since the frontends don't yet have a full thread state
tracking, there is an opaque pointer that needs to be managed.

In the followup commits this will be changed to have the syscall handler
to be the thread object manager.