### PR TITLE
FEXCore: Describe exit function linking object with a structure

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -277,12 +277,17 @@ namespace FEXCore::Context {
     static void ThreadRemoveCodeEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
     static void ThreadAddBlockLink(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestDestination, uintptr_t HostLink, const std::function<void()> &delinker);
 
+    struct ExitFunctionLinkData {
+      uint64_t HostBranch;
+      uint64_t GuestRIP;
+    };
+
     template<auto Fn>
-    static uint64_t ThreadExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, uint64_t *record) {
+    static uint64_t ThreadExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, ExitFunctionLinkData *Record) {
       auto Thread = Frame->Thread;
       auto lk = GuardSignalDeferringSection<std::shared_lock>(static_cast<ContextImpl*>(Thread->CTX)->CodeInvalidationMutex, Thread);
 
-      return Fn(Frame, record);
+      return Fn(Frame, Record);
     }
 
     // Wrapper which takes CpuStateFrame instead of InternalThreadState and unique_locks CodeInvalidationMutex


### PR DESCRIPTION
Instead of just poking raw uint64_t data values, describe it with a struct.

This will be a read-only in the future.