### PR TITLE
Fixes Proton again

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -385,7 +385,6 @@ struct StackFrameData {
   FEXCore::Context::Context *CTX{};
   FEXCore::Core::CpuStateFrame NewFrame{};
   FEX::HLE::clone3_args GuestArgs{};
-  size_t StackSize;
 };
 
 struct StackFramePlusRet {
@@ -469,7 +468,7 @@ static uint64_t Clone2Handler(FEXCore::Core::CpuStateFrame *Frame, FEX::HLE::clo
   uint64_t Flags = args->args.flags & ~INVALID_FOR_HOST;
   uint64_t Result = ::clone(
     Clone2HandlerRet, // To be called function
-    (void*)((uint64_t)args->NewStack + Data->StackSize), // Stack
+    (void*)((uint64_t)args->NewStack + args->StackSize), // Stack
     Flags, //Flags
     Data, //Argument
     (pid_t*)args->args.parent_tid, // parent_tid

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -62,8 +62,6 @@ namespace FEX::HLE {
     memcpy(&NewThreadState, Frame, sizeof(FEXCore::Core::CPUState));
 
     NewThreadState.gregs[FEXCore::X86State::REG_RAX] = 0;
-    NewThreadState.gregs[FEXCore::X86State::REG_RBX] = 0;
-    NewThreadState.gregs[FEXCore::X86State::REG_RBP] = 0;
     if (args->Type == TYPE_CLONE3) {
       // stack pointer points to the lowest address to the stack
       // set RSP to stack + size
@@ -156,8 +154,6 @@ namespace FEX::HLE {
       memcpy(&NewThreadState, Frame, sizeof(FEXCore::Core::CPUState));
 
       NewThreadState.gregs[FEXCore::X86State::REG_RAX] = 0;
-      NewThreadState.gregs[FEXCore::X86State::REG_RBX] = 0;
-      NewThreadState.gregs[FEXCore::X86State::REG_RBP] = 0;
       if (GuestArgs->stack == 0) {
         // Copies in the original thread's stack
       }
@@ -185,8 +181,6 @@ namespace FEX::HLE {
       ::syscall(SYS_rt_sigprocmask, SIG_SETMASK, &CloneArgs->SignalMask, nullptr, sizeof(CloneArgs->SignalMask));
 
       Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RAX] = 0;
-      Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RBX] = 0;
-      Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RBP] = 0;
       if (GuestArgs->stack == 0) {
         // Copies in the original thread's stack
       }


### PR DESCRIPTION
Fixes a couple of crashes in bubblewrap that seem to have cropped up. Potentially SLR updated the version of bubblewrap they ship?

I have unit tests coming for this but it is uncovering some more bugs in
FEX's thread handling. Some of which are getting fixed with the current
PRs that are moving the thread handling to the frontend.

But since proton is broken now, this needs to get in.