### PR TITLE
OpcodeDispatcher: Optimize SIB addr calculation 

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -85,6 +85,16 @@ DEF_OP(Add) {
   }
 }
 
+DEF_OP(AddShift) {
+  auto Op = IROp->C<IR::IROp_AddShift>();
+  const uint8_t OpSize = IROp->Size;
+
+  LOGMAN_THROW_AA_FMT(OpSize == 4 || OpSize == 8, "Unsupported {} size: {}", __func__, OpSize);
+  const auto EmitSize = OpSize == 8 ? ARMEmitter::Size::i64Bit : ARMEmitter::Size::i32Bit;
+
+  add(EmitSize, GetReg(Node), GetReg(Op->Src1.ID()), GetReg(Op->Src2.ID()), ConvertIRShiftType(Op->Shift), Op->ShiftAmount);
+}
+
 DEF_OP(AddNZCV) {
   auto Op = IROp->C<IR::IROp_AddNZCV>();
   const auto OpSize = IROp->Size;

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -953,6 +953,16 @@
           "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
+      "GPR = AddShift OpSize:#Size, GPR:$Src1, GPR:$Src2, ShiftType:$Shift{ShiftType::LSL}, u8:$ShiftAmount{0}": {
+        "Desc": [ "Integer Add with shifted register",
+                  "Will truncate to 64 or 32bits"
+                ],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit",
+          "_Shift != ShiftType::ROR"
+        ]
+      },
       "AddNZCV OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Set NZCV for the sum of two GPRs"],
         "HasSideEffects": true,

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -27,9 +27,9 @@
         "cmp     esi, ebx"
       ],
       "ExpectedArm64ASM": [
-        "add w20, w5, w10",
+        "add w20, w10, w5",
         "ldrb w6, [x20]",
-        "add w20, w11, w10",
+        "add w20, w10, w11",
         "ldrb w5, [x20]",
         "orr w20, w6, #0xffff0000",
         "mov w6, w20",

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -2476,7 +2476,7 @@
       "ExpectedInstructionCount": 2,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "add x20, x5, x7",
+        "add x20, x7, x5",
         "bfxil x4, x20, #0, #16"
       ]
     },
@@ -2484,7 +2484,7 @@
       "ExpectedInstructionCount": 3,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "add x20, x5, x7",
+        "add x20, x7, x5",
         "mov x20, x20",
         "mov w4, w20"
       ]
@@ -2493,88 +2493,179 @@
       "ExpectedInstructionCount": 1,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "add x4, x5, x7"
+        "add x4, x7, x5"
       ]
     },
     "lea ax, [rbx+rcx*2 + 0]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "lsl x20, x5, #1",
-        "add x20, x20, x7",
+        "add x20, x7, x5, lsl #1",
         "bfxil x4, x20, #0, #16"
       ]
     },
     "lea eax, [rbx+rcx*2 + 0]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "lsl x20, x5, #1",
-        "add x20, x20, x7",
+        "add x20, x7, x5, lsl #1",
         "mov x20, x20",
         "mov w4, w20"
       ]
     },
     "lea rax, [rbx+rcx*2 + 0]": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "lsl x20, x5, #1",
-        "add x4, x20, x7"
+        "add x4, x7, x5, lsl #1"
       ]
     },
     "lea ax, [rbx+rcx*4 + 0]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "lsl x20, x5, #2",
-        "add x20, x20, x7",
+        "add x20, x7, x5, lsl #2",
         "bfxil x4, x20, #0, #16"
       ]
     },
     "lea eax, [rbx+rcx*4 + 0]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "lsl x20, x5, #2",
-        "add x20, x20, x7",
+        "add x20, x7, x5, lsl #2",
         "mov x20, x20",
         "mov w4, w20"
       ]
     },
     "lea rax, [rbx+rcx*4 + 0]": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "lsl x20, x5, #2",
-        "add x4, x20, x7"
+        "add x4, x7, x5, lsl #2"
       ]
     },
     "lea ax, [rbx+rcx*8 + 0]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "lsl x20, x5, #3",
-        "add x20, x20, x7",
+        "add x20, x7, x5, lsl #3",
         "bfxil x4, x20, #0, #16"
       ]
     },
     "lea eax, [rbx+rcx*8 + 0]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "lsl x20, x5, #3",
-        "add x20, x20, x7",
+        "add x20, x7, x5, lsl #3",
         "mov x20, x20",
         "mov w4, w20"
       ]
     },
     "lea rax, [rbx+rcx*8 + 0]": {
+      "ExpectedInstructionCount": 1,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x4, x7, x5, lsl #3"
+      ]
+    },
+    "lea ax, [ebx+ecx*1 + 0]": {
+      "ExpectedInstructionCount": 3,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5",
+        "mov w20, w20",
+        "bfxil x4, x20, #0, #16"
+      ]
+    },
+    "lea eax, [ebx+ecx*1 + 0]": {
       "ExpectedInstructionCount": 2,
       "Comment": "0x8d",
       "ExpectedArm64ASM": [
-        "lsl x20, x5, #3",
-        "add x4, x20, x7"
+        "add x20, x7, x5",
+        "mov w4, w20"
+      ]
+    },
+    "lea rax, [ebx+ecx*1 + 0]": {
+      "ExpectedInstructionCount": 2,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5",
+        "mov w4, w20"
+      ]
+    },
+    "lea ax, [ebx+ecx*2 + 0]": {
+      "ExpectedInstructionCount": 3,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5, lsl #1",
+        "mov w20, w20",
+        "bfxil x4, x20, #0, #16"
+      ]
+    },
+    "lea eax, [ebx+ecx*2 + 0]": {
+      "ExpectedInstructionCount": 2,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5, lsl #1",
+        "mov w4, w20"
+      ]
+    },
+    "lea rax, [ebx+ecx*2 + 0]": {
+      "ExpectedInstructionCount": 2,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5, lsl #1",
+        "mov w4, w20"
+      ]
+    },
+    "lea ax, [ebx+ecx*4 + 0]": {
+      "ExpectedInstructionCount": 3,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5, lsl #2",
+        "mov w20, w20",
+        "bfxil x4, x20, #0, #16"
+      ]
+    },
+    "lea eax, [ebx+ecx*4 + 0]": {
+      "ExpectedInstructionCount": 2,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5, lsl #2",
+        "mov w4, w20"
+      ]
+    },
+    "lea rax, [ebx+ecx*4 + 0]": {
+      "ExpectedInstructionCount": 2,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5, lsl #2",
+        "mov w4, w20"
+      ]
+    },
+    "lea ax, [ebx+ecx*8 + 0]": {
+      "ExpectedInstructionCount": 3,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5, lsl #3",
+        "mov w20, w20",
+        "bfxil x4, x20, #0, #16"
+      ]
+    },
+    "lea eax, [ebx+ecx*8 + 0]": {
+      "ExpectedInstructionCount": 2,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5, lsl #3",
+        "mov w4, w20"
+      ]
+    },
+    "lea rax, [ebx+ecx*8 + 0]": {
+      "ExpectedInstructionCount": 2,
+      "Comment": "0x8d",
+      "ExpectedArm64ASM": [
+        "add x20, x7, x5, lsl #3",
+        "mov w4, w20"
       ]
     },
     "mov cs, ax": {


### PR DESCRIPTION
When the address calculation for SIB has both index and base then we can
optimize this to an add with a shifted register. This will convert a
three instruction sequence in to one instruction in most cases.