### PR TITLE
Linux: Adjust when clone allocates stack memory

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/Syscalls.h
@@ -432,6 +432,10 @@ enum TypeOfClone {
 struct clone3_args {
   TypeOfClone Type;
   uint64_t SignalMask;
+
+  uint64_t StackSize;
+  void *NewStack;
+
   kernel_clone3_args args;
 };
 


### PR DESCRIPTION
clone needs to allocate memory before the fork locks are held, otherwise they will hang forever waiting on a locked mutex.

This wasn't previously seen since nothing was using fork with clone3.