### PR TITLE
Dispatcher: Convert GetCompileBlockPtr to using PMF helper

### DIFF
--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -114,8 +114,6 @@ protected:
 
   static void SleepThread(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::CpuStateFrame *Frame);
 
-  static uint64_t GetCompileBlockPtr();
-
   using AsmDispatch = void(*)(FEXCore::Core::CpuStateFrame *Frame);
   using JITCallback = void(*)(FEXCore::Core::CpuStateFrame *Frame, uint64_t RIP);
 


### PR DESCRIPTION
~~Needs #3323 merged first.~~

This was older code that was written before the PMF helper was available.
Switch it over.