### PR TITLE
FEXCore: Removes GetExitReason

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -52,10 +52,6 @@ namespace FEXCore::Context {
     CompileBlock(Thread->CurrentFrame, GuestRIP, MaxInst);
   }
 
-  FEXCore::Context::ExitReason FEXCore::Context::ContextImpl::GetExitReason() {
-    return ParentThread->ExitReason;
-  }
-
   bool FEXCore::Context::ContextImpl::IsDone() const {
     return IsPaused();
   }

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -93,8 +93,6 @@ namespace FEXCore::Context {
 
       int GetProgramStatus() const override;
 
-      ExitReason GetExitReason() override;
-
       bool IsDone() const override;
 
       void GetCPUState(FEXCore::Core::CPUState *State) const override;

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -212,15 +212,6 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual int GetProgramStatus() const = 0;
 
       /**
-       * @brief [[threadsafe]] Returns the ExitReason of the parent thread. Typically used for async result status
-       *
-       * @param CTX The context that we created
-       *
-       * @return The ExitReason for the parentthread
-       */
-      FEX_DEFAULT_VISIBILITY virtual ExitReason GetExitReason() = 0;
-
-      /**
        * @brief [[theadsafe]] Checks if the Context is either done working or paused(in the case of single stepping)
        *
        * Use this when the context is async running to determine if it is done


### PR DESCRIPTION
Split off from #3282 to reduce burden.
We read the member directly now. Removes one usage of ParentThread in FEXCore.