### PR TITLE
Support disabling SHA in CPUID

### DIFF
--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -441,6 +441,30 @@ def print_parse_envloader_options(options):
                 output_argloader.write("}\n")
     output_argloader.write("#endif\n")
 
+def print_parse_jsonloader_options(options):
+    output_argloader.write("#ifdef JSONLOADER\n")
+    output_argloader.write("#undef JSONLOADER\n")
+    output_argloader.write("if (false) {}\n")
+    for op_group, group_vals in options.items():
+        for op_key, op_vals in group_vals.items():
+            value_type = op_vals["Type"]
+            if (value_type == "strenum"):
+                output_argloader.write("else if (KeyName == \"{0}\") {{\n".format(op_key))
+                output_argloader.write("Set(KeyOption, FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, Value_View));\n".format(op_key, op_key, op_key))
+                output_argloader.write("}\n")
+
+            if ("ArgumentHandler" in op_vals):
+                conversion_func = "FEXCore::Config::Handler::{0}".format(op_vals["ArgumentHandler"])
+                output_argloader.write("else if (KeyName == \"{0}\") {{\n".format(op_key))
+                output_argloader.write("Set(KeyOption, {0}(Value_View));\n".format(conversion_func))
+                output_argloader.write("}\n")
+
+    output_argloader.write("else {{\n".format(op_key))
+    output_argloader.write("Set(KeyOption, ConfigString);\n")
+    output_argloader.write("}\n")
+
+    output_argloader.write("#endif\n")
+
 def print_parse_enum_options(options):
     output_argloader.write("#ifdef ENUMDEFINES\n")
     output_argloader.write("#undef ENUMDEFINES\n")
@@ -555,6 +579,9 @@ print_parse_argloader_options(options);
 
 # Generate environment loader code
 print_parse_envloader_options(options);
+
+# Generate json loader code
+print_parse_jsonloader_options(options);
 
 # Generate enum variable options
 print_parse_enum_options(options);

--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -99,6 +99,19 @@
           "\t{enable,disable}crypto: Will force enable or disable crypto extensions even if the host doesn't support it",
           "\t{enable,disable}rpres: Will force enable or disable rpres even if the host doesn't support it"
         ]
+      },
+      "CPUID": {
+        "Type": "strenum",
+        "Default": "FEXCore::Config::CPUID::OFF",
+        "Enums": {
+          "ENABLESHA": "enablesha",
+          "DISABLESHA": "disablesha"
+        },
+        "Desc": [
+          "Allows controlling of the CPU features are exposed in CPUID.",
+          "\toff: Default CPU features queried from CPU features",
+          "\t{enable,disable}sha: Will force enable or disable sha even if the host doesn't support it"
+        ]
       }
     },
     "Emulation": {

--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -136,6 +136,15 @@ private:
   constexpr static uint64_t XCR0_SSE = 1ULL << 1;
   constexpr static uint64_t XCR0_AVX = 1ULL << 2;
 
+  struct FeaturesConfig {
+    uint64_t SHA  : 1;
+    uint64_t _pad : 63;
+  };
+
+  FeaturesConfig Features {
+    .SHA = 1,
+  };
+
   uint64_t XCR0 {
     XCR0_X87 |
     XCR0_SSE
@@ -189,6 +198,7 @@ private:
   FEXCore::CPUID::XCRResults XCRFunction_0h() const;
 
   void SetupHostHybridFlag();
+  void SetupFeatures();
   static constexpr size_t PRIMARY_FUNCTION_COUNT = 27;
   static constexpr size_t HYPERVISOR_FUNCTION_COUNT = 2;
   static constexpr size_t EXTENDED_FUNCTION_COUNT = 32;

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -165,7 +165,11 @@ namespace JSON {
   void OptionMapper::MapNameToOption(const char *ConfigName, const char *ConfigString) {
     auto it = ConfigLookup.find(ConfigName);
     if (it != ConfigLookup.end()) {
-      Set(it->second, ConfigString);
+      const auto KeyOption = it->second;
+      const auto KeyName = std::string_view(ConfigName);
+      const auto Value_View = std::string_view(ConfigString);
+#define JSONLOADER
+#include <FEXCore/Config/ConfigOptions.inl>
     }
   }
 


### PR DESCRIPTION
OpenSSL ships a fairly nasty [bug](https://github.com/openssl/openssl/issues/23144) that crashes games when they are calculating SHA on systems without AVX. This is hit by the game [Claybook](https://wiki.fex-emu.com/index.php/Claybook) which statically links in OpenSSL.

Adds a config option to allow adjusting CPUID options with only SHA being supported by now. This lets users create a config option for the game to disable SHA.

```
$ cat Steam_661920_Claybook-Win64-Shipping.exe.json
{
  "Config": {
    "CPUID": "disablesha"
  }
}
```