### PR TITLE
FEXCore: Optimize HostFeatures and CPUID feature calculation

### DIFF
--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -441,6 +441,30 @@ def print_parse_envloader_options(options):
                 output_argloader.write("}\n")
     output_argloader.write("#endif\n")
 
+def print_parse_jsonloader_options(options):
+    output_argloader.write("#ifdef JSONLOADER\n")
+    output_argloader.write("#undef JSONLOADER\n")
+    output_argloader.write("if (false) {}\n")
+    for op_group, group_vals in options.items():
+        for op_key, op_vals in group_vals.items():
+            value_type = op_vals["Type"]
+            if (value_type == "strenum"):
+                output_argloader.write("else if (KeyName == \"{0}\") {{\n".format(op_key))
+                output_argloader.write("Set(KeyOption, FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, Value_View));\n".format(op_key, op_key, op_key))
+                output_argloader.write("}\n")
+
+            if ("ArgumentHandler" in op_vals):
+                conversion_func = "FEXCore::Config::Handler::{0}".format(op_vals["ArgumentHandler"])
+                output_argloader.write("else if (KeyName == \"{0}\") {{\n".format(op_key))
+                output_argloader.write("Set(KeyOption, {0}(Value_View));\n".format(conversion_func))
+                output_argloader.write("}\n")
+
+    output_argloader.write("else {{\n".format(op_key))
+    output_argloader.write("Set(KeyOption, ConfigString);\n")
+    output_argloader.write("}\n")
+
+    output_argloader.write("#endif\n")
+
 def print_parse_enum_options(options):
     output_argloader.write("#ifdef ENUMDEFINES\n")
     output_argloader.write("#undef ENUMDEFINES\n")
@@ -555,6 +579,9 @@ print_parse_argloader_options(options);
 
 # Generate environment loader code
 print_parse_envloader_options(options);
+
+# Generate json loader code
+print_parse_jsonloader_options(options);
 
 # Generate enum variable options
 print_parse_enum_options(options);

--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -99,6 +99,19 @@
           "\t{enable,disable}crypto: Will force enable or disable crypto extensions even if the host doesn't support it",
           "\t{enable,disable}rpres: Will force enable or disable rpres even if the host doesn't support it"
         ]
+      },
+      "CPUID": {
+        "Type": "strenum",
+        "Default": "FEXCore::Config::CPUID::OFF",
+        "Enums": {
+          "ENABLESHA": "enablesha",
+          "DISABLESHA": "disablesha"
+        },
+        "Desc": [
+          "Allows controlling of the CPU features are exposed in CPUID.",
+          "\toff: Default CPU features queried from CPU features",
+          "\t{enable,disable}sha: Will force enable or disable sha even if the host doesn't support it"
+        ]
       }
     },
     "Emulation": {

--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -372,18 +372,18 @@ void CPUIDEmu::SetupFeatures() {
     return;
   }
 
-#define ENABLE_DISABLE_OPTION(name, enum_name) \
+#define ENABLE_DISABLE_OPTION(FeatureName, name, enum_name) \
+    do { \
     const bool Disable##name = (CPUIDFeatures() & FEXCore::Config::CPUID::DISABLE##enum_name) != 0; \
     const bool Enable##name = (CPUIDFeatures() & FEXCore::Config::CPUID::ENABLE##enum_name) != 0;   \
-    LogMan::Throw::AFmt(!(Disable##name && Enable##name), "Disabling and Enabling CPUID feature (" #name ") is mutually exclusive");
+      LogMan::Throw::AFmt(!(Disable##name && Enable##name), "Disabling and Enabling CPU feature (" #name ") is mutually exclusive"); \
+      const bool AlreadyEnabled = Features.FeatureName; \
+      const bool Result = (AlreadyEnabled | Enable##name) & !Disable##name; \
+      Features.FeatureName = Result; \
+    } while (0)
 
-  ENABLE_DISABLE_OPTION(SHA, SHA);
-  if (EnableSHA) {
-    Features.SHA = true;
-  }
-  else if (DisableSHA) {
-    Features.SHA = false;
-  }
+  ENABLE_DISABLE_OPTION(SHA, SHA, SHA);
+#undef ENABLE_DISABLE_OPTION
 }
 
 FEXCore::CPUID::FunctionResults CPUIDEmu::Function_0h(uint32_t Leaf) const {

--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -136,6 +136,15 @@ private:
   constexpr static uint64_t XCR0_SSE = 1ULL << 1;
   constexpr static uint64_t XCR0_AVX = 1ULL << 2;
 
+  struct FeaturesConfig {
+    uint64_t SHA  : 1;
+    uint64_t _pad : 63;
+  };
+
+  FeaturesConfig Features {
+    .SHA = 1,
+  };
+
   uint64_t XCR0 {
     XCR0_X87 |
     XCR0_SSE
@@ -189,6 +198,7 @@ private:
   FEXCore::CPUID::XCRResults XCRFunction_0h() const;
 
   void SetupHostHybridFlag();
+  void SetupFeatures();
   static constexpr size_t PRIMARY_FUNCTION_COUNT = 27;
   static constexpr size_t HYPERVISOR_FUNCTION_COUNT = 2;
   static constexpr size_t EXTENDED_FUNCTION_COUNT = 32;

--- a/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -69,114 +69,41 @@ static void OverrideFeatures(HostFeatures *Features) {
     return;
   }
 
-#define ENABLE_DISABLE_OPTION(name, enum_name) \
+#define ENABLE_DISABLE_OPTION(FeatureName, name, enum_name) \
+    do { \
+      const bool Disable##name = (HostFeatures() & FEXCore::Config::HostFeatures::DISABLE##enum_name) != 0; \
+      const bool Enable##name = (HostFeatures() & FEXCore::Config::HostFeatures::ENABLE##enum_name) != 0;   \
+      LogMan::Throw::AFmt(!(Disable##name && Enable##name), "Disabling and Enabling CPU feature (" #name ") is mutually exclusive"); \
+      const bool AlreadyEnabled = Features->FeatureName; \
+      const bool Result = (AlreadyEnabled | Enable##name) & !Disable##name; \
+      Features->FeatureName = Result; \
+    } while (0)
+
+#define GET_SINGLE_OPTION(name, enum_name) \
     const bool Disable##name = (HostFeatures() & FEXCore::Config::HostFeatures::DISABLE##enum_name) != 0; \
     const bool Enable##name = (HostFeatures() & FEXCore::Config::HostFeatures::ENABLE##enum_name) != 0;   \
     LogMan::Throw::AFmt(!(Disable##name && Enable##name), "Disabling and Enabling CPU feature (" #name ") is mutually exclusive");
 
-  ENABLE_DISABLE_OPTION(AVX, AVX);
-  ENABLE_DISABLE_OPTION(AVX2, AVX2);
-  ENABLE_DISABLE_OPTION(SVE, SVE);
-  ENABLE_DISABLE_OPTION(AFP, AFP);
-  ENABLE_DISABLE_OPTION(LRCPC, LRCPC);
-  ENABLE_DISABLE_OPTION(LRCPC2, LRCPC2);
-  ENABLE_DISABLE_OPTION(CSSC, CSSC);
-  ENABLE_DISABLE_OPTION(PMULL128, PMULL128);
-  ENABLE_DISABLE_OPTION(RNG, RNG);
-  ENABLE_DISABLE_OPTION(CLZERO, CLZERO);
-  ENABLE_DISABLE_OPTION(Atomics, ATOMICS);
-  ENABLE_DISABLE_OPTION(FCMA, FCMA);
-  ENABLE_DISABLE_OPTION(FlagM, FLAGM);
-  ENABLE_DISABLE_OPTION(FlagM2, FLAGM2);
-  ENABLE_DISABLE_OPTION(Crypto, CRYPTO);
-  ENABLE_DISABLE_OPTION(RPRES, RPRES);
+  ENABLE_DISABLE_OPTION(SupportsAVX, AVX, AVX);
+  ENABLE_DISABLE_OPTION(SupportsAVX2, AVX2, AVX2);
+  ENABLE_DISABLE_OPTION(SupportsSVE, SVE, SVE);
+  ENABLE_DISABLE_OPTION(SupportsAFP, AFP, AFP);
+  ENABLE_DISABLE_OPTION(SupportsRCPC, LRCPC, LRCPC);
+  ENABLE_DISABLE_OPTION(SupportsTSOImm9, LRCPC2, LRCPC2);
+  ENABLE_DISABLE_OPTION(SupportsCSSC, CSSC, CSSC);
+  ENABLE_DISABLE_OPTION(SupportsPMULL_128Bit, PMULL128, PMULL128);
+  ENABLE_DISABLE_OPTION(SupportsRAND, RNG, RNG);
+  ENABLE_DISABLE_OPTION(SupportsCLZERO, CLZERO, CLZERO);
+  ENABLE_DISABLE_OPTION(SupportsAtomics, Atomics, ATOMICS);
+  ENABLE_DISABLE_OPTION(SupportsFCMA, FCMA, FCMA);
+  ENABLE_DISABLE_OPTION(SupportsFlagM, FlagM, FLAGM);
+  ENABLE_DISABLE_OPTION(SupportsFlagM2, FlagM2, FLAGM2);
+  ENABLE_DISABLE_OPTION(SupportsRPRES, RPRES, RPRES);
+  GET_SINGLE_OPTION(Crypto, CRYPTO);
 
 #undef ENABLE_DISABLE_OPTION
+#undef GET_SINGLE_OPTION
 
-  if (EnableAVX) {
-    Features->SupportsAVX = true;
-  }
-  else if (DisableAVX) {
-    Features->SupportsAVX = false;
-  }
-  if (EnableAVX2) {
-    Features->SupportsAVX2 = true;
-  }
-  else if (DisableAVX2) {
-    Features->SupportsAVX2 = false;
-  }
-  if (EnableSVE) {
-    Features->SupportsSVE = true;
-  }
-  else if (DisableSVE) {
-    Features->SupportsSVE = false;
-  }
-  if (EnableAFP) {
-    Features->SupportsAFP = true;
-  }
-  else if (DisableAFP) {
-    Features->SupportsAFP = false;
-  }
-  if (EnableLRCPC) {
-    Features->SupportsRCPC = true;
-  }
-  else if (DisableLRCPC) {
-    Features->SupportsRCPC = false;
-  }
-  if (EnableLRCPC2) {
-    Features->SupportsTSOImm9 = true;
-  }
-  else if (DisableLRCPC2) {
-    Features->SupportsTSOImm9 = false;
-  }
-  if (EnableCSSC) {
-    Features->SupportsCSSC = true;
-  }
-  else if (DisableCSSC) {
-    Features->SupportsCSSC = false;
-  }
-  if (EnablePMULL128) {
-    Features->SupportsPMULL_128Bit = true;
-  }
-  else if (DisablePMULL128) {
-    Features->SupportsPMULL_128Bit = false;
-  }
-  if (EnableRNG) {
-    Features->SupportsRAND = true;
-  }
-  else if (DisableRNG) {
-    Features->SupportsRAND = false;
-  }
-  if (EnableCLZERO) {
-    Features->SupportsCLZERO = true;
-  }
-  else if (DisableCLZERO) {
-    Features->SupportsCLZERO = false;
-  }
-  if (EnableAtomics) {
-    Features->SupportsAtomics = true;
-  }
-  else if (DisableAtomics) {
-    Features->SupportsAtomics = false;
-  }
-  if (EnableFCMA) {
-    Features->SupportsFCMA = true;
-  }
-  else if (DisableFCMA) {
-    Features->SupportsFCMA = false;
-  }
-  if (EnableFlagM) {
-    Features->SupportsFlagM = true;
-  }
-  else if (DisableFlagM) {
-    Features->SupportsFlagM = false;
-  }
-  if (EnableFlagM2) {
-    Features->SupportsFlagM2 = true;
-  }
-  else if (DisableFlagM2) {
-    Features->SupportsFlagM2 = false;
-  }
   if (EnableCrypto) {
     Features->SupportsAES = true;
     Features->SupportsCRC = true;
@@ -188,12 +115,6 @@ static void OverrideFeatures(HostFeatures *Features) {
     Features->SupportsCRC = false;
     Features->SupportsSHA = false;
     Features->SupportsPMULL_128Bit = false;
-  }
-  if (EnableRPRES) {
-    Features->SupportsRPRES = true;
-  }
-  else if (DisableRPRES) {
-    Features->SupportsRPRES = false;
   }
 }
 

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -165,7 +165,11 @@ namespace JSON {
   void OptionMapper::MapNameToOption(const char *ConfigName, const char *ConfigString) {
     auto it = ConfigLookup.find(ConfigName);
     if (it != ConfigLookup.end()) {
-      Set(it->second, ConfigString);
+      const auto KeyOption = it->second;
+      const auto KeyName = std::string_view(ConfigName);
+      const auto Value_View = std::string_view(ConfigString);
+#define JSONLOADER
+#include <FEXCore/Config/ConfigOptions.inl>
     }
   }
 


### PR DESCRIPTION
~~Need https://github.com/FEX-Emu/FEX/pull/3348 merged first.~~

As I was casually thinking, this code made me realize that it was quite
branch heavy and could likely be optimized to logic.

The previous code generated some fairly nasty branch heavy code. This
can be optimized to be branchless and take roughly five instructions
per flag. Using a bitfield for each feature would turn each calculation
in to 3-4 instructions but that seems overkill.

Very minor thing.

Before:
![Image_2023-12-25_05-03-14](https://github.com/FEX-Emu/FEX/assets/1018829/264f7505-e38a-4959-9712-33dcd945c21a)

After:
![Image_2023-12-25_05-03-22](https://github.com/FEX-Emu/FEX/assets/1018829/0bf1807e-b7ab-4c17-ba5f-66c08e4ca396)
