### PR TITLE
Improvements to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ FROM ubuntu:20.04 as builder
 
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update
 RUN DEBIAN_FRONTEND="noninteractive" apt install -y cmake \
-clang-10 llvm-10 nasm ninja-build \
-libcap-dev libglfw3-dev libepoxy-dev python3-dev \
-python3 linux-headers-generic
+clang-10 llvm-10 nasm ninja-build pkg-config \
+libcap-dev libglfw3-dev libepoxy-dev python3-dev libsdl2-dev \
+python3 linux-headers-generic \
+git
 
-COPY . /opt/FEX
+RUN git clone --recurse-submodules https://github.com/FEX-Emu/FEX.git
 
 CMD [ "mkdir /opt/FEX/build" ]
 


### PR DESCRIPTION
I added the `pkg-config` that is missing in the Dockerfile, and make the git clone the repository direct from the image, so the user don't need to clone it manually and after that pulls inside the Dockerfile!

If the git change is too much, tell me that I remove it and keep only the dependecies update, because without it, it's not compiling at all.