### PR TITLE
PassManager: Removes unused exit handler

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -544,9 +544,6 @@ namespace FEXCore::Context {
     Thread->LookupCache = fextl::make_unique<FEXCore::LookupCache>(this);
     Thread->FrontendDecoder = fextl::make_unique<FEXCore::Frontend::Decoder>(this);
     Thread->PassManager = fextl::make_unique<FEXCore::IR::PassManager>();
-    Thread->PassManager->RegisterExitHandler([this]() {
-        Stop(false /* Ignore current thread */);
-    });
 
     Thread->CurrentFrame->Pointers.Common.L1Pointer = Thread->LookupCache->GetL1Pointer();
     Thread->CurrentFrame->Pointers.Common.L2Pointer = Thread->LookupCache->GetPagePointer();

--- a/FEXCore/Source/Interface/IR/PassManager.h
+++ b/FEXCore/Source/Interface/IR/PassManager.h
@@ -29,8 +29,6 @@ namespace FEXCore::IR {
 class PassManager;
 class IREmitter;
 
-using ShouldExitHandler = std::function<void(void)>;
-
 class Pass {
 public:
   virtual ~Pass() = default;
@@ -62,10 +60,6 @@ public:
 
   bool Run(IREmitter *IREmit);
 
-  void RegisterExitHandler(ShouldExitHandler Handler) {
-    ExitHandler = std::move(Handler);
-  }
-
   bool HasPass(fextl::string Name) const {
     return NameToPassMaping.contains(Name);
   }
@@ -86,7 +80,6 @@ public:
   void Finalize();
 
 protected:
-  ShouldExitHandler ExitHandler;
   FEXCore::HLE::SyscallHandler *SyscallHandler;
 
 private:


### PR DESCRIPTION
git blame shows that 718b3e6b4cc577cda8710b8c1f7ac5b59563814c added this handler.

It doesn't explain why this was desired but it was never wired up to anything. Just remove it.