### PR TITLE
Config: Fixes JSON parsing of "ArgumentHandler" types

### DIFF
--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -453,12 +453,6 @@ def print_parse_jsonloader_options(options):
                 output_argloader.write("Set(KeyOption, FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, Value_View));\n".format(op_key, op_key, op_key))
                 output_argloader.write("}\n")
 
-            if ("ArgumentHandler" in op_vals):
-                conversion_func = "FEXCore::Config::Handler::{0}".format(op_vals["ArgumentHandler"])
-                output_argloader.write("else if (KeyName == \"{0}\") {{\n".format(op_key))
-                output_argloader.write("Set(KeyOption, {0}(Value_View));\n".format(conversion_func))
-                output_argloader.write("}\n")
-
     output_argloader.write("else {{\n".format(op_key))
     output_argloader.write("Set(KeyOption, ConfigString);\n")
     output_argloader.write("}\n")


### PR DESCRIPTION
When 4d109c9ce02bbc392e59c74d34b885de8fa8efde fixed parsing strenum types in the json, it also added `ArgumentHandler` types to the json parsing. This was incorrect as those types are already stored in the json in their decoded numerical format.

Without this change, all config options with `ArgumentHandler` will decode as "0" which is incorrect. The main killer here is that SMCChecks gets disabled (visible in both FEXConfig and when applications are running) which was causing spurious failures.