### PR TITLE
FEXCore: Removes InitializeContext API

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -26,12 +26,6 @@ namespace FEXCore::Context {
     return fextl::make_unique<FEXCore::Context::ContextImpl>();
   }
 
-  bool FEXCore::Context::ContextImpl::InitializeContext() {
-    // This should be used for generating things that are shared between threads
-    CPUID.Init(this);
-    return true;
-  }
-
   void FEXCore::Context::ContextImpl::SetExitHandler(ExitHandler handler) {
     CustomExitHandler = std::move(handler);
   }

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -72,8 +72,6 @@ namespace FEXCore::Context {
   class ContextImpl final : public FEXCore::Context::Context {
     public:
       // Context base class implementation.
-      bool InitializeContext() override;
-
       FEXCore::Core::InternalThreadState* InitCore(uint64_t InitialRIP, uint64_t StackPointer) override;
 
       void SetExitHandler(ExitHandler handler) override;

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -99,6 +99,8 @@ namespace FEXCore::Context {
 
     // Track atomic TSO emulation configuration.
     UpdateAtomicTSOEmulationConfig();
+
+    CPUID.Init(this);
   }
 
   ContextImpl::~ContextImpl() {

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -117,16 +117,6 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY static fextl::unique_ptr<FEXCore::Context::Context> CreateNewContext();
 
       /**
-       * @brief Post creation context initialization
-       * Once configurations have been set, do the post-creation initialization with that configuration
-       *
-       * @param CTX The context that we created
-       *
-       * @return true if we managed to initialize correctly
-       */
-      FEX_DEFAULT_VISIBILITY virtual bool InitializeContext() = 0;
-
-      /**
        * @brief Allows setting up in memory code and other things prior to launchign code execution
        *
        * @param CTX The context that we created

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -553,7 +553,6 @@ int main(int argc, char **argv, char **const envp) {
   // Create FEXCore context.
   auto CTX = FEXCore::Context::Context::CreateNewContext();
 
-  CTX->InitializeContext();
   auto SignalDelegation = FEX::DummyHandlers::CreateSignalDelegator();
   auto SyscallHandler = FEX::DummyHandlers::CreateSyscallHandler();
 

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -444,7 +444,6 @@ int main(int argc, char **argv, char **const envp) {
   FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
 
   auto CTX = FEXCore::Context::Context::CreateNewContext();
-  CTX->InitializeContext();
 
   // Setup TSO hardware emulation immediately after initializing the context.
   FEX::TSO::SetupTSOEmulation(CTX.get());

--- a/Source/Tools/FEXLoader/IRLoader.cpp
+++ b/Source/Tools/FEXLoader/IRLoader.cpp
@@ -160,7 +160,6 @@ int main(int argc, char **argv, char **const envp)
 
   FEXCore::Context::InitializeStaticTables();
   auto CTX = FEXCore::Context::Context::CreateNewContext();
-  CTX->InitializeContext();
 
   auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), {});
 

--- a/Source/Tools/FEXLoader/TestHarnessRunner.cpp
+++ b/Source/Tools/FEXLoader/TestHarnessRunner.cpp
@@ -245,8 +245,6 @@ int main(int argc, char **argv, char **const envp) {
 
   auto CTX = FEXCore::Context::Context::CreateNewContext();
 
-  CTX->InitializeContext();
-
 #ifndef _WIN32
   auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), {});
 #else

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -515,7 +515,6 @@ void BTCpuProcessInit() {
   SyscallHandler = fextl::make_unique<WowSyscallHandler>();
 
   CTX = FEXCore::Context::Context::CreateNewContext();
-  CTX->InitializeContext();
   CTX->SetSignalDelegator(SignalDelegator.get());
   CTX->SetSyscallHandler(SyscallHandler.get());
   CTX->InitCore(0, 0);


### PR DESCRIPTION
This isn't necessary anymore, just initialize everything on context creation immediately. All use cases just called this immediately afterwards.