### PR TITLE
Arm64: Removes a vtable indirection in syscalls 

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -392,6 +392,4 @@ namespace FEXCore::Context {
     fextl::unordered_map<uint64_t, std::tuple<CustomIREntrypointHandler, void *, void *>> CustomIRHandlers;
     FEXCore::CPU::DispatcherConfig DispatcherConfig;
   };
-
-  uint64_t HandleSyscall(FEXCore::HLE::SyscallHandler *Handler, FEXCore::Core::CpuStateFrame *Frame, FEXCore::HLE::SyscallArguments *Args);
 }

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -1003,12 +1003,6 @@ namespace FEXCore::Context {
     });
   }
 
-  uint64_t HandleSyscall(FEXCore::HLE::SyscallHandler *Handler, FEXCore::Core::CpuStateFrame *Frame, FEXCore::HLE::SyscallArguments *Args) {
-    uint64_t Result{};
-    Result = Handler->HandleSyscall(Frame, Args);
-    return Result;
-  }
-
   IR::AOTIRCacheEntry *ContextImpl::LoadAOTIRCacheEntry(const fextl::string &filename) {
     auto rv = IRCaptureCache.LoadAOTIRCacheEntry(filename);
     return rv;

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -29,6 +29,7 @@ $end_info$
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/Profiler.h>
+#include <FEXCore/HLE/SyscallHandler.h>
 
 #include "Interface/Core/Interpreter/InterpreterOps.h"
 
@@ -574,8 +575,11 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl *ctx, FEXCore::Core::In
       Common.XCRFunction = PMF.GetConvertedPointer();
     }
 
-    Common.SyscallHandlerObj = reinterpret_cast<uint64_t>(CTX->SyscallHandler);
-    Common.SyscallHandlerFunc = reinterpret_cast<uint64_t>(FEXCore::Context::HandleSyscall);
+    {
+      FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::HLE::SyscallHandler::HandleSyscall);
+      Common.SyscallHandlerObj = reinterpret_cast<uint64_t>(CTX->SyscallHandler);
+      Common.SyscallHandlerFunc = PMF.GetVTableEntry(CTX->SyscallHandler);
+    }
     Common.ExitFunctionLink = reinterpret_cast<uintptr_t>(&Context::ContextImpl::ThreadExitFunctionLink<Arm64JITCore_ExitFunctionLink>);
 
     // Fill in the fallback handlers

--- a/FEXCore/Source/Utils/MemberFunctionToPointer.h
+++ b/FEXCore/Source/Utils/MemberFunctionToPointer.h
@@ -17,13 +17,15 @@ class MemberFunctionToPointerCast final {
   public:
     MemberFunctionToPointerCast(PointerToMemberType Function) {
       memcpy(&PMF, &Function, sizeof(PMF));
+    }
 
+    uintptr_t GetConvertedPointer() const {
 #ifdef _M_X86_64
       // Itanium C++ ABI (https://itanium-cxx-abi.github.io/cxx-abi/abi.html#member-function-pointers)
       // Low bit of ptr specifies if this Member function pointer is virtual or not
       // Throw an assert if we were trying to cast a virtual member
       LOGMAN_THROW_AA_FMT((PMF.ptr & 1) == 0, "C++ Pointer-To-Member representation didn't have low bit set to 0. Are you trying to cast a virtual member?");
-#elif defined(_M_ARM_64 )
+#elif defined(_M_ARM_64)
       // C++ ABI for the Arm 64-bit Architecture (IHI 0059E)
       // 4.2.1 Representation of pointer to member function
       // Differs from Itanium specification
@@ -31,10 +33,36 @@ class MemberFunctionToPointerCast final {
 #else
 #error Don't know how to cast Member to function here. Likely just Itanium
 #endif
+      return PMF.ptr;
     }
 
-    uintptr_t GetConvertedPointer() const {
+    // Gets the vtable entry position of a virtual member function.
+    size_t GetVTableOffset() const {
+#ifdef _M_X86_64
+      // Itanium C++ ABI (https://itanium-cxx-abi.github.io/cxx-abi/abi.html#member-function-pointers)
+      // Low bit of ptr specifies if this Member function pointer is virtual or not
+      // Throw an assert if we are not loading a virtual member.
+      LOGMAN_THROW_AA_FMT((PMF.ptr & 1) == 1, "C++ Pointer-To-Member representation didn't have low bit set to 1. This cast only works for virtual members.");
+      return PMF.ptr & ~1ULL;
+#elif defined(_M_ARM_64)
+      // C++ ABI for the Arm 64-bit Architecture (IHI 0059E)
+      // 4.2.1 Representation of pointer to member function
+      // Differs from Itanium specification
+      LOGMAN_THROW_AA_FMT((PMF.adj & 1) == 1, "C++ Pointer-To-Member representation didn't have adj == 1. This cast only works for virtual members.");
       return PMF.ptr;
+#else
+#error Don't know how to cast Member to function here. Likely just Itanium
+#endif
+    }
+
+    // Gets the pointer to the vtable entry for the object passed it.
+    template<typename Class>
+    uintptr_t GetVTableEntry(Class *VirtualClass) const {
+      // VTable is always stored at the beginning of a class object.
+      uintptr_t *VTable = *reinterpret_cast<uintptr_t**>(VirtualClass);
+
+      size_t Offset = GetVTableOffset() / sizeof(void*);
+      return VTable[Offset];
     }
 
   private:


### PR DESCRIPTION
We can safely call virtual functions through the JIT with a little bit
of work.

FEX's JIT has quite a few steps before it gets to a syscall handler.

Before this commit:
JIT->static HandleSyscall->SyscallHandler::HandleSyscall->SyscallHandler

After this commit:
JIT->SyscallHandler::HandleSyscall->SyscallHandler

A bit hard to notice this when this interface can spin at 67-million
calls per second though.