### PR TITLE
Dispatcher: Removes unused asserting CompileBlock function

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -324,9 +324,6 @@ namespace FEXCore::Context {
     [[nodiscard]] CompileCodeResult CompileCode(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP, uint64_t MaxInst = 0);
     uintptr_t CompileBlock(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP, uint64_t MaxInst = 0);
 
-    // same as CompileBlock, but aborts on failure
-    void CompileBlockJit(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP);
-
     // Used for thread creation from syscalls
     /**
      * @brief Initializes TID, PID and TLS data for a thread

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -997,17 +997,6 @@ namespace FEXCore::Context {
     };
   }
 
-  void ContextImpl::CompileBlockJit(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP) {
-    auto NewBlock = CompileBlock(Frame, GuestRIP);
-
-    if (NewBlock == 0) {
-      LogMan::Msg::EFmt("CompileBlockJit: Failed to compile code {:X} - aborting process", GuestRIP);
-      // Return similar behaviour of SIGILL abort
-      Frame->Thread->StatusCode = 128 + SIGILL;
-      Stop(false /* Ignore current thread */);
-    }
-  }
-
   uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame *Frame, uint64_t GuestRIP, uint64_t MaxInst) {
     FEXCORE_PROFILE_SCOPED("CompileBlock");
     auto Thread = Frame->Thread;


### PR DESCRIPTION
While we were calling this function, its asserting nature hasn't been used for a long time.

This used to trigger more frequently when CompileBlock would fail to compile code, either due to not being able to decode an instruction or hitting an instruction that FEX doesn't understand.

When these cases are hit today we still generate code blocks which generate SIGILL. This means that this code was actually never hit.

Completely remove this function and have the JIT's dispatcher call the CompileBlock function directly. Signature is slightly different since we need to set x3 to be 0.