### PR TITLE
SpinLockWait: Fixes unexpected lock success

### DIFF
--- a/FEXCore/Source/Utils/SpinWaitLock.h
+++ b/FEXCore/Source/Utils/SpinWaitLock.h
@@ -259,6 +259,7 @@ namespace FEXCore::Utils::SpinWaitLock {
     do {
       // Wait until the futex is unlocked.
       Wait(Futex, 0);
+      Expected = 0;
     } while (!AtomicFutex->compare_exchange_strong(Expected, Desired));
   }
 


### PR DESCRIPTION
With a contended unique lock, we forgot to reset the `Expected` value to zero. This was causing a contended mutex to incorrectly succeed.

Noticed this when converting some pthread mutexes over to spinloops to remove strace noise.

The reference wfe_mutex library I wrote didn't have this problem since the implementation is slightly different.