### PR TITLE
JIT: Fixes crash in TestNZ

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -122,7 +122,7 @@ DEF_OP(SbbNZCV) {
 
 DEF_OP(TestNZ) {
   auto Op = IROp->C<IR::IROp_TestNZ>();
-  const uint8_t OpSize = Op->Size;
+  const uint8_t OpSize = IROp->Size;
   const auto EmitSize = OpSize == 8 ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
 
   uint64_t Const;

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1295,7 +1295,7 @@ private:
   }
 
   void SetNZ_ZeroCV(unsigned SrcSize, OrderedNode *Res) {
-    _TestNZ(SrcSize, Res, Res);
+    _TestNZ(IR::SizeToOpSize(SrcSize), Res, Res);
     CachedNZCV = _LoadNZCV();
     PossiblySetNZCVBits = (1u << 31) | (1u << 30);
     NZCVDirty = false;

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1083,8 +1083,9 @@
           "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
-      "TestNZ u8:$Size, GPR:$Src1, GPR:$Src2": {
+      "TestNZ OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Set NZCV for the binary AND of two GPRs, setting N and Z accordingly and zeroing C and V"],
+        "DestSize": "Size",
         "HasSideEffects": true
       },
       "GPR = Lshl OpSize:#Size, GPR:$Src1, GPR:$Src2": {

--- a/unittests/ASM/FEX_bugs/ShiftConstantBug.asm
+++ b/unittests/ASM/FEX_bugs/ShiftConstantBug.asm
@@ -1,0 +1,15 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x500000020"
+  }
+}
+%endif
+
+; FEX had a bug in its `TestNZ` opcode where it would try to load a constant in to the tst instruction
+; If the constant didn't fit in a logical encoding it would generate invalid instructions and also crash.
+; This snippet of code was found in libGLX.so.0.0.0 when trying to load steamwebhelper.
+mov     eax, 0x28000001
+shl     rax, 0x5
+
+hlt


### PR DESCRIPTION
In some situations TestNZ is generated with a constant that is using a
constant that can't fit inside of the tst instruction.

This was found in libGLX with virgl, crashing invalid instruction
generation and crashing steamwebhelper