### PR TITLE
FEXCore: Removes old InternalThreadState header

### DIFF
--- a/FEXCore/Source/Interface/Core/InternalThreadState.h
+++ b/FEXCore/Source/Interface/Core/InternalThreadState.h
@@ -1,2 +1,0 @@
-// SPDX-License-Identifier: MIT
-#include <FEXCore/Debug/InternalThreadState.h>

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -11,9 +11,9 @@ $end_info$
 #include "Interface/Core/LookupCache.h"
 
 #include "Interface/Core/JIT/Arm64/JITClass.h"
-#include "Interface/Core/InternalThreadState.h"
 
 #include <FEXCore/Core/X86Enums.h>
+#include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <FEXCore/Utils/MathUtils.h>
 #include <Interface/HLE/Thunks/Thunks.h>

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -18,13 +18,13 @@ $end_info$
 
 #include "Interface/Core/Dispatcher/Dispatcher.h"
 #include "Interface/Core/JIT/Arm64/JITClass.h"
-#include "Interface/Core/InternalThreadState.h"
 
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
 
 #include "Utils/MemberFunctionToPointer.h"
 
 #include <FEXCore/Core/X86Enums.h>
+#include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/EnumUtils.h>


### PR DESCRIPTION
This was a temporary header to help with when this header was migrated to our public API headers.

It's temporary nature is no longer necessary, just get rid of it.