### PR TITLE
FEXCore: Moves OS thread creation to the frontend 

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -117,7 +117,8 @@ namespace FEXCore::Context {
        *    - CTX->RunUntilExit(Thread);
        *  OS thread Creation:
        *    - Thread = CreateThread(0, 0, NewState, PPID);
-       *    - InitializeThread(Thread);
+       *    - Thread->ExecutionThread = FEXCore::Threads::Thread::Create(ThreadHandler, Arg);
+       *    - ThreadHandler calls `CTX->ExecutionThread(Thread)`
        *  OS fork (New thread created with a clone of thread state):
        *    - clone{2, 3}
        *    - Thread = CreateThread(0, 0, CopyOfThreadState, PPID);
@@ -132,14 +133,6 @@ namespace FEXCore::Context {
 
       // Public for threading
       void ExecutionThread(FEXCore::Core::InternalThreadState *Thread) override;
-      /**
-       * @brief Initializes the OS thread object and prepares to start executing on that new OS thread
-       *
-       * @param Thread The internal FEX thread state object
-       *
-       * The OS thread will wait until RunThread is executed
-       */
-      void InitializeThread(FEXCore::Core::InternalThreadState *Thread) override;
       /**
        * @brief Starts the OS thread object to start executing guest code
        *

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -256,7 +256,6 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual FEXCore::Core::InternalThreadState* CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::Core::CPUState *NewThreadState = nullptr, uint64_t ParentTID = 0) = 0;
 
       FEX_DEFAULT_VISIBILITY virtual void ExecutionThread(FEXCore::Core::InternalThreadState *Thread) = 0;
-      FEX_DEFAULT_VISIBILITY virtual void InitializeThread(FEXCore::Core::InternalThreadState *Thread) = 0;
       FEX_DEFAULT_VISIBILITY virtual void RunThread(FEXCore::Core::InternalThreadState *Thread) = 0;
       FEX_DEFAULT_VISIBILITY virtual void StopThread(FEXCore::Core::InternalThreadState *Thread) = 0;
       FEX_DEFAULT_VISIBILITY virtual void DestroyThread(FEXCore::Core::InternalThreadState *Thread) = 0;


### PR DESCRIPTION
~~Needs #3294 merged first.~~

Fairly lightweight since it is almost 1:1 transplanting the code from
FEXCore in to the SyscallHandler's thread creation code.

Minor changes:
- ExecutionThreadHandler gets freed before executing the thread
   - Saves 16-bytes of memory per thread
- Start all threads paused by default
   - Since I moved the code to the frontend, I noticed we needed to do
     some post thread-creation setup.
   - Without the pause we were racing code execution with TLS setup and
     a few other things.