### PR TITLE
Library Forwarding: Flip order of nullptr check and custom repacking

### DIFF
--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -275,14 +275,14 @@ struct repack_wrapper {
   ~repack_wrapper() {
     // TODO: Properly detect opaque types
     if constexpr (requires(guest_layout<T> t, decltype(data) h) { t.get_pointer(); (bool)h; *data; }) {
-      // NOTE: It's assumed that the native host library didn't modify any
-      //       const-pointees, so we skip automatic exit repacking for them.
-      //       However, *custom* repacking must still be applied since it might
-      //       have unrelated side effects (such as deallocation of memory
-      //       reserved on entry)
-      if (!fex_apply_custom_repacking_exit(*orig_arg.get_pointer(), *data)) {
-        if constexpr (!std::is_const_v<std::remove_pointer_t<T>>) { // Skip exit-repacking for const pointees
-          if (data) {
+      if (data) {
+        // NOTE: It's assumed that the native host library didn't modify any
+        //       const-pointees, so we skip automatic exit repacking for them.
+        //       However, *custom* repacking must still be applied since it
+        //       might have unrelated side effects (such as deallocation of
+        //       memory reserved on entry)
+        if (!fex_apply_custom_repacking_exit(*orig_arg.get_pointer(), *data)) {
+          if constexpr (!std::is_const_v<std::remove_pointer_t<T>>) { // Skip exit-repacking for const pointees
             constexpr bool is_compatible = has_compatible_data_layout<T> && std::is_same_v<T, GuestT>;
             if constexpr (!is_compatible && std::is_class_v<std::remove_pointer_t<T>>) {
               *orig_arg.get_pointer() = to_guest(*data); // TODO: Only if annotated as out-parameter


### PR DESCRIPTION
Minor fix to #3373, which dereferenced `data` for custom repacking before performing the `nullptr` check. This wasn't hit in practice even in my WIP branch, but could've caused crashes when using custom repacking with arguments that can be null.
