### PR TITLE
FEXCore: Removes Get/SetCPUState

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -60,14 +60,6 @@ namespace FEXCore::Context {
     return IsPaused();
   }
 
-  void FEXCore::Context::ContextImpl::GetCPUState(FEXCore::Core::CPUState *State) const {
-    memcpy(State, ParentThread->CurrentFrame, sizeof(FEXCore::Core::CPUState));
-  }
-
-  void FEXCore::Context::ContextImpl::SetCPUState(const FEXCore::Core::CPUState *State) {
-    memcpy(ParentThread->CurrentFrame, State, sizeof(FEXCore::Core::CPUState));
-  }
-
   void FEXCore::Context::ContextImpl::SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) {
     CustomCPUFactory = std::move(Factory);
   }

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -97,9 +97,6 @@ namespace FEXCore::Context {
 
       bool IsDone() const override;
 
-      void GetCPUState(FEXCore::Core::CPUState *State) const override;
-      void SetCPUState(const FEXCore::Core::CPUState *State) override;
-
       void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) override;
 
       HostFeatures GetHostFeatures() const override;

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -232,22 +232,6 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual bool IsDone() const = 0;
 
       /**
-       * @brief Gets a copy the CPUState of the parent thread
-       *
-       * @param CTX The context that we created
-       * @param State The state object to populate
-       */
-      FEX_DEFAULT_VISIBILITY virtual void GetCPUState(FEXCore::Core::CPUState *State) const = 0;
-
-      /**
-       * @brief Copies the CPUState provided to the parent thread
-       *
-       * @param CTX The context that we created
-       * @param State The satate object to copy from
-       */
-      FEX_DEFAULT_VISIBILITY virtual void SetCPUState(const FEXCore::Core::CPUState *State) = 0;
-
-      /**
        * @brief Allows the frontend to pass in a custom CPUBackend creation factory
        *
        * This allows the frontend to have its own frontend. Typically for debugging

--- a/Source/Tools/FEXLoader/IRLoader.cpp
+++ b/Source/Tools/FEXLoader/IRLoader.cpp
@@ -179,7 +179,7 @@ int main(int argc, char **argv, char **const envp)
 
   if (Loader.LoadIR(CTX.get()))
   {
-    CTX->InitCore(Loader.DefaultRIP(), Loader.GetStackPointer());
+    auto ParentThread = CTX->InitCore(Loader.DefaultRIP(), Loader.GetStackPointer());
 
     auto ShutdownReason = FEXCore::Context::ExitReason::EXIT_SHUTDOWN;
 
@@ -211,10 +211,7 @@ int main(int argc, char **argv, char **const envp)
     LogMan::Msg::DFmt("Reason we left VM: {}", FEXCore::ToUnderlying(ShutdownReason));
 
     // Just re-use compare state. It also checks against the expected values in config.
-    FEXCore::Core::CPUState State;
-    CTX->GetCPUState(&State);
-
-    const bool Passed = Loader.CompareStates(&State, SupportsAVX);
+    const bool Passed = Loader.CompareStates(&ParentThread->CurrentFrame->State, SupportsAVX);
 
     LogMan::Msg::IFmt("Passed? {}\n", Passed ? "Yes" : "No");
 

--- a/Source/Tools/FEXLoader/TestHarnessRunner.cpp
+++ b/Source/Tools/FEXLoader/TestHarnessRunner.cpp
@@ -303,9 +303,9 @@ int main(int argc, char **argv, char **const envp) {
     CTX->SetSignalDelegator(SignalDelegation.get());
     CTX->SetSyscallHandler(SyscallHandler.get());
 
-    bool Result1 = CTX->InitCore(Loader.DefaultRIP(), Loader.GetStackPointer());
+    auto ParentThread = CTX->InitCore(Loader.DefaultRIP(), Loader.GetStackPointer());
 
-    if (!Result1) {
+    if (!ParentThread) {
       return 1;
     }
 
@@ -315,7 +315,7 @@ int main(int argc, char **argv, char **const envp) {
     }
 
     // Just re-use compare state. It also checks against the expected values in config.
-    CTX->GetCPUState(&State);
+    memcpy(&State, &ParentThread->CurrentFrame->State, sizeof(State));
 
     SyscallHandler.reset();
   }


### PR DESCRIPTION
Split off from #3282 to reduce burden.
We can read the data member directly now since it isn't opaque. In fact we already do in the signal handlers. Removes these redundant helpers.

Removes one usage of ParentThread in FEXCore.