### PR TITLE
Library Forwarding: Emit layout helpers to allow repacking struct data

### DIFF
--- a/ThunkLibs/Generator/analysis.cpp
+++ b/ThunkLibs/Generator/analysis.cpp
@@ -62,7 +62,6 @@ static NamespaceAnnotations GetNamespaceAnnotations(clang::ASTContext& context, 
 enum class CallbackStrategy {
     Default,
     Stub,
-    Guest,
 };
 
 struct Annotations {
@@ -88,8 +87,6 @@ static Annotations GetAnnotations(clang::ASTContext& context, clang::CXXRecordDe
             ret.custom_host_impl = true;
         } else if (annotation == "fexgen::callback_stub") {
             ret.callback_strategy = CallbackStrategy::Stub;
-        } else if (annotation == "fexgen::callback_guest") {
-            ret.callback_strategy = CallbackStrategy::Guest;
         } else if (annotation == "fexgen::custom_guest_entrypoint") {
             ret.custom_guest_entrypoint = true;
         } else {
@@ -376,15 +373,10 @@ void AnalysisAction::ParseInterface(clang::ASTContext& context) {
                                 callback.param_types.push_back(cb_param);
                             }
                             callback.is_stub = annotations.callback_strategy == CallbackStrategy::Stub;
-                            callback.is_guest = annotations.callback_strategy == CallbackStrategy::Guest;
                             callback.is_variadic = funcptr->isVariadic();
 
-                            if (callback.is_guest && !data.custom_host_impl) {
-                                throw report_error(template_arg_loc, "callback_guest can only be used with custom_host_impl");
-                            }
-
                             data.callbacks.emplace(param_idx, callback);
-                            if (!callback.is_stub && !callback.is_guest && !data.custom_host_impl) {
+                            if (!callback.is_stub && !data.custom_host_impl) {
                                 thunked_funcptrs[emitted_function->getNameAsString() + "_cb" + std::to_string(param_idx)] = std::pair { context.getCanonicalType(funcptr), no_param_annotations };
                             }
 

--- a/ThunkLibs/Generator/analysis.h
+++ b/ThunkLibs/Generator/analysis.h
@@ -18,7 +18,6 @@ struct ThunkedCallback : FunctionParams {
     clang::QualType return_type;
 
     bool is_stub = false;  // Callback will be replaced by a stub that calls std::abort
-    bool is_guest = false; // Callback will never be called on the host
     bool is_variadic = false;
 };
 

--- a/ThunkLibs/Generator/analysis.h
+++ b/ThunkLibs/Generator/analysis.h
@@ -119,6 +119,9 @@ public:
     struct RepackedType {
         bool assumed_compatible = false;         // opaque_type or assume_compatible_data_layout
         bool pointers_only = assumed_compatible; // if true, only pointers to this type may be used
+
+        // If true, emit guest_layout/host_layout definitions even if the type is non-repackable
+        bool emit_layout_wrappers = false;
     };
 
 protected:

--- a/ThunkLibs/Generator/data_layout.cpp
+++ b/ThunkLibs/Generator/data_layout.cpp
@@ -85,6 +85,7 @@ std::unordered_map<const clang::Type*, TypeInfo> ComputeDataLayout(const clang::
                 .type_name = get_type_name(context, field_type),
                 .member_name = field->getNameAsString(),
                 .array_size = array_size,
+                .is_function_pointer = field_type->isFunctionPointerType(),
             };
 
             // TODO: Process types in dependency-order. Currently we skip this

--- a/ThunkLibs/Generator/data_layout.h
+++ b/ThunkLibs/Generator/data_layout.h
@@ -114,6 +114,6 @@ public:
 
     FuncPtrInfo LookupGuestFuncPtrInfo(const char* funcptr_id);
 
-private:
+protected:
     const ABI& guest_abi;
 };

--- a/ThunkLibs/Generator/data_layout.h
+++ b/ThunkLibs/Generator/data_layout.h
@@ -28,13 +28,15 @@ struct StructInfo : SimpleTypeInfo {
         std::string type_name;
         std::string member_name;
         std::optional<uint64_t> array_size;
+        bool is_function_pointer;
 
         bool operator==(const MemberInfo& other) const {
             return  size_bits == other.size_bits &&
                     offset_bits == other.offset_bits &&
                     type_name == other.type_name &&
                     member_name == other.member_name &&
-                    array_size == other.array_size;
+                    array_size == other.array_size &&
+                    is_function_pointer == other.is_function_pointer;
         }
     };
 

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -190,7 +190,7 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
                 auto cb = data.callbacks.find(idx);
 
                 file << "  args.a_" << idx << " = ";
-                if (cb == data.callbacks.end() || cb->second.is_stub || cb->second.is_guest) {
+                if (cb == data.callbacks.end() || cb->second.is_stub) {
                     file << "a_" << idx << ";\n";
                 } else {
                     // Before passing guest function pointers to the host, wrap them in a host-callable trampoline
@@ -270,15 +270,11 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
             if (thunk.custom_host_impl) {
                 file << "static auto fexfn_impl_" << libname << "_" << function_name << "(";
                 for (std::size_t idx = 0; idx < thunk.param_types.size(); ++idx) {
-                    // TODO: fex_guest_function_ptr for guest callbacks?
                     auto& type = thunk.param_types[idx];
 
                     file << (idx == 0 ? "" : ", ");
 
-                    auto cb = thunk.callbacks.find(idx);
-                    if (cb != thunk.callbacks.end() && cb->second.is_guest) {
-                        file << "fex_guest_function_ptr a_" << idx;
-                    } else if (thunk.param_annotations[idx].is_passthrough) {
+                    if (thunk.param_annotations[idx].is_passthrough) {
                         fmt::print(file, "guest_layout<{}> a_{}", type.getAsString(), idx);
                     } else {
                         file << format_decl(type, fmt::format("a_{}", idx));
@@ -373,8 +369,6 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
                     auto cb = thunk.callbacks.find(idx);
                     if (cb != thunk.callbacks.end() && cb->second.is_stub) {
                         return "fexfn_unpack_" + get_callback_name(function_name, cb->first) + "_stub";
-                    } else if (cb != thunk.callbacks.end() && cb->second.is_guest) {
-                        return fmt::format("fex_guest_function_ptr {{ {} }}", raw_arg);
                     } else if (cb != thunk.callbacks.end()) {
                         auto arg_name = fmt::format("args->a_{}.data", idx);
                         // Use comma operator to inject a function call before returning the argument

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -174,7 +174,7 @@ void GenerateThunkLibsAction::EmitLayoutWrappers(
             // Disallow use of layout wrappers for this type by specializing without a definition
             fmt::print(file, "template<>\nstruct guest_layout<{}>;\n", struct_name);
             fmt::print(file, "template<>\nstruct host_layout<{}>;\n", struct_name);
-            fmt::print(file, "guest_layout<{}> to_guest(const host_layout<{}>&) = delete;\n", struct_name, struct_name);
+            fmt::print(file, "guest_layout<{}>& to_guest(const host_layout<{}>&) = delete;\n", struct_name, struct_name);
             continue;
         }
 

--- a/ThunkLibs/include/common/GeneratorInterface.h
+++ b/ThunkLibs/include/common/GeneratorInterface.h
@@ -12,6 +12,11 @@ struct callback_annotation_base {
 };
 struct callback_stub : callback_annotation_base {};
 
+// Type annotation to indicate that guest_layout/host_layout definitions should
+// be emitted even if the type is non-repackable. Pointer members will be
+// copied (or zero-extended) without regard for the referred data.
+struct emit_layout_wrappers {};
+
 struct type_annotation_base { bool prevent_multiple; };
 
 // Pointers to types annotated with this will be passed through without change

--- a/ThunkLibs/include/common/GeneratorInterface.h
+++ b/ThunkLibs/include/common/GeneratorInterface.h
@@ -11,7 +11,6 @@ struct callback_annotation_base {
     bool prevent_multiple;
 };
 struct callback_stub : callback_annotation_base {};
-struct callback_guest : callback_annotation_base {};
 
 struct type_annotation_base { bool prevent_multiple; };
 

--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -48,27 +48,6 @@ struct ExportEntry { uint8_t* sha256; void(*fn)(void *); };
 
 typedef void fex_call_callback_t(uintptr_t callback, void *arg0, void* arg1);
 
-/**
- * Opaque wrapper around a guest function pointer.
- *
- * This prevents accidental calls to foreign function pointers while still
- * allowing us to label function pointers as such.
- */
-struct fex_guest_function_ptr {
-private:
-    void* value = nullptr;
-
-public:
-    fex_guest_function_ptr() = default;
-
-    template<typename Ret, typename... Args>
-    fex_guest_function_ptr(Ret (*ptr)(Args...)) : value(reinterpret_cast<void*>(ptr)) {}
-
-    inline operator bool() const {
-      return value != nullptr;
-    }
-};
-
 #define EXPORTS(name) \
   extern "C" { \
     ExportEntry* fexthunks_exports_##name() { \

--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -125,6 +125,24 @@ struct host_layout {
   }
 };
 
+// Explicitly turn a host type into its corresponding host_layout
+template<typename T>
+const host_layout<T>& to_host_layout(const T& t) {
+  static_assert(std::is_same_v<decltype(host_layout<T>::data), T>);
+  return reinterpret_cast<const host_layout<T>&>(t);
+}
+
+template<typename T>
+inline guest_layout<T> to_guest(const host_layout<T>& from) {
+  if constexpr (std::is_enum_v<T>) {
+    // enums are represented by fixed-size integers in guest_layout, so explicitly cast them
+    return guest_layout<T> { static_cast<std::underlying_type_t<T>>(from.data) };
+  } else {
+    guest_layout<T> ret { .data = from.data };
+    return ret;
+  }
+}
+
 template<typename>
 struct CallbackUnpack;
 

--- a/ThunkLibs/libvulkan/Host.cpp
+++ b/ThunkLibs/libvulkan/Host.cpp
@@ -77,11 +77,21 @@ static VkResult FEXFN_IMPL(vkCreateInstance)(const VkInstanceCreateInfo* a_0, co
     }
   }
 
-  return LDR_PTR(vkCreateInstance)(vk_struct_base, nullptr, a_2.data);
+  VkInstance out;
+  auto ret = LDR_PTR(vkCreateInstance)(vk_struct_base, nullptr, &out);
+  if (ret == VK_SUCCESS) {
+    *a_2.get_pointer() = to_guest(to_host_layout(out));
+  }
+  return ret;
 }
 
 static VkResult FEXFN_IMPL(vkCreateDevice)(VkPhysicalDevice a_0, const VkDeviceCreateInfo* a_1, const VkAllocationCallbacks* a_2, guest_layout<VkDevice*> a_3){
-  return LDR_PTR(vkCreateDevice)(a_0, a_1, nullptr, a_3.data);
+  VkDevice out;
+  auto ret = LDR_PTR(vkCreateDevice)(a_0, a_1, nullptr, &out);
+  if (ret == VK_SUCCESS) {
+    *a_3.get_pointer() = to_guest(to_host_layout(out));
+  }
+  return ret;
 }
 
 static VkResult FEXFN_IMPL(vkAllocateMemory)(VkDevice a_0, const VkMemoryAllocateInfo* a_1, const VkAllocationCallbacks* a_2, VkDeviceMemory* a_3){
@@ -95,7 +105,7 @@ static void FEXFN_IMPL(vkFreeMemory)(VkDevice a_0, VkDeviceMemory a_1, const VkA
 }
 
 static VkResult FEXFN_IMPL(vkCreateDebugReportCallbackEXT)(VkInstance a_0, guest_layout<const VkDebugReportCallbackCreateInfoEXT*> a_1, const VkAllocationCallbacks* a_2, VkDebugReportCallbackEXT* a_3) {
-  VkDebugReportCallbackCreateInfoEXT overridden_callback = *a_1.data;
+  auto overridden_callback = host_layout<VkDebugReportCallbackCreateInfoEXT> { *a_1.get_pointer() }.data;
   overridden_callback.pfnCallback = DummyVkDebugReportCallback;
   (void*&)LDR_PTR(vkCreateDebugReportCallbackEXT) = (void*)LDR_PTR(vkGetInstanceProcAddr)(a_0, "vkCreateDebugReportCallbackEXT");
   return LDR_PTR(vkCreateDebugReportCallbackEXT)(a_0, &overridden_callback, nullptr, a_3);
@@ -115,7 +125,7 @@ extern "C" VkBool32 DummyVkDebugUtilsMessengerCallback(
 static VkResult FEXFN_IMPL(vkCreateDebugUtilsMessengerEXT)(
     VkInstance_T* a_0, guest_layout<const VkDebugUtilsMessengerCreateInfoEXT*> a_1,
     const VkAllocationCallbacks* a_2, VkDebugUtilsMessengerEXT* a_3) {
-  VkDebugUtilsMessengerCreateInfoEXT overridden_callback = *a_1.data;
+  auto overridden_callback = host_layout<VkDebugUtilsMessengerCreateInfoEXT> { *a_1.get_pointer() }.data;
   overridden_callback.pfnUserCallback = DummyVkDebugUtilsMessengerCallback;
   (void*&)LDR_PTR(vkCreateDebugUtilsMessengerEXT) = (void*)LDR_PTR(vkGetInstanceProcAddr)(a_0, "vkCreateDebugUtilsMessengerEXT");
   return LDR_PTR(vkCreateDebugUtilsMessengerEXT)(a_0, &overridden_callback, nullptr, a_3);

--- a/ThunkLibs/libvulkan/libvulkan_interface.cpp
+++ b/ThunkLibs/libvulkan/libvulkan_interface.cpp
@@ -52,6 +52,11 @@ template<> struct fex_gen_type<VkDeviceOrHostAddressConstKHR> : fexgen::assume_c
 template<> struct fex_gen_type<VkPerformanceValueDataINTEL> : fexgen::assume_compatible_data_layout {};
 #endif
 
+// Structures that contain function pointers
+// TODO: Use custom repacking for these instead
+template<> struct fex_gen_type<VkDebugReportCallbackCreateInfoEXT> : fexgen::emit_layout_wrappers {};
+template<> struct fex_gen_type<VkDebugUtilsMessengerCreateInfoEXT> : fexgen::emit_layout_wrappers {};
+
 #ifndef IS_32BIT_THUNK
 // The pNext member of this is a pointer to another VkBaseOutStructure, so data layout compatibility can't be inferred automatically
 template<> struct fex_gen_type<VkBaseOutStructure> : fexgen::assume_compatible_data_layout {};

--- a/ThunkLibs/libwayland-client/Host.cpp
+++ b/ThunkLibs/libwayland-client/Host.cpp
@@ -60,7 +60,7 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
     // ? just indicates that the argument may be null, so it doesn't change the signature
     signature.erase(std::remove(signature.begin(), signature.end(), '?'), signature.end());
 
-    auto callback = callback_raw.data[i];
+    auto callback = reinterpret_cast<void(*)()>(uintptr_t { callback_raw.get_pointer()[i].data });
 
     if (signature == "") {
       // E.g. xdg_toplevel::close
@@ -162,7 +162,9 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
   }
 
   // Pass the original function pointer table to the host wayland library. This ensures the table is valid until the listener is unregistered.
-  return fexldr_ptr_libwayland_client_wl_proxy_add_listener(proxy, callback_raw.data, data);
+  return fexldr_ptr_libwayland_client_wl_proxy_add_listener(proxy,
+                                                            reinterpret_cast<void(**)(void)>(callback_raw.get_pointer()),
+                                                            data);
 }
 
 wl_interface* fexfn_impl_libwayland_client_fex_wl_exchange_interface_pointer(wl_interface* guest_interface, char const* name) {

--- a/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
+++ b/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
@@ -30,8 +30,6 @@ TEST_CASE_METHOD(Fixture, "Trivial") {
   CHECK(GetDoubledValue(10) == 20);
 }
 
-// Passing pointers across architecture boundaries is not yet supported on 32-bit
-#if __SIZEOF_POINTER__ != 4
 TEST_CASE_METHOD(Fixture, "Opaque data types") {
   {
     auto data = MakeOpaqueType(0x1234);
@@ -44,4 +42,3 @@ TEST_CASE_METHOD(Fixture, "Opaque data types") {
     CHECK(GetUnionTypeA(&data) == 0x04030201);
   }
 }
-#endif

--- a/unittests/ThunkLibs/common.h
+++ b/unittests/ThunkLibs/common.h
@@ -90,6 +90,8 @@ struct custom_host_impl {};
 struct callback_annotation_base { bool prevent_multiple; };
 struct callback_stub : callback_annotation_base {};
 
+struct emit_layout_wrappers {};
+
 struct opaque_type {};
 struct assume_compatible_data_layout {};
 

--- a/unittests/ThunkLibs/common.h
+++ b/unittests/ThunkLibs/common.h
@@ -89,7 +89,6 @@ struct returns_guest_pointer {};
 struct custom_host_impl {};
 struct callback_annotation_base { bool prevent_multiple; };
 struct callback_stub : callback_annotation_base {};
-struct callback_guest : callback_annotation_base {};
 
 struct opaque_type {};
 struct assume_compatible_data_layout {};

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -436,32 +436,6 @@ TEST_CASE_METHOD(Fixture, "FunctionPointerParameter") {
             )));
 }
 
-// Parameter is a guest function pointer
-TEST_CASE_METHOD(Fixture, "GuestFunctionPointerParameter") {
-    const std::string prelude =
-        "struct fex_guest_function_ptr { int (*x)(char,char); };\n"
-        "static void fexfn_impl_libtest_func(fex_guest_function_ptr) {}\n";
-    const auto output = run_thunkgen(prelude,
-        "#include <thunks_common.h>\n"
-        "void func(int (*funcptr)(char, char));\n"
-        "template<auto> struct fex_gen_config {};\n"
-        "template<> struct fex_gen_config<func> : fexgen::callback_guest, fexgen::custom_host_impl {};\n");
-
-    CHECK_THAT(output.guest,
-        matches(functionDecl(
-            hasName("fexfn_pack_func"),
-            returns(asString("void")),
-            parameterCountIs(1),
-            hasParameter(0, hasType(asString("int (*)(char, char)")))
-        )));
-
-    // Host-side implementation only sees an opaque type that it can't call
-    CHECK_THAT(output.host,
-        matches(callExpr(callee(functionDecl(hasName("fexfn_impl_libtest_func"))),
-                         hasArgument(0, hasType(asStructString("fex_guest_function_ptr")))
-            )));
-}
-
 TEST_CASE_METHOD(Fixture, "MultipleParameters") {
     const std::string prelude =
         "struct TestStruct { int member; };\n";

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -287,14 +287,26 @@ SourceWithAST Fixture::run_thunkgen_host(std::string_view prelude, std::string_v
         "};\n"
         "\n"
         "template<typename T>\n"
+        "struct guest_layout<T*> {\n"
+        "#ifdef IS_32BIT_THUNK\n"
+        "  using type = uint32_t;\n"
+        "#else\n"
+        "  using type = uint64_t;\n"
+        "#endif\n"
+        "  type data;\n"
+        "};\n"
+        "\n"
+        "template<typename T>\n"
         "struct host_layout {\n"
         "  T data;\n"
         "\n"
         "  host_layout(const guest_layout<T>& from);\n"
         "};\n"
         "\n"
-        "template<typename T> guest_layout<T> to_guest(const host_layout<T>& from);\n"
+        "template<typename T> guest_layout<T> to_guest(const host_layout<T>& from) requires(!std::is_pointer_v<T>);\n"
+        "template<typename T> guest_layout<T*> to_guest(const host_layout<T*>& from);\n"
         "template<typename F> void FinalizeHostTrampolineForGuestFunction(F*);\n"
+        "template<typename F> void FinalizeHostTrampolineForGuestFunction(guest_layout<F*>);\n"
         "template<typename T> const host_layout<T>& to_host_layout(const T& t);\n";
 
     auto& filename = output_filenames.host;
@@ -434,7 +446,7 @@ TEST_CASE_METHOD(Fixture, "FunctionPointerParameter") {
             hasDescendant(callExpr(callee(functionDecl(hasName("FinalizeHostTrampolineForGuestFunction"))), hasArgument(0, expr().bind("funcptr"))))
         )).check_binding("funcptr", +[](const clang::Expr* funcptr) {
             // Check that the argument type matches the function pointer
-            return funcptr->getType().getAsString() == "int (*)(char, char)";
+            return funcptr->getType().getAsString() == "guest_layout<int (*)(char, char)>";
         }));
 
     // Host should export the unpacking function for function pointer arguments

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -251,6 +251,7 @@ SourceWithAST Fixture::run_thunkgen_host(std::string_view prelude, std::string_v
     std::string result =
         "#include <array>\n"
         "#include <cstdint>\n"
+        "#include <cstring>\n"
         "#include <dlfcn.h>\n"
         "#include <type_traits>\n"
         "template<typename Fn>\n"
@@ -283,6 +284,13 @@ SourceWithAST Fixture::run_thunkgen_host(std::string_view prelude, std::string_v
         "template<typename T>\n"
         "struct guest_layout {\n"
         "  T data;\n"
+        "};\n"
+        "\n"
+        "template<typename T>\n"
+        "struct host_layout {\n"
+        "  T data;\n"
+        "\n"
+        "  host_layout(const guest_layout<T>& from);\n"
         "};\n"
         "\n"
         "template<typename F> void FinalizeHostTrampolineForGuestFunction(F*);\n";


### PR DESCRIPTION
## Overview

This PR makes the thunk generator emit helper structures to allow repacking `struct`s that have different data layout on the guest than on the host. The new `guest_layout` and `host_layout` wrappers are emitted for each type used in APIs of forwarded libraries. These structures have the same members as the original structure but they are defined in an architecture-agnostic way. This allows the host to read guest structures without having to worry about member offsets, type size differences, or other sorts of differences in the data layout.

There is no *automatic* struct repacking yet, but the wrappers allow for *manual* repacking by converting a `guest_layout` is converted to a `host_layout`, or vice-versa.

See #3156 for the data layout analysis framework that gathers the required metadata.

## Implementation: Layout wrappers

The layout wrappers are only generated for types that don't have consistent data layout between guest and host **and** if they considered "repackable" by the data analysis pass. For non-repackable types, layout wrappers must explicitly be enabled using the new `emit_layout_wrappers` annotation (*no* repacking code will be generated in that case).

`guest_layout` and `host_layout` are C++ templates specialized for each type. This allows a number of utility functions to be defined generically, so that the generator only needs to emit the bare minimum of type-specific information. `guest_layout` maps built-in types to themselves, and it recursively maps structs to structs of `guest_layout`s. For example:
```cpp
template<>
struct guest_layout<VkDisplayModeCreateInfoKHR> {
    struct type {
        guest_layout<VkStructureType>             sType;
        guest_layout<const void*>                 pNext;
        guest_layout<VkDisplayModeCreateFlagsKHR> flags;
        guest_layout<VkDisplayModeParametersKHR>  parameters;
    };
    type data;
};

template<>
struct guest_layout<VkDisplayModeParametersKHR> {
    struct type {
        guest_layout<VkExtent2D> visibleRegion;
        guest_layout<uint32_t>   refreshRate;
    };
    type data;
};

// ...
```

Since these structures are only ever used on the host, `host_layout` is a simple wrapper around the unchanged type *and* a constructor from `guest_layout`. This layer of indirection adds type-safety and makes sure any conversions are intentional:
```cpp
template<>
struct host_layout<VkDisplayModeCreateInfoKHR> {
  using type = VkDisplayModeCreateInfoKHR;
  type data;

  host_layout(const guest_layout<VkDisplayModeCreateInfoKHR>& from) :
    data { from.data } {
  }
};

// ...
```

## Implementation: Struct repacking

Repacking happens whenever a `guest_layout` is converted to a `host_layout`, or vice-versa. To avoid performance overhead or compatibility problems from "accidental" repacking, strong typing is used consistently for these layout wrappers.

Conversion between the unwrapped type and the wrappers is done using the `host_layout` constructor and two utility functions (`to_guest` (host->guest), `to_host_layout` (Type -> host_layout)). This diagram illustrates the different pathways of conversion:
```mermaid
flowchart TD
    Type -->|to_host_layout| A["host_layout&lt;Type&gt"]
    A["host_layout&lt;Type&gt;"] -->|to_guest| G["guest_layout&lt;Type&gt;"]
    G["guest_layout&lt;Type&gt;"] -->|"host_layout()"| A["host_layout&lt;Type&gt"]
    A["host_layout&lt;Type&gt"] -->|.data| Type
```

## Impact

The layout wrappers aren't automatically used anywhere yet, so this has no immediate impact on compatibility or performance.

## Future

The repacking machinery added here is the basis for automatic struct repacking, where parameters passed to forwarded APIs are automatically repacked as needed.

Furthermore, `guest_layout` does not yet take care of size differences of built-in types (`size_t`, ...). A future change will map these to fixed-size integers.

## TODO

- [ ] Assess potential future performance impact
- [x] Fix build problems with old libclang
