### PR TITLE
GdbServer: Fixes crash on gdb detach

### DIFF
--- a/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
+++ b/Source/Tools/FEXLoader/LinuxSyscalls/GdbServer.h
@@ -39,6 +39,7 @@ private:
     void Break(int signal);
 
     void OpenListenSocket();
+    void CloseListenSocket();
     enum class WaitForConnectionResult {
       CONNECTION,
       ERROR,


### PR DESCRIPTION
GdbServer object was getting deleted before the socket thread was shutdown which was causing a crash on detach.

Now on destructor it will wait for the thread to thread to exit.