### PR TITLE
Dispatcher: Fixes corruption when spilling SRA registers

### DIFF
--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -85,7 +85,9 @@ public:
 #endif
 
   uint16_t GetSRAGPRCount() const {
-    return StaticRegisters.size();
+    // PF/AF are the final two SRA registers.
+    // Only return the SRA for GPRs.
+    return StaticRegisters.size() - 2;
   }
 
   uint16_t GetSRAFPRCount() const {
@@ -93,7 +95,7 @@ public:
   }
 
   void GetSRAGPRMapping(uint8_t Mapping[16]) const {
-    for (size_t i = 0; i < StaticRegisters.size(); ++i) {
+    for (size_t i = 0; i < StaticRegisters.size() - 2; ++i) {
       Mapping[i] = StaticRegisters[i].Idx();
     }
   }


### PR DESCRIPTION
These functions only want the GPRs returned for SRA. This is because the signal handler needs this map to relation between x86 GPRs and AArch64 GPRs.

When we added AF and PF to the SRA array we accidentally started returning two more GPRs to the frontend. This caused the signal delegator to start corrupting the members after GPRs in FEX's CoreState.

Corrupting 16-bytes after the gregs[] array.
This included corrupting:
   - es_idx, cs_idx, ss_idx, ds_idx, gs_idx, fs_idx, _pad[]