### PR TITLE
Library Forwarding: Implement assisted struct repacking

### DIFF
--- a/ThunkLibs/Generator/analysis.h
+++ b/ThunkLibs/Generator/analysis.h
@@ -122,6 +122,16 @@ public:
 
         // If true, emit guest_layout/host_layout definitions even if the type is non-repackable
         bool emit_layout_wrappers = false;
+
+        // Set of members (identified by their field name) with custom repacking
+        std::unordered_set<std::string> custom_repacked_members;
+
+        bool UsesCustomRepackFor(const clang::FieldDecl* member) const {
+            return custom_repacked_members.contains(member->getNameAsString());
+        }
+        bool UsesCustomRepackFor(const std::string& member_name) const {
+            return custom_repacked_members.contains(member_name);
+        }
     };
 
 protected:

--- a/ThunkLibs/Generator/data_layout.cpp
+++ b/ThunkLibs/Generator/data_layout.cpp
@@ -272,7 +272,9 @@ TypeCompatibility DataLayoutCompareAction::GetTypeCompatibility(
                 // * Pointer member is annotated
                 // TODO: Don't restrict this to structure types. it applies to pointers to builtin types too!
                 auto host_member_pointee_type = context.getCanonicalType(host_member_type->getPointeeType().getTypePtr());
-                if (types.contains(host_member_pointee_type) && types.at(host_member_pointee_type).assumed_compatible) {
+                if (types.at(type).UsesCustomRepackFor(host_member_field)) {
+                    member_compat.push_back(TypeCompatibility::Repackable);
+                } else if (types.contains(host_member_pointee_type) && types.at(host_member_pointee_type).assumed_compatible) {
                     // Pointee doesn't need repacking, but pointer needs extending on 32-bit
                     member_compat.push_back(is_32bit ? TypeCompatibility::Repackable : TypeCompatibility::Full);
                 } else if (host_member_pointee_type->isPointerType()) {

--- a/ThunkLibs/include/common/GeneratorInterface.h
+++ b/ThunkLibs/include/common/GeneratorInterface.h
@@ -12,6 +12,22 @@ struct callback_annotation_base {
 };
 struct callback_stub : callback_annotation_base {};
 
+// Member annotation to mark members handled by custom repacking. This enables
+// automatic struct repacking of structs with non-trivial members (pointers,
+// unions, ...). Repacking logic is auto-generated as usual, with the
+// difference that an external function is called to manually repack the
+// annotated members.
+//
+// Two functions must be implemented for the parent struct type:
+// * fex_custom_repack_entry, called after automatic repacking of the other members
+// * fex_custom_repack_exit, called on exit but before automatic exit-repacking
+//     of the other members. Non-trivial implementations must perform host->guest
+//     repacking manually and return the boolean value true.
+//
+// If multiple members of the same struct are annotated as custom_repack,
+// they must be handled in the same fex_custom_repack_entry/exit functions.
+struct custom_repack {};
+
 // Type annotation to indicate that guest_layout/host_layout definitions should
 // be emitted even if the type is non-repackable. Pointer members will be
 // copied (or zero-extended) without regard for the referred data.

--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -262,17 +262,31 @@ struct repack_wrapper {
   repack_wrapper(guest_layout<GuestT>& orig_arg_) : orig_arg(orig_arg_) {
     if (orig_arg.get_pointer()) {
       data = { *orig_arg_.get_pointer() };
+
+      if constexpr (!std::is_enum_v<T>) {
+        constexpr bool is_compatible = has_compatible_data_layout<T> && std::is_same_v<T, GuestT>;
+        if constexpr (!is_compatible && std::is_class_v<std::remove_pointer_t<T>>) {
+          fex_apply_custom_repacking_entry(*data, *orig_arg_.get_pointer());
+        }
+      }
     }
   }
 
   ~repack_wrapper() {
     // TODO: Properly detect opaque types
     if constexpr (requires(guest_layout<T> t, decltype(data) h) { t.get_pointer(); (bool)h; *data; }) {
-      if constexpr (!std::is_const_v<std::remove_pointer_t<T>>) { // Skip exit-repacking for const pointees
-        if (data) {
-          constexpr bool is_compatible = has_compatible_data_layout<T> && std::is_same_v<T, GuestT>;
-          if constexpr (!is_compatible && std::is_class_v<std::remove_pointer_t<T>>) {
-            *orig_arg.get_pointer() = to_guest(*data); // TODO: Only if annotated as out-parameter
+      // NOTE: It's assumed that the native host library didn't modify any
+      //       const-pointees, so we skip automatic exit repacking for them.
+      //       However, *custom* repacking must still be applied since it might
+      //       have unrelated side effects (such as deallocation of memory
+      //       reserved on entry)
+      if (!fex_apply_custom_repacking_exit(*orig_arg.get_pointer(), *data)) {
+        if constexpr (!std::is_const_v<std::remove_pointer_t<T>>) { // Skip exit-repacking for const pointees
+          if (data) {
+            constexpr bool is_compatible = has_compatible_data_layout<T> && std::is_same_v<T, GuestT>;
+            if constexpr (!is_compatible && std::is_class_v<std::remove_pointer_t<T>>) {
+              *orig_arg.get_pointer() = to_guest(*data); // TODO: Only if annotated as out-parameter
+            }
           }
         }
       }

--- a/ThunkLibs/libfex_thunk_test/Host.cpp
+++ b/ThunkLibs/libfex_thunk_test/Host.cpp
@@ -21,4 +21,12 @@ static uint32_t fexfn_impl_libfex_thunk_test_QueryOffsetOf(guest_layout<Reorderi
     }
 }
 
+void fex_custom_repack_entry(host_layout<CustomRepackedType>& to, guest_layout<CustomRepackedType> const& from) {
+  to.data.custom_repack_invoked = 1;
+}
+
+bool fex_custom_repack_exit(guest_layout<CustomRepackedType>& to, host_layout<CustomRepackedType> const& from) {
+  return false;
+}
+
 EXPORTS(libfex_thunk_test)

--- a/ThunkLibs/libfex_thunk_test/api.h
+++ b/ThunkLibs/libfex_thunk_test/api.h
@@ -49,4 +49,17 @@ uint32_t GetReorderingTypeMember(ReorderingType*, int index);
 void ModifyReorderingTypeMembers(ReorderingType* data);
 uint32_t QueryOffsetOf(ReorderingType*, int index);
 
+
+/// Interfaces used to test assisted struct repacking
+
+// We enable custom repacking on the "data" member, with repacking code that
+// sets the first bit of "custom_repack_invoked" to 1 on entry.
+struct CustomRepackedType {
+    ReorderingType* data;
+    int custom_repack_invoked;
+};
+
+// Should return true if the custom repacker set "custom_repack_invoked" to true
+int RanCustomRepack(CustomRepackedType*);
+
 }

--- a/ThunkLibs/libfex_thunk_test/lib.cpp
+++ b/ThunkLibs/libfex_thunk_test/lib.cpp
@@ -47,4 +47,8 @@ void ModifyReorderingTypeMembers(ReorderingType* data) {
   data->b += 2;
 }
 
+int RanCustomRepack(CustomRepackedType* data) {
+  return data->custom_repack_invoked;
+}
+
 } // extern "C"

--- a/ThunkLibs/libfex_thunk_test/libfex_thunk_test_interface.cpp
+++ b/ThunkLibs/libfex_thunk_test/libfex_thunk_test_interface.cpp
@@ -28,3 +28,6 @@ template<> struct fex_gen_config<ModifyReorderingTypeMembers> {};
 
 template<> struct fex_gen_config<QueryOffsetOf> : fexgen::custom_host_impl {};
 template<> struct fex_gen_param<QueryOffsetOf, 0, ReorderingType*> : fexgen::ptr_passthrough {};
+
+template<> struct fex_gen_config<&CustomRepackedType::data> : fexgen::custom_repack {};
+template<> struct fex_gen_config<RanCustomRepack> {};

--- a/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
+++ b/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
@@ -29,6 +29,8 @@ struct Fixture {
   GET_SYMBOL(GetReorderingTypeMember);
   GET_SYMBOL(ModifyReorderingTypeMembers);
   GET_SYMBOL(QueryOffsetOf);
+
+  GET_SYMBOL(RanCustomRepack);
 };
 
 TEST_CASE_METHOD(Fixture, "Trivial") {
@@ -68,4 +70,9 @@ TEST_CASE_METHOD(Fixture, "Automatic struct repacking") {
     CHECK(GetReorderingTypeMember(&test_struct, 0) == 0x1235);
     CHECK(GetReorderingTypeMember(&test_struct, 1) == 0x567a);
   };
+}
+
+TEST_CASE_METHOD(Fixture, "Assisted struct repacking") {
+  CustomRepackedType data {};
+  CHECK(RanCustomRepack(&data) == 1);
 }

--- a/unittests/ThunkLibs/common.h
+++ b/unittests/ThunkLibs/common.h
@@ -90,6 +90,7 @@ struct custom_host_impl {};
 struct callback_annotation_base { bool prevent_multiple; };
 struct callback_stub : callback_annotation_base {};
 
+struct custom_repack {};
 struct emit_layout_wrappers {};
 
 struct opaque_type {};

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -711,6 +711,11 @@ TEST_CASE_METHOD(Fixture, "StructRepacking") {
         SECTION("Parameter annotated as ptr_passthrough") {
             CHECK_NOTHROW(run_thunkgen_host(prelude, code + "template<> struct fex_gen_param<func, 0, A*> : fexgen::ptr_passthrough {};\n", guest_abi));
         }
+
+        SECTION("Struct member annotated as custom_repack") {
+            CHECK_NOTHROW(run_thunkgen_host("struct A { void* a; };\n",
+                  code + "template<> struct fex_gen_config<&A::a> : fexgen::custom_repack {};\n", guest_abi));
+        }
     }
 
     SECTION("Pointer to struct with pointer member of consistent data layout") {
@@ -780,5 +785,16 @@ TEST_CASE_METHOD(Fixture, "VoidPointerParameter") {
         } else {
             CHECK_NOTHROW(run_thunkgen_host(prelude, code, guest_abi));
         }
+    }
+
+    SECTION("Custom repack in struct") {
+        const char* prelude =
+            "struct A { void* a; };\n";
+        const char* code =
+            "#include <thunks_common.h>\n"
+            "void func(A*);\n"
+            "template<> struct fex_gen_config<&A::a> : fexgen::custom_repack {};\n"
+            "template<> struct fex_gen_config<func> {};\n";
+        CHECK_NOTHROW(run_thunkgen_host(prelude, code, guest_abi));
     }
 }


### PR DESCRIPTION
## Overview

The machinery for *automatic struct repacking* (#3371) is limited to "simple" data, i.e. structs of which all members are either integers or other structs that themselves are simple. The real world is more messy than that, because structs frequently contain pointers. This PR adds a *custom repacking* mechanism for specific members to be repacked manually while leaving the rest to be handled by the same autogenerated boilerplate code as before. This allows a wider range of structs to be repacked automatically with minimal additional manual work.

## Implementation

For a struct member `MyStruct::MyMember` annotated as `fexgen::custom_repack`, two functions must be implemented in the FEX's host-side glue code (Host.cpp):

```cpp
void fex_custom_repack_entry(host_layout<MyStruct>& into, const guest_layout<MyStruct>& from) {
    // "into" is already filled with data members in host layout.
    // Only the annotated members need to be initialized manually
    into.MyMember = some_conversion_logic(from.MyMember);
}

bool fex_custom_repack_exit(guest_layout<MyStruct>& into, const host_layout<MyStruct>& from) {
    // return false if trivial, otherwise repack manually and return true:
    into = to_guest(from);
    // (other custom logic goes here)
    return true;
}
```

(Note in particular they're implemented for `MyStruct`, i.e. when more than one member is customized, the repacking logic for each go into the same two functions.)

## Impact

No members are annotated as `custom_repack` outside of tests, so this has no immediate impact.

Once we start annotating members for real libraries, no performance overhead is anticipated by the added function calls (other than any non-trivial logic inside of them): This is because all function definitions are visible in the calling code, so the compiler can trivially inline them.

## Future

This completes the struct repacking work, however further work is needed to deal with conversions between plain integers of differing sizes between guest and host.
