### PR TITLE
IREmitter: Slightly optimize linked list appending

### DIFF
--- a/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -100,7 +100,7 @@ void IREmitter::ResetWorkingList() {
   CodeBlocks.clear();
   CurrentWriteCursor = nullptr;
   // This is necessary since we do "null" pointer checks
-  InvalidNode = reinterpret_cast<OrderedNode*>(DualListData.ListAllocate(sizeof(OrderedNode)));
+  CurrentWriteCursor = InvalidNode = reinterpret_cast<OrderedNode*>(DualListData.ListAllocate(sizeof(OrderedNode)));
   memset(InvalidNode, 0, sizeof(OrderedNode));
   CurrentCodeBlock = nullptr;
 }

--- a/FEXCore/include/FEXCore/IR/IREmitter.h
+++ b/FEXCore/include/FEXCore/IR/IREmitter.h
@@ -314,11 +314,8 @@ friend class FEXCore::IR::PassManager;
       OrderedNode *Node = new (Ptr) OrderedNode();
       Node->Header.Value.SetOffset(DualListData.DataBegin(), reinterpret_cast<uintptr_t>(Op));
 
-      if (CurrentWriteCursor) {
-        CurrentWriteCursor->append(ListBegin, Node);
-      }
-      CurrentWriteCursor = Node;
-      return Node;
+      CurrentWriteCursor = CurrentWriteCursor->append(ListBegin, Node);
+      return CurrentWriteCursor;
     }
 
     OrderedNode *GetNode(uint32_t SSANode) {


### PR DESCRIPTION
If we set `CurrentWriteCursor` to the invalid node immediately then we can remove the per operation check in `CreateNode` which wasn't getting optimized away. This was causing checks to occur for every node emitted even in opdispatch handlers that emitted several IR operations unconditionally.

Since we always need to emit the `InvalidNode` upfront anyway, we know we will always have a linked list object to append to, eliminating the check at all times.

This flattens a bunch of code generated in the opcode dispatcher that I had presumed would only do a single check upfront. The amount of code actually emitted is still very similar so this won't be a significant savings.

Before:
![Image_2023-12-18_19-44-30](https://github.com/FEX-Emu/FEX/assets/1018829/c88b7409-0390-47cf-9f5e-4b15b2bf6468)

After:
![Image_2023-12-18_19-44-41](https://github.com/FEX-Emu/FEX/assets/1018829/8cae4fe4-365e-4f1d-a57d-75443e2857af)
