### PR TITLE
Library Forwarding: Disable struct padding for packed arguments

### DIFF
--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
@@ -45,7 +45,7 @@ namespace FEX::VDSO {
     // glibc handlers
     namespace glibc {
       static void time(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           time_t *a_0;
           uint64_t rv;
         } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
@@ -55,7 +55,7 @@ namespace FEX::VDSO {
       }
 
       static void gettimeofday(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           struct timeval *tv;
           struct timezone *tz;
           uint64_t rv;
@@ -66,7 +66,7 @@ namespace FEX::VDSO {
       }
 
       static void clock_gettime(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           clockid_t clk_id;
           struct timespec *tp;
           uint64_t rv;
@@ -77,7 +77,7 @@ namespace FEX::VDSO {
       }
 
       static void clock_getres(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           clockid_t clk_id;
           struct timespec *tp;
           uint64_t rv;
@@ -88,7 +88,7 @@ namespace FEX::VDSO {
       }
 
       static void getcpu(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           uint32_t *cpu;
           uint32_t *node;
           uint64_t rv;
@@ -102,7 +102,7 @@ namespace FEX::VDSO {
     namespace VDSO {
       // VDSO handlers
       static void time(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           time_t *a_0;
           uint64_t rv;
         } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
@@ -111,7 +111,7 @@ namespace FEX::VDSO {
       }
 
       static void gettimeofday(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           struct timeval *tv;
           struct timezone *tz;
           uint64_t rv;
@@ -121,7 +121,7 @@ namespace FEX::VDSO {
       }
 
       static void clock_gettime(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           clockid_t clk_id;
           struct timespec *tp;
           uint64_t rv;
@@ -131,7 +131,7 @@ namespace FEX::VDSO {
       }
 
       static void clock_getres(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           clockid_t clk_id;
           struct timespec *tp;
           uint64_t rv;
@@ -141,7 +141,7 @@ namespace FEX::VDSO {
       }
 
       static void getcpu(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           uint32_t *cpu;
           uint32_t *node;
           uint64_t rv;
@@ -168,7 +168,7 @@ namespace FEX::VDSO {
 
       // glibc handlers
       static void time(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           HLE::x32::compat_ptr<FEX::HLE::x32::old_time32_t> a_0;
           int rv;
         } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
@@ -182,7 +182,7 @@ namespace FEX::VDSO {
       }
 
       static void gettimeofday(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           HLE::x32::compat_ptr<FEX::HLE::x32::timeval32> tv;
           HLE::x32::compat_ptr<struct timezone> tz;
           int rv;
@@ -203,7 +203,7 @@ namespace FEX::VDSO {
       }
 
       static void clock_gettime(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           clockid_t clk_id;
           HLE::x32::compat_ptr<HLE::x32::timespec32> tp;
           int rv;
@@ -219,7 +219,7 @@ namespace FEX::VDSO {
       }
 
       static void clock_gettime64(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           clockid_t clk_id;
           HLE::x32::compat_ptr<struct timespec> tp;
           int rv;
@@ -230,7 +230,7 @@ namespace FEX::VDSO {
       }
 
       static void clock_getres(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           clockid_t clk_id;
           HLE::x32::compat_ptr<HLE::x32::timespec32> tp;
           int rv;
@@ -247,7 +247,7 @@ namespace FEX::VDSO {
       }
 
       static void getcpu(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           HLE::x32::compat_ptr<uint32_t> cpu;
           HLE::x32::compat_ptr<uint32_t> node;
           int rv;
@@ -265,7 +265,7 @@ namespace FEX::VDSO {
 
       // VDSO handlers
       static void time(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           HLE::x32::compat_ptr<FEX::HLE::x32::old_time32_t> a_0;
           int rv;
         } *args = reinterpret_cast<ArgsRV_t*>(ArgsRV);
@@ -279,7 +279,7 @@ namespace FEX::VDSO {
       }
 
       static void gettimeofday(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           HLE::x32::compat_ptr<FEX::HLE::x32::timeval32> tv;
           HLE::x32::compat_ptr<struct timezone> tz;
           int rv;
@@ -300,7 +300,7 @@ namespace FEX::VDSO {
       }
 
       static void clock_gettime(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           clockid_t clk_id;
           HLE::x32::compat_ptr<HLE::x32::timespec32> tp;
           int rv;
@@ -316,7 +316,7 @@ namespace FEX::VDSO {
       }
 
       static void clock_gettime64(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           clockid_t clk_id;
           HLE::x32::compat_ptr<struct timespec> tp;
           int rv;
@@ -326,7 +326,7 @@ namespace FEX::VDSO {
       }
 
       static void clock_getres(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           clockid_t clk_id;
           HLE::x32::compat_ptr<HLE::x32::timespec32> tp;
           int rv;
@@ -343,7 +343,7 @@ namespace FEX::VDSO {
       }
 
       static void getcpu(void* ArgsRV) {
-        struct ArgsRV_t {
+        struct __attribute__((packed)) ArgsRV_t {
           HLE::x32::compat_ptr<uint32_t> cpu;
           HLE::x32::compat_ptr<uint32_t> node;
           int rv;

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -164,7 +164,7 @@ void GenerateThunkLibsAction::EmitLayoutWrappers(
         }
 
         if (type->isEnumeralType()) {
-            fmt::print(file, "template<>\nstruct guest_layout<{}> {{\n", struct_name);
+            fmt::print(file, "template<>\nstruct __attribute__((packed)) guest_layout<{}> {{\n", struct_name);
             fmt::print(file, "  using type = {}int{}_t;\n",
                        type->isUnsignedIntegerOrEnumerationType() ? "u" : "",
                        guest_abi.at(struct_name).get_if_simple_or_struct()->size_bits);
@@ -182,12 +182,13 @@ void GenerateThunkLibsAction::EmitLayoutWrappers(
         }
 
         // Guest layout definition
-        fmt::print(file, "template<>\nstruct guest_layout<{}> {{\n", struct_name);
+        // NOTE: uint64_t has lower alignment requirements on 32-bit than on 64-bit, so we require tightly packed structs
+        // TODO: Now we must emit padding bytes explicitly, though!
+        fmt::print(file, "template<>\nstruct __attribute__((packed)) guest_layout<{}> {{\n", struct_name);
         if (type_compat.at(type) == TypeCompatibility::Full) {
             fmt::print(file, "  using type = {};\n", struct_name);
         } else {
             fmt::print(file, "  struct type {{\n");
-            // TODO: Insert any required padding bytes
             for (auto& member : guest_abi.at(struct_name).get_if_struct()->members) {
                 fmt::print( file, "    guest_layout<{}{}> {};\n",
                             member.type_name,
@@ -454,7 +455,7 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
             }
             // Using trailing return type as it makes handling function pointer returns much easier
             file << ") -> " << data.return_type.getAsString() << " {\n";
-            file << "  struct {\n";
+            file << "  struct __attribute__((packed)) {\n";
             for (std::size_t idx = 0; idx < data.param_types.size(); ++idx) {
                 auto& type = data.param_types[idx];
                 file << "    " << format_decl(type.getUnqualifiedType(), fmt::format("a_{}", idx)) << ";\n";
@@ -600,7 +601,7 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
             // Packed argument structs used in fexfn_unpack_*
             auto GeneratePackedArgs = [&](const auto &function_name, const ThunkedFunction &thunk) -> std::string {
                 std::string struct_name = "fexfn_packed_args_" + libname + "_" + function_name;
-                file << "struct " << struct_name << " {\n";
+                file << "struct __attribute__((packed)) " << struct_name << " {\n";
 
                 for (std::size_t idx = 0; idx < thunk.param_types.size(); ++idx) {
                     fmt::print(file, "  guest_layout<{}> a_{};\n", get_guest_type_name(thunk.param_types[idx]), idx);

--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -121,7 +121,7 @@ template<> inline constexpr bool has_compatible_data_layout<const void**> = true
 
 // Placeholder type to indicate the given data is in guest-layout
 template<typename T>
-struct guest_layout {
+struct __attribute__((packed)) guest_layout {
   static_assert(!std::is_class_v<T>, "No guest layout defined for this non-opaque struct type. This may be a bug in the thunk generator.");
   static_assert(!std::is_union_v<T>, "No guest layout defined for this non-opaque union type. This may be a bug in the thunk generator.");
   static_assert(!std::is_enum_v<T>, "No guest layout defined for this enum type. This is a bug in the thunk generator.");

--- a/ThunkLibs/include/common/PackedArguments.h
+++ b/ThunkLibs/include/common/PackedArguments.h
@@ -5,45 +5,45 @@
 #include <utility>
 
 template<typename Result, typename... Args>
-struct PackedArguments;
+struct __attribute__((packed)) PackedArguments;
 
 template<typename R>
-struct PackedArguments<R> { R rv; };
+struct __attribute__((packed)) PackedArguments<R> { R rv; };
 template<typename R, typename A0>
-struct PackedArguments<R, A0> { A0 a0; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0> { A0 a0; R rv; };
 template<typename R, typename A0, typename A1>
-struct PackedArguments<R, A0, A1> { A0 a0; A1 a1; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1> { A0 a0; A1 a1; R rv; };
 template<typename R, typename A0, typename A1, typename A2>
-struct PackedArguments<R, A0, A1, A2> { A0 a0; A1 a1; A2 a2; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2> { A0 a0; A1 a1; A2 a2; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3>
-struct PackedArguments<R, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-struct PackedArguments<R, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; R rv; };
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; R rv; };
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; R rv; };
 
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9,
          typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17, typename A18, typename A19,
          typename A20, typename A21, typename A22>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9,
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9,
                        A10, A11, A12, A13, A14, A15, A16, A17, A18, A19,
                        A20, A21, A22> {
     A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9;
@@ -54,7 +54,7 @@ struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9,
 template<typename R, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9,
          typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17, typename A18, typename A19,
          typename A20, typename A21, typename A22, typename A23>
-struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9,
+struct __attribute__((packed)) PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9,
                        A10, A11, A12, A13, A14, A15, A16, A17, A18, A19,
                        A20, A21, A22, A23> {
     A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9;
@@ -63,45 +63,45 @@ struct PackedArguments<R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9,
 };
 
 template<>
-struct PackedArguments<void> { };
+struct __attribute__((packed)) PackedArguments<void> { };
 template<typename A0>
-struct PackedArguments<void, A0> { A0 a0; };
+struct __attribute__((packed)) PackedArguments<void, A0> { A0 a0; };
 template<typename A0, typename A1>
-struct PackedArguments<void, A0, A1> { A0 a0; A1 a1; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1> { A0 a0; A1 a1; };
 template<typename A0, typename A1, typename A2>
-struct PackedArguments<void, A0, A1, A2> { A0 a0; A1 a1; A2 a2; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2> { A0 a0; A1 a1; A2 a2; };
 template<typename A0, typename A1, typename A2, typename A3>
-struct PackedArguments<void, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3> { A0 a0; A1 a1; A2 a2; A3 a3; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4>
-struct PackedArguments<void, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; };
 template<typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17, typename A18>
-struct PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; A18 a18; };
+struct __attribute__((packed)) PackedArguments<void, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18> { A0 a0; A1 a1; A2 a2; A3 a3; A4 a4; A5 a5; A6 a6; A7 a7; A8 a8; A9 a9; A10 a10; A11 a11; A12 a12; A13 a13; A14 a14; A15 a15; A16 a16; A17 a17; A18 a18; };
 
 // Helper struct that allows assigning the result of a function to a variable, even if that result is a void type.
 //


### PR DESCRIPTION
ARM64, x86 (64-bit), and x86 (32-bit) each have different alignment requirements, so this change ensures that consistent data layout is used for packing and unpacking.

Ready for review, but let's merge it after the February release.
