### PR TITLE
FEXLoader: Fix incorrect format strings

### DIFF
--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -461,7 +461,7 @@ int main(int argc, char **argv, char **const envp) {
 
     if (!Loader.MapMemory(SyscallHandler.get())) {
       // failed to map
-      LogMan::Msg::EFmt("Failed to map %d-bit elf file.", Loader.Is64BitMode() ? 64 : 32);
+      LogMan::Msg::EFmt("Failed to map {}-bit elf file.", Loader.Is64BitMode() ? 64 : 32);
       return -ENOEXEC;
     }
   }

--- a/Source/Tools/FEXLoader/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/x64/Syscalls.cpp
@@ -108,7 +108,7 @@ namespace FEX::HLE::x64 {
 #if PRINT_MISSING_SYSCALLS
     for (auto &Syscall: SyscallNames) {
       if (Definitions[Syscall.first].Ptr == cvt(&UnimplementedSyscall)) {
-        LogMan::Msg::DFmt("Unimplemented syscall: %s", Syscall.second);
+        LogMan::Msg::DFmt("Unimplemented syscall: {}", Syscall.second);
       }
     }
 #endif

--- a/Source/Tools/FEXLoader/TestHarnessRunner.cpp
+++ b/Source/Tools/FEXLoader/TestHarnessRunner.cpp
@@ -294,7 +294,7 @@ int main(int argc, char **argv, char **const envp) {
     // Run through FEX
     if (!Loader.MapMemory()) {
       // failed to map
-      LogMan::Msg::EFmt("Failed to map %d-bit elf file.", Loader.Is64BitMode() ? 64 : 32);
+      LogMan::Msg::EFmt("Failed to map {}-bit elf file.", Loader.Is64BitMode() ? 64 : 32);
       return -ENOEXEC;
     }
 
@@ -324,7 +324,7 @@ int main(int argc, char **argv, char **const envp) {
     SignalDelegation->RegisterTLSState((FEXCore::Core::InternalThreadState*)UINTPTR_MAX);
     if (!Loader.MapMemory()) {
       // failed to map
-      LogMan::Msg::EFmt("Failed to map %d-bit elf file.", Loader.Is64BitMode() ? 64 : 32);
+      LogMan::Msg::EFmt("Failed to map {}-bit elf file.", Loader.Is64BitMode() ? 64 : 32);
       return -ENOEXEC;
     }
 


### PR DESCRIPTION
These appear to have slipped through the migration to fmt syntax.
