### PR TITLE
Library Forwarding: Test interaction of struct repacking and assume_compatible_data_layout

### DIFF
--- a/ThunkLibs/Generator/main.cpp
+++ b/ThunkLibs/Generator/main.cpp
@@ -77,6 +77,7 @@ int main(int argc, char* const argv[]) {
             AdjustedArgs.push_back(std::string { "--target=" } + platform + "-linux-unknown");
             AdjustedArgs.push_back("-isystem");
             AdjustedArgs.push_back(std::string { "/usr/" } + platform + "-linux-gnu/include/");
+            AdjustedArgs.push_back("-DGUEST_THUNK_LIBRARY");
             return AdjustedArgs;
         };
         GuestTool.appendArgumentsAdjuster(append_guest_args);

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -51,7 +51,6 @@ function(generate NAME SOURCE_FILE)
   # Interface target for the user to add include directories
   add_library(${NAME}-guest-deps INTERFACE)
   target_include_directories(${NAME}-guest-deps INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
-  target_compile_definitions(${NAME}-guest-deps INTERFACE GUEST_THUNK_LIBRARY)
   if (BITNESS EQUAL 32)
     target_compile_definitions(${NAME}-guest-deps INTERFACE IS_32BIT_THUNK)
   endif ()

--- a/ThunkLibs/libfex_thunk_test/api.h
+++ b/ThunkLibs/libfex_thunk_test/api.h
@@ -45,10 +45,12 @@ struct ReorderingType {
 };
 
 ReorderingType MakeReorderingType(uint32_t a, uint32_t b);
-uint32_t GetReorderingTypeMember(ReorderingType*, int index);
+uint32_t GetReorderingTypeMember(const ReorderingType*, int index);
 void ModifyReorderingTypeMembers(ReorderingType* data);
 uint32_t QueryOffsetOf(ReorderingType*, int index);
 
+// Uses assume_compatible_data_layout to skip repacking
+uint32_t GetReorderingTypeMemberWithoutRepacking(const ReorderingType*, int index);
 
 /// Interfaces used to test assisted struct repacking
 

--- a/ThunkLibs/libfex_thunk_test/lib.cpp
+++ b/ThunkLibs/libfex_thunk_test/lib.cpp
@@ -34,12 +34,16 @@ ReorderingType MakeReorderingType(uint32_t a, uint32_t b) {
   return ReorderingType { .a = a, .b = b };
 }
 
-uint32_t GetReorderingTypeMember(ReorderingType* data, int index) {
+uint32_t GetReorderingTypeMember(const ReorderingType* data, int index) {
   if (index == 0) {
     return data->a;
   } else {
     return data->b;
   }
+}
+
+uint32_t GetReorderingTypeMemberWithoutRepacking(const ReorderingType* data, int index) {
+  return GetReorderingTypeMember(data, index);
 }
 
 void ModifyReorderingTypeMembers(ReorderingType* data) {

--- a/ThunkLibs/libfex_thunk_test/libfex_thunk_test_interface.cpp
+++ b/ThunkLibs/libfex_thunk_test/libfex_thunk_test_interface.cpp
@@ -24,6 +24,8 @@ template<> struct fex_gen_config<GetUnionTypeA> {};
 
 template<> struct fex_gen_config<MakeReorderingType> {};
 template<> struct fex_gen_config<GetReorderingTypeMember> {};
+template<> struct fex_gen_config<GetReorderingTypeMemberWithoutRepacking> {};
+template<> struct fex_gen_param<GetReorderingTypeMemberWithoutRepacking, 0, const ReorderingType*> : fexgen::assume_compatible_data_layout {};
 template<> struct fex_gen_config<ModifyReorderingTypeMembers> {};
 
 template<> struct fex_gen_config<QueryOffsetOf> : fexgen::custom_host_impl {};

--- a/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
+++ b/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
@@ -27,6 +27,7 @@ struct Fixture {
 
   GET_SYMBOL(MakeReorderingType);
   GET_SYMBOL(GetReorderingTypeMember);
+  GET_SYMBOL(GetReorderingTypeMemberWithoutRepacking);
   GET_SYMBOL(ModifyReorderingTypeMembers);
   GET_SYMBOL(QueryOffsetOf);
 
@@ -64,6 +65,10 @@ TEST_CASE_METHOD(Fixture, "Automatic struct repacking") {
     // Test repacking of input pointers
     CHECK(GetReorderingTypeMember(&test_struct, 0) == 0x1234);
     CHECK(GetReorderingTypeMember(&test_struct, 1) == 0x5678);
+
+    // Test that we can force reinterpreting the data in guest layout as host layout
+    CHECK(GetReorderingTypeMemberWithoutRepacking(&test_struct, 0) == 0x5678);
+    CHECK(GetReorderingTypeMemberWithoutRepacking(&test_struct, 1) == 0x1234);
 
     // Test repacking of output pointers
     ModifyReorderingTypeMembers(&test_struct);

--- a/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
+++ b/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
@@ -1,3 +1,5 @@
+#define GUEST_THUNK_LIBRARY
+
 #include <dlfcn.h>
 
 #include <stdexcept>


### PR DESCRIPTION
~~Needs https://github.com/FEX-Emu/FEX/pull/3373 merged first.~~

This just adds one more test to test the interaction between automatic struct repacking (added in #3371) and the previously added `assume_compatible_data_layout` annotation (#3177). This serves mainly as a consistency check to ensure other tests don't just pass "by accident".

While developing this, I also found that we aren't setting up `GUEST_THUNK_LIBRARY` properly, which the test library needs to enable guest-specific behavior however. A fix for this is included in the PR now as well.