### PR TITLE
Library Forwarding: Implement automatic argument repacking

### DIFF
--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -144,6 +144,9 @@ void GenerateThunkLibsAction::EmitLayoutWrappers(
 
         // Opaque types don't need layout definitions
         if (type_repack_info.assumed_compatible && type_repack_info.pointers_only) {
+            if (guest_abi.pointer_size != 4) {
+                fmt::print(file, "template<> inline constexpr bool has_compatible_data_layout<{}*> = true;\n", struct_name);
+            }
             continue;
         } else if (type_repack_info.assumed_compatible) {
             // TODO: Handle more cleanly
@@ -280,6 +283,10 @@ void GenerateThunkLibsAction::EmitLayoutWrappers(
         }
         fmt::print(file, "  return ret;\n");
         fmt::print(file, "}}\n\n");
+
+        if (type_compat.at(type) == TypeCompatibility::Full) {
+            fmt::print(file, "template<> inline constexpr bool has_compatible_data_layout<{}> = true;\n", struct_name);
+        }
     }
 }
 

--- a/ThunkLibs/libfex_thunk_test/Host.cpp
+++ b/ThunkLibs/libfex_thunk_test/Host.cpp
@@ -13,4 +13,12 @@ $end_info$
 
 #include "thunkgen_host_libfex_thunk_test.inl"
 
+static uint32_t fexfn_impl_libfex_thunk_test_QueryOffsetOf(guest_layout<ReorderingType*> data, int index) {
+    if (index == 0) {
+        return offsetof(guest_layout<ReorderingType>::type, a);
+    } else {
+        return offsetof(guest_layout<ReorderingType>::type, b);
+    }
+}
+
 EXPORTS(libfex_thunk_test)

--- a/ThunkLibs/libfex_thunk_test/api.h
+++ b/ThunkLibs/libfex_thunk_test/api.h
@@ -28,4 +28,25 @@ union UnionType {
 UnionType MakeUnionType(uint8_t a, uint8_t b, uint8_t c, uint8_t d);
 uint32_t GetUnionTypeA(UnionType*);
 
+
+/// Interfaces used to test automatic struct repacking
+
+// A simple struct with data layout that differs between guest and host.
+// The thunk generator should emit code that swaps the member data into
+// correct position.
+struct ReorderingType {
+#if !defined(GUEST_THUNK_LIBRARY)
+    uint32_t a;
+    uint32_t b;
+#else
+    uint32_t b;
+    uint32_t a;
+#endif
+};
+
+ReorderingType MakeReorderingType(uint32_t a, uint32_t b);
+uint32_t GetReorderingTypeMember(ReorderingType*, int index);
+void ModifyReorderingTypeMembers(ReorderingType* data);
+uint32_t QueryOffsetOf(ReorderingType*, int index);
+
 }

--- a/ThunkLibs/libfex_thunk_test/lib.cpp
+++ b/ThunkLibs/libfex_thunk_test/lib.cpp
@@ -30,4 +30,21 @@ uint32_t GetUnionTypeA(UnionType* value) {
   return value->a;
 }
 
+ReorderingType MakeReorderingType(uint32_t a, uint32_t b) {
+  return ReorderingType { .a = a, .b = b };
+}
+
+uint32_t GetReorderingTypeMember(ReorderingType* data, int index) {
+  if (index == 0) {
+    return data->a;
+  } else {
+    return data->b;
+  }
+}
+
+void ModifyReorderingTypeMembers(ReorderingType* data) {
+  data->a += 1;
+  data->b += 2;
+}
+
 } // extern "C"

--- a/ThunkLibs/libfex_thunk_test/libfex_thunk_test_interface.cpp
+++ b/ThunkLibs/libfex_thunk_test/libfex_thunk_test_interface.cpp
@@ -21,3 +21,10 @@ template<> struct fex_gen_config<DestroyOpaqueType> {};
 template<> struct fex_gen_type<UnionType> : fexgen::assume_compatible_data_layout {};
 template<> struct fex_gen_config<MakeUnionType> {};
 template<> struct fex_gen_config<GetUnionTypeA> {};
+
+template<> struct fex_gen_config<MakeReorderingType> {};
+template<> struct fex_gen_config<GetReorderingTypeMember> {};
+template<> struct fex_gen_config<ModifyReorderingTypeMembers> {};
+
+template<> struct fex_gen_config<QueryOffsetOf> : fexgen::custom_host_impl {};
+template<> struct fex_gen_param<QueryOffsetOf, 0, ReorderingType*> : fexgen::ptr_passthrough {};

--- a/ThunkLibs/libvulkan/libvulkan_interface.cpp
+++ b/ThunkLibs/libvulkan/libvulkan_interface.cpp
@@ -52,6 +52,9 @@ template<> struct fex_gen_type<VkDeviceOrHostAddressConstKHR> : fexgen::assume_c
 template<> struct fex_gen_type<VkPerformanceValueDataINTEL> : fexgen::assume_compatible_data_layout {};
 #endif
 
+// Explicitly register types that are only ever referenced through nested pointers
+template<> struct fex_gen_type<VkAccelerationStructureBuildRangeInfoKHR> {};
+
 // Structures that contain function pointers
 // TODO: Use custom repacking for these instead
 template<> struct fex_gen_type<VkDebugReportCallbackCreateInfoEXT> : fexgen::emit_layout_wrappers {};

--- a/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
+++ b/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
@@ -24,6 +24,11 @@ struct Fixture {
 
   GET_SYMBOL(MakeUnionType);
   GET_SYMBOL(GetUnionTypeA);
+
+  GET_SYMBOL(MakeReorderingType);
+  GET_SYMBOL(GetReorderingTypeMember);
+  GET_SYMBOL(ModifyReorderingTypeMembers);
+  GET_SYMBOL(QueryOffsetOf);
 };
 
 TEST_CASE_METHOD(Fixture, "Trivial") {
@@ -41,4 +46,26 @@ TEST_CASE_METHOD(Fixture, "Opaque data types") {
     auto data = MakeUnionType(0x1, 0x2, 0x3, 0x4);
     CHECK(GetUnionTypeA(&data) == 0x04030201);
   }
+}
+
+TEST_CASE_METHOD(Fixture, "Automatic struct repacking") {
+  {
+    // Test repacking of return values
+    ReorderingType test_struct = MakeReorderingType(0x1234, 0x5678);
+    REQUIRE(test_struct.a == 0x1234);
+    REQUIRE(test_struct.b == 0x5678);
+
+    // Test offsets of the host-side guest_layout wrapper match the guest-side ones
+    CHECK(QueryOffsetOf(&test_struct, 0) == offsetof(ReorderingType, a));
+    CHECK(QueryOffsetOf(&test_struct, 1) == offsetof(ReorderingType, b));
+
+    // Test repacking of input pointers
+    CHECK(GetReorderingTypeMember(&test_struct, 0) == 0x1234);
+    CHECK(GetReorderingTypeMember(&test_struct, 1) == 0x5678);
+
+    // Test repacking of output pointers
+    ModifyReorderingTypeMembers(&test_struct);
+    CHECK(GetReorderingTypeMember(&test_struct, 0) == 0x1235);
+    CHECK(GetReorderingTypeMember(&test_struct, 1) == 0x567a);
+  };
 }

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -713,6 +713,11 @@ TEST_CASE_METHOD(Fixture, "StructRepacking") {
         }
     }
 
+    SECTION("Pointer to struct with pointer member of consistent data layout") {
+        std::string type = GENERATE("char", "short", "int", "float");
+        REQUIRE_NOTHROW(run_thunkgen_host("struct A { " + type + "* a; };\n", code, guest_abi));
+    }
+
     SECTION("Pointer to struct with pointer member of opaque type") {
         const auto prelude =
             "struct B;\n"
@@ -720,6 +725,10 @@ TEST_CASE_METHOD(Fixture, "StructRepacking") {
 
         // Unannotated
         REQUIRE_THROWS_WITH(run_thunkgen_host(prelude, code, guest_abi), Catch::Contains("incomplete type"));
+
+        // Annotated as opaque_type
+        CHECK_NOTHROW(run_thunkgen_host(prelude,
+              code + "template<> struct fex_gen_type<B> : fexgen::opaque_type {};\n", guest_abi));
     }
 }
 

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -304,10 +304,16 @@ SourceWithAST Fixture::run_thunkgen_host(std::string_view prelude, std::string_v
         "  host_layout(const guest_layout<T>& from);\n"
         "};\n"
         "\n"
+        "template<typename T, typename GuestT>\n"
+        "struct repack_wrapper {};\n"
+        "template<typename T, typename GuestT>\n"
+        "repack_wrapper<T, GuestT> make_repack_wrapper(guest_layout<GuestT>& orig_arg);\n"
         "template<typename T> guest_layout<T> to_guest(const host_layout<T>& from) requires(!std::is_pointer_v<T>);\n"
         "template<typename T> guest_layout<T*> to_guest(const host_layout<T*>& from);\n"
         "template<typename F> void FinalizeHostTrampolineForGuestFunction(F*);\n"
         "template<typename F> void FinalizeHostTrampolineForGuestFunction(guest_layout<F*>);\n"
+        "template<typename T> T& unwrap_host(host_layout<T>&);\n"
+        "template<typename T, typename GuestT> T* unwrap_host(repack_wrapper<T*, GuestT>&);\n"
         "template<typename T> const host_layout<T>& to_host_layout(const T& t);\n";
 
     auto& filename = output_filenames.host;

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -281,6 +281,7 @@ SourceWithAST Fixture::run_thunkgen_host(std::string_view prelude, std::string_v
         "};\n"
         "struct ExportEntry { uint8_t* sha256; void(*fn)(void *); };\n"
         "void *dlsym_default(void* handle, const char* symbol);\n"
+        "template<typename T> inline constexpr bool has_compatible_data_layout = std::is_integral_v<T> || std::is_enum_v<T>;\n"
         "template<typename T>\n"
         "struct guest_layout {\n"
         "  T data;\n"


### PR DESCRIPTION
## Overview

Struct data passed across architecture boundaries requires repacking of the contained data if the data layout differs between the guest and host architectures. Similarly, integers and pointers need to be zero-extended when their guest size differs from the host. This PR extends the thunk generator to automatically use the guest_layout/host_layout wrappers added in #3318 to convert data where needed.

Simplified examples of generated code:
```cpp
struct fexfn_packed_args_glBindBufferRange {
  guest_layout<GLenum> a_0;
  guest_layout<GLuint> a_1;
  guest_layout<GLuint> a_2;
  guest_layout<GLintptr> a_3;
  guest_layout<GLsizeiptr> a_4;
};
static void fexfn_unpack_glBindBufferRange(fexfn_packed_args_glBindBufferRange* args) {
  host_layout<GLenum> a_0 { args->a_0 };
  host_layout<GLuint> a_1 { args->a_1 };
  host_layout<GLuint> a_2 { args->a_2 };
  host_layout<GLintptr> a_3 { args->a_3 };   // zero-extends to 64-bit for 32-bit guests
  host_layout<GLsizeiptr> a_4 { args->a_4 }; // zero-extends to 64-bit for 32-bit guests
  fexldr_ptr_glBindBufferRange(unwrap_host(a_0), unwrap_host(a_1), unwrap_host(a_2), unwrap_host(a_3), unwrap_host(a_4));
}
```

Note that struct data is usually passed by-pointer and hence requires additional storage for repacked data, which is provided by a new `repack_wrapper` abstraction (see below):
```cpp
struct fexfn_packed_args_vkCreateDisplayModeKHR {
  guest_layout<VkPhysicalDevice_T *> a_0;
  guest_layout<VkDisplayKHR> a_1;
  guest_layout<VkDisplayModeCreateInfoKHR *> a_2;
  guest_layout<VkAllocationCallbacks *> a_3;
  guest_layout<VkDisplayModeKHR *> a_4;
  guest_layout<VkResult> rv;
};
static void fexfn_unpack_vkCreateDisplayModeKHR(fexfn_packed_args_libvulkan_vkCreateDisplayModeKHR* args) {
  host_layout<VkPhysicalDevice_T *> a_0 { args->a_0 };
  host_layout<VkDisplayKHR> a_1 { args->a_1 };
  repack_wrapper<VkDisplayModeCreateInfoKHR *> a_2 { args->a_2 }; // repacks struct data into internal storage
  repack_wrapper<VkAllocationCallbacks *> a_3 { args->a_3 }; // repacks struct data into internal storage
  host_layout<VkDisplayModeKHR *> a_4 { args->a_4 }; // zero-extends pointer if needed, but no repack_wrapper needed since pointee data has fixed-size
  args->rv = to_guest(to_host_layout<VkResult>(fexldr_ptr_vkCreateDisplayModeKHR(unwrap_host(a_0), unwrap_host(a_1), unwrap_host(a_2), unwrap_host(a_3), unwrap_host(a_4))));
}
```

## Implementation: Pointer parameters

Struct parameters are usually passed by-pointer instead of by-value. However, `host_layout<T*> arg { guest_ptr }` itself only extends the guest pointer to host size, without repacking the struct itself (after all, where would it store the repacked data?). To zero-extend the pointer *and* repack the pointee data, a separate wrapper (`repack_wrapper<T*>`) is added. Crucially, that wrapper not only "looks like" a `host_layout<T*>`, but it also provides storage for repacked data.

```cpp
template<typename T, typename GuestT>
struct repack_wrapper {
  static_assert(std::is_pointer_v<T>);

  using PointeeT = std::remove_pointer_t<T>;

  host_layout<PointeeT> data; // Storage for repacked data
  guest_layout<GuestT>& orig_arg;

  repack_wrapper(guest_layout<GuestT>& orig_arg_) : orig_arg(orig_arg_) {
    // Repack orig_arg to host layout
    data = { *orig_arg_.get_pointer() };
  }

  ~repack_wrapper() {
    // Repack data back to guest_layout (applied for non-const types only)
    *orig_arg.get_pointer() = to_guest(data);
  }
};
```

## Impact on compatibility

Automatic repacking has some pitfalls: Pointers-to-arrays are treated as if they were single elements, so the native host library will trample our stack in those cases. We should consider making automatic repacking opt-in in the future hence, potentially per-type or per-function. Since will cause a lot of friction though, more implementation experience should be gathered before deciding how to move forward here.

## Impact on performance

`thunkgen` uses the same code paths for 32-bit and 64-bit, but data layout analysis will produce very different output for each. Hence in practice, `repack_wrapper` is never emitted for 64-bit guests currently (other than in tests) since all data layout is consistent. Meanwhile, `host_layout` only copies around small data, which compilers should hopefully be smart enough to optimize away.

On 32-bit, there will be non-negligible overhead due to struct repacking, which is unavoidable. The chosen design allocates the repacked data on-stack to minimize the overhead.

As a further optimization, `const` parameters are never repacked (from host to guest layout) on exit. This seems reasonable intuitively, however in theory a forwarded library could modify pointee data through a non-const pointer member of a pointee struct. This doesn't present a compatibility issue however, since such constructions can't be automatically repacked anyway. (`thunkgen` would throw an error if it were to encounter this.) Of course, a library could also chose to circumvent the `const` qualifier. If we were to encounter such a library, an annotation could be added to force exit-repacking on a case-by-case basis.

## Future

Automatic struct repacking is limited to structs where this is "safe" to do, i.e. those that don't contain pointers and only structures that themselves are repackable. To further extend the set of forwardable APIs, a future PR will add a mechanism to assist automatic repacking for "problematic" struct members.
