### PR TITLE
Fixes one mutex hang

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -174,6 +174,10 @@ namespace FEXCore::Context {
       void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread) override;
       void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) override;
       void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, CodeRangeInvalidationFn callback) override;
+      FEXCore::ForkableSharedMutex &GetCodeInvalidationMutex() override {
+        return CodeInvalidationMutex;
+      }
+
       void MarkMemoryShared(FEXCore::Core::InternalThreadState *Thread) override;
 
       void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, fextl::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress) override;

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -928,20 +928,10 @@ namespace FEXCore::Context {
   }
 
   void ContextImpl::InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) {
-    // Potential deferred since Thread might not be valid.
-    // Thread object isn't valid very early in frontend's initialization.
-    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
-    auto lk = GuardSignalDeferringSectionWithFallback(CodeInvalidationMutex, Thread);
-
     InvalidateGuestThreadCodeRange(Thread, Start, Length);
   }
 
   void ContextImpl::InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, CodeRangeInvalidationFn CallAfter) {
-    // Potential deferred since Thread might not be valid.
-    // Thread object isn't valid very early in frontend's initialization.
-    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
-    auto lk = GuardSignalDeferringSectionWithFallback(CodeInvalidationMutex, Thread);
-
     InvalidateGuestThreadCodeRange(Thread, Start, Length);
     CallAfter(Start, Length);
   }

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -20,6 +20,7 @@
 namespace FEXCore {
   class CodeLoader;
   class HostFeatures;
+  class ForkableSharedMutex;
 }
 
 namespace FEXCore::Core {
@@ -228,6 +229,8 @@ namespace FEXCore::Context {
       FEX_DEFAULT_VISIBILITY virtual void ClearCodeCache(FEXCore::Core::InternalThreadState *Thread) = 0;
       FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) = 0;
       FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length, CodeRangeInvalidationFn callback) = 0;
+      FEX_DEFAULT_VISIBILITY virtual FEXCore::ForkableSharedMutex &GetCodeInvalidationMutex() = 0;
+
       FEX_DEFAULT_VISIBILITY virtual void MarkMemoryShared(FEXCore::Core::InternalThreadState *Thread) = 0;
 
       FEX_DEFAULT_VISIBILITY virtual void ConfigureAOTGen(FEXCore::Core::InternalThreadState *Thread, fextl::set<uint64_t> *ExternalBranches, uint64_t SectionMaxAddress) = 0;

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -7,6 +7,7 @@
 #include <FEXCore/Utils/File.h>
 #include <FEXCore/Utils/FileLoading.h>
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/SignalScopeGuards.h>
 
 namespace CodeSize {
   class CodeSizeValidation final {
@@ -199,6 +200,7 @@ namespace CodeSize {
     ClearStats();
 
     // Invalidate the code ranges to be safe.
+    auto CodeInvalidationlk = FEXCore::GuardSignalDeferringSection(CTX->GetCodeInvalidationMutex(), Thread);
     CTX->InvalidateGuestCodeRange(Thread, (uint64_t)NOP, sizeof(NOP));
     CTX->InvalidateGuestCodeRange(Thread, (uint64_t)MFENCE, sizeof(MFENCE));
     SetupInfoDisabled = false;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -134,6 +134,11 @@ class ThreadManager final {
     void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *CallingThread, uint64_t Start, uint64_t Length) {
       std::lock_guard lk(ThreadCreationMutex);
 
+      // Potential deferred since Thread might not be valid.
+      // Thread object isn't valid very early in frontend's initialization.
+      // To be more optimal the frontend should provide this code with a valid Thread object earlier.
+      auto CodeInvalidationlk = GuardSignalDeferringSectionWithFallback(CTX->GetCodeInvalidationMutex(), CallingThread);
+
       for (auto &Thread : Threads) {
         CTX->InvalidateGuestCodeRange(Thread, Start, Length);
       }
@@ -141,6 +146,11 @@ class ThreadManager final {
 
     void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState *CallingThread, uint64_t Start, uint64_t Length, FEXCore::Context::CodeRangeInvalidationFn callback) {
       std::lock_guard lk(ThreadCreationMutex);
+
+      // Potential deferred since Thread might not be valid.
+      // Thread object isn't valid very early in frontend's initialization.
+      // To be more optimal the frontend should provide this code with a valid Thread object earlier.
+      auto CodeInvalidationlk = GuardSignalDeferringSectionWithFallback(CTX->GetCodeInvalidationMutex(), CallingThread);
 
       for (auto &Thread : Threads) {
         CTX->InvalidateGuestCodeRange(Thread, Start, Length, callback);


### PR DESCRIPTION
When code invalidation is happening we currently have the issue that a thread can acquire the code invalidation mutex in the middle of invalidation. This is due to us acquiring and releasing the mutex between each thread's code invalidation.

We need to hold the mutex for the entire duration for all thread's code invalidation.
This fixes a rare hang on proton startup and resolves a consistent hang on Proton application shutdown.

This now puts us on par with FEX-2312.1 with hanging.

This does not fix a relatively rare hang on fork (which also existed with FEX-2312.1).

This also does not fix the issue that the intersection of our mutexes between frontend and backend are very convoluted. In part of the work that is going to fix the rare fork mutex hang will change more of this.