### PR TITLE
FEXCore: Decompose some std::function usage to regular pointers

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -68,6 +68,13 @@ namespace FEXCore::Context {
     MODE_SINGLESTEP = 1,
   };
 
+  struct ExitFunctionLinkData {
+    uint64_t HostBranch;
+    uint64_t GuestRIP;
+  };
+
+  using BlockDelinkerFunc = void(*)(FEXCore::Core::CpuStateFrame *Frame, FEXCore::Context::ExitFunctionLinkData *Record);
+
   class ContextImpl final : public FEXCore::Context::Context {
     public:
       // Context base class implementation.
@@ -274,12 +281,7 @@ namespace FEXCore::Context {
     void SignalThread(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::SignalEvent Event);
 
     static void ThreadRemoveCodeEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
-    static void ThreadAddBlockLink(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestDestination, uintptr_t HostLink, const std::function<void()> &delinker);
-
-    struct ExitFunctionLinkData {
-      uint64_t HostBranch;
-      uint64_t GuestRIP;
-    };
+    static void ThreadAddBlockLink(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestDestination, FEXCore::Context::ExitFunctionLinkData *HostLink, const BlockDelinkerFunc &delinker);
 
     template<auto Fn>
     static uint64_t ThreadExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, ExitFunctionLinkData *Record) {

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -1237,7 +1237,7 @@ namespace FEXCore::Context {
     }
   }
 
-  void ContextImpl::ThreadAddBlockLink(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestDestination, uintptr_t HostLink, const std::function<void()> &delinker) {
+  void ContextImpl::ThreadAddBlockLink(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestDestination, FEXCore::Context::ExitFunctionLinkData *HostLink, const FEXCore::Context::BlockDelinkerFunc &delinker) {
     auto lk = GuardSignalDeferringSection<std::shared_lock>(static_cast<ContextImpl*>(Thread->CTX)->CodeInvalidationMutex, Thread);
 
     Thread->LookupCache->AddBlockLink(GuestDestination, HostLink, delinker);
@@ -1249,7 +1249,7 @@ namespace FEXCore::Context {
     std::lock_guard<std::recursive_mutex> lk(Thread->LookupCache->WriteLock);
 
     Thread->DebugStore.erase(GuestRIP);
-    Thread->LookupCache->Erase(GuestRIP);
+    Thread->LookupCache->Erase(Thread->CurrentFrame, GuestRIP);
   }
 
   CustomIRResult ContextImpl::AddCustomIREntrypoint(uintptr_t Entrypoint, CustomIREntrypointHandler Handler, void *Creator, void *Data) {


### PR DESCRIPTION
The delinker step of the JIT was using std::function with capture lambdas that required memory allocation when unnecessary. Because the compiler can't see through our std::function usage it could never decompose these by itself.

By passing the Thread's frame and record to the function as arguments then we can have the signature be a raw function pointer.

This fixes an area of concern from:
https://github.com/FEX-Emu/FEX/blob/main/docs/ProgrammingConcerns.md#stdfunction-and-lambdas