### PR TITLE
FEXCore: Removes GetProgramStatus

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -91,8 +91,6 @@ namespace FEXCore::Context {
       void CompileRIP(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP) override;
       void CompileRIPCount(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst) override;
 
-      int GetProgramStatus() const override;
-
       bool IsDone() const override;
 
       void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) override;

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -509,10 +509,6 @@ namespace FEXCore::Context {
     Dispatcher->ExecuteDispatch(Thread->CurrentFrame);
   }
 
-  int ContextImpl::GetProgramStatus() const {
-    return ParentThread->StatusCode;
-  }
-
   struct ExecutionThreadHandler {
     ContextImpl *This;
     FEXCore::Core::InternalThreadState *Thread;

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -202,16 +202,6 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual void CompileRIPCount(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst) = 0;
 
       /**
-       * @brief Gets the program exit status
-       *
-       *
-       * @param CTX The context that we created
-       *
-       * @return The program exit status
-       */
-      FEX_DEFAULT_VISIBILITY virtual int GetProgramStatus() const = 0;
-
-      /**
        * @brief [[theadsafe]] Checks if the Context is either done working or paused(in the case of single stepping)
        *
        * Use this when the context is async running to determine if it is done

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -481,7 +481,8 @@ int main(int argc, char **argv, char **const envp) {
   if (GdbServer) {
     DebugServer = fextl::make_unique<FEX::GdbServer>(CTX.get(), SignalDelegation.get(), SyscallHandler.get());
   }
-  CTX->InitCore(Loader.DefaultRIP(), Loader.GetStackPointer());
+
+  auto ParentThread = CTX->InitCore(Loader.DefaultRIP(), Loader.GetStackPointer());
 
   // Pass in our VDSO thunks
   CTX->AppendThunkDefinitions(FEX::VDSO::GetVDSOThunkDefinitions());
@@ -557,7 +558,7 @@ int main(int argc, char **argv, char **const envp) {
     }
   }
 
-  auto ProgramStatus = CTX->GetProgramStatus();
+  auto ProgramStatus = ParentThread->StatusCode;
 
   DebugServer.reset();
   SyscallHandler.reset();


### PR DESCRIPTION
Split from #3284 without changing ownership semantics while I reduce the debugging surface here.

Removes one usage of ParentThread from FEXCore. Which can be done since it is no longer an opaque structure, we can read the StatusCode directly.

No functional change.