### PR TITLE
Optimize CDQOp

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1395,11 +1395,12 @@ void OpDispatchBuilder::XCHGOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::CDQOp(OpcodeArgs) {
-  OrderedNode *Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
   uint8_t DstSize = GetDstSize(Op);
   uint8_t SrcSize = DstSize >> 1;
+  OrderedNode *Src = LoadGPRRegister(X86State::REG_RAX, SrcSize, 0, true);
 
-  Src = _Sbfe(OpSize::i64Bit, SrcSize * 8, 0, Src);
+  Src = _Sbfe(DstSize <= 4 ? OpSize::i32Bit : OpSize::i64Bit, SrcSize * 8, 0,
+              Src);
 
   StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Src, DstSize, -1);
 }

--- a/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -833,12 +833,17 @@ bool ConstProp::ConstantPropagation(IREmitter *IREmit, const IRListView& Current
       uint64_t Constant;
       if (IREmit->IsValueConstant(Op->Src, &Constant)) {
         // SBFE of a constant can be converted to a constant.
-        uint64_t SourceMask = Op->Width == 64 ? ~0ULL : ((1ULL << Op->Width) - 1);
+        uint64_t SourceMask =
+            Op->Width == 64 ? ~0ULL : ((1ULL << Op->Width) - 1);
+        uint64_t DestSizeInBits = IROp->Size * 8;
+        uint64_t DestMask =
+            DestSizeInBits == 64 ? ~0ULL : ((1ULL << DestSizeInBits) - 1);
         SourceMask <<= Op->lsb;
 
         int64_t NewConstant = (Constant & SourceMask) >> Op->lsb;
         NewConstant <<= 64 - Op->Width;
         NewConstant >>= 64 - Op->Width;
+        NewConstant &= DestMask;
         IREmit->ReplaceWithConstant(CodeNode, NewConstant);
 
         Changed = true;

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -2786,8 +2786,7 @@
       "ExpectedInstructionCount": 3,
       "Comment": "0x98",
       "ExpectedArm64ASM": [
-        "uxth w20, w4",
-        "sxtb x20, w20",
+        "sxtb w20, w4",
         "bfxil x4, x20, #0, #16"
       ]
     },
@@ -2795,9 +2794,7 @@
       "ExpectedInstructionCount": 3,
       "Comment": "0x98",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "sxth x20, w20",
-        "mov w4, w20"
+        "sxth w4, w4"
       ]
     },
     "cdqe": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -2783,7 +2783,7 @@
       "ExpectedArm64ASM": []
     },
     "cbw": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": "0x98",
       "ExpectedArm64ASM": [
         "sxtb w20, w4",
@@ -2791,7 +2791,7 @@
       ]
     },
     "cwde": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Comment": "0x98",
       "ExpectedArm64ASM": [
         "sxth w4, w4"


### PR DESCRIPTION
Optimize `cwde` and `cbw`.

Change OpcodeDispatcher CDQOp to load directly from GPR, and recognize instruction width.

Also change Constant Propagation to synthesize 32bits constant when necessary.

Update instcountci files.