### PR TITLE
Linux: Decouple thread object creation and tracking

### DIFF
--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -483,6 +483,7 @@ int main(int argc, char **argv, char **const envp) {
   }
 
   auto ParentThread = SyscallHandler->TM.CreateThread(Loader.DefaultRIP(), Loader.GetStackPointer());
+  SyscallHandler->TM.TrackThread(ParentThread);
 
   // Pass in our VDSO thunks
   CTX->AppendThunkDefinitions(FEX::VDSO::GetVDSOThunkDefinitions());

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -105,6 +105,10 @@ class ThreadManager final {
     ~ThreadManager();
 
     FEXCore::Core::InternalThreadState *CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::Core::CPUState *NewThreadState = nullptr, uint64_t ParentTID = 0);
+    void TrackThread(FEXCore::Core::InternalThreadState *Thread) {
+      std::lock_guard lk(ThreadCreationMutex);
+      Threads.emplace_back(Thread);
+    }
 
     void DestroyThread(FEXCore::Core::InternalThreadState *Thread);
     void StopThread(FEXCore::Core::InternalThreadState *Thread);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -9,9 +9,6 @@ namespace FEX::HLE {
   FEXCore::Core::InternalThreadState *ThreadManager::CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::Core::CPUState *NewThreadState, uint64_t ParentTID) {
     auto Thread = CTX->CreateThread(InitialRIP, StackPointer, NewThreadState, ParentTID);
 
-    std::lock_guard lk(ThreadCreationMutex);
-    Threads.emplace_back(Thread);
-
     ++IdleWaitRefCount;
     return Thread;
   }


### PR DESCRIPTION
If the thread object is added to the tracking vector immediately then there ends up being a race condition before the thread manages to fill out the thread-specific data that only occurs at the start of the new thread.

This manifests in a crash when a thread is allocating memory while another thread is getting constructed. Easy fix is to defer the tracking until the thread has setup its state.