### PR TITLE
IR: Moves remaining NZCV operations to use DestSize

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -87,7 +87,7 @@ DEF_OP(Add) {
 
 DEF_OP(AddNZCV) {
   auto Op = IROp->C<IR::IROp_AddNZCV>();
-  const IR::OpSize OpSize = Op->Size;
+  const auto OpSize = IROp->Size;
 
   LOGMAN_THROW_AA_FMT(OpSize == IR::i32Bit || OpSize == IR::i64Bit, "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = OpSize == IR::i64Bit ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
@@ -102,7 +102,7 @@ DEF_OP(AddNZCV) {
 
 DEF_OP(AdcNZCV) {
   auto Op = IROp->C<IR::IROp_AdcNZCV>();
-  const IR::OpSize OpSize = Op->Size;
+  const auto OpSize = IROp->Size;
 
   LOGMAN_THROW_AA_FMT(OpSize == IR::i32Bit || OpSize == IR::i64Bit, "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = OpSize == IR::i64Bit ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
@@ -112,7 +112,7 @@ DEF_OP(AdcNZCV) {
 
 DEF_OP(SbbNZCV) {
   auto Op = IROp->C<IR::IROp_SbbNZCV>();
-  const IR::OpSize OpSize = Op->Size;
+  const auto OpSize = IROp->Size;
 
   LOGMAN_THROW_AA_FMT(OpSize == IR::i32Bit || OpSize == IR::i64Bit, "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = OpSize == IR::i64Bit ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
@@ -184,7 +184,7 @@ DEF_OP(SubShift) {
 
 DEF_OP(SubNZCV) {
   auto Op = IROp->C<IR::IROp_SubNZCV>();
-  const IR::OpSize OpSize = Op->Size;
+  const auto OpSize = IROp->Size;
 
   LOGMAN_THROW_AA_FMT(OpSize == IR::i32Bit || OpSize == IR::i64Bit, "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = OpSize == IR::i64Bit ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
@@ -247,7 +247,7 @@ ARMEmitter::Condition MapSelectCC(IR::CondClassType Cond) {
 
 DEF_OP(CondAddNZCV) {
   auto Op = IROp->C<IR::IROp_CondAddNZCV>();
-  const IR::OpSize OpSize = Op->Size;
+  const auto OpSize = IROp->Size;
 
   LOGMAN_THROW_AA_FMT(OpSize == IR::i32Bit || OpSize == IR::i64Bit, "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = OpSize == IR::i64Bit ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -953,11 +953,12 @@
           "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
-      "AddNZCV OpSize:$Size, GPR:$Src1, GPR:$Src2": {
+      "AddNZCV OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Set NZCV for the sum of two GPRs"],
         "HasSideEffects": true,
+        "DestSize": "Size",
         "EmitValidation": [
-          "_Size == FEXCore::IR::OpSize::i32Bit || _Size == FEXCore::IR::OpSize::i64Bit"
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
       "CarryInvert": {
@@ -972,25 +973,28 @@
         "Desc": ["Rotate, mask, and insert into NZCV on FlagM platforms"],
         "HasSideEffects": true
       },
-      "CondAddNZCV OpSize:$Size, GPR:$Src1, GPR:$Src2, CondClass:$Cond, u8:$FalseNZCV": {
+      "CondAddNZCV OpSize:#Size, GPR:$Src1, GPR:$Src2, CondClass:$Cond, u8:$FalseNZCV": {
         "Desc": ["If condition is true, set NZCV per sum of GPRs, else force NZCV to a constant."],
         "HasSideEffects": true,
+        "DestSize": "Size",
         "EmitValidation": [
-          "_Size == FEXCore::IR::OpSize::i32Bit || _Size == FEXCore::IR::OpSize::i64Bit"
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
-      "AdcNZCV OpSize:$Size, GPR:$Src1, GPR:$Src2": {
+      "AdcNZCV OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Set NZCV for the sum of two GPRs and carry-in given as NZCV"],
         "HasSideEffects": true,
+        "DestSize": "Size",
         "EmitValidation": [
-          "_Size == FEXCore::IR::OpSize::i32Bit || _Size == FEXCore::IR::OpSize::i64Bit"
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
-      "SbbNZCV OpSize:$Size, GPR:$Src1, GPR:$Src2": {
+      "SbbNZCV OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Set NZCV for the difference of two GPRs and carry-in given as NZCV"],
         "HasSideEffects": true,
+        "DestSize": "Size",
         "EmitValidation": [
-          "_Size == FEXCore::IR::OpSize::i32Bit || _Size == FEXCore::IR::OpSize::i64Bit"
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
       "GPR = Sub OpSize:#Size, GPR:$Src1, GPR:$Src2": {
@@ -1012,13 +1016,14 @@
           "_Shift != ShiftType::ROR"
         ]
       },
-      "SubNZCV OpSize:$Size, GPR:$Src1, GPR:$Src2": {
+      "SubNZCV OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Set NZCV for the difference of two GPRs. ",
                  "Carry flag uses arm64 definition, inverted x86.",
                  ""],
+        "DestSize": "Size",
         "HasSideEffects": true,
         "EmitValidation": [
-          "_Size == FEXCore::IR::OpSize::i32Bit || _Size == FEXCore::IR::OpSize::i64Bit"
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
       "GPR = Or OpSize:#Size, GPR:$Src1, GPR:$Src2": {


### PR DESCRIPTION
Just like in #3305 but wasn't causing any known issues