### PR TITLE
CPUID: Removes Init and just uses constructor

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -237,8 +237,6 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(DisableVixlIndirectCalls, DISABLE_VIXL_INDIRECT_RUNTIME_CALLS);
     } Config;
 
-    FEXCore::HostFeatures HostFeatures;
-
     std::mutex ThreadCreationMutex;
     FEXCore::Core::InternalThreadState* ParentThread{};
     fextl::vector<FEXCore::Core::InternalThreadState*> Threads;
@@ -253,6 +251,8 @@ namespace FEXCore::Context {
 
     FEXCore::ForkableSharedMutex CodeInvalidationMutex;
 
+    FEXCore::HostFeatures HostFeatures;
+    // CPUID depends on HostFeatures so needs to be initialized after that.
     FEXCore::CPUIDEmu CPUID;
     FEXCore::HLE::SyscallHandler *SyscallHandler{};
     FEXCore::HLE::SourcecodeResolver *SourcecodeResolver{};

--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -1205,8 +1205,8 @@ FEXCore::CPUID::XCRResults CPUIDEmu::XCRFunction_0h() const {
   return Res;
 }
 
-void CPUIDEmu::Init(FEXCore::Context::ContextImpl *ctx) {
-  CTX = ctx;
+CPUIDEmu::CPUIDEmu(FEXCore::Context::ContextImpl const *ctx)
+  : CTX {ctx} {
   Cores = FEXCore::CPUInfo::CalculateNumberOfCPUs();
 
   // Setup some state tracking

--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -28,11 +28,11 @@ private:
   constexpr static uint32_t CPUID_VENDOR_AMD3 = 0x444D4163; // "cAMD"
 
 public:
+  CPUIDEmu(FEXCore::Context::ContextImpl const *ctx);
+
   // X86 cacheline size effectively has to be hardcoded to 64
   // if we report anything differently then applications are likely to break
   constexpr static uint64_t CACHELINE_SIZE = 64;
-
-  void Init(FEXCore::Context::ContextImpl *ctx);
 
   FEXCore::CPUID::FunctionResults RunFunction(uint32_t Function, uint32_t Leaf) const {
     if (Function < Primary.size()) {
@@ -111,7 +111,7 @@ public:
   }
 
 private:
-  FEXCore::Context::ContextImpl *CTX;
+  FEXCore::Context::ContextImpl const *CTX;
   bool Hybrid{};
   uint32_t Cores{};
   FEX_CONFIG_OPT(HideHypervisorBit, HIDEHYPERVISORBIT);

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -78,7 +78,8 @@ $end_info$
 
 namespace FEXCore::Context {
   ContextImpl::ContextImpl()
-  : IRCaptureCache {this} {
+  : CPUID {this}
+  , IRCaptureCache {this} {
 #ifdef BLOCKSTATS
     BlockData = std::make_unique<FEXCore::BlockSamplingData>();
 #endif
@@ -99,8 +100,6 @@ namespace FEXCore::Context {
 
     // Track atomic TSO emulation configuration.
     UpdateAtomicTSOEmulationConfig();
-
-    CPUID.Init(this);
   }
 
   ContextImpl::~ContextImpl() {


### PR DESCRIPTION
No need to wait for initialization on for this anymore. Ever since Init was refactored to do basically no work, this hasn't been necessary.

CPUID does need to still be initialized after HostFeatures though, so need to ensure correct member ordering there.