### PR TITLE
VDSO: Fixes symbol fetching for a few symbols

### DIFF
--- a/Source/Tools/FEXLoader/VDSO_Emulation.cpp
+++ b/Source/Tools/FEXLoader/VDSO_Emulation.cpp
@@ -374,21 +374,32 @@ namespace FEX::VDSO {
       return;
     }
 
-    auto SymbolPtr = dlsym(vdso, "__vdso_time");
+    auto SymbolPtr = dlsym(vdso, "__kernel_time");
+    if (!SymbolPtr) {
+      SymbolPtr = dlsym(vdso, "__vdso_time");
+    }
     if (SymbolPtr) {
       VDSOHandlers::TimePtr = reinterpret_cast<VDSOHandlers::TimeType>(SymbolPtr);
       x64::Handler_time = x64::VDSO::time;
       x32::Handler_time = x32::VDSO::time;
     }
 
-    SymbolPtr = dlsym(vdso, "__vdso_gettimeofday");
+    SymbolPtr = dlsym(vdso, "__kernel_gettimeofday");
+    if (!SymbolPtr) {
+      SymbolPtr = dlsym(vdso, "__vdso_gettimeofday");
+    }
+
     if (SymbolPtr) {
       VDSOHandlers::GetTimeOfDayPtr = reinterpret_cast<VDSOHandlers::GetTimeOfDayType>(SymbolPtr);
       x64::Handler_gettimeofday = x64::VDSO::gettimeofday;
       x32::Handler_gettimeofday = x32::VDSO::gettimeofday;
     }
 
-    SymbolPtr = dlsym(vdso, "__vdso_clock_gettime");
+    SymbolPtr = dlsym(vdso, "__kernel_clock_gettime");
+    if (!SymbolPtr) {
+      SymbolPtr = dlsym(vdso, "__vdso_clock_gettime");
+    }
+
     if (SymbolPtr) {
       VDSOHandlers::ClockGetTimePtr = reinterpret_cast<VDSOHandlers::ClockGetTimeType>(SymbolPtr);
       x64::Handler_clock_gettime = x64::VDSO::clock_gettime;
@@ -396,14 +407,22 @@ namespace FEX::VDSO {
       x32::Handler_clock_gettime64 = x32::VDSO::clock_gettime64;
     }
 
-    SymbolPtr = dlsym(vdso, "__vdso_clock_getres");
+    SymbolPtr = dlsym(vdso, "__kernel_clock_getres");
+    if (!SymbolPtr) {
+      SymbolPtr = dlsym(vdso, "__vdso_clock_getres");
+    }
+
     if (SymbolPtr) {
       VDSOHandlers::ClockGetResPtr = reinterpret_cast<VDSOHandlers::ClockGetResType>(SymbolPtr);
       x64::Handler_clock_getres = x64::VDSO::clock_getres;
       x32::Handler_clock_getres = x32::VDSO::clock_getres;
     }
 
-    SymbolPtr = dlsym(vdso, "__vdso_getcpu");
+    SymbolPtr = dlsym(vdso, "__kernel_getcpu");
+    if (!SymbolPtr) {
+      SymbolPtr = dlsym(vdso, "__vdso_getcpu");
+    }
+
     if (SymbolPtr) {
       VDSOHandlers::GetCPUPtr = reinterpret_cast<VDSOHandlers::GetCPUType>(SymbolPtr);
       x64::Handler_getcpu = x64::VDSO::getcpu;


### PR DESCRIPTION
When originally written I was testing symbol loading on an x86 host assuming that the vdso symbol names were the same between x86 and aarch64.

Turns out this is not true and aarch64 uses `__kernel_` prefix instead of x86's `__vdso_`.

AArch64 VDSO only provides us with four symbols right now
- __kernel_rt_sigreturn
- __kernel_gettimeofday
- __kernel_clock_gettime
- __kernel_clock_getres

This means that currently AArch64 is missing getcpu and time. time is unlikely to ever be implemented so the vdso scanning for that is unlikely to ever get a pointer and will need to go down the glibc path.

getcpu is likely to get an implementation at some point. There's even an old patch series that implemented it[1]. Currently the patch has been dropped on the floor for whatever reason but hopefully they will come back to it.

Benchmarks on Cortex-X1C:
- Native AArch64 clock_gettime bench
   - VDSO: 33.3ns per call
   - glibc (which uses vdso): 33.3ns per call
   - Roughly equivalent
   - Syscall: 141.8ns per call
- Emulated x86_64 clock_gettime bench
   - Prior to fix: - 49ns per call for both VDSO and glibc
   - After fix:
      - VDSO: ~46ns per call
      - glibc: ~49ns per call
   - Unaffected:
      - Syscall (uses glibc):  50ns per call
- Emulated i386 clock_gettime bench
   - Only tested after fix
   - VDSO: 50ns per call
   - glibc: 65ns per call
   - Unaffected:
      - Syscall (uses glibc):  54ns per call

The only way to improve this further would be to optimize thunks to push certain function signature arguments in registers instead of stack. Which is a future optimization as time goes on.

[1] https://patchwork.kernel.org/project/linux-kselftest/list/?series=335203