### PR TITLE
ThreadManager: StealAndDropActiveLocks in the child forked process

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -165,7 +165,7 @@ class ThreadManager final {
     FEXCore::Context::Context *CTX;
     FEX::HLE::SignalDelegator *SignalDelegation;
 
-    std::mutex ThreadCreationMutex;
+    FEXCore::ForkableUniqueMutex ThreadCreationMutex;
     fextl::vector<FEXCore::Core::InternalThreadState *> Threads;
 
     // Thread idling support.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -303,7 +303,7 @@ public:
   FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestAddr) final override;
 
   ///// FORK tracking /////
-  void LockBeforeFork();
+  void LockBeforeFork(FEXCore::Core::InternalThreadState *Thread);
   void UnlockAfterFork(FEXCore::Core::InternalThreadState *LiveThread, bool Child);
 
   SourcecodeResolver *GetSourcecodeResolver() override { return this; }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -233,9 +233,8 @@ namespace FEX::HLE {
 
     uint64_t Mask{~0ULL};
     ::syscall(SYS_rt_sigprocmask, SIG_SETMASK, &Mask, &Mask, sizeof(Mask));
-    Thread->CTX->LockBeforeFork(Frame->Thread);
 
-    FEX::HLE::_SyscallHandler->LockBeforeFork();
+    FEX::HLE::_SyscallHandler->LockBeforeFork(Frame->Thread);
 
     const bool IsVFork = flags & CLONE_VFORK;
     pid_t Result{};

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -223,6 +223,7 @@ namespace FEX::HLE {
 
     // We now only have one thread.
     IdleWaitRefCount = 1;
+    ThreadCreationMutex.StealAndDropActiveLocks();
   }
 
   void ThreadManager::WaitForIdle() {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -185,8 +185,6 @@ namespace FEX::HLE {
   }
 
   void ThreadManager::UnlockAfterFork(FEXCore::Core::InternalThreadState *LiveThread, bool Child) {
-    CTX->UnlockAfterFork(LiveThread, Child);
-
     if (!Child) return;
 
     // This function is called after fork

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -97,7 +97,7 @@ namespace FEX::HLE {
   void ThreadManager::WaitForThreadsToRun() {
     size_t NumThreads{};
     {
-      std::lock_guard<std::mutex> lk(ThreadCreationMutex);
+      std::lock_guard lk(ThreadCreationMutex);
       NumThreads = Threads.size();
     }
 
@@ -134,7 +134,7 @@ namespace FEX::HLE {
 
     // Tell all the threads that they should stop
     {
-      std::lock_guard<std::mutex> lk(ThreadCreationMutex);
+      std::lock_guard lk(ThreadCreationMutex);
       for (auto &Thread : Threads) {
         if (IgnoreCurrentThread &&
             Thread->ThreadManager.TID == tid) {


### PR DESCRIPTION
The creation mutex could have been held if the parent thread was in the
middle of creating a thread when forking. This would result in a
deadlock once the fork child attempted to create another thread.

Forcefully dropping the lock in the fork child works around this
deadlock. This comes at the expense of potentially leaving resources
guarded by the thread creation mutex in an invalid state. Crashes caused
by this are easier to reason about than a delayed deadlock, though.