### PR TITLE
Clang Format file proposal

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,109 @@
+Language: Cpp
+BasedOnStyle: WebKit
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: None
+AlignEscapedNewlines: DontAlign
+AlignOperands: DontAlign
+AlignTrailingComments: false
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: Inline
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: No
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeElse: false
+  BeforeLambdaBody: true
+  BeforeWhile: false
+  IndentBraces: false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeColon
+ColumnLimit: 140
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 0
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+EmptyLineAfterAccessModifier: Leave
+EmptyLineBeforeAccessModifier: Leave
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+IncludeBlocks: Preserve
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentRequires: false
+IndentWidth: 2
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: OuterScope
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: Inner
+PackConstructorInitializers: Never
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 2
+PenaltyBreakOpenParenthesis: 2
+PenaltyBreakTemplateDeclaration: 8
+PenaltyExcessCharacter: 2
+PenaltyIndentedWhitespace: 1024
+PenaltyReturnTypeOnItsOwnLine: 16
+PointerAlignment: Left
+QualifierAlignment: Leave
+RemoveBracesLLVM: false
+ReflowComments: false
+RequiresClausePosition: WithPreceding
+SeparateDefinitionBlocks: Leave
+SortIncludes: Never
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterFunctionDeclarationName: false
+  AfterFunctionDefinitionName: false
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: true
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: Leave
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInParentheses: false
+Standard: c++20
+UseTab: Never


### PR DESCRIPTION
This is a proposal to add a `.clang-format` file to be used as the basis for a code formatting standard inside FEX.

This PR is meant for us to discuss if we are open to a `.clang-format` and how to adopt it. 
If I run [clang-unformat](https://github.com/alandefreitas/clang-unformat) on different files and different directories inside FEX, I get different configuration files since there is a number of coding guidelines being used.

Therefore I took the two top level directories: `Source`, and `FEXCore` and created for each, a clang-format file that minimizes the amount of necessary changes. The version included in this PR, is the version generated by `clang-unformat` for the FEXCore directory.

I also created two branches that format the whole FEX tree by each of these files. The branches are:

* Format according to FEXCore: https://github.com/pmatos/FEX/tree/ClangFormatFEXCore
* Format according to Source: https://github.com/pmatos/FEX/tree/ClangFormatSource

My initial feeling is, whatever `.clang-format` is chosen, we could just use it to format the snippets we edit without doing a full tree format and slowly make it the adopted code formatting convention. The nuclear option is to reformat the whole tree and add the commit to a `.git-blame-ignore-revs` file (see for the example the one for LLVM [here](https://github.com/llvm/llvm-project/blob/main/.git-blame-ignore-revs)).

If you have suggestions about a different convention, and would like to see it applied to the tree or a specific file, let me know and I can generate that for you if you wish.