### PR TITLE
FEXCore: Removes stale references to x86 JIT

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -44,7 +44,6 @@ namespace CodeSerialize {
 
 namespace CPU {
   class Arm64JITCore;
-  class X86JITCore;
   class Dispatcher;
 }
 namespace HLE {
@@ -191,9 +190,6 @@ namespace FEXCore::Context {
     friend class FEXCore::HLE::SyscallHandler;
   #ifdef JIT_ARM64
     friend class FEXCore::CPU::Arm64JITCore;
-  #endif
-  #ifdef JIT_X86_64
-    friend class FEXCore::CPU::X86JITCore;
   #endif
 
     friend class FEXCore::IR::Validation::IRValidation;

--- a/FEXCore/Source/Interface/Core/JIT/JITCore.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITCore.h
@@ -15,10 +15,6 @@ struct InternalThreadState;
 namespace FEXCore::CPU {
 class CPUBackend;
 
-[[nodiscard]] fextl::unique_ptr<CPUBackend> CreateX86JITCore(FEXCore::Context::ContextImpl *ctx,
-                                                           FEXCore::Core::InternalThreadState *Thread);
-CPUBackendFeatures GetX86JITBackendFeatures();
-
 [[nodiscard]] fextl::unique_ptr<CPUBackend> CreateArm64JITCore(FEXCore::Context::ContextImpl *ctx,
                                                              FEXCore::Core::InternalThreadState *Thread);
 CPUBackendFeatures GetArm64JITBackendFeatures();


### PR DESCRIPTION
It doesn't exist anymore.