### PR TITLE
FEXCore: Pass thread object to HandleUnalignedAccess

### DIFF
--- a/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
+++ b/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
@@ -2025,7 +2025,7 @@ static uint64_t HandleAtomicLoadstoreExclusive(uintptr_t ProgramCounter, uint64_
   return NumInstructionsToSkip * 4;
 }
 
-[[nodiscard]] std::pair<bool, int32_t> HandleUnalignedAccess(bool ParanoidTSO, uintptr_t ProgramCounter, uint64_t *GPRs) {
+[[nodiscard]] std::pair<bool, int32_t> HandleUnalignedAccess(FEXCore::Core::InternalThreadState *Thread, bool ParanoidTSO, uintptr_t ProgramCounter, uint64_t *GPRs) {
 #ifdef _M_ARM_64
   constexpr bool is_arm64 = true;
 #else

--- a/FEXCore/Source/Utils/ArchHelpers/Arm64_stubs.cpp
+++ b/FEXCore/Source/Utils/ArchHelpers/Arm64_stubs.cpp
@@ -23,7 +23,7 @@ bool HandleAtomicMemOp(void *_ucontext, void *_info, uint32_t Instr) {
     ERROR_AND_DIE_FMT("HandleAtomicMemOp Not Implemented");
 }
 
-std::pair<bool, int32_t> HandleUnalignedAccess(bool ParanoidTSO, uintptr_t ProgramCounter, uint64_t *GPRs) {
+std::pair<bool, int32_t> HandleUnalignedAccess(FEXCore::Core::InternalThreadState *Thread, bool ParanoidTSO, uintptr_t ProgramCounter, uint64_t *GPRs) {
   ERROR_AND_DIE_FMT("HandleAtomicMemOp Not Implemented");
 }
 

--- a/FEXCore/include/FEXCore/Utils/ArchHelpers/Arm64.h
+++ b/FEXCore/include/FEXCore/Utils/ArchHelpers/Arm64.h
@@ -6,6 +6,10 @@
 #include <stdint.h>
 #include <utility>
 
+namespace FEXCore::Core {
+  struct InternalThreadState;
+}
+
 namespace FEXCore::ArchHelpers::Arm64 {
   constexpr uint32_t CASPAL_MASK = 0xBF'E0'FC'00;
   constexpr uint32_t CASPAL_INST = 0x08'60'FC'00;
@@ -121,5 +125,5 @@ namespace FEXCore::ArchHelpers::Arm64 {
    */
   [[nodiscard]]
   FEX_DEFAULT_VISIBILITY
-  std::pair<bool, int32_t> HandleUnalignedAccess(bool ParanoidTSO, uintptr_t ProgramCounter, uint64_t *GPRs);
+  std::pair<bool, int32_t> HandleUnalignedAccess(FEXCore::Core::InternalThreadState *Thread, bool ParanoidTSO, uintptr_t ProgramCounter, uint64_t *GPRs);
 }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -1764,7 +1764,7 @@ namespace FEX::HLE {
         return false;
       }
 
-      const auto Result = FEXCore::ArchHelpers::Arm64::HandleUnalignedAccess(GlobalDelegator->ParanoidTSO(), PC, ArchHelpers::Context::GetArmGPRs(ucontext));
+      const auto Result = FEXCore::ArchHelpers::Arm64::HandleUnalignedAccess(Thread, GlobalDelegator->ParanoidTSO(), PC, ArchHelpers::Context::GetArmGPRs(ucontext));
       ArchHelpers::Context::SetPc(ucontext, PC + Result.second);
       return Result.first;
     };

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -269,7 +269,7 @@ namespace Context {
     }
 
     FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
-    const auto Result = FEXCore::ArchHelpers::Arm64::HandleUnalignedAccess(ParanoidTSO(), Context->Pc, &Context->X0);
+    const auto Result = FEXCore::ArchHelpers::Arm64::HandleUnalignedAccess(GetTLS().ThreadState(), ParanoidTSO(), Context->Pc, &Context->X0);
     if (!Result.first) {
       return false;
     }


### PR DESCRIPTION
Currently no functional change but public API breaks should come early.

The thread state object will be used for looking up thread specific codebuffers in the future when we support MDWE with code mirrors.