### PR TITLE
X86Tables: Converts tables to be mostly consteval

### DIFF
--- a/FEXCore/Source/Interface/Core/X86Tables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables.cpp
@@ -12,51 +12,16 @@ $end_info$
 
 namespace FEXCore::X86Tables {
 
-std::array<X86InstInfo, MAX_PRIMARY_TABLE_SIZE> BaseOps{};
-std::array<X86InstInfo, MAX_SECOND_TABLE_SIZE> SecondBaseOps{};
-std::array<X86InstInfo, MAX_REP_MOD_TABLE_SIZE> RepModOps{};
-std::array<X86InstInfo, MAX_REPNE_MOD_TABLE_SIZE> RepNEModOps{};
-std::array<X86InstInfo, MAX_OPSIZE_MOD_TABLE_SIZE> OpSizeModOps{};
-
-std::array<X86InstInfo, MAX_INST_GROUP_TABLE_SIZE> PrimaryInstGroupOps{};
-std::array<X86InstInfo, MAX_INST_SECOND_GROUP_TABLE_SIZE> SecondInstGroupOps{};
-std::array<X86InstInfo, MAX_SECOND_MODRM_TABLE_SIZE> SecondModRMTableOps{};
-std::array<X86InstInfo, MAX_X87_TABLE_SIZE> X87Ops{};
-std::array<X86InstInfo, MAX_3DNOW_TABLE_SIZE> DDDNowOps{};
-std::array<X86InstInfo, MAX_0F_38_TABLE_SIZE> H0F38TableOps{};
-std::array<X86InstInfo, MAX_0F_3A_TABLE_SIZE> H0F3ATableOps{};
-std::array<X86InstInfo, MAX_VEX_TABLE_SIZE> VEXTableOps{};
-std::array<X86InstInfo, MAX_VEX_GROUP_TABLE_SIZE> VEXTableGroupOps{};
-std::array<X86InstInfo, MAX_XOP_TABLE_SIZE> XOPTableOps{};
-std::array<X86InstInfo, MAX_XOP_GROUP_TABLE_SIZE> XOPTableGroupOps{};
-std::array<X86InstInfo, MAX_EVEX_TABLE_SIZE> EVEXTableOps{};
-
 void InitializeBaseTables(Context::OperatingMode Mode);
 void InitializeSecondaryTables(Context::OperatingMode Mode);
 void InitializePrimaryGroupTables(Context::OperatingMode Mode);
-void InitializeSecondaryGroupTables();
-void InitializeSecondaryModRMTables();
-void InitializeX87Tables();
-void InitializeDDDTables();
-void InitializeH0F38Tables();
 void InitializeH0F3ATables(Context::OperatingMode Mode);
-void InitializeVEXTables();
-void InitializeXOPTables();
-void InitializeEVEXTables();
 
 void InitializeInfoTables(Context::OperatingMode Mode) {
   InitializeBaseTables(Mode);
   InitializeSecondaryTables(Mode);
   InitializePrimaryGroupTables(Mode);
-  InitializeSecondaryGroupTables();
-  InitializeSecondaryModRMTables();
-  InitializeX87Tables();
-  InitializeDDDTables();
-  InitializeH0F38Tables();
   InitializeH0F3ATables(Mode);
-  InitializeVEXTables();
-  InitializeXOPTables();
-  InitializeEVEXTables();
 }
 
 }

--- a/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -14,8 +14,10 @@ $end_info$
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
 
-void InitializeBaseTables(Context::OperatingMode Mode) {
-  static constexpr U8U8InfoStruct BaseOpTable[] = {
+std::array<X86InstInfo, MAX_PRIMARY_TABLE_SIZE> BaseOps = []() consteval {
+  std::array<X86InstInfo, MAX_PRIMARY_TABLE_SIZE> Table{};
+
+  constexpr U8U8InfoStruct BaseOpTable[] = {
     // Prefixes
     // Operand size overide
     {0x66, 1, X86InstInfo{"",      TYPE_PREFIX, FLAGS_NONE,        0, nullptr}},
@@ -233,6 +235,12 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0xC4, 2, X86InstInfo{"",   TYPE_VEX_TABLE_PREFIX, FLAGS_NONE, 0, nullptr}},
   };
 
+  GenerateTable(&Table.at(0), BaseOpTable, std::size(BaseOpTable));
+
+  return Table;
+}();
+
+void InitializeBaseTables(Context::OperatingMode Mode) {
   static constexpr U8U8InfoStruct BaseOpTable_64[] = {
     {0x06, 2, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
     {0x0E, 1, X86InstInfo{"[INV]",  TYPE_INVALID, FLAGS_NONE,                                                                     0, nullptr}},
@@ -290,8 +298,6 @@ void InitializeBaseTables(Context::OperatingMode Mode) {
     {0xD6, 1, X86InstInfo{"SALC",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_SF_DST_RAX | FLAGS_SF_SRC_RAX, 0, nullptr}},
     {0xEA, 1, X86InstInfo{"JMPF",   TYPE_INST, FLAGS_NONE,                                                        0, nullptr}},
   };
-
-  GenerateTable(&BaseOps.at(0), BaseOpTable, std::size(BaseOpTable));
 
   if (Mode == Context::MODE_64BIT) {
     GenerateTable(&BaseOps.at(0), BaseOpTable_64, std::size(BaseOpTable_64));

--- a/FEXCore/Source/Interface/Core/X86Tables/DDDTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/DDDTables.cpp
@@ -12,8 +12,9 @@ $end_info$
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
 
-void InitializeDDDTables() {
-  static constexpr U8U8InfoStruct DDDNowOpTable[] = {
+std::array<X86InstInfo, MAX_3DNOW_TABLE_SIZE> DDDNowOps = []() consteval {
+  std::array<X86InstInfo, MAX_3DNOW_TABLE_SIZE> Table{};
+  constexpr U8U8InfoStruct DDDNowOpTable[] = {
     {0x0C, 1, X86InstInfo{"PI2FW",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX, 0, nullptr}},
     {0x0D, 1, X86InstInfo{"PI2FD",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX, 0, nullptr}},
     {0x1C, 1, X86InstInfo{"PF2IW",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX, 0, nullptr}},
@@ -52,6 +53,8 @@ void InitializeDDDTables() {
     {0xBF, 1, X86InstInfo{"PAVGUSB",  TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX, 0, nullptr}},
   };
 
-  GenerateTable(&DDDNowOps.at(0), DDDNowOpTable, std::size(DDDNowOpTable));
-}
+  GenerateTable(&Table.at(0), DDDNowOpTable, std::size(DDDNowOpTable));
+  return Table;
+}();
+
 }

--- a/FEXCore/Source/Interface/Core/X86Tables/EVEXTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/EVEXTables.cpp
@@ -11,9 +11,9 @@ $end_info$
 
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
-
-void InitializeEVEXTables() {
-  static constexpr U16U8InfoStruct EVEXTable[] = {
+std::array<X86InstInfo, MAX_EVEX_TABLE_SIZE> EVEXTableOps = []() consteval {
+  std::array<X86InstInfo, MAX_EVEX_TABLE_SIZE> Table{};
+  constexpr U16U8InfoStruct EVEXTable[] = {
     {0x10, 1, X86InstInfo{"VMOVUPS",         TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
     {0x11, 1, X86InstInfo{"VMOVUPS",         TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS, 0, nullptr}},
     {0x18, 1, X86InstInfo{"VBROADCASTSS",    TYPE_INST, FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
@@ -29,6 +29,9 @@ void InitializeEVEXTables() {
     {0xE7, 1, X86InstInfo{"VMOVNTDQ",        TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_XMM_FLAGS, 0, nullptr}},
   };
 
-  GenerateTable(&EVEXTableOps.at(0), EVEXTable, std::size(EVEXTable));
-}
+  GenerateTable(&Table.at(0), EVEXTable, std::size(EVEXTable));
+
+  return Table;
+}();
+
 }

--- a/FEXCore/Source/Interface/Core/X86Tables/H0F38Tables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/H0F38Tables.cpp
@@ -12,15 +12,16 @@ $end_info$
 
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
+std::array<X86InstInfo, MAX_0F_38_TABLE_SIZE> H0F38TableOps = []() consteval {
+  std::array<X86InstInfo, MAX_0F_38_TABLE_SIZE> Table{};
 
-void InitializeH0F38Tables() {
 #define OPD(prefix, opcode) (((prefix) << 8) | opcode)
   constexpr uint16_t PF_38_NONE = 0;
   constexpr uint16_t PF_38_66   = (1U << 0);
   constexpr uint16_t PF_38_F2   = (1U << 1);
   constexpr uint16_t PF_38_F3   = (1U << 2);
 
-  static constexpr U16U8InfoStruct H0F38Table[] = {
+  constexpr U16U8InfoStruct H0F38Table[] = {
     {OPD(PF_38_NONE, 0x00), 1, X86InstInfo{"PSHUFB",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT)  | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX, 0, nullptr}},
     {OPD(PF_38_66,   0x00), 1, X86InstInfo{"PSHUFB",     TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
     {OPD(PF_38_NONE, 0x01), 1, X86InstInfo{"PHADDW",     TYPE_INST, GenFlagsSameSize(SIZE_64BIT)  | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX, 0, nullptr}},
@@ -117,6 +118,8 @@ void InitializeH0F38Tables() {
   };
 #undef OPD
 
-  GenerateTable(&H0F38TableOps.at(0), H0F38Table, std::size(H0F38Table));
-}
+  GenerateTable(&Table.at(0), H0F38Table, std::size(H0F38Table));
+  return Table;
+}();
+
 }

--- a/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
@@ -14,13 +14,13 @@ $end_info$
 
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
-
-void InitializeH0F3ATables(Context::OperatingMode Mode) {
 #define OPD(REX, prefix, opcode) ((REX << 9) | (prefix << 8) | opcode)
-  constexpr uint16_t PF_3A_NONE = 0;
-  constexpr uint16_t PF_3A_66   = 1;
+constexpr uint16_t PF_3A_NONE = 0;
+constexpr uint16_t PF_3A_66   = 1;
 
-  static constexpr U16U8InfoStruct H0F3ATable[] = {
+std::array<X86InstInfo, MAX_0F_3A_TABLE_SIZE> H0F3ATableOps = []() consteval {
+  std::array<X86InstInfo, MAX_0F_3A_TABLE_SIZE> Table{};
+  constexpr U16U8InfoStruct H0F3ATable[] = {
     {OPD(0, PF_3A_NONE, 0x0F), 1, X86InstInfo{"PALIGNR",         TYPE_INST, GenFlagsSameSize(SIZE_64BIT)  | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX, 1, nullptr}},
     {OPD(0, PF_3A_66,   0x08), 1, X86InstInfo{"ROUNDPS",         TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(0, PF_3A_66,   0x09), 1, X86InstInfo{"ROUNDPD",         TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
@@ -54,6 +54,11 @@ void InitializeH0F3ATables(Context::OperatingMode Mode) {
     {OPD(0, PF_3A_66,   0xDF), 1, X86InstInfo{"AESKEYGENASSIST", TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
   };
 
+  GenerateTable(&Table.at(0), H0F3ATable, std::size(H0F3ATable));
+  return Table;
+}();
+
+void InitializeH0F3ATables(Context::OperatingMode Mode) {
   static constexpr U16U8InfoStruct H0F3ATable_64[] = {
     {OPD(1, PF_3A_66,   0x0F), 1, X86InstInfo{"PALIGNR",         TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(1, PF_3A_66,   0x16), 1, X86InstInfo{"PEXTRQ",          TYPE_INST, GenFlagsSizes(SIZE_64BIT, SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_DST_GPR | FLAGS_XMM_FLAGS, 1, nullptr}},
@@ -61,8 +66,6 @@ void InitializeH0F3ATables(Context::OperatingMode Mode) {
   };
 
 #undef OPD
-
-  GenerateTable(&H0F3ATableOps.at(0), H0F3ATable, std::size(H0F3ATable));
 
   if (Mode == Context::MODE_64BIT) {
     GenerateTable(&H0F3ATableOps.at(0), H0F3ATable_64, std::size(H0F3ATable_64));

--- a/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
@@ -13,10 +13,10 @@ $end_info$
 
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
-
-void InitializePrimaryGroupTables(Context::OperatingMode Mode) {
+std::array<X86InstInfo, MAX_INST_GROUP_TABLE_SIZE> PrimaryInstGroupOps = []() consteval {
+  std::array<X86InstInfo, MAX_INST_GROUP_TABLE_SIZE> Table{};
 #define OPD(group, prefix, Reg) (((group - FEXCore::X86Tables::TYPE_GROUP_1) << 6) | (prefix) << 3 | (Reg))
-  const U16U8InfoStruct PrimaryGroupOpTable[] = {
+  constexpr U16U8InfoStruct PrimaryGroupOpTable[] = {
     // GROUP_1 | 0x80 | reg
     {OPD(TYPE_GROUP_1, OpToIndex(0x80), 0), 1, X86InstInfo{"ADD",  TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                      1, nullptr}},
     {OPD(TYPE_GROUP_1, OpToIndex(0x80), 1), 1, X86InstInfo{"OR",   TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                                      1, nullptr}},
@@ -141,9 +141,13 @@ void InitializePrimaryGroupTables(Context::OperatingMode Mode) {
     {OPD(TYPE_GROUP_11, OpToIndex(0xC7), 0), 1, X86InstInfo{"MOV",  TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2,                                   4, nullptr}},
     {OPD(TYPE_GROUP_11, OpToIndex(0xC7), 1), 5, X86InstInfo{"",     TYPE_INVALID, FLAGS_NONE,                                                       0, nullptr}},
     {OPD(TYPE_GROUP_11, OpToIndex(0xC7), 7), 1, X86InstInfo{"XBEGIN", TYPE_INST, FLAGS_MODRM | FLAGS_SRC_SEXT | FLAGS_SETS_RIP | FLAGS_DISPLACE_SIZE_DIV_2,                                                       4, nullptr}},
-
   };
 
+  GenerateTable(&Table.at(0), PrimaryGroupOpTable, std::size(PrimaryGroupOpTable));
+  return Table;
+}();
+
+void InitializePrimaryGroupTables(Context::OperatingMode Mode) {
   const U16U8InfoStruct PrimaryGroupOpTable_64[] = {
     // Invalid in 64bit mode
     {OPD(TYPE_GROUP_1, OpToIndex(0x82), 0), 8, X86InstInfo{"",     TYPE_INVALID, FLAGS_NONE,                                                        0, nullptr}},
@@ -163,7 +167,6 @@ void InitializePrimaryGroupTables(Context::OperatingMode Mode) {
 
 #undef OPD
 
-  GenerateTable(&PrimaryInstGroupOps.at(0), PrimaryGroupOpTable, std::size(PrimaryGroupOpTable));
   if (Mode == Context::MODE_64BIT) {
     GenerateTable(&PrimaryInstGroupOps.at(0), PrimaryGroupOpTable_64, std::size(PrimaryGroupOpTable_64));
   }

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
@@ -12,15 +12,15 @@ $end_info$
 
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
-
-void InitializeSecondaryGroupTables() {
+std::array<X86InstInfo, MAX_INST_SECOND_GROUP_TABLE_SIZE> SecondInstGroupOps = []() consteval {
+  std::array<X86InstInfo, MAX_INST_SECOND_GROUP_TABLE_SIZE> Table{};
 #define OPD(group, prefix, Reg) (((group - FEXCore::X86Tables::TYPE_GROUP_6) << 5) | (prefix) << 3 | (Reg))
   constexpr uint16_t PF_NONE = 0;
   constexpr uint16_t PF_F3   = 1;
   constexpr uint16_t PF_66   = 2;
   constexpr uint16_t PF_F2   = 3;
 
-  static constexpr U16U8InfoStruct SecondaryExtensionOpTable[] = {
+  constexpr U16U8InfoStruct SecondaryExtensionOpTable[] = {
     // GROUP 1
     // GROUP 2
     // GROUP 3
@@ -487,7 +487,8 @@ void InitializeSecondaryGroupTables() {
   };
 #undef OPD
 
-  GenerateTable(&SecondInstGroupOps.at(0), SecondaryExtensionOpTable, std::size(SecondaryExtensionOpTable));
-}
+  GenerateTable(&Table.at(0), SecondaryExtensionOpTable, std::size(SecondaryExtensionOpTable));
+  return Table;
+}();
 
 }

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
@@ -11,9 +11,9 @@ $end_info$
 
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
-
-void InitializeSecondaryModRMTables() {
-  static constexpr U8U8InfoStruct SecondaryModRMExtensionOpTable[] = {
+std::array<X86InstInfo, MAX_SECOND_MODRM_TABLE_SIZE> SecondModRMTableOps = []() consteval {
+  std::array<X86InstInfo, MAX_SECOND_MODRM_TABLE_SIZE> Table{};
+  constexpr U8U8InfoStruct SecondaryModRMExtensionOpTable[] = {
     // REG /1
     {((0 << 3) | 0), 1, X86InstInfo{"MONITOR",  TYPE_PRIV,    FLAGS_NONE, 0, nullptr}},
     {((0 << 3) | 1), 1, X86InstInfo{"MWAIT",    TYPE_PRIV,    FLAGS_NONE, 0, nullptr}},
@@ -55,6 +55,8 @@ void InitializeSecondaryModRMTables() {
     {((3 << 3) | 7), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0, nullptr}},
   };
 
-  GenerateTable(&SecondModRMTableOps.at(0), SecondaryModRMExtensionOpTable, std::size(SecondaryModRMExtensionOpTable));
-}
+  GenerateTable(&Table.at(0), SecondaryModRMExtensionOpTable, std::size(SecondaryModRMExtensionOpTable));
+  return Table;
+}();
+
 }

--- a/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -11,10 +11,10 @@ $end_info$
 
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
-
-void InitializeVEXTables() {
+std::array<X86InstInfo, MAX_VEX_TABLE_SIZE> VEXTableOps = []() consteval {
+  std::array<X86InstInfo, MAX_VEX_TABLE_SIZE> Table{};
 #define OPD(map_select, pp, opcode) (((map_select - 1) << 10) | (pp << 8) | (opcode))
-  static constexpr U16U8InfoStruct VEXTable[] = {
+  constexpr U16U8InfoStruct VEXTable[] = {
     // Map 0 (Reserved)
     // VEX Map 1
     {OPD(1, 0b00, 0x10), 1, X86InstInfo{"VMOVUPS",   TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS, 0, nullptr}},
@@ -488,8 +488,15 @@ void InitializeVEXTables() {
   };
 #undef OPD
 
+  GenerateTable(&Table.at(0), VEXTable, std::size(VEXTable));
+  return Table;
+}();
+
+std::array<X86InstInfo, MAX_VEX_GROUP_TABLE_SIZE> VEXTableGroupOps = []() consteval {
+  std::array<X86InstInfo, MAX_VEX_GROUP_TABLE_SIZE> Table{};
+
 #define OPD(group, pp, opcode) (((group - TYPE_VEX_GROUP_12) << 4) | (pp << 3) | (opcode))
-  static constexpr U8U8InfoStruct VEXGroupTable[] = {
+  constexpr U8U8InfoStruct VEXGroupTable[] = {
     {OPD(TYPE_VEX_GROUP_12, 1, 0b010), 1, X86InstInfo{"VPSRLW",   TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_VEX_DST | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(TYPE_VEX_GROUP_12, 1, 0b100), 1, X86InstInfo{"VPSRAW",   TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_VEX_DST | FLAGS_XMM_FLAGS, 1, nullptr}},
     {OPD(TYPE_VEX_GROUP_12, 1, 0b110), 1, X86InstInfo{"VPSLLW",   TYPE_INST, GenFlagsSameSize(SIZE_128BIT) | FLAGS_MODRM | FLAGS_VEX_DST | FLAGS_XMM_FLAGS, 1, nullptr}},
@@ -512,7 +519,8 @@ void InitializeVEXTables() {
   };
 #undef OPD
 
-  GenerateTable(&VEXTableOps.at(0), VEXTable, std::size(VEXTable));
-  GenerateTable(&VEXTableGroupOps.at(0), VEXGroupTable, std::size(VEXGroupTable));
-}
+  GenerateTable(&Table.at(0), VEXGroupTable, std::size(VEXGroupTable));
+
+  return Table;
+}();
 }

--- a/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
@@ -11,11 +11,11 @@ $end_info$
 
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
-
-void InitializeX87Tables() {
+std::array<X86InstInfo, MAX_X87_TABLE_SIZE> X87Ops = []() consteval {
+  std::array<X86InstInfo, MAX_X87_TABLE_SIZE> Table{};
 #define OPD(op, modrmop) (((op - 0xD8) << 8) | modrmop)
 #define OPDReg(op, reg) (((op - 0xD8) << 8) | (reg << 3))
-  static constexpr U16U8InfoStruct X87OpTable[] = {
+  constexpr U16U8InfoStruct X87OpTable[] = {
     // 0xD8
     {OPDReg(0xD8, 0), 1, X86InstInfo{"FADD",  TYPE_X87, FLAGS_MODRM, 0, nullptr}},
     {OPDReg(0xD8, 1), 1, X86InstInfo{"FMUL",  TYPE_X87, FLAGS_MODRM, 0, nullptr}},
@@ -263,6 +263,8 @@ void InitializeX87Tables() {
 #undef OPD
 #undef OPDReg
 
-  GenerateX87Table(&X87Ops.at(0), X87OpTable, std::size(X87OpTable));
-}
+  GenerateX87Table(&Table.at(0), X87OpTable, std::size(X87OpTable));
+  return Table;
+}();
+
 }

--- a/FEXCore/Source/Interface/Core/X86Tables/XOPTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/XOPTables.cpp
@@ -12,14 +12,14 @@ $end_info$
 
 namespace FEXCore::X86Tables {
 using namespace InstFlags;
-
-void InitializeXOPTables() {
+std::array<X86InstInfo, MAX_XOP_TABLE_SIZE> XOPTableOps = []() consteval {
+  std::array<X86InstInfo, MAX_XOP_TABLE_SIZE> Table{};
 #define OPD(group, pp, opcode) ( (group << 10) | (pp << 8) | (opcode))
   constexpr uint16_t XOP_GROUP_8 = 0;
   constexpr uint16_t XOP_GROUP_9 = 1;
   constexpr uint16_t XOP_GROUP_A = 2;
 
-  static constexpr U16U8InfoStruct XOPTable[] = {
+  constexpr U16U8InfoStruct XOPTable[] = {
     // Group 8
     {OPD(XOP_GROUP_8, 0, 0x85), 1, X86InstInfo{"VPMAXSSWW",  TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(XOP_GROUP_8, 0, 0x86), 1, X86InstInfo{"VPMACSSWD",  TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
@@ -104,8 +104,15 @@ void InitializeXOPTables() {
   };
 #undef OPD
 
+  GenerateTable(&Table.at(0), XOPTable, std::size(XOPTable));
+
+  return Table;
+}();
+
+std::array<X86InstInfo, MAX_XOP_GROUP_TABLE_SIZE> XOPTableGroupOps = []() consteval {
+  std::array<X86InstInfo, MAX_XOP_GROUP_TABLE_SIZE> Table{};
 #define OPD(subgroup, opcode)  (((subgroup - 1) << 3) | (opcode))
-  static constexpr U8U8InfoStruct XOPGroupTable[] = {
+  constexpr U8U8InfoStruct XOPGroupTable[] = {
     // Group 1
     {OPD(1, 1), 1, X86InstInfo{"BLCFILL",     TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
     {OPD(1, 2), 1, X86InstInfo{"BLSFILL",     TYPE_UNDEC, FLAGS_NONE, 0, nullptr}},
@@ -129,7 +136,8 @@ void InitializeXOPTables() {
   };
 #undef OPD
 
-  GenerateTable(&XOPTableOps.at(0), XOPTable, std::size(XOPTable));
-  GenerateTable(&XOPTableGroupOps.at(0), XOPGroupTable, std::size(XOPGroupTable));
-}
+  GenerateTable(&Table.at(0), XOPGroupTable, std::size(XOPGroupTable));
+  return Table;
+}();
+
 }


### PR DESCRIPTION
Reduces the ELF's VM size from 9.8MB down to 9.37MB and should reduce initialization time a smidge.

Slammed this out while waiting for other PRs to get reviewed.