### PR TITLE
Optimize 8/16-bit adds/subs

### DIFF
--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -964,10 +964,7 @@
       "AddNZCV OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Set NZCV for the sum of two GPRs"],
         "HasSideEffects": true,
-        "DestSize": "Size",
-        "EmitValidation": [
-          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
-        ]
+        "DestSize": "Size"
       },
       "CarryInvert": {
         "Desc": ["Invert carry flag in NZCV"],
@@ -1029,10 +1026,7 @@
                  "Carry flag uses arm64 definition, inverted x86.",
                  ""],
         "DestSize": "Size",
-        "HasSideEffects": true,
-        "EmitValidation": [
-          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
-        ]
+        "HasSideEffects": true
       },
       "GPR = Or OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Integer binary or"

--- a/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -970,7 +970,9 @@ bool ConstProp::ConstantInlining(IREmitter *IREmit, const IRListView& CurrentIR)
 
         uint64_t Constant2{};
         if (IREmit->IsValueConstant(Op->Header.Args[1], &Constant2)) {
-          if (IsImmAddSub(Constant2)) {
+          // We don't allow 8/16-bit operations to have constants, since no
+          // constant would be in bounds after the JIT's 24/16 shift.
+          if (IsImmAddSub(Constant2) && Op->Header.Size >= 4) {
             IREmit->SetWriteCursor(CurrentIR.GetNode(Op->Header.Args[1]));
 
             IREmit->ReplaceNodeArgument(CodeNode, 1, CreateInlineConstant(IREmit, Constant2));

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -11,43 +11,25 @@
   },
   "Instructions": {
     "lock add byte [rax], cl": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 5,
       "Comment": "0x00",
       "ExpectedArm64ASM": [
-        "uxtb w20, w5",
-        "ldaddalb w20, w21, [x4]",
-        "add w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "ldaddalb w5, w20, [x4]",
+        "add w26, w20, w5",
+        "eor w27, w20, w5",
+        "lsl w0, w20, #24",
+        "cmn w0, w5, lsl #24"
       ]
     },
     "lock add word [rax], cx": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 5,
       "Comment": "0x01",
       "ExpectedArm64ASM": [
-        "uxth w20, w5",
-        "ldaddalh w20, w21, [x4]",
-        "add w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "ldaddalh w5, w20, [x4]",
+        "add w26, w20, w5",
+        "eor w27, w20, w5",
+        "lsl w0, w20, #16",
+        "cmn w0, w5, lsl #16"
       ]
     },
     "lock add dword [rax], ecx": {
@@ -264,44 +246,32 @@
       ]
     },
     "lock sub byte [rax], cl": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 9,
       "Comment": "0x28",
       "ExpectedArm64ASM": [
-        "uxtb w20, w5",
-        "neg w1, w20",
-        "ldaddalb w1, w21, [x4]",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
+        "neg w1, w5",
+        "ldaddalb w1, w20, [x4]",
+        "sub w26, w20, w5",
+        "eor w27, w20, w5",
+        "lsl w0, w20, #24",
+        "cmp w0, w5, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "lock sub word [rax], cx": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 9,
       "Comment": "0x28",
       "ExpectedArm64ASM": [
-        "uxth w20, w5",
-        "neg w1, w20",
-        "ldaddalh w1, w21, [x4]",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
+        "neg w1, w5",
+        "ldaddalh w1, w20, [x4]",
+        "sub w26, w20, w5",
+        "eor w27, w20, w5",
+        "lsl w0, w20, #16",
+        "cmp w0, w5, lsl #16",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -391,7 +361,7 @@
       ]
     },
     "xadd byte [rax], bl": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -399,20 +369,12 @@
         "bfxil x7, x21, #0, #8",
         "add w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "xadd word [rax], bx": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -420,16 +382,8 @@
         "bfxil x7, x21, #0, #16",
         "add w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "xadd dword [rax], ebx": {
@@ -455,73 +409,49 @@
       ]
     },
     "lock add byte [rax], 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldaddalb w20, w27, [x4]",
         "add w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #24",
-        "mrs x20, nzcv",
-        "ubfx x21, x26, #8, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w26, w27",
-        "ubfx x21, x21, #7, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w27, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "lock add byte [rax], 0xFF": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
-        "ldaddalb w20, w20, [x4]",
-        "add w26, w20, #0xff (255)",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "ubfx x22, x26, #8, #1",
-        "orr w21, w21, w22, lsl #29",
-        "bic w20, w20, w26",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
+        "ldaddalb w20, w21, [x4]",
+        "add w26, w21, #0xff (255)",
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "lock add word [rax], 0x100": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "ldaddalh w20, w27, [x4]",
         "add w26, w27, #0x100 (256)",
-        "cmn wzr, w26, lsl #16",
-        "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w26, w27",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "lock add word [rax], 0xFFFF": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "ldaddalh w20, w21, [x4]",
         "add w26, w21, w20",
         "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
-        "mrs x20, nzcv",
-        "ubfx x22, x26, #16, #1",
-        "orr w20, w20, w22, lsl #29",
-        "bic w21, w21, w26",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "lock add dword [rax], 0x100": {
@@ -566,20 +496,14 @@
       ]
     },
     "lock add word [rax], 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldaddalh w20, w27, [x4]",
         "add w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #16",
-        "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w26, w27",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "lock add dword [rax], 1": {
@@ -1275,62 +1199,53 @@
       ]
     },
     "lock sub byte [rax], 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "neg w1, w20",
         "ldaddalb w1, w27, [x4]",
         "sub w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #24",
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #8, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w27, w26",
-        "ubfx x21, x21, #7, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "lock sub byte [rax], 0xFF": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
         "neg w1, w20",
-        "ldaddalb w1, w20, [x4]",
-        "sub w26, w20, #0xff (255)",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "ubfx x22, x26, #8, #1",
-        "orr w21, w21, w22, lsl #29",
-        "bic w20, w26, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w21, w20, lsl #28",
+        "ldaddalb w1, w21, [x4]",
+        "sub w26, w21, #0xff (255)",
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmp w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "lock sub word [rax], 0x100": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "neg w1, w20",
         "ldaddalh w1, w27, [x4]",
         "sub w26, w27, #0x100 (256)",
-        "cmn wzr, w26, lsl #16",
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w27, w26",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "lock sub word [rax], 0xFFFF": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1338,13 +1253,10 @@
         "ldaddalh w1, w21, [x4]",
         "sub w26, w21, w20",
         "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
+        "lsl w0, w21, #16",
+        "cmp w0, w20, lsl #16",
         "mrs x20, nzcv",
-        "ubfx x22, x26, #16, #1",
-        "orr w20, w20, w22, lsl #29",
-        "bic w21, w26, w21",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1406,20 +1318,17 @@
       ]
     },
     "lock sub word [rax], 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "neg w1, w20",
         "ldaddalh w1, w27, [x4]",
         "sub w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #16",
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w27, w26",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1562,20 +1471,18 @@
       ]
     },
     "lock dec byte [rax]": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "neg w1, w20",
         "ldaddalb w1, w27, [x4]",
         "sub w26, w27, #0x1 (1)",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "bic w22, w27, w26",
-        "ubfx x22, x22, #7, #1",
-        "orr w21, w21, w22, lsl #28",
-        "orr w20, w21, w20, lsl #29",
+        "cset w21, hs",
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
         "msr nzcv, x20"
       ]
     },
@@ -1612,7 +1519,7 @@
       ]
     },
     "lock neg byte [rax]": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP2 0xf6 /3",
       "ExpectedArm64ASM": [
         "ldaxrb w1, [x4]",
@@ -1621,18 +1528,14 @@
         "cbnz w3, #-0xc",
         "mov w27, w1",
         "neg w26, w27",
-        "cmn wzr, w26, lsl #24",
+        "cmp wzr, w27, lsl #24",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #8, #1",
-        "orr w20, w20, w21, lsl #29",
-        "and w21, w26, w27",
-        "ubfx x21, x21, #7, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "lock neg word [rax]": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "ldaxrh w1, [x4]",
@@ -1641,13 +1544,9 @@
         "cbnz w3, #-0xc",
         "mov w27, w1",
         "neg w26, w27",
-        "cmn wzr, w26, lsl #16",
+        "cmp wzr, w27, lsl #16",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "and w21, w26, w27",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1684,20 +1583,18 @@
       ]
     },
     "lock dec word [rax]": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "neg w1, w20",
         "ldaddalh w1, w27, [x4]",
         "sub w26, w27, #0x1 (1)",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #16",
-        "mrs x21, nzcv",
-        "bic w22, w27, w26",
-        "ubfx x22, x22, #15, #1",
-        "orr w21, w21, w22, lsl #28",
-        "orr w20, w21, w20, lsl #29",
+        "cset w21, hs",
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
         "msr nzcv, x20"
       ]
     },
@@ -1736,36 +1633,32 @@
       ]
     },
     "lock inc byte [rax]": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldaddalb w20, w27, [x4]",
         "add w26, w27, #0x1 (1)",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "bic w22, w26, w27",
-        "ubfx x22, x22, #7, #1",
-        "orr w21, w21, w22, lsl #28",
-        "orr w20, w21, w20, lsl #29",
+        "cset w21, hs",
+        "lsl w0, w27, #24",
+        "cmn w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
         "msr nzcv, x20"
       ]
     },
     "lock inc word [rax]": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldaddalh w20, w27, [x4]",
         "add w26, w27, #0x1 (1)",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #16",
-        "mrs x21, nzcv",
-        "bic w22, w26, w27",
-        "ubfx x22, x22, #15, #1",
-        "orr w21, w21, w22, lsl #28",
-        "orr w20, w21, w20, lsl #29",
+        "cset w21, hs",
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
         "msr nzcv, x20"
       ]
     },

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -12,35 +12,25 @@
   },
   "Instructions": {
     "lock add byte [rax], cl": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 5,
       "Comment": "0x00",
       "ExpectedArm64ASM": [
-        "uxtb w20, w5",
-        "ldaddalb w20, w21, [x4]",
-        "add w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "ldaddalb w5, w20, [x4]",
+        "add w26, w20, w5",
+        "eor w27, w20, w5",
+        "lsl w0, w20, #24",
+        "cmn w0, w5, lsl #24"
       ]
     },
     "lock add word [rax], cx": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 5,
       "Comment": "0x01",
       "ExpectedArm64ASM": [
-        "uxth w20, w5",
-        "ldaddalh w20, w21, [x4]",
-        "add w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "ldaddalh w5, w20, [x4]",
+        "add w26, w20, w5",
+        "eor w27, w20, w5",
+        "lsl w0, w20, #16",
+        "cmn w0, w5, lsl #16"
       ]
     },
     "lock add dword [rax], ecx": {
@@ -249,37 +239,29 @@
       ]
     },
     "lock sub byte [rax], cl": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x28",
       "ExpectedArm64ASM": [
-        "uxtb w20, w5",
-        "neg w1, w20",
-        "ldaddalb w1, w21, [x4]",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "neg w1, w5",
+        "ldaddalb w1, w20, [x4]",
+        "sub w26, w20, w5",
+        "eor w27, w20, w5",
+        "lsl w0, w20, #24",
+        "cmp w0, w5, lsl #24",
+        "cfinv"
       ]
     },
     "lock sub word [rax], cx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x28",
       "ExpectedArm64ASM": [
-        "uxth w20, w5",
-        "neg w1, w20",
-        "ldaddalh w1, w21, [x4]",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "neg w1, w5",
+        "ldaddalh w1, w20, [x4]",
+        "sub w26, w20, w5",
+        "eor w27, w20, w5",
+        "lsl w0, w20, #16",
+        "cmp w0, w5, lsl #16",
+        "cfinv"
       ]
     },
     "lock sub dword [rax], ecx": {
@@ -332,7 +314,7 @@
       ]
     },
     "xadd byte [rax], bl": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -340,16 +322,12 @@
         "bfxil x7, x21, #0, #8",
         "add w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "xadd word [rax], bx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -357,12 +335,8 @@
         "bfxil x7, x21, #0, #16",
         "add w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "xadd dword [rax], ebx": {
@@ -388,57 +362,49 @@
       ]
     },
     "lock add byte [rax], 1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldaddalb w20, w27, [x4]",
         "add w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w26, w27",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w27, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "lock add byte [rax], 0xFF": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
-        "ldaddalb w20, w20, [x4]",
-        "add w26, w20, #0xff (255)",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w20, w26",
-        "rmif x20, #7, #nzcV"
+        "ldaddalb w20, w21, [x4]",
+        "add w26, w21, #0xff (255)",
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "lock add word [rax], 0x100": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "ldaddalh w20, w27, [x4]",
         "add w26, w27, #0x100 (256)",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w26, w27",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "lock add word [rax], 0xFFFF": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
         "ldaddalh w20, w21, [x4]",
         "add w26, w21, w20",
         "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w21, w26",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "lock add dword [rax], 0x100": {
@@ -483,16 +449,14 @@
       ]
     },
     "lock add word [rax], 1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldaddalh w20, w27, [x4]",
         "add w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w26, w27",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "lock add dword [rax], 1": {
@@ -1154,50 +1118,47 @@
       ]
     },
     "lock sub byte [rax], 1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "neg w1, w20",
         "ldaddalb w1, w27, [x4]",
         "sub w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w27, w26",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "lock sub byte [rax], 0xFF": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xff",
         "neg w1, w20",
-        "ldaddalb w1, w20, [x4]",
-        "sub w26, w20, #0xff (255)",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w26, w20",
-        "rmif x20, #7, #nzcV"
+        "ldaddalb w1, w21, [x4]",
+        "sub w26, w21, #0xff (255)",
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "lock sub word [rax], 0x100": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "neg w1, w20",
         "ldaddalh w1, w27, [x4]",
         "sub w26, w27, #0x100 (256)",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w27, w26",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
+        "cfinv"
       ]
     },
     "lock sub word [rax], 0xFFFF": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP1 0x81 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
@@ -1205,10 +1166,9 @@
         "ldaddalh w1, w21, [x4]",
         "sub w26, w21, w20",
         "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w26, w21",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w21, #16",
+        "cmp w0, w20, lsl #16",
+        "cfinv"
       ]
     },
     "lock sub dword [rax], 0x100": {
@@ -1261,17 +1221,16 @@
       ]
     },
     "lock sub word [rax], 1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x83 /5",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "neg w1, w20",
         "ldaddalh w1, w27, [x4]",
         "sub w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w27, w26",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
+        "cfinv"
       ]
     },
     "lock sub dword [rax], 1": {
@@ -1409,18 +1368,17 @@
       ]
     },
     "lock dec byte [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "neg w1, w20",
         "ldaddalb w1, w27, [x4]",
         "sub w26, w27, #0x1 (1)",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #24",
-        "bic w21, w27, w26",
-        "rmif x21, #7, #nzcV",
-        "rmif x20, #63, #nzCv"
+        "cset w21, hs",
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
+        "rmif x21, #63, #nzCv"
       ]
     },
     "lock not byte [rax]": {
@@ -1456,7 +1414,7 @@
       ]
     },
     "lock neg byte [rax]": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP2 0xf6 /3",
       "ExpectedArm64ASM": [
         "ldaxrb w1, [x4]",
@@ -1465,14 +1423,12 @@
         "cbnz w3, #-0xc",
         "mov w27, w1",
         "neg w26, w27",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "and w20, w26, w27",
-        "rmif x20, #7, #nzcV"
+        "cmp wzr, w27, lsl #24",
+        "cfinv"
       ]
     },
     "lock neg word [rax]": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP2 0xf7 /3",
       "ExpectedArm64ASM": [
         "ldaxrh w1, [x4]",
@@ -1481,10 +1437,8 @@
         "cbnz w3, #-0xc",
         "mov w27, w1",
         "neg w26, w27",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "and w20, w26, w27",
-        "rmif x20, #15, #nzcV"
+        "cmp wzr, w27, lsl #16",
+        "cfinv"
       ]
     },
     "lock neg dword [rax]": {
@@ -1516,18 +1470,17 @@
       ]
     },
     "lock dec word [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "neg w1, w20",
         "ldaddalh w1, w27, [x4]",
         "sub w26, w27, #0x1 (1)",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #16",
-        "bic w21, w27, w26",
-        "rmif x21, #15, #nzcV",
-        "rmif x20, #63, #nzCv"
+        "cset w21, hs",
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
+        "rmif x21, #63, #nzCv"
       ]
     },
     "lock dec dword [rax]": {
@@ -1557,31 +1510,29 @@
       ]
     },
     "lock inc byte [rax]": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldaddalb w20, w27, [x4]",
         "add w26, w27, #0x1 (1)",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #24",
-        "bic w21, w26, w27",
-        "rmif x21, #7, #nzcV",
-        "rmif x20, #63, #nzCv"
+        "cset w21, hs",
+        "lsl w0, w27, #24",
+        "cmn w0, w20, lsl #24",
+        "rmif x21, #63, #nzCv"
       ]
     },
     "lock inc word [rax]": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldaddalh w20, w27, [x4]",
         "add w26, w27, #0x1 (1)",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #16",
-        "bic w21, w26, w27",
-        "rmif x21, #15, #nzcV",
-        "rmif x20, #63, #nzCv"
+        "cset w21, hs",
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16",
+        "rmif x21, #63, #nzCv"
       ]
     },
     "lock inc dword [rax]": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -12,37 +12,29 @@
   },
   "Instructions": {
     "add bl, cl": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x00",
       "ExpectedArm64ASM": [
-        "uxtb w20, w5",
-        "uxtb w21, w7",
-        "add w26, w21, w20",
+        "mov x20, x7",
+        "add w26, w20, w5",
+        "mov x7, x20",
         "bfxil x7, x26, #0, #8",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "eor w27, w20, w5",
+        "lsl w0, w20, #24",
+        "cmn w0, w5, lsl #24"
       ]
     },
     "add bx, cx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x01",
       "ExpectedArm64ASM": [
-        "uxth w20, w5",
-        "uxth w21, w7",
-        "add w26, w21, w20",
+        "mov x20, x7",
+        "add w26, w20, w5",
+        "mov x7, x20",
         "bfxil x7, x26, #0, #16",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "eor w27, w20, w5",
+        "lsl w0, w20, #16",
+        "cmn w0, w5, lsl #16"
       ]
     },
     "add ebx, ecx": {
@@ -68,43 +60,35 @@
       ]
     },
     "db 0x02, 0xcb": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "0x02",
         "add bl, cl but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxtb w20, w7",
-        "uxtb w21, w5",
-        "add w26, w21, w20",
+        "mov x20, x5",
+        "add w26, w20, w7",
+        "mov x5, x20",
         "bfxil x5, x26, #0, #8",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "eor w27, w20, w7",
+        "lsl w0, w20, #24",
+        "cmn w0, w7, lsl #24"
       ]
     },
     "db 0x66, 0x03, 0xcb": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "0x03",
         "add bx, cx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w7",
-        "uxth w21, w5",
-        "add w26, w21, w20",
+        "mov x20, x5",
+        "add w26, w20, w7",
+        "mov x5, x20",
         "bfxil x5, x26, #0, #16",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "eor w27, w20, w7",
+        "lsl w0, w20, #16",
+        "cmn w0, w7, lsl #16"
       ]
     },
     "db 0x03, 0xcb": {
@@ -139,26 +123,26 @@
       "ExpectedInstructionCount": 7,
       "Comment": "0x04",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "add w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #8",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w26, w27",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w27, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "add ax, 1": {
       "ExpectedInstructionCount": 7,
       "Comment": "0x05",
       "ExpectedArm64ASM": [
-        "uxth w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "add w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w26, w27",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, 1": {
@@ -185,29 +169,28 @@
       "ExpectedInstructionCount": 8,
       "Comment": "0x04",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "add w26, w20, #0xff (255)",
+        "mov w20, #0xff",
+        "mov x21, x4",
+        "add w26, w21, #0xff (255)",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #8",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w20, w26",
-        "rmif x20, #7, #nzcV"
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "add ax, -1": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
-        "uxth w21, w4",
+        "mov x21, x4",
         "add w26, w21, w20",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #16",
         "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w21, w26",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, -1": {
@@ -1237,37 +1220,31 @@
       ]
     },
     "sub bl, cl": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x28",
       "ExpectedArm64ASM": [
-        "uxtb w20, w5",
-        "uxtb w21, w7",
-        "sub w26, w21, w20",
+        "mov x20, x7",
+        "sub w26, w20, w5",
+        "mov x7, x20",
         "bfxil x7, x26, #0, #8",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "eor w27, w20, w5",
+        "lsl w0, w20, #24",
+        "cmp w0, w5, lsl #24",
+        "cfinv"
       ]
     },
     "sub bx, cx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x29",
       "ExpectedArm64ASM": [
-        "uxth w20, w5",
-        "uxth w21, w7",
-        "sub w26, w21, w20",
+        "mov x20, x7",
+        "sub w26, w20, w5",
+        "mov x7, x20",
         "bfxil x7, x26, #0, #16",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "eor w27, w20, w5",
+        "lsl w0, w20, #16",
+        "cmp w0, w5, lsl #16",
+        "cfinv"
       ]
     },
     "sub ebx, ecx": {
@@ -1295,43 +1272,37 @@
       ]
     },
     "db 0x2A, 0xcb": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "0x2A",
         "sub bl, cl but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxtb w20, w7",
-        "uxtb w21, w5",
-        "sub w26, w21, w20",
+        "mov x20, x5",
+        "sub w26, w20, w7",
+        "mov x5, x20",
         "bfxil x5, x26, #0, #8",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "eor w27, w20, w7",
+        "lsl w0, w20, #24",
+        "cmp w0, w7, lsl #24",
+        "cfinv"
       ]
     },
     "db 0x66, 0x2B, 0xcb": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "0x2B",
         "sub bx, cx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w7",
-        "uxth w21, w5",
-        "sub w26, w21, w20",
+        "mov x20, x5",
+        "sub w26, w20, w7",
+        "mov x5, x20",
         "bfxil x5, x26, #0, #16",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "eor w27, w20, w7",
+        "lsl w0, w20, #16",
+        "cmp w0, w7, lsl #16",
+        "cfinv"
       ]
     },
     "db 0x2B, 0xcb": {
@@ -1365,29 +1336,31 @@
       ]
     },
     "sub al, 1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x2C",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #8",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w27, w26",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "sub ax, 1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
-        "uxth w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w27, w26",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
+        "cfinv"
       ]
     },
     "sub eax, 1": {
@@ -1413,17 +1386,18 @@
       ]
     },
     "sub al, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 9,
       "Comment": "0x2C",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "sub w26, w20, #0xff (255)",
+        "mov w20, #0xff",
+        "mov x21, x4",
+        "sub w26, w21, #0xff (255)",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #8",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w26, w20",
-        "rmif x20, #7, #nzcV"
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "sub ax, -1": {
@@ -1431,14 +1405,14 @@
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
-        "uxth w21, w4",
+        "mov x21, x4",
         "sub w26, w21, w20",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #16",
         "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w26, w21",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w21, #16",
+        "cmp w0, w20, lsl #16",
+        "cfinv"
       ]
     },
     "sub eax, -1": {
@@ -1588,19 +1562,14 @@
       ]
     },
     "cmp bl, cl": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 5,
       "Comment": "0x38",
       "ExpectedArm64ASM": [
-        "uxtb w20, w5",
-        "uxtb w21, w7",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "sub w26, w7, w5",
+        "eor w27, w7, w5",
+        "lsl w0, w7, #24",
+        "cmp w0, w5, lsl #24",
+        "cfinv"
       ]
     },
     "xor al, -1": {
@@ -1642,19 +1611,14 @@
       ]
     },
     "cmp bx, cx": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 5,
       "Comment": "0x39",
       "ExpectedArm64ASM": [
-        "uxth w20, w5",
-        "uxth w21, w7",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "sub w26, w7, w5",
+        "eor w27, w7, w5",
+        "lsl w0, w7, #16",
+        "cmp w0, w5, lsl #16",
+        "cfinv"
       ]
     },
     "cmp ebx, ecx": {
@@ -1678,41 +1642,31 @@
       ]
     },
     "db 0x3A, 0xcb": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0x3A",
         "cmp bl, cl but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxtb w20, w7",
-        "uxtb w21, w5",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "sub w26, w5, w7",
+        "eor w27, w5, w7",
+        "lsl w0, w5, #24",
+        "cmp w0, w7, lsl #24",
+        "cfinv"
       ]
     },
     "db 0x66, 0x3B, 0xcb": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0x3B",
         "cmp bx, cx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w7",
-        "uxth w21, w5",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "sub w26, w5, w7",
+        "eor w27, w5, w7",
+        "lsl w0, w5, #16",
+        "cmp w0, w7, lsl #16",
+        "cfinv"
       ]
     },
     "db 0x3B, 0xcb": {
@@ -1745,24 +1699,24 @@
       "ExpectedInstructionCount": 6,
       "Comment": "0x3C",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w27, w26",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "cmp ax, 1": {
       "ExpectedInstructionCount": 6,
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
-        "uxth w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w27, w26",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
+        "cfinv"
       ]
     },
     "cmp eax, 1": {
@@ -1786,30 +1740,27 @@
       ]
     },
     "cmp al, -1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": "0x3C",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "sub w26, w20, #0xff (255)",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w26, w20",
-        "rmif x20, #7, #nzcV"
+        "mov w20, #0xff",
+        "sub w26, w4, #0xff (255)",
+        "eor w27, w4, #0xff",
+        "lsl w0, w4, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "cmp ax, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
-        "uxth w21, w4",
-        "sub w26, w21, w20",
-        "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w26, w21",
-        "rmif x20, #15, #nzcV"
+        "sub w26, w4, w20",
+        "eor w27, w4, #0xffff",
+        "lsl w0, w4, #16",
+        "cmp w0, w20, lsl #16",
+        "cfinv"
       ]
     },
     "cmp eax, -1": {
@@ -2104,7 +2055,7 @@
       ]
     },
     "cmpsb": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xa6"
       ],
@@ -2118,16 +2069,13 @@
         "add x11, x11, x22",
         "add x10, x10, x22",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w21, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "cmpsw": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xa7"
       ],
@@ -2141,12 +2089,9 @@
         "add x11, x11, x22",
         "add x10, x10, x22",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w21, #16",
+        "cmp w0, w20, lsl #16",
+        "cfinv"
       ]
     },
     "cmpsd": {
@@ -2188,53 +2133,47 @@
       ]
     },
     "repz cmpsb": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 16,
       "Comment": "0xa6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x1",
         "sub x20, x21, x20, lsl #1",
-        "cbz x5, #+0x40",
+        "cbz x5, #+0x34",
         "ldrb w21, [x11]",
         "ldrb w22, [x10]",
         "sub w26, w22, w21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "rmif x21, #7, #nzcV",
+        "lsl w0, w22, #24",
+        "cmp w0, w21, lsl #24",
+        "cfinv",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "add x10, x10, x20",
         "cset w21, eq",
-        "cbnz w21, #-0x3c"
+        "cbnz w21, #-0x30"
       ]
     },
     "repz cmpsw": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 16,
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x2",
         "sub x20, x21, x20, lsl #2",
-        "cbz x5, #+0x40",
+        "cbz x5, #+0x34",
         "ldrh w21, [x11]",
         "ldrh w22, [x10]",
         "sub w26, w22, w21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "rmif x21, #15, #nzcV",
+        "lsl w0, w22, #16",
+        "cmp w0, w21, lsl #16",
+        "cfinv",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "add x10, x10, x20",
         "cset w21, eq",
-        "cbnz w21, #-0x3c"
+        "cbnz w21, #-0x30"
       ]
     },
     "repz cmpsd": {
@@ -2280,53 +2219,47 @@
       ]
     },
     "repnz cmpsb": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 16,
       "Comment": "0xa6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x1",
         "sub x20, x21, x20, lsl #1",
-        "cbz x5, #+0x40",
+        "cbz x5, #+0x34",
         "ldrb w21, [x11]",
         "ldrb w22, [x10]",
         "sub w26, w22, w21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "rmif x21, #7, #nzcV",
+        "lsl w0, w22, #24",
+        "cmp w0, w21, lsl #24",
+        "cfinv",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "add x10, x10, x20",
         "cset w21, eq",
-        "cbz w21, #-0x3c"
+        "cbz w21, #-0x30"
       ]
     },
     "repnz cmpsw": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 16,
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x2",
         "sub x20, x21, x20, lsl #2",
-        "cbz x5, #+0x40",
+        "cbz x5, #+0x34",
         "ldrh w21, [x11]",
         "ldrh w22, [x10]",
         "sub w26, w22, w21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "rmif x21, #15, #nzcV",
+        "lsl w0, w22, #16",
+        "cmp w0, w21, lsl #16",
+        "cfinv",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "add x10, x10, x20",
         "cset w21, eq",
-        "cbz w21, #-0x3c"
+        "cbz w21, #-0x30"
       ]
     },
     "repnz cmpsd": {
@@ -2432,7 +2365,7 @@
       ]
     },
     "scasb": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 11,
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2443,16 +2376,13 @@
         "sub x22, x23, x22, lsl #1",
         "add x11, x11, x22",
         "eor w27, w20, w21",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w21, w20, w21",
-        "eor w20, w26, w20",
-        "and w20, w20, w21",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w20, #24",
+        "cmp w0, w21, lsl #24",
+        "cfinv"
       ]
     },
     "scasw": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 11,
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2463,12 +2393,9 @@
         "sub x22, x23, x22, lsl #2",
         "add x11, x11, x22",
         "eor w27, w20, w21",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w21, w20, w21",
-        "eor w20, w26, w20",
-        "and w20, w20, w21",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w20, #16",
+        "cmp w0, w21, lsl #16",
+        "cfinv"
       ]
     },
     "scasd": {
@@ -2503,51 +2430,45 @@
       ]
     },
     "repz scasb": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x1",
         "sub x20, x21, x20, lsl #1",
-        "cbz x5, #+0x3c",
+        "cbz x5, #+0x30",
         "uxtb w21, w4",
         "ldrb w22, [x11]",
         "sub w26, w21, w22",
         "eor w27, w21, w22",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w22, w21, w22",
-        "eor w21, w26, w21",
-        "and w21, w21, w22",
-        "rmif x21, #7, #nzcV",
+        "lsl w0, w21, #24",
+        "cmp w0, w22, lsl #24",
+        "cfinv",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "cset w21, eq",
-        "cbnz w21, #-0x38"
+        "cbnz w21, #-0x2c"
       ]
     },
     "repz scasw": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x2",
         "sub x20, x21, x20, lsl #2",
-        "cbz x5, #+0x3c",
+        "cbz x5, #+0x30",
         "uxth w21, w4",
         "ldrh w22, [x11]",
         "sub w26, w21, w22",
         "eor w27, w21, w22",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w22, w21, w22",
-        "eor w21, w26, w21",
-        "and w21, w21, w22",
-        "rmif x21, #15, #nzcV",
+        "lsl w0, w21, #16",
+        "cmp w0, w22, lsl #16",
+        "cfinv",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "cset w21, eq",
-        "cbnz w21, #-0x38"
+        "cbnz w21, #-0x2c"
       ]
     },
     "repz scasd": {
@@ -2590,51 +2511,45 @@
       ]
     },
     "repnz scasb": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x1",
         "sub x20, x21, x20, lsl #1",
-        "cbz x5, #+0x3c",
+        "cbz x5, #+0x30",
         "uxtb w21, w4",
         "ldrb w22, [x11]",
         "sub w26, w21, w22",
         "eor w27, w21, w22",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w22, w21, w22",
-        "eor w21, w26, w21",
-        "and w21, w21, w22",
-        "rmif x21, #7, #nzcV",
+        "lsl w0, w21, #24",
+        "cmp w0, w22, lsl #24",
+        "cfinv",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "cset w21, eq",
-        "cbz w21, #-0x38"
+        "cbz w21, #-0x2c"
       ]
     },
     "repnz scasw": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 15,
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x2",
         "sub x20, x21, x20, lsl #2",
-        "cbz x5, #+0x3c",
+        "cbz x5, #+0x30",
         "uxth w21, w4",
         "ldrh w22, [x11]",
         "sub w26, w21, w22",
         "eor w27, w21, w22",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w22, w21, w22",
-        "eor w21, w26, w21",
-        "and w21, w21, w22",
-        "rmif x21, #15, #nzcV",
+        "lsl w0, w21, #16",
+        "cmp w0, w22, lsl #16",
+        "cfinv",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "cset w21, eq",
-        "cbz w21, #-0x38"
+        "cbz w21, #-0x2c"
       ]
     },
     "repnz scasd": {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -15,13 +15,13 @@
       "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "add w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #8",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w26, w27",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w27, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "or al, 1": {
@@ -93,16 +93,17 @@
       ]
     },
     "sub al, 1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #8",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w27, w26",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "xor al, 1": {
@@ -118,26 +119,26 @@
       "ExpectedInstructionCount": 6,
       "Comment": "GROUP1 0x80 /7",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w27, w26",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "add al, -1": {
       "ExpectedInstructionCount": 8,
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "add w26, w20, #0xff (255)",
+        "mov w20, #0xff",
+        "mov x21, x4",
+        "add w26, w21, #0xff (255)",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #8",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w20, w26",
-        "rmif x20, #7, #nzcV"
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "or al, -1": {
@@ -211,17 +212,18 @@
       ]
     },
     "sub al, -1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "sub w26, w20, #0xff (255)",
+        "mov w20, #0xff",
+        "mov x21, x4",
+        "sub w26, w21, #0xff (255)",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #8",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w26, w20",
-        "rmif x20, #7, #nzcV"
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "xor al, -1": {
@@ -234,29 +236,28 @@
       ]
     },
     "cmp al, -1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP1 0x80 /7",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "sub w26, w20, #0xff (255)",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "bic w20, w26, w20",
-        "rmif x20, #7, #nzcV"
+        "mov w20, #0xff",
+        "sub w26, w4, #0xff (255)",
+        "eor w27, w4, #0xff",
+        "lsl w0, w4, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "add ax, 256": {
       "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
-        "uxth w27, w4",
+        "mov w20, #0x100",
+        "mov x27, x4",
         "add w26, w27, #0x100 (256)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w26, w27",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, 256": {
@@ -430,17 +431,16 @@
       ]
     },
     "add ax, -256": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xff00",
-        "uxth w27, w4",
+        "mov x27, x4",
         "add w26, w27, w20",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w27, w26",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, -256": {
@@ -623,13 +623,13 @@
       "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
-        "uxth w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "add w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w26, w27",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, 1": {
@@ -803,18 +803,17 @@
       ]
     },
     "add ax, -1": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
-        "uxth w21, w4",
+        "mov x21, x4",
         "add w26, w21, w20",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #16",
         "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "bic w20, w21, w26",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, -1": {
@@ -2236,16 +2235,14 @@
       ]
     },
     "neg bl": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP2 0xf6 /3",
       "ExpectedArm64ASM": [
         "uxtb w27, w7",
         "neg w26, w27",
         "bfxil x7, x26, #0, #8",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "and w20, w26, w27",
-        "rmif x20, #7, #nzcV"
+        "cmp wzr, w27, lsl #24",
+        "cfinv"
       ]
     },
     "mul bl": {
@@ -2356,16 +2353,14 @@
       ]
     },
     "neg bx": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "uxth w27, w7",
         "neg w26, w27",
         "bfxil x7, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "and w20, w26, w27",
-        "rmif x20, #15, #nzcV"
+        "cmp wzr, w27, lsl #16",
+        "cfinv"
       ]
     },
     "neg ebx": {
@@ -2492,42 +2487,42 @@
       "ExpectedInstructionCount": 8,
       "Comment": "GROUP3 0xfe /0",
       "ExpectedArm64ASM": [
+        "mov w20, #0x1",
         "uxtb w27, w4",
         "add w26, w27, #0x1 (1)",
         "bfxil x4, x26, #0, #8",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #24",
-        "bic w21, w26, w27",
-        "rmif x21, #7, #nzcV",
-        "rmif x20, #63, #nzCv"
+        "cset w21, hs",
+        "lsl w0, w27, #24",
+        "cmn w0, w20, lsl #24",
+        "rmif x21, #63, #nzCv"
       ]
     },
     "dec al": {
       "ExpectedInstructionCount": 8,
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
+        "mov w20, #0x1",
         "uxtb w27, w4",
         "sub w26, w27, #0x1 (1)",
         "bfxil x4, x26, #0, #8",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #24",
-        "bic w21, w27, w26",
-        "rmif x21, #7, #nzcV",
-        "rmif x20, #63, #nzCv"
+        "cset w21, hs",
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
+        "rmif x21, #63, #nzCv"
       ]
     },
     "inc ax": {
       "ExpectedInstructionCount": 8,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
+        "mov w20, #0x1",
         "uxth w27, w4",
         "add w26, w27, #0x1 (1)",
         "bfxil x4, x26, #0, #16",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #16",
-        "bic w21, w26, w27",
-        "rmif x21, #15, #nzcV",
-        "rmif x20, #63, #nzCv"
+        "cset w21, hs",
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16",
+        "rmif x21, #63, #nzCv"
       ]
     },
     "inc eax": {
@@ -2558,14 +2553,14 @@
       "ExpectedInstructionCount": 8,
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
+        "mov w20, #0x1",
         "uxth w27, w4",
         "sub w26, w27, #0x1 (1)",
         "bfxil x4, x26, #0, #16",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #16",
-        "bic w21, w27, w26",
-        "rmif x21, #15, #nzcV",
-        "rmif x20, #63, #nzCv"
+        "cset w21, hs",
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
+        "rmif x21, #63, #nzCv"
       ]
     },
     "dec eax": {

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -1021,38 +1021,32 @@
       ]
     },
     "cmpxchg cl, bl": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 11,
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
         "uxtb w21, w5",
         "uxtb x22, w4",
         "sub x26, x22, x21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w23, w22, w21",
-        "eor w22, w26, w22",
-        "and w22, w22, w23",
-        "rmif x22, #7, #nzcV",
+        "lsl w0, w22, #24",
+        "cmp w0, w21, lsl #24",
+        "cfinv",
         "bfxil x4, x21, #0, #8",
         "csel x20, x20, x21, eq",
         "bfxil x5, x20, #0, #8"
       ]
     },
     "cmpxchg cx, bx": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 11,
       "ExpectedArm64ASM": [
         "uxth w20, w7",
         "uxth w21, w5",
         "uxth x22, w4",
         "sub x26, x22, x21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w23, w22, w21",
-        "eor w22, w26, w22",
-        "and w22, w22, w23",
-        "rmif x22, #15, #nzcV",
+        "lsl w0, w22, #16",
+        "cmp w0, w21, lsl #16",
+        "cfinv",
         "bfxil x4, x21, #0, #16",
         "csel x20, x20, x21, eq",
         "bfxil x5, x20, #0, #16"
@@ -1099,7 +1093,7 @@
       ]
     },
     "cmpxchg al, bl": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 9,
       "Comment": "0x0f 0xb0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -1107,17 +1101,14 @@
         "uxtb x22, w4",
         "sub x26, x22, x21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "rmif x21, #7, #nzcV",
+        "lsl w0, w22, #24",
+        "cmp w0, w21, lsl #24",
+        "cfinv",
         "bfxil x4, x20, #0, #8"
       ]
     },
     "cmpxchg [rax], bl": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 11,
       "Comment": "0x0f 0xb0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -1128,16 +1119,13 @@
         "bfxil x4, x20, #0, #8",
         "sub w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w21, #24",
+        "cmp w0, w20, lsl #24",
+        "cfinv"
       ]
     },
     "cmpxchg ax, bx": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 9,
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1145,17 +1133,14 @@
         "uxth x22, w4",
         "sub x26, x22, x21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "rmif x21, #15, #nzcV",
+        "lsl w0, w22, #16",
+        "cmp w0, w21, lsl #16",
+        "cfinv",
         "bfxil x4, x20, #0, #16"
       ]
     },
     "cmpxchg [rax], bx": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 11,
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1166,12 +1151,9 @@
         "bfxil x4, x20, #0, #16",
         "sub w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w21, #16",
+        "cmp w0, w20, lsl #16",
+        "cfinv"
       ]
     },
     "cmpxchg eax, ebx": {
@@ -1543,7 +1525,7 @@
       ]
     },
     "xadd al, bl": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1552,16 +1534,12 @@
         "bfxil x7, x20, #0, #8",
         "bfxil x4, x26, #0, #8",
         "eor w27, w20, w21",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w21, w20, w21",
-        "eor w20, w26, w20",
-        "bic w20, w20, w21",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w20, #24",
+        "cmn w0, w21, lsl #24"
       ]
     },
     "xadd [rax], bl": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -1569,16 +1547,12 @@
         "bfxil x7, x21, #0, #8",
         "add w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "rmif x26, #7, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "rmif x20, #7, #nzcV"
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "xadd ax, bx": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1587,16 +1561,12 @@
         "bfxil x7, x20, #0, #16",
         "bfxil x4, x26, #0, #16",
         "eor w27, w20, w21",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w21, w20, w21",
-        "eor w20, w26, w20",
-        "bic w20, w20, w21",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w20, #16",
+        "cmn w0, w21, lsl #16"
       ]
     },
     "xadd [rax], bx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1604,12 +1574,8 @@
         "bfxil x7, x21, #0, #16",
         "add w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "rmif x26, #15, #nzCv",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "rmif x20, #15, #nzcV"
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "xadd eax, ebx": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -11,45 +11,29 @@
   },
   "Instructions": {
     "add bl, cl": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x00",
       "ExpectedArm64ASM": [
-        "uxtb w20, w5",
-        "uxtb w21, w7",
-        "add w26, w21, w20",
+        "mov x20, x7",
+        "add w26, w20, w5",
+        "mov x7, x20",
         "bfxil x7, x26, #0, #8",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "eor w27, w20, w5",
+        "lsl w0, w20, #24",
+        "cmn w0, w5, lsl #24"
       ]
     },
     "add bx, cx": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x01",
       "ExpectedArm64ASM": [
-        "uxth w20, w5",
-        "uxth w21, w7",
-        "add w26, w21, w20",
+        "mov x20, x7",
+        "add w26, w20, w5",
+        "mov x7, x20",
         "bfxil x7, x26, #0, #16",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "eor w27, w20, w5",
+        "lsl w0, w20, #16",
+        "cmn w0, w5, lsl #16"
       ]
     },
     "add ebx, ecx": {
@@ -75,51 +59,35 @@
       ]
     },
     "db 0x02, 0xcb": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "0x02",
         "add bl, cl but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxtb w20, w7",
-        "uxtb w21, w5",
-        "add w26, w21, w20",
+        "mov x20, x5",
+        "add w26, w20, w7",
+        "mov x5, x20",
         "bfxil x5, x26, #0, #8",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "eor w27, w20, w7",
+        "lsl w0, w20, #24",
+        "cmn w0, w7, lsl #24"
       ]
     },
     "db 0x66, 0x03, 0xcb": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "0x03",
         "add bx, cx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w7",
-        "uxth w21, w5",
-        "add w26, w21, w20",
+        "mov x20, x5",
+        "add w26, w20, w7",
+        "mov x5, x20",
         "bfxil x5, x26, #0, #16",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "eor w27, w20, w7",
+        "lsl w0, w20, #16",
+        "cmn w0, w7, lsl #16"
       ]
     },
     "db 0x03, 0xcb": {
@@ -151,37 +119,29 @@
       ]
     },
     "add al, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x04",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "add w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #8",
-        "cmn wzr, w26, lsl #24",
-        "mrs x20, nzcv",
-        "ubfx x21, x26, #8, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w26, w27",
-        "ubfx x21, x21, #7, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w27, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "add ax, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x05",
       "ExpectedArm64ASM": [
-        "uxth w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "add w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
-        "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w26, w27",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, 1": {
@@ -205,40 +165,31 @@
       ]
     },
     "add al, -1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x04",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "add w26, w20, #0xff (255)",
+        "mov w20, #0xff",
+        "mov x21, x4",
+        "add w26, w21, #0xff (255)",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #8",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "ubfx x22, x26, #8, #1",
-        "orr w21, w21, w22, lsl #29",
-        "bic w20, w20, w26",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "add ax, -1": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x05",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
-        "uxth w21, w4",
+        "mov x21, x4",
         "add w26, w21, w20",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #16",
         "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
-        "mrs x20, nzcv",
-        "ubfx x22, x26, #16, #1",
-        "orr w20, w20, w22, lsl #29",
-        "bic w21, w21, w26",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, -1": {
@@ -1316,44 +1267,34 @@
       ]
     },
     "sub bl, cl": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 10,
       "Comment": "0x28",
       "ExpectedArm64ASM": [
-        "uxtb w20, w5",
-        "uxtb w21, w7",
-        "sub w26, w21, w20",
+        "mov x20, x7",
+        "sub w26, w20, w5",
+        "mov x7, x20",
         "bfxil x7, x26, #0, #8",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
+        "eor w27, w20, w5",
+        "lsl w0, w20, #24",
+        "cmp w0, w5, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "sub bx, cx": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 10,
       "Comment": "0x29",
       "ExpectedArm64ASM": [
-        "uxth w20, w5",
-        "uxth w21, w7",
-        "sub w26, w21, w20",
+        "mov x20, x7",
+        "sub w26, w20, w5",
+        "mov x7, x20",
         "bfxil x7, x26, #0, #16",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
+        "eor w27, w20, w5",
+        "lsl w0, w20, #16",
+        "cmp w0, w5, lsl #16",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1386,50 +1327,40 @@
       ]
     },
     "db 0x2A, 0xcb": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "0x2A",
         "sub bl, cl but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxtb w20, w7",
-        "uxtb w21, w5",
-        "sub w26, w21, w20",
+        "mov x20, x5",
+        "sub w26, w20, w7",
+        "mov x5, x20",
         "bfxil x5, x26, #0, #8",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
+        "eor w27, w20, w7",
+        "lsl w0, w20, #24",
+        "cmp w0, w7, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "db 0x66, 0x2B, 0xcb": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "0x2B",
         "sub bx, cx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w7",
-        "uxth w21, w5",
-        "sub w26, w21, w20",
+        "mov x20, x5",
+        "sub w26, w20, w7",
+        "mov x5, x20",
         "bfxil x5, x26, #0, #16",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
+        "eor w27, w20, w7",
+        "lsl w0, w20, #16",
+        "cmp w0, w7, lsl #16",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1468,36 +1399,34 @@
       ]
     },
     "sub al, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": "0x2C",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #8",
-        "cmn wzr, w26, lsl #24",
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #8, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w27, w26",
-        "ubfx x21, x21, #7, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "sub ax, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
-        "uxth w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w27, w26",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1528,39 +1457,36 @@
       ]
     },
     "sub al, -1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Comment": "0x2C",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "sub w26, w20, #0xff (255)",
+        "mov w20, #0xff",
+        "mov x21, x4",
+        "sub w26, w21, #0xff (255)",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #8",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "ubfx x22, x26, #8, #1",
-        "orr w21, w21, w22, lsl #29",
-        "bic w20, w26, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w21, w20, lsl #28",
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmp w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "sub ax, -1": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 11,
       "Comment": "0x2D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
-        "uxth w21, w4",
+        "mov x21, x4",
         "sub w26, w21, w20",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #16",
         "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
+        "lsl w0, w21, #16",
+        "cmp w0, w20, lsl #16",
         "mrs x20, nzcv",
-        "ubfx x22, x26, #16, #1",
-        "orr w20, w20, w22, lsl #29",
-        "bic w21, w26, w21",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1715,22 +1641,15 @@
       ]
     },
     "cmp bl, cl": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x38",
       "ExpectedArm64ASM": [
-        "uxtb w20, w5",
-        "uxtb w21, w7",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
+        "sub w26, w7, w5",
+        "eor w27, w7, w5",
+        "lsl w0, w7, #24",
+        "cmp w0, w5, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1773,22 +1692,15 @@
       ]
     },
     "cmp bx, cx": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x39",
       "ExpectedArm64ASM": [
-        "uxth w20, w5",
-        "uxth w21, w7",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
+        "sub w26, w7, w5",
+        "eor w27, w7, w5",
+        "lsl w0, w7, #16",
+        "cmp w0, w5, lsl #16",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1817,48 +1729,34 @@
       ]
     },
     "db 0x3A, 0xcb": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "0x3A",
         "cmp bl, cl but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxtb w20, w7",
-        "uxtb w21, w5",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
+        "sub w26, w5, w7",
+        "eor w27, w5, w7",
+        "lsl w0, w5, #24",
+        "cmp w0, w7, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "db 0x66, 0x3B, 0xcb": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "0x3B",
         "cmp bx, cx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
-        "uxth w20, w7",
-        "uxth w21, w5",
-        "sub w26, w21, w20",
-        "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
+        "sub w26, w5, w7",
+        "eor w27, w5, w7",
+        "lsl w0, w5, #16",
+        "cmp w0, w7, lsl #16",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1893,34 +1791,30 @@
       ]
     },
     "cmp al, 1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x3C",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #24",
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #8, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w27, w26",
-        "ubfx x21, x21, #7, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "cmp ax, 1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
-        "uxth w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #16",
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w27, w26",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -1949,37 +1843,30 @@
       ]
     },
     "cmp al, -1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x3C",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "sub w26, w20, #0xff (255)",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "ubfx x22, x26, #8, #1",
-        "orr w21, w21, w22, lsl #29",
-        "bic w20, w26, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w21, w20, lsl #28",
+        "mov w20, #0xff",
+        "sub w26, w4, #0xff (255)",
+        "eor w27, w4, #0xff",
+        "lsl w0, w4, #24",
+        "cmp w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "cmp ax, -1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x3D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
-        "uxth w21, w4",
-        "sub w26, w21, w20",
-        "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
+        "sub w26, w4, w20",
+        "eor w27, w4, #0xffff",
+        "lsl w0, w4, #16",
+        "cmp w0, w20, lsl #16",
         "mrs x20, nzcv",
-        "ubfx x22, x26, #16, #1",
-        "orr w20, w20, w22, lsl #29",
-        "bic w21, w26, w21",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -3266,7 +3153,7 @@
       ]
     },
     "cmpsb": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 14,
       "Comment": [
         "0xa6"
       ],
@@ -3280,20 +3167,15 @@
         "add x11, x11, x22",
         "add x10, x10, x22",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
+        "lsl w0, w21, #24",
+        "cmp w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "cmpsw": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 14,
       "Comment": [
         "0xa7"
       ],
@@ -3307,15 +3189,10 @@
         "add x11, x11, x22",
         "add x10, x10, x22",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
+        "lsl w0, w21, #16",
+        "cmp w0, w20, lsl #16",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -3362,61 +3239,51 @@
       ]
     },
     "repz cmpsb": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 18,
       "Comment": "0xa6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x1",
         "sub x20, x21, x20, lsl #1",
-        "cbz x5, #+0x50",
+        "cbz x5, #+0x3c",
         "ldrb w21, [x11]",
         "ldrb w22, [x10]",
         "sub w26, w22, w21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #24",
-        "mrs x23, nzcv",
-        "ubfx x24, x26, #8, #1",
-        "orr w23, w23, w24, lsl #29",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "ubfx x21, x21, #7, #1",
-        "orr w21, w23, w21, lsl #28",
+        "lsl w0, w22, #24",
+        "cmp w0, w21, lsl #24",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
         "msr nzcv, x21",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "add x10, x10, x20",
         "cset w21, eq",
-        "cbnz w21, #-0x4c"
+        "cbnz w21, #-0x38"
       ]
     },
     "repz cmpsw": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 18,
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x2",
         "sub x20, x21, x20, lsl #2",
-        "cbz x5, #+0x50",
+        "cbz x5, #+0x3c",
         "ldrh w21, [x11]",
         "ldrh w22, [x10]",
         "sub w26, w22, w21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #16",
-        "mrs x23, nzcv",
-        "ubfx x24, x26, #16, #1",
-        "orr w23, w23, w24, lsl #29",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "ubfx x21, x21, #15, #1",
-        "orr w21, w23, w21, lsl #28",
+        "lsl w0, w22, #16",
+        "cmp w0, w21, lsl #16",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
         "msr nzcv, x21",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "add x10, x10, x20",
         "cset w21, eq",
-        "cbnz w21, #-0x4c"
+        "cbnz w21, #-0x38"
       ]
     },
     "repz cmpsd": {
@@ -3466,61 +3333,51 @@
       ]
     },
     "repnz cmpsb": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 18,
       "Comment": "0xa6",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x1",
         "sub x20, x21, x20, lsl #1",
-        "cbz x5, #+0x50",
+        "cbz x5, #+0x3c",
         "ldrb w21, [x11]",
         "ldrb w22, [x10]",
         "sub w26, w22, w21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #24",
-        "mrs x23, nzcv",
-        "ubfx x24, x26, #8, #1",
-        "orr w23, w23, w24, lsl #29",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "ubfx x21, x21, #7, #1",
-        "orr w21, w23, w21, lsl #28",
+        "lsl w0, w22, #24",
+        "cmp w0, w21, lsl #24",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
         "msr nzcv, x21",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "add x10, x10, x20",
         "cset w21, eq",
-        "cbz w21, #-0x4c"
+        "cbz w21, #-0x38"
       ]
     },
     "repnz cmpsw": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 18,
       "Comment": "0xa7",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x2",
         "sub x20, x21, x20, lsl #2",
-        "cbz x5, #+0x50",
+        "cbz x5, #+0x3c",
         "ldrh w21, [x11]",
         "ldrh w22, [x10]",
         "sub w26, w22, w21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #16",
-        "mrs x23, nzcv",
-        "ubfx x24, x26, #16, #1",
-        "orr w23, w23, w24, lsl #29",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "ubfx x21, x21, #15, #1",
-        "orr w21, w23, w21, lsl #28",
+        "lsl w0, w22, #16",
+        "cmp w0, w21, lsl #16",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
         "msr nzcv, x21",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "add x10, x10, x20",
         "cset w21, eq",
-        "cbz w21, #-0x4c"
+        "cbz w21, #-0x38"
       ]
     },
     "repnz cmpsd": {
@@ -3876,7 +3733,7 @@
       ]
     },
     "scasb": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 13,
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -3887,20 +3744,15 @@
         "sub x22, x23, x22, lsl #1",
         "add x11, x11, x22",
         "eor w27, w20, w21",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w21, w20, w21",
-        "eor w20, w26, w20",
-        "and w20, w20, w21",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
+        "lsl w0, w20, #24",
+        "cmp w0, w21, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "scasw": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 13,
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -3911,15 +3763,10 @@
         "sub x22, x23, x22, lsl #2",
         "add x11, x11, x22",
         "eor w27, w20, w21",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w21, w20, w21",
-        "eor w20, w26, w20",
-        "and w20, w20, w21",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
+        "lsl w0, w20, #16",
+        "cmp w0, w21, lsl #16",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -3959,59 +3806,49 @@
       ]
     },
     "repz scasb": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 17,
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x1",
         "sub x20, x21, x20, lsl #1",
-        "cbz x5, #+0x4c",
+        "cbz x5, #+0x38",
         "uxtb w21, w4",
         "ldrb w22, [x11]",
         "sub w26, w21, w22",
         "eor w27, w21, w22",
-        "cmn wzr, w26, lsl #24",
-        "mrs x23, nzcv",
-        "ubfx x24, x26, #8, #1",
-        "orr w23, w23, w24, lsl #29",
-        "eor w22, w21, w22",
-        "eor w21, w26, w21",
-        "and w21, w21, w22",
-        "ubfx x21, x21, #7, #1",
-        "orr w21, w23, w21, lsl #28",
+        "lsl w0, w21, #24",
+        "cmp w0, w22, lsl #24",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
         "msr nzcv, x21",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "cset w21, eq",
-        "cbnz w21, #-0x48"
+        "cbnz w21, #-0x34"
       ]
     },
     "repz scasw": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 17,
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x2",
         "sub x20, x21, x20, lsl #2",
-        "cbz x5, #+0x4c",
+        "cbz x5, #+0x38",
         "uxth w21, w4",
         "ldrh w22, [x11]",
         "sub w26, w21, w22",
         "eor w27, w21, w22",
-        "cmn wzr, w26, lsl #16",
-        "mrs x23, nzcv",
-        "ubfx x24, x26, #16, #1",
-        "orr w23, w23, w24, lsl #29",
-        "eor w22, w21, w22",
-        "eor w21, w26, w21",
-        "and w21, w21, w22",
-        "ubfx x21, x21, #15, #1",
-        "orr w21, w23, w21, lsl #28",
+        "lsl w0, w21, #16",
+        "cmp w0, w22, lsl #16",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
         "msr nzcv, x21",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "cset w21, eq",
-        "cbnz w21, #-0x48"
+        "cbnz w21, #-0x34"
       ]
     },
     "repz scasd": {
@@ -4058,59 +3895,49 @@
       ]
     },
     "repnz scasb": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 17,
       "Comment": "0xae",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x1",
         "sub x20, x21, x20, lsl #1",
-        "cbz x5, #+0x4c",
+        "cbz x5, #+0x38",
         "uxtb w21, w4",
         "ldrb w22, [x11]",
         "sub w26, w21, w22",
         "eor w27, w21, w22",
-        "cmn wzr, w26, lsl #24",
-        "mrs x23, nzcv",
-        "ubfx x24, x26, #8, #1",
-        "orr w23, w23, w24, lsl #29",
-        "eor w22, w21, w22",
-        "eor w21, w26, w21",
-        "and w21, w21, w22",
-        "ubfx x21, x21, #7, #1",
-        "orr w21, w23, w21, lsl #28",
+        "lsl w0, w21, #24",
+        "cmp w0, w22, lsl #24",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
         "msr nzcv, x21",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "cset w21, eq",
-        "cbz w21, #-0x48"
+        "cbz w21, #-0x34"
       ]
     },
     "repnz scasw": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 17,
       "Comment": "0xaf",
       "ExpectedArm64ASM": [
         "ldrb w20, [x28, #714]",
         "mov w21, #0x2",
         "sub x20, x21, x20, lsl #2",
-        "cbz x5, #+0x4c",
+        "cbz x5, #+0x38",
         "uxth w21, w4",
         "ldrh w22, [x11]",
         "sub w26, w21, w22",
         "eor w27, w21, w22",
-        "cmn wzr, w26, lsl #16",
-        "mrs x23, nzcv",
-        "ubfx x24, x26, #16, #1",
-        "orr w23, w23, w24, lsl #29",
-        "eor w22, w21, w22",
-        "eor w21, w26, w21",
-        "and w21, w21, w22",
-        "ubfx x21, x21, #15, #1",
-        "orr w21, w23, w21, lsl #28",
+        "lsl w0, w21, #16",
+        "cmp w0, w22, lsl #16",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
         "msr nzcv, x21",
         "sub x5, x5, #0x1 (1)",
         "add x11, x11, x20",
         "cset w21, eq",
-        "cbz w21, #-0x48"
+        "cbz w21, #-0x34"
       ]
     },
     "repnz scasd": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -15,20 +15,16 @@
   ],
   "Instructions": {
     "add al, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "add w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #8",
-        "cmn wzr, w26, lsl #24",
-        "mrs x20, nzcv",
-        "ubfx x21, x26, #8, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w26, w27",
-        "ubfx x21, x21, #7, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w27, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "or al, 1": {
@@ -102,19 +98,18 @@
       ]
     },
     "sub al, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #8",
-        "cmn wzr, w26, lsl #24",
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #8, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w27, w26",
-        "ubfx x21, x21, #7, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -128,37 +123,31 @@
       ]
     },
     "cmp al, 1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP1 0x80 /7",
       "ExpectedArm64ASM": [
-        "uxtb w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "sub w26, w27, #0x1 (1)",
-        "cmn wzr, w26, lsl #24",
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #8, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w27, w26",
-        "ubfx x21, x21, #7, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "add al, -1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP1 0x80 /0",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "add w26, w20, #0xff (255)",
+        "mov w20, #0xff",
+        "mov x21, x4",
+        "add w26, w21, #0xff (255)",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #8",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "ubfx x22, x26, #8, #1",
-        "orr w21, w21, w22, lsl #29",
-        "bic w20, w20, w26",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "or al, -1": {
@@ -234,20 +223,19 @@
       ]
     },
     "sub al, -1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP1 0x80 /5",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "sub w26, w20, #0xff (255)",
+        "mov w20, #0xff",
+        "mov x21, x4",
+        "sub w26, w21, #0xff (255)",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #8",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "ubfx x22, x26, #8, #1",
-        "orr w21, w21, w22, lsl #29",
-        "bic w20, w26, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w21, w20, lsl #28",
+        "eor w27, w21, #0xff",
+        "lsl w0, w21, #24",
+        "cmp w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -261,37 +249,30 @@
       ]
     },
     "cmp al, -1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP1 0x80 /7",
       "ExpectedArm64ASM": [
-        "uxtb w20, w4",
-        "sub w26, w20, #0xff (255)",
-        "eor w27, w20, #0xff",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "ubfx x22, x26, #8, #1",
-        "orr w21, w21, w22, lsl #29",
-        "bic w20, w26, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w21, w20, lsl #28",
+        "mov w20, #0xff",
+        "sub w26, w4, #0xff (255)",
+        "eor w27, w4, #0xff",
+        "lsl w0, w4, #24",
+        "cmp w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "add ax, 256": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
-        "uxth w27, w4",
+        "mov w20, #0x100",
+        "mov x27, x4",
         "add w26, w27, #0x100 (256)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
-        "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w26, w27",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, 256": {
@@ -481,21 +462,16 @@
       ]
     },
     "add ax, -256": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x81 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xff00",
-        "uxth w27, w4",
+        "mov x27, x4",
         "add w26, w27, w20",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
-        "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w27, w26",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, -256": {
@@ -691,20 +667,16 @@
       ]
     },
     "add ax, 1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
-        "uxth w27, w4",
+        "mov w20, #0x1",
+        "mov x27, x4",
         "add w26, w27, #0x1 (1)",
+        "mov x4, x27",
         "bfxil x4, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
-        "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "bic w21, w26, w27",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, 1": {
@@ -894,22 +866,17 @@
       ]
     },
     "add ax, -1": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP1 0x83 /0",
       "ExpectedArm64ASM": [
         "mov w20, #0xffff",
-        "uxth w21, w4",
+        "mov x21, x4",
         "add w26, w21, w20",
+        "mov x4, x21",
         "bfxil x4, x26, #0, #16",
         "eor w27, w21, #0xffff",
-        "cmn wzr, w26, lsl #16",
-        "mrs x20, nzcv",
-        "ubfx x22, x26, #16, #1",
-        "orr w20, w20, w22, lsl #29",
-        "bic w21, w21, w26",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "add eax, -1": {
@@ -2726,19 +2693,15 @@
       ]
     },
     "neg bl": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP2 0xf6 /3",
       "ExpectedArm64ASM": [
         "uxtb w27, w7",
         "neg w26, w27",
         "bfxil x7, x26, #0, #8",
-        "cmn wzr, w26, lsl #24",
+        "cmp wzr, w27, lsl #24",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #8, #1",
-        "orr w20, w20, w21, lsl #29",
-        "and w21, w26, w27",
-        "ubfx x21, x21, #7, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -2871,19 +2834,15 @@
       ]
     },
     "neg bx": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP2 0xf7 /2",
       "ExpectedArm64ASM": [
         "uxth w27, w7",
         "neg w26, w27",
         "bfxil x7, x26, #0, #16",
-        "cmn wzr, w26, lsl #16",
+        "cmp wzr, w27, lsl #16",
         "mrs x20, nzcv",
-        "ubfx x21, x26, #16, #1",
-        "orr w20, w20, w21, lsl #29",
-        "and w21, w26, w27",
-        "ubfx x21, x21, #15, #1",
-        "orr w20, w20, w21, lsl #28",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -3134,53 +3093,50 @@
       ]
     },
     "inc al": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP3 0xfe /0",
       "ExpectedArm64ASM": [
+        "mov w20, #0x1",
         "uxtb w27, w4",
         "add w26, w27, #0x1 (1)",
         "bfxil x4, x26, #0, #8",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "bic w22, w26, w27",
-        "ubfx x22, x22, #7, #1",
-        "orr w21, w21, w22, lsl #28",
-        "orr w20, w21, w20, lsl #29",
+        "cset w21, hs",
+        "lsl w0, w27, #24",
+        "cmn w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
         "msr nzcv, x20"
       ]
     },
     "dec al": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
+        "mov w20, #0x1",
         "uxtb w27, w4",
         "sub w26, w27, #0x1 (1)",
         "bfxil x4, x26, #0, #8",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #24",
-        "mrs x21, nzcv",
-        "bic w22, w27, w26",
-        "ubfx x22, x22, #7, #1",
-        "orr w21, w21, w22, lsl #28",
-        "orr w20, w21, w20, lsl #29",
+        "cset w21, hs",
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
         "msr nzcv, x20"
       ]
     },
     "inc ax": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
+        "mov w20, #0x1",
         "uxth w27, w4",
         "add w26, w27, #0x1 (1)",
         "bfxil x4, x26, #0, #16",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #16",
-        "mrs x21, nzcv",
-        "bic w22, w26, w27",
-        "ubfx x22, x22, #15, #1",
-        "orr w21, w21, w22, lsl #28",
-        "orr w20, w21, w20, lsl #29",
+        "cset w21, hs",
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
         "msr nzcv, x20"
       ]
     },
@@ -3217,19 +3173,18 @@
       ]
     },
     "dec ax": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
+        "mov w20, #0x1",
         "uxth w27, w4",
         "sub w26, w27, #0x1 (1)",
         "bfxil x4, x26, #0, #16",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #16",
-        "mrs x21, nzcv",
-        "bic w22, w27, w26",
-        "ubfx x22, x22, #15, #1",
-        "orr w21, w21, w22, lsl #28",
-        "orr w20, w21, w20, lsl #29",
+        "cset w21, hs",
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
         "msr nzcv, x20"
       ]
     },

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -267,19 +267,18 @@
       ]
     },
     "inc ax": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": "0x40",
       "ExpectedArm64ASM": [
+        "mov w20, #0x1",
         "uxth w27, w4",
         "add w26, w27, #0x1 (1)",
         "bfxil w4, w26, #0, #16",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #16",
-        "mrs x21, nzcv",
-        "bic w22, w26, w27",
-        "ubfx x22, x22, #15, #1",
-        "orr w21, w21, w22, lsl #28",
-        "orr w20, w21, w20, lsl #29",
+        "cset w21, hs",
+        "lsl w0, w27, #16",
+        "cmn w0, w20, lsl #16",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
         "msr nzcv, x20"
       ]
     },
@@ -300,19 +299,18 @@
       ]
     },
     "dec ax": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": "0x48",
       "ExpectedArm64ASM": [
+        "mov w20, #0x1",
         "uxth w27, w4",
         "sub w26, w27, #0x1 (1)",
         "bfxil w4, w26, #0, #16",
-        "cset w20, hs",
-        "cmn wzr, w26, lsl #16",
-        "mrs x21, nzcv",
-        "bic w22, w27, w26",
-        "ubfx x22, x22, #15, #1",
-        "orr w21, w21, w22, lsl #28",
-        "orr w20, w21, w20, lsl #29",
+        "cset w21, hs",
+        "lsl w0, w27, #16",
+        "cmp w0, w20, lsl #16",
+        "mrs x20, nzcv",
+        "bfi w20, w21, #29, #1",
         "msr nzcv, x20"
       ]
     },

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -1882,7 +1882,7 @@
       ]
     },
     "cmpxchg al, bl": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 11,
       "Comment": "0x0f 0xb0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -1890,21 +1890,16 @@
         "uxtb x22, w4",
         "sub x26, x22, x21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #24",
-        "mrs x23, nzcv",
-        "ubfx x24, x26, #8, #1",
-        "orr w23, w23, w24, lsl #29",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "ubfx x21, x21, #7, #1",
-        "orr w21, w23, w21, lsl #28",
+        "lsl w0, w22, #24",
+        "cmp w0, w21, lsl #24",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
         "msr nzcv, x21",
         "bfxil x4, x20, #0, #8"
       ]
     },
     "cmpxchg [rax], bl": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 13,
       "Comment": "0x0f 0xb0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -1915,20 +1910,15 @@
         "bfxil x4, x20, #0, #8",
         "sub w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
+        "lsl w0, w21, #24",
+        "cmp w0, w20, lsl #24",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
     "cmpxchg ax, bx": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 11,
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1936,21 +1926,16 @@
         "uxth x22, w4",
         "sub x26, x22, x21",
         "eor w27, w22, w21",
-        "cmn wzr, w26, lsl #16",
-        "mrs x23, nzcv",
-        "ubfx x24, x26, #16, #1",
-        "orr w23, w23, w24, lsl #29",
-        "eor w21, w22, w21",
-        "eor w22, w26, w22",
-        "and w21, w22, w21",
-        "ubfx x21, x21, #15, #1",
-        "orr w21, w23, w21, lsl #28",
+        "lsl w0, w22, #16",
+        "cmp w0, w21, lsl #16",
+        "mrs x21, nzcv",
+        "eor w21, w21, #0x20000000",
         "msr nzcv, x21",
         "bfxil x4, x20, #0, #16"
       ]
     },
     "cmpxchg [rax], bx": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 13,
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -1961,15 +1946,10 @@
         "bfxil x4, x20, #0, #16",
         "sub w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "and w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
+        "lsl w0, w21, #16",
+        "cmp w0, w20, lsl #16",
+        "mrs x20, nzcv",
+        "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
     },
@@ -2558,7 +2538,7 @@
       ]
     },
     "xadd al, bl": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -2567,20 +2547,12 @@
         "bfxil x7, x20, #0, #8",
         "bfxil x4, x26, #0, #8",
         "eor w27, w20, w21",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w21, w20, w21",
-        "eor w20, w26, w20",
-        "bic w20, w20, w21",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w20, #24",
+        "cmn w0, w21, lsl #24"
       ]
     },
     "xadd [rax], bl": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x0f 0xc0",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2588,20 +2560,12 @@
         "bfxil x7, x21, #0, #8",
         "add w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #24",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #8, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "ubfx x20, x20, #7, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24"
       ]
     },
     "xadd ax, bx": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -2610,20 +2574,12 @@
         "bfxil x7, x20, #0, #16",
         "bfxil x4, x26, #0, #16",
         "eor w27, w20, w21",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w21, w20, w21",
-        "eor w20, w26, w20",
-        "bic w20, w20, w21",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w20, #16",
+        "cmn w0, w21, lsl #16"
       ]
     },
     "xadd [rax], bx": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x0f 0xc1",
       "ExpectedArm64ASM": [
         "uxth w20, w7",
@@ -2631,16 +2587,8 @@
         "bfxil x7, x21, #0, #16",
         "add w26, w21, w20",
         "eor w27, w21, w20",
-        "cmn wzr, w26, lsl #16",
-        "mrs x22, nzcv",
-        "ubfx x23, x26, #16, #1",
-        "orr w22, w22, w23, lsl #29",
-        "eor w20, w21, w20",
-        "eor w21, w26, w21",
-        "bic w20, w21, w20",
-        "ubfx x20, x20, #15, #1",
-        "orr w20, w22, w20, lsl #28",
-        "msr nzcv, x20"
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16"
       ]
     },
     "xadd eax, ebx": {


### PR DESCRIPTION
If we shift first, NZCV matches up exactly :+1: 