### PR TITLE
ArmEmitter: Support single use forward labels

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -68,6 +68,13 @@ namespace FEXCore::Context {
     MODE_SINGLESTEP = 1,
   };
 
+  struct ExitFunctionLinkData {
+    uint64_t HostBranch;
+    uint64_t GuestRIP;
+  };
+
+  using BlockDelinkerFunc = void(*)(FEXCore::Core::CpuStateFrame *Frame, FEXCore::Context::ExitFunctionLinkData *Record);
+
   class ContextImpl final : public FEXCore::Context::Context {
     public:
       // Context base class implementation.
@@ -274,12 +281,7 @@ namespace FEXCore::Context {
     void SignalThread(FEXCore::Core::InternalThreadState *Thread, FEXCore::Core::SignalEvent Event);
 
     static void ThreadRemoveCodeEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestRIP);
-    static void ThreadAddBlockLink(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestDestination, uintptr_t HostLink, const std::function<void()> &delinker);
-
-    struct ExitFunctionLinkData {
-      uint64_t HostBranch;
-      uint64_t GuestRIP;
-    };
+    static void ThreadAddBlockLink(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestDestination, FEXCore::Context::ExitFunctionLinkData *HostLink, const BlockDelinkerFunc &delinker);
 
     template<auto Fn>
     static uint64_t ThreadExitFunctionLink(FEXCore::Core::CpuStateFrame *Frame, ExitFunctionLinkData *Record) {

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/ALUOps.inl
@@ -35,8 +35,10 @@ public:
     constexpr uint32_t Op = 0b0001'0000 << 24;
     DataProcessing_PCRel_Imm(Op, rd, Imm);
   }
-  void adr(FEXCore::ARMEmitter::Register rd, ForwardLabel *Label) {
-    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::ADR });
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void adr(FEXCore::ARMEmitter::Register rd, LabelType *Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::ADR });
     constexpr uint32_t Op = 0b0001'0000 << 24;
     DataProcessing_PCRel_Imm(Op, rd, 0);
   }
@@ -62,8 +64,10 @@ public:
     constexpr uint32_t Op = 0b1001'0000 << 24;
     DataProcessing_PCRel_Imm(Op, rd, Imm);
   }
-  void adrp(FEXCore::ARMEmitter::Register rd, ForwardLabel *Label) {
-    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::ADRP });
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void adrp(FEXCore::ARMEmitter::Register rd, LabelType *Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::ADRP });
     constexpr uint32_t Op = 0b1001'0000 << 24;
     DataProcessing_PCRel_Imm(Op, rd, 0);
   }
@@ -105,7 +109,7 @@ public:
     }
   }
   void LongAddressGen(FEXCore::ARMEmitter::Register rd, ForwardLabel* Label) {
-    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::LONG_ADDRESS_GEN });
+    Label->Insts.emplace_back(SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::LONG_ADDRESS_GEN });
     // Emit a register index and a nop. These will be backpatched.
     dc32(rd.Idx());
     nop();

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/BranchOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/BranchOps.inl
@@ -18,8 +18,10 @@ public:
       constexpr uint32_t Op = 0b0101'010 << 25;
       Branch_Conditional(Op, 0, 0, Cond, Imm >> 2);
     }
-    void b(FEXCore::ARMEmitter::Condition Cond, ForwardLabel *Label) {
-      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::BC });
+    template<typename LabelType>
+    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+    void b(FEXCore::ARMEmitter::Condition Cond, LabelType *Label) {
+      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC });
       constexpr uint32_t Op = 0b0101'010 << 25;
       Branch_Conditional(Op, 0, 0, Cond, 0);
     }
@@ -45,8 +47,10 @@ public:
       Branch_Conditional(Op, 0, 1, Cond, Imm >> 2);
     }
 
-    void bc(FEXCore::ARMEmitter::Condition Cond, ForwardLabel *Label) {
-      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::BC });
+    template<typename LabelType>
+    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+    void bc(FEXCore::ARMEmitter::Condition Cond, LabelType *Label) {
+      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC });
       constexpr uint32_t Op = 0b0101'010 << 25;
       Branch_Conditional(Op, 0, 1, Cond, 0);
     }
@@ -102,8 +106,10 @@ public:
 
       UnconditionalBranch(Op, Imm >> 2);
     }
-    void b(ForwardLabel *Label) {
-      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::B });
+    template<typename LabelType>
+    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+    void b(LabelType *Label) {
+      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::B });
       constexpr uint32_t Op = 0b0001'01 << 26;
 
       UnconditionalBranch(Op, 0);
@@ -131,8 +137,10 @@ public:
 
       UnconditionalBranch(Op, Imm >> 2);
     }
-    void bl(ForwardLabel *Label) {
-      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::B });
+    template<typename LabelType>
+    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+    void bl(LabelType *Label) {
+      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::B });
       constexpr uint32_t Op = 0b1001'01 << 26;
 
       UnconditionalBranch(Op, 0);
@@ -163,8 +171,10 @@ public:
       CompareAndBranch(Op, s, rt, Imm >> 2);
     }
 
-    void cbz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, ForwardLabel *Label) {
-      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::BC });
+    template<typename LabelType>
+    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+    void cbz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, LabelType *Label) {
+      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC });
 
       constexpr uint32_t Op = 0b0011'0100 << 24;
 
@@ -195,8 +205,10 @@ public:
       CompareAndBranch(Op, s, rt, Imm >> 2);
     }
 
-    void cbnz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, ForwardLabel *Label) {
-      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::BC });
+    template<typename LabelType>
+    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+    void cbnz(FEXCore::ARMEmitter::Size s, FEXCore::ARMEmitter::Register rt, LabelType *Label) {
+      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC });
 
       constexpr uint32_t Op = 0b0011'0101 << 24;
 
@@ -226,8 +238,11 @@ public:
 
       TestAndBranch(Op, rt, Bit, Imm >> 2);
     }
-    void tbz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, ForwardLabel *Label) {
-      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::TEST_BRANCH });
+
+    template<typename LabelType>
+    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+    void tbz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, LabelType *Label) {
+      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::TEST_BRANCH });
 
       constexpr uint32_t Op = 0b0011'0110 << 24;
 
@@ -256,8 +271,11 @@ public:
 
       TestAndBranch(Op, rt, Bit, Imm >> 2);
     }
-    void tbnz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, ForwardLabel *Label) {
-      Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::TEST_BRANCH });
+
+    template<typename LabelType>
+    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+    void tbnz(FEXCore::ARMEmitter::Register rt, uint32_t Bit, LabelType *Label) {
+      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::TEST_BRANCH });
       constexpr uint32_t Op = 0b0011'0111 << 24;
 
       TestAndBranch(Op, rt, Bit, 0);

--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
@@ -2121,38 +2121,58 @@ public:
     LoadStoreLiteral(Op, prfop, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
   }
 
-  void ldr(FEXCore::ARMEmitter::WRegister rt, ForwardLabel *Label) {
-    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void ldr(FEXCore::ARMEmitter::WRegister rt, LabelType *Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
     constexpr uint32_t Op = 0b0001'1000 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
-  void ldr(FEXCore::ARMEmitter::SRegister rt, ForwardLabel *Label) {
-    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void ldr(FEXCore::ARMEmitter::SRegister rt, LabelType *Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
     constexpr uint32_t Op = 0b0001'1100 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
-  void ldr(FEXCore::ARMEmitter::XRegister rt, ForwardLabel *Label) {
-    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void ldr(FEXCore::ARMEmitter::XRegister rt, LabelType *Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
     constexpr uint32_t Op = 0b0101'1000 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
-  void ldr(FEXCore::ARMEmitter::DRegister rt, ForwardLabel *Label) {
-    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void ldr(FEXCore::ARMEmitter::DRegister rt, LabelType *Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
     constexpr uint32_t Op = 0b0101'1100 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
-  void ldrsw(FEXCore::ARMEmitter::XRegister rt, ForwardLabel *Label) {
-    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void ldrsw(FEXCore::ARMEmitter::XRegister rt, LabelType *Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
     constexpr uint32_t Op = 0b1001'1000 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
-  void ldr(FEXCore::ARMEmitter::QRegister rt, ForwardLabel *Label) {
-    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void ldr(FEXCore::ARMEmitter::QRegister rt, LabelType *Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
     constexpr uint32_t Op = 0b1001'1100 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
-  void prfm(FEXCore::ARMEmitter::Prefetch prfop, ForwardLabel *Label) {
-    Label->Insts.emplace_back(ForwardLabel::Instructions{ .Location = GetCursorAddress<uint8_t*>(), .Type = ForwardLabel::Instructions::InstType::RELATIVE_LOAD });
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void prfm(FEXCore::ARMEmitter::Prefetch prfop, LabelType *Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
     constexpr uint32_t Op = 0b1101'1000 << 24;
     LoadStoreLiteral(Op, prfop, 0);
   }

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -1237,7 +1237,7 @@ namespace FEXCore::Context {
     }
   }
 
-  void ContextImpl::ThreadAddBlockLink(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestDestination, uintptr_t HostLink, const std::function<void()> &delinker) {
+  void ContextImpl::ThreadAddBlockLink(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestDestination, FEXCore::Context::ExitFunctionLinkData *HostLink, const FEXCore::Context::BlockDelinkerFunc &delinker) {
     auto lk = GuardSignalDeferringSection<std::shared_lock>(static_cast<ContextImpl*>(Thread->CTX)->CodeInvalidationMutex, Thread);
 
     Thread->LookupCache->AddBlockLink(GuestDestination, HostLink, delinker);
@@ -1249,7 +1249,7 @@ namespace FEXCore::Context {
     std::lock_guard<std::recursive_mutex> lk(Thread->LookupCache->WriteLock);
 
     Thread->DebugStore.erase(GuestRIP);
-    Thread->LookupCache->Erase(GuestRIP);
+    Thread->LookupCache->Erase(Thread->CurrentFrame, GuestRIP);
   }
 
   CustomIRResult ContextImpl::AddCustomIREntrypoint(uintptr_t Entrypoint, CustomIREntrypointHandler Handler, void *Creator, void *Data) {

--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -73,8 +73,8 @@ void Dispatcher::EmitDispatcher() {
   // }
 
   ARMEmitter::ForwardLabel l_CTX;
-  ARMEmitter::ForwardLabel l_Sleep;
-  ARMEmitter::ForwardLabel l_CompileBlock;
+  ARMEmitter::SingleUseForwardLabel l_Sleep;
+  ARMEmitter::SingleUseForwardLabel l_CompileBlock;
 
   // Push all the register we need to save
   PushCalleeSavedRegisters();

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -731,9 +731,9 @@ DEF_OP(PDep) {
                          1U << MaskReg.Idx() |
                          1U << DestReg.Idx();
 
-  ARMEmitter::ForwardLabel EarlyExit;
+  ARMEmitter::SingleUseForwardLabel EarlyExit;
   ARMEmitter::BackwardLabel NextBit;
-  ARMEmitter::ForwardLabel Done;
+  ARMEmitter::SingleUseForwardLabel Done;
   cbz(EmitSize, Mask, &EarlyExit);
   mov(EmitSize, IndexReg, ZeroReg);
 
@@ -792,9 +792,9 @@ DEF_OP(PExt) {
   const auto BitReg   = TMP2;
   const auto ValueReg = TMP3;
 
-  ARMEmitter::ForwardLabel EarlyExit;
+  ARMEmitter::SingleUseForwardLabel EarlyExit;
   ARMEmitter::BackwardLabel NextBit;
-  ARMEmitter::ForwardLabel Done;
+  ARMEmitter::SingleUseForwardLabel Done;
 
   cbz(EmitSize, Mask, &EarlyExit);
   mov(EmitSize, MaskReg, Mask);
@@ -848,8 +848,8 @@ DEF_OP(LDiv) {
     break;
     }
     case 8: {
-      ARMEmitter::ForwardLabel Only64Bit{};
-      ARMEmitter::ForwardLabel LongDIVRet{};
+      ARMEmitter::SingleUseForwardLabel Only64Bit{};
+      ARMEmitter::SingleUseForwardLabel LongDIVRet{};
 
       // Check if the upper bits match the top bit of the lower 64-bits
       // Sign extend the top bit of lower bits
@@ -920,8 +920,8 @@ DEF_OP(LUDiv) {
     break;
     }
     case 8: {
-      ARMEmitter::ForwardLabel Only64Bit{};
-      ARMEmitter::ForwardLabel LongDIVRet{};
+      ARMEmitter::SingleUseForwardLabel Only64Bit{};
+      ARMEmitter::SingleUseForwardLabel LongDIVRet{};
 
       // Check the upper bits for zero
       // If the upper bits are zero then we can do a 64-bit divide
@@ -992,8 +992,8 @@ DEF_OP(LRem) {
     break;
     }
     case 8: {
-      ARMEmitter::ForwardLabel Only64Bit{};
-      ARMEmitter::ForwardLabel LongDIVRet{};
+      ARMEmitter::SingleUseForwardLabel Only64Bit{};
+      ARMEmitter::SingleUseForwardLabel LongDIVRet{};
 
       // Check if the upper bits match the top bit of the lower 64-bits
       // Sign extend the top bit of lower bits
@@ -1066,8 +1066,8 @@ DEF_OP(LURem) {
     break;
     }
     case 8: {
-      ARMEmitter::ForwardLabel Only64Bit{};
-      ARMEmitter::ForwardLabel LongDIVRet{};
+      ARMEmitter::SingleUseForwardLabel Only64Bit{};
+      ARMEmitter::SingleUseForwardLabel LongDIVRet{};
 
       // Check the upper bits for zero
       // If the upper bits are zero then we can do a 64-bit divide

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -32,8 +32,8 @@ DEF_OP(CASPair) {
   }
   else {
     ARMEmitter::BackwardLabel LoopTop;
-    ARMEmitter::ForwardLabel LoopNotExpected;
-    ARMEmitter::ForwardLabel LoopExpected;
+    ARMEmitter::SingleUseForwardLabel LoopNotExpected;
+    ARMEmitter::SingleUseForwardLabel LoopExpected;
     Bind(&LoopTop);
 
     ldaxp(EmitSize, TMP2, TMP3, MemSrc);
@@ -82,8 +82,8 @@ DEF_OP(CAS) {
   }
   else {
     ARMEmitter::BackwardLabel LoopTop;
-    ARMEmitter::ForwardLabel LoopNotExpected;
-    ARMEmitter::ForwardLabel LoopExpected;
+    ARMEmitter::SingleUseForwardLabel LoopNotExpected;
+    ARMEmitter::SingleUseForwardLabel LoopExpected;
     Bind(&LoopTop);
     ldaxr(SubEmitSize, TMP2, MemSrc);
     if (OpSize == 1) {

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -53,20 +53,17 @@ DEF_OP(ExitFunction) {
   uint64_t NewRIP;
 
   if (IsInlineConstant(Op->NewRIP, &NewRIP) || IsInlineEntrypointOffset(Op->NewRIP, &NewRIP)) {
-    ARMEmitter::ForwardLabel l_BranchHost;
-    ARMEmitter::ForwardLabel l_BranchGuest;
+    ARMEmitter::SingleUseForwardLabel l_BranchHost;
 
     ldr(ARMEmitter::XReg::x0, &l_BranchHost);
     blr(ARMEmitter::Reg::r0);
 
     Bind(&l_BranchHost);
     dc64(ThreadState->CurrentFrame->Pointers.Common.ExitFunctionLinker);
-    Bind(&l_BranchGuest);
     dc64(NewRIP);
-
   } else {
 
-    ARMEmitter::ForwardLabel FullLookup;
+    ARMEmitter::SingleUseForwardLabel FullLookup;
     auto RipReg = GetReg(Op->NewRIP.ID());
 
     // L1 Cache

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -485,7 +485,7 @@ static void DirectBlockDelinker(FEXCore::Core::CpuStateFrame *Frame, FEXCore::Co
   auto LinkerAddress = Frame->Pointers.Common.ExitFunctionLinker;
   uintptr_t branch = (uintptr_t)(Record) - 8;
   FEXCore::ARMEmitter::Emitter emit((uint8_t*)(branch), 8);
-  FEXCore::ARMEmitter::ForwardLabel l_BranchHost;
+  FEXCore::ARMEmitter::SingleUseForwardLabel l_BranchHost;
   emit.ldr(FEXCore::ARMEmitter::XReg::x0, &l_BranchHost);
   emit.blr(FEXCore::ARMEmitter::Reg::r0);
   emit.Bind(&l_BranchHost);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -175,7 +175,7 @@ DEF_OP(LoadRegister) {
     if (HostSupportsSVE256) {
       const auto regOffs = Op->Offset & 31;
 
-      ARMEmitter::ForwardLabel DataLocation;
+      ARMEmitter::SingleUseForwardLabel DataLocation;
       const auto LoadPredicate = [this, &DataLocation] {
         const auto Predicate = ARMEmitter::PReg::p0;
         adr(TMP1, &DataLocation);
@@ -184,7 +184,7 @@ DEF_OP(LoadRegister) {
       };
 
       const auto EmitData = [this, &DataLocation](uint32_t Value) {
-        ARMEmitter::ForwardLabel PastConstant;
+        ARMEmitter::SingleUseForwardLabel PastConstant;
         b(&PastConstant);
         Bind(&DataLocation);
         dc32(Value);
@@ -364,7 +364,7 @@ DEF_OP(StoreRegister) {
       const auto regOffs = Op->Offset & 31;
 
       // Compartmentalized setting up of the predicate for the cases that need it.
-      ARMEmitter::ForwardLabel DataLocation;
+      ARMEmitter::SingleUseForwardLabel DataLocation;
       const auto LoadPredicate = [this, &DataLocation] {
         const auto Predicate = ARMEmitter::PReg::p0;
         adr(TMP1, &DataLocation);
@@ -377,7 +377,7 @@ DEF_OP(StoreRegister) {
       // It's helpful to treat LoadPredicate and EmitData as a prologue and epilogue
       // respectfully.
       const auto EmitData = [this, &DataLocation](uint32_t Data) {
-        ARMEmitter::ForwardLabel PastConstant;
+        ARMEmitter::SingleUseForwardLabel PastConstant;
         b(&PastConstant);
         Bind(&DataLocation);
         dc32(Data);
@@ -1715,8 +1715,8 @@ DEF_OP(MemSet) {
   //
   // Counter is decremented regardless.
 
-  ARMEmitter::ForwardLabel BackwardImpl{};
-  ARMEmitter::ForwardLabel Done{};
+  ARMEmitter::SingleUseForwardLabel BackwardImpl{};
+  ARMEmitter::SingleUseForwardLabel Done{};
 
   mov(TMP1, Length.X());
   if (Op->Prefix.IsInvalid()) {
@@ -1789,7 +1789,7 @@ DEF_OP(MemSet) {
     const int32_t SizeDirection = Size * Direction;
 
     ARMEmitter::BackwardLabel AgainInternal{};
-    ARMEmitter::ForwardLabel DoneInternal{};
+    ARMEmitter::SingleUseForwardLabel DoneInternal{};
 
     // Early exit if zero count.
     cbz(ARMEmitter::Size::i64Bit, TMP1, &DoneInternal);
@@ -1895,8 +1895,8 @@ DEF_OP(MemCpy) {
   //
   // Counter is decremented regardless.
 
-  ARMEmitter::ForwardLabel BackwardImpl{};
-  ARMEmitter::ForwardLabel Done{};
+  ARMEmitter::SingleUseForwardLabel BackwardImpl{};
+  ARMEmitter::SingleUseForwardLabel Done{};
 
   mov(TMP1, Length.X());
   if (Op->PrefixDest.IsInvalid()) {
@@ -2050,7 +2050,7 @@ DEF_OP(MemCpy) {
     const int32_t SizeDirection = Size * Direction;
 
     ARMEmitter::BackwardLabel AgainInternal{};
-    ARMEmitter::ForwardLabel DoneInternal{};
+    ARMEmitter::SingleUseForwardLabel DoneInternal{};
 
     // Early exit if zero count.
     cbz(ARMEmitter::Size::i64Bit, TMP1, &DoneInternal);


### PR DESCRIPTION
~~Needs #3361 merged first.~~

Previously forward labels needed to be pessimistic about multiple instructions binding to a label. This results in forward labels having a vector that always allocates memory. Instead if we know the data is only going to be used by a single instruction then we don't need to allocate any memory. This is the common case in FEX.

In particular the delinker step for the JIT blocks was always allocating memory due to the forward label. Now it no longer allocates any memory since it uses a single use forward label.