### PR TITLE
FEXCore: Fixes imul returning garbage data

### DIFF
--- a/unittests/32Bit_ASM/FEX_bugs/IMUL_garbagedata.asm
+++ b/unittests/32Bit_ASM/FEX_bugs/IMUL_garbagedata.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x000000007dbf2800",
+    "RDX": "0x0000000000000000",
+    "RBX": "0x000000000000004f",
+    "RCX": "0x000000000000004f",
+    "RBP": "0x0000000000009e4f",
+    "RSI": "0x0000000000009e4f",
+    "RSP": "0x000000000000004f"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; FEX had a bug where smaller than 64-bit imul could leave garbage data in the upper 32-bits of the 32-bit result.
+; This would cause subsequent instructions after the imul to receive garbage bits.
+; In particular this would feed in to address calculation in DXVK with "Dungeon Defenders" doing address calculation.
+; The address calculation did something similar to:
+;   xor edx, edx
+;   mov eax, 0x7dbf2800
+;   imul ebx, ebx, 0xaaaaaaab
+;   div ebx
+; Divide expected 0x4f but received 0xffffffb1'0000'004f
+
+; Dividend
+xor edx, edx
+mov eax, 0x7dbf2800
+
+; Multiply starting value
+mov ebx, 0xED
+
+jmp .test
+
+.test:
+
+; imul 1-src
+mov edi, 0xaaaaaaab
+imul di, bx
+mov esp, 0xaaaaaaab
+imul esp, ebx
+
+; imul 2-src 8-bit check
+imul bp, bx, 0xab
+imul esi, ebx, 0xab
+
+; imul 2-src 16-bit check
+imul cx, bx, 0xaaab
+imul ebx, ebx, 0xaaaaaaab
+
+hlt


### PR DESCRIPTION
When a 32-bit imul was being executed it had a chance of returning garbage data in the upper 32-bits of the 64-bit result. While this didn't typically cause problems, this gets exacerbated from 32-bit applications executing multiplies for address calculations.

A combination of commits 714669136086cee0d2cc4dfb479e26b204206c37 and d01b457727208fd34511d48e850e3b4a33d76147 exposed this problem where previously there would be multiple moves between the calculation and data use which would have zero'd the upper bits for us previously.

Now that we are no longer doing that, we need to make sure the opcode dispatcher doesn't generate broken code instead.

Fixes Dungeon Defenders, which hasn't worked since FEX-2308.

Adds an ASM test that ensures we don't break it again.