### PR TITLE
FEXCore: Removes context wide and map lookup

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -389,6 +389,7 @@ namespace FEXCore::Context {
     FEX_CONFIG_OPT(AppFilename, APP_FILENAME);
 
     std::shared_mutex CustomIRMutex;
+    std::atomic<bool> HasCustomIRHandlers{};
     fextl::unordered_map<uint64_t, std::tuple<CustomIREntrypointHandler, void *, void *>> CustomIRHandlers;
     FEXCore::CPU::DispatcherConfig DispatcherConfig;
   };


### PR DESCRIPTION
While locking a shared_lock and doing an empty table lookup is fairly fast, just remove them from the hot path entirely if no custom IR handlers are installed.

This is only used for our IRLoader, which is losing its importance significantly and should probably be removed anyway.