### PR TITLE
FEX: Removes legacy kernel 32-bit allocator

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,7 +13,6 @@ env:
   BUILD_TYPE: Release
   CC: clang
   CXX: clang++
-  FEX_FORCE32BITALLOCATOR: 1
   FEX_ENABLEAVX: 1
 
 jobs:

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -20,7 +20,6 @@ env:
   BUILD_TYPE: Release
   CC: clang
   CXX: clang++
-  FEX_FORCE32BITALLOCATOR: 1
   FEX_ENABLEAVX: 1
 
 jobs:

--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -254,16 +254,6 @@
           "Set to false to disable Static Register Allocation"
         ]
       },
-      "Force32BitAllocator": {
-        "Type": "bool",
-        "Default": "false",
-        "Desc": [
-          "Forces use of the 32-bit allocator on 32-bit applications",
-          "Used to work around ulimit problems of CI runner",
-          "Potentially useful for debugging memory problems",
-          "32-bit allocator is always used if your host kernel is older than 4.17"
-        ]
-      },
       "GlobalJITNaming": {
         "Type": "bool",
         "Default": "false",

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -223,17 +223,8 @@ int main(int argc, char **argv, char **const envp) {
 
   if (!Loader.Is64BitMode()) {
     // Setup our userspace allocator
-    uint32_t KernelVersion = FEX::HLE::SyscallHandler::CalculateHostKernelVersion();
-    if (KernelVersion >= FEX::HLE::SyscallHandler::KernelVersion(4, 17)) {
-      FEXCore::Allocator::SetupHooks();
-    }
-
-    if (KernelVersion < FEX::HLE::SyscallHandler::KernelVersion(4, 17)) {
-      Allocator = FEX::HLE::Create32BitAllocator();
-    }
-    else {
-      Allocator = FEX::HLE::CreatePassthroughAllocator();
-    }
+    FEXCore::Allocator::SetupHooks();
+    Allocator = FEX::HLE::CreatePassthroughAllocator();
   }
 #endif
 


### PR DESCRIPTION
We only used this so that our Xavier CI system which were running old kernels could run unit tests. We have now removed the Xaviers from CI and this is no longer necessary.

Stop pretending that we support kernels older than 5.0 and allowing this fallback.

The 32-bit allocator is still used for the MAP_32BIT mmap flag, so the load bearing code can't be fully removed. Just remove the config and the frontend things using it.