### PR TITLE
Library Forwarding: Add support for 32-bit Wayland

### DIFF
--- a/ThunkLibs/Generator/analysis.cpp
+++ b/ThunkLibs/Generator/analysis.cpp
@@ -366,6 +366,13 @@ void AnalysisAction::ParseInterface(clang::ASTContext& context) {
                             continue;
                         }
 
+                        // Skip pointers-to-structs passed through to the host in guest_layout.
+                        // This avoids pulling in member types that can't be processed.
+                        if (data.param_annotations[param_idx].is_passthrough &&
+                            param_type->isPointerType() && param_type->getPointeeType()->isStructureType()) {
+                            continue;
+                        }
+
                         auto check_struct_type = [&](const clang::Type* type) {
                             if (type->isIncompleteType()) {
                                 throw report_error(type->getAsTagDecl()->getBeginLoc(), "Unannotated pointer with incomplete struct type; consider using an opaque_type annotation")

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -588,11 +588,11 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
                 if (!param_type->isPointerType() || !param_type->getPointeeType()->isStructureType()) {
                     continue;
                 }
-                auto type = param_type->getPointeeType();
-                if (!types.at(context.getCanonicalType(type.getTypePtr())).assumed_compatible && type_compat.at(context.getCanonicalType(type.getTypePtr())) == TypeCompatibility::None) {
-                    // TODO: Factor in "assume_compatible_layout" annotations here
-                    //       That annotation should cause the type to be treated as TypeCompatibility::Full
-                    if (!thunk.param_annotations[param_idx].is_passthrough) {
+                if (!thunk.param_annotations[param_idx].is_passthrough) {
+                    auto type = param_type->getPointeeType();
+                    if (!types.at(context.getCanonicalType(type.getTypePtr())).assumed_compatible && type_compat.at(context.getCanonicalType(type.getTypePtr())) == TypeCompatibility::None) {
+                        // TODO: Factor in "assume_compatible_layout" annotations here
+                        //       That annotation should cause the type to be treated as TypeCompatibility::Full
                         throw report_error(thunk.decl->getLocation(), "Unsupported parameter type %0").AddTaggedVal(param_type);
                     }
                 }

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -232,9 +232,6 @@ if (BITNESS EQUAL 64)
   target_compile_definitions(libxcb-guest-deps INTERFACE -DXCB_VERSION_MINOR=${XCB_VERSION_MINOR})
   target_compile_definitions(libxcb-guest-deps INTERFACE -DXCB_VERSION_PATCH=${XCB_VERSION_PATCH})
 
-  generate(libwayland-client ${CMAKE_CURRENT_SOURCE_DIR}/../libwayland-client/libwayland-client_interface.cpp)
-  add_guest_lib(wayland-client "libwayland-client.so.0.20.0")
-
   generate(libxcb-dri2 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri2/libxcb-dri2_interface.cpp)
   add_guest_lib(xcb-dri2 "libxcb-dri2.so.0")
 
@@ -267,6 +264,9 @@ if (BITNESS EQUAL 64)
   target_include_directories(libdrm-guest-deps INTERFACE /usr/include/libdrm/)
   add_guest_lib(drm "libdrm.so.2")
 endif()
+
+generate(libwayland-client ${CMAKE_CURRENT_SOURCE_DIR}/../libwayland-client/libwayland-client_interface.cpp)
+add_guest_lib(wayland-client "libwayland-client.so.0.20.0")
 
 generate(libVDSO ${CMAKE_CURRENT_SOURCE_DIR}/../libVDSO/libVDSO_interface.cpp)
 add_guest_lib(VDSO "linux-vdso.so.1")

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -163,9 +163,6 @@ foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
   target_compile_definitions(libxcb-${GUEST_BITNESS}-deps INTERFACE -DXCB_VERSION_MINOR=${XCB_VERSION_MINOR})
   target_compile_definitions(libxcb-${GUEST_BITNESS}-deps INTERFACE -DXCB_VERSION_PATCH=${XCB_VERSION_PATCH})
 
-  generate(libwayland-client ${CMAKE_CURRENT_SOURCE_DIR}/../libwayland-client/libwayland-client_interface.cpp ${GUEST_BITNESS})
-  add_host_lib(wayland-client ${GUEST_BITNESS})
-
   generate(libxcb-dri2 ${CMAKE_CURRENT_SOURCE_DIR}/../libxcb-dri2/libxcb-dri2_interface.cpp ${GUEST_BITNESS})
   add_host_lib(xcb-dri2 ${GUEST_BITNESS})
 
@@ -203,6 +200,9 @@ set (BITNESS_LIST "32;64")
 foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
   generate(libfex_thunk_test ${CMAKE_CURRENT_SOURCE_DIR}/../libfex_thunk_test/libfex_thunk_test_interface.cpp ${GUEST_BITNESS})
   add_host_lib(fex_thunk_test ${GUEST_BITNESS})
+
+  generate(libwayland-client ${CMAKE_CURRENT_SOURCE_DIR}/../libwayland-client/libwayland-client_interface.cpp ${GUEST_BITNESS})
+  add_host_lib(wayland-client ${GUEST_BITNESS})
 endforeach()
 
 add_library(fex_thunk_test SHARED ../libfex_thunk_test/lib.cpp)

--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -167,6 +167,14 @@ struct guest_layout<T*> {
   const guest_layout<T>* get_pointer() const {
     return reinterpret_cast<const guest_layout<T>*>(uintptr_t { data });
   }
+
+  T* force_get_host_pointer() {
+    return reinterpret_cast<T*>(uintptr_t { data });
+  }
+
+  const T* force_get_host_pointer() const {
+    return reinterpret_cast<const T*>(uintptr_t { data });
+  }
 };
 
 template<typename T>

--- a/ThunkLibs/libwayland-client/Guest.cpp
+++ b/ThunkLibs/libwayland-client/Guest.cpp
@@ -265,6 +265,38 @@ extern "C" void wl_proxy_marshal(wl_proxy *proxy, uint32_t opcode, ...) {
   wl_proxy_marshal_array(proxy, opcode, args);
 }
 
+extern "C" wl_proxy *wl_proxy_marshal_constructor(wl_proxy *proxy, uint32_t opcode,
+           const wl_interface *interface, ...) {
+  wl_argument args[WL_CLOSURE_MAX_ARGS];
+  va_list ap;
+
+  va_start(ap, interface);
+  // This is equivalent to reading ((wl_proxy_private*)proxy)->interface->methods[opcode].signature on 64-bit.
+  // On 32-bit, the data layout differs between host and guest however, so we let the host extract the data.
+  char signature[64];
+  fex_wl_get_method_signature(proxy, opcode, signature);
+  wl_argument_from_va_list(signature, args, WL_CLOSURE_MAX_ARGS, ap);
+  va_end(ap);
+
+  return wl_proxy_marshal_array_constructor(proxy, opcode, args, interface);
+}
+
+extern "C" wl_proxy *wl_proxy_marshal_constructor_versioned(wl_proxy *proxy, uint32_t opcode,
+           const wl_interface *interface, uint32_t version, ...) {
+  wl_argument args[WL_CLOSURE_MAX_ARGS];
+  va_list ap;
+
+  va_start(ap, version);
+  // This is equivalent to reading ((wl_proxy_private*)proxy)->interface->methods[opcode].signature on 64-bit.
+  // On 32-bit, the data layout differs between host and guest however, so we let the host extract the data.
+  char signature[64];
+  fex_wl_get_method_signature(proxy, opcode, signature);
+  wl_argument_from_va_list(signature, args, WL_CLOSURE_MAX_ARGS, ap);
+  va_end(ap);
+
+  return wl_proxy_marshal_array_constructor_versioned(proxy, opcode, args, interface, version);
+}
+
 extern "C" wl_proxy *wl_proxy_marshal_flags(wl_proxy *proxy, uint32_t opcode,
            const wl_interface *interface,
            uint32_t version,
@@ -288,6 +320,11 @@ extern "C" wl_proxy *wl_proxy_marshal_flags(wl_proxy *proxy, uint32_t opcode,
   __builtin_trap();
 #endif
 }
+
+extern "C" void wl_log_set_handler_client(wl_log_func_t handler) {
+  // Ignore
+}
+
 
 void OnInit() {
   fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_output_interface), "wl_output");

--- a/ThunkLibs/libwayland-client/Guest.cpp
+++ b/ThunkLibs/libwayland-client/Guest.cpp
@@ -327,17 +327,17 @@ extern "C" void wl_log_set_handler_client(wl_log_func_t handler) {
 
 
 void OnInit() {
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_output_interface), "wl_output");
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_shm_pool_interface), "wl_shm_pool");
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_pointer_interface), "wl_pointer");
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_compositor_interface), "wl_compositor");
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_shm_interface), "wl_shm");
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_registry_interface), "wl_registry");
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_buffer_interface), "wl_buffer");
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_seat_interface), "wl_seat");
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_surface_interface), "wl_surface");
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_keyboard_interface), "wl_keyboard");
-  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_callback_interface), "wl_callback");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_output_interface), "wl_output_interface");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_shm_pool_interface), "wl_shm_pool_interface");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_pointer_interface), "wl_pointer_interface");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_compositor_interface), "wl_compositor_interface");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_shm_interface), "wl_shm_interface");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_registry_interface), "wl_registry_interface");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_buffer_interface), "wl_buffer_interface");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_seat_interface), "wl_seat_interface");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_surface_interface), "wl_surface_interface");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_keyboard_interface), "wl_keyboard_interface");
+  fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_callback_interface), "wl_callback_interface");
 }
 
 LOAD_LIB_INIT(libwayland-client, OnInit)

--- a/ThunkLibs/libwayland-client/Host.cpp
+++ b/ThunkLibs/libwayland-client/Host.cpp
@@ -437,7 +437,7 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
 void fexfn_impl_libwayland_client_fex_wl_exchange_interface_pointer(guest_layout<wl_interface*> guest_interface_raw, const char* name) {
   auto& guest_interface = *guest_interface_raw.get_pointer();
   auto& host_interface = guest_to_host_interface[reinterpret_cast<guest_layout<const wl_interface>*>(&guest_interface)];
-  host_interface = reinterpret_cast<wl_interface*>(dlsym(fexldr_ptr_libwayland_client_so, (std::string { name } + "_interface").c_str()));
+  host_interface = reinterpret_cast<wl_interface*>(dlsym(fexldr_ptr_libwayland_client_so, name));
   if (!host_interface) {
     fprintf(stderr, "Could not find host interface corresponding to %p (%s)\n", &guest_interface, name);
     std::abort();

--- a/ThunkLibs/libwayland-client/Host.cpp
+++ b/ThunkLibs/libwayland-client/Host.cpp
@@ -5,6 +5,7 @@ $end_info$
 */
 
 #include <string_view>
+#include <unordered_map>
 #include <wayland-client.h>
 
 #include <stdio.h>
@@ -19,13 +20,217 @@ $end_info$
 #include <charconv>
 #include <cstring>
 #include <map>
+#include <span>
 #include <string>
 
+#include <ranges>
+
+template<>
+struct guest_layout<wl_argument> {
+#ifdef IS_32BIT_THUNK
+  using type = uint32_t;
+#else
+  using type = wl_argument;
+#endif
+  type data;
+
+  guest_layout& operator=(const wl_argument from) {
+#ifdef IS_32BIT_THUNK
+    data = from.u;
+#else
+    data = from;
+#endif
+    return *this;
+  }
+};
+
 #include "thunkgen_host_libwayland-client.inl"
+
+// Maps guest interface to host_interfaces
+static std::unordered_map<guest_layout<const wl_interface>*, wl_interface*> guest_to_host_interface;
 
 static wl_interface* get_proxy_interface(wl_proxy* proxy) {
   // wl_proxy is a private struct, but its first member is the wl_interface pointer
   return *reinterpret_cast<wl_interface**>(proxy);
+}
+
+static void assert_is_valid_host_interface(const wl_interface* interface) {
+  // The 32-bit data layout of wl_interface differs from the 64-bit one due to
+  // its pointer members. Our repacking code takes care of these differences.
+  //
+  // To ensure this indeed functions properly, a simple consistency check is
+  // applied here: If any of the message counts are absurdly high, it means
+  // data from pointer members leaked into other members.
+
+  if ((uint32_t)interface->method_count >= 0x1000 || (uint32_t)interface->event_count >= 0x1000) {
+    fprintf(stderr, "ERROR: Expected %p to be a host wl_interface, but it's not\n", interface);
+    std::abort();
+  }
+}
+
+#ifdef IS_32BIT_THUNK
+static void assert_is_valid_guest_interface(guest_layout<const wl_interface*> guest_interface) {
+  // Consistency check for expected data layout.
+  // See assert_is_valid_host_interface for details
+
+  const wl_interface* as_host_interface = (const wl_interface*)guest_interface.force_get_host_pointer();
+  if ((uint32_t)as_host_interface->method_count < 0x1000 && (uint32_t)as_host_interface->event_count < 0x1000) {
+    fprintf(stderr, "ERROR: Expected %p to be a guest wl_interface, but it's not\n", guest_interface.force_get_host_pointer());
+    std::abort();
+  }
+}
+
+static void repack_guest_wl_interface_to_host(guest_layout<const wl_interface*> guest_interface_ptr, wl_interface* host_interface) {
+  auto& guest_interface = *guest_interface_ptr.get_pointer();
+  static_assert(sizeof(guest_interface) == 24);
+
+  *host_interface = host_layout<wl_interface> { guest_interface }.data;
+  fex_apply_custom_repacking_entry(reinterpret_cast<host_layout<wl_interface>&>(*host_interface), guest_interface);
+}
+
+// Maps guest interface pointers to host pointers
+static const wl_interface* lookup_wl_interface(guest_layout<const wl_interface*> interface) {
+  // Used e.g. for wl_shm_pool_destroy
+  if (interface.force_get_host_pointer() == nullptr) {
+    return nullptr;
+  }
+
+  auto [host_interface_it, inserted] = guest_to_host_interface.emplace(interface.get_pointer(), nullptr);
+  if (!inserted) {
+    assert_is_valid_host_interface(host_interface_it->second);
+    return host_interface_it->second;
+  }
+
+  assert_is_valid_guest_interface(interface);
+
+  fprintf(stderr, "Unknown wayland interface %p, adding to registry\n", interface.get_pointer());
+
+  host_interface_it->second = new wl_interface;
+  wl_interface* host_interface = host_interface_it->second;
+  repack_guest_wl_interface_to_host(interface, host_interface);
+  return host_interface_it->second;
+}
+
+void fex_custom_repack_entry(host_layout<wl_interface>& into, guest_layout<wl_interface> const& from) {
+  // NOTE: These arrays are complements to global symbols in the guest, so we
+  //       never explicitly free this memory
+  auto& host_interface = into.data;
+  into.data.methods = new wl_message[into.data.method_count];
+  into.data.events = new wl_message[into.data.event_count];
+
+  memset((void*)host_interface.methods, 0, sizeof(wl_message) * host_interface.method_count);
+  for (int i = 0; i < host_interface.method_count; ++i) {
+    const auto& guest_method { from.data.methods.get_pointer()[i] };
+    host_layout<wl_message> host_method { guest_method };
+    fex_apply_custom_repacking_entry(host_method, guest_method);
+    memcpy((void*)&host_interface.methods[i], &host_method, sizeof(host_method));
+  }
+
+  memset((void*)host_interface.events, 0, sizeof(wl_message) * host_interface.event_count);
+  for (int i = 0; i < host_interface.event_count; ++i) {
+    const auto& guest_event { from.data.events.get_pointer()[i] };
+    host_layout<wl_message> host_event { guest_event };
+    fex_apply_custom_repacking_entry(host_event, guest_event);
+    memcpy((void*)&host_interface.events[i], &host_event, sizeof(host_event));
+  }
+}
+
+bool fex_custom_repack_exit(guest_layout<wl_interface>&, host_layout<wl_interface> const&) {
+  fprintf(stderr, "Should not be called: %s\n", __PRETTY_FUNCTION__);
+  std::abort();
+}
+void fex_custom_repack_entry(host_layout<wl_message>& into, guest_layout<wl_message> const& from) {
+  auto& host_method = into.data;
+  auto num_types = std::ranges::count_if(std::string_view { host_method.signature }, isalpha);
+  if (num_types) {
+    host_method.types = new const wl_interface*[num_types];
+    for (int type = 0; type < num_types; ++type) {
+      auto guest_interface_addr = from.data.types.get_pointer()[type];
+      host_method.types[type] = guest_interface_addr.force_get_host_pointer() ? lookup_wl_interface(guest_interface_addr) : nullptr;
+    }
+  }
+}
+bool fex_custom_repack_exit(guest_layout<wl_message>&, host_layout<wl_message> const&) {
+  fprintf(stderr, "Should not be called: %s\n", __PRETTY_FUNCTION__);
+  std::abort();
+}
+#else
+const wl_interface* lookup_wl_interface(guest_layout<const wl_interface*> interface) {
+  return interface.force_get_host_pointer();
+}
+#endif
+
+static wl_proxy* fexfn_impl_libwayland_client_wl_proxy_create(wl_proxy* proxy, guest_layout<const wl_interface*> guest_interface_raw) {
+  auto host_interface = lookup_wl_interface(guest_interface_raw);
+  return fexldr_ptr_libwayland_client_wl_proxy_create(proxy, host_interface);
+}
+
+#define WL_CLOSURE_MAX_ARGS 20
+static auto
+fex_wl_remap_argument_list(guest_layout<wl_argument*> args, const wl_message& message) {
+#ifndef IS_32BIT_THUNK
+  // Cast to host layout and return as std::span
+  wl_argument* host_args = host_layout<wl_argument*> { args }.data;
+  return std::span<wl_argument, WL_CLOSURE_MAX_ARGS> { host_args, WL_CLOSURE_MAX_ARGS };
+#else
+  // Return a new array of elements zero-extended to 64-bit
+  std::array<wl_argument, WL_CLOSURE_MAX_ARGS> host_args;
+  int arg_count = std::ranges::count_if(std::string_view { message.signature }, isalpha);
+  for (int i = 0; i < arg_count; ++i) {
+    // NOTE: wl_argument can store a pointer argument, so for 32-bit guests
+    //       we need to make sure the upper 32-bits are explicitly zeroed
+    std::memset(&host_args[i], 0, sizeof(host_args[i]));
+    std::memcpy(&host_args[i], &args.get_pointer()[i], sizeof(args.get_pointer()[i]));
+  }
+  return host_args;
+#endif
+}
+
+extern "C" void
+fexfn_impl_libwayland_client_wl_proxy_marshal_array(
+            wl_proxy *proxy, uint32_t opcode,
+            guest_layout<wl_argument*> args) {
+  auto host_args = fex_wl_remap_argument_list(args, get_proxy_interface(proxy)->methods[opcode]);
+  fexldr_ptr_libwayland_client_wl_proxy_marshal_array(proxy, opcode, host_args.data());
+}
+
+static wl_proxy*
+fex_wl_proxy_marshal_array(
+            wl_proxy *proxy, uint32_t opcode,
+            guest_layout<wl_argument*> args,
+            guest_layout<const wl_interface*> guest_interface,
+            std::optional<uint32_t> version,
+            std::optional<uint32_t> flags) {
+  auto interface = lookup_wl_interface(guest_interface);
+
+  assert_is_valid_host_interface(get_proxy_interface(proxy));
+
+  auto host_args = fex_wl_remap_argument_list(args, get_proxy_interface(proxy)->methods[opcode]);
+
+  if (false) {
+  } else if (!version && !flags) {
+    return nullptr;
+  } else if (version && flags) {
+    // wl_proxy_marshal_array_flags is only available starting from Wayland 1.19.91
+#if WAYLAND_VERSION_MAJOR * 10000 + WAYLAND_VERSION_MINOR * 100 + WAYLAND_VERSION_MICRO >= 11991
+    return fexldr_ptr_libwayland_client_wl_proxy_marshal_array_flags(proxy, opcode, interface, version.value(), flags.value(), host_args.data());
+#else
+    fprintf(stderr, "Host Wayland version is too old to support FEX thunking\n");
+    __builtin_trap();
+#endif
+  } else {
+    fprintf(stderr, "Invalid configuration\n");
+    __builtin_trap();
+  }
+}
+
+extern "C" wl_proxy*
+fexfn_impl_libwayland_client_wl_proxy_marshal_array_flags(
+            wl_proxy *proxy, uint32_t opcode,
+            guest_layout<const wl_interface*> interface,
+            uint32_t version, uint32_t flags,
+            guest_layout<wl_argument*> args) {
+  return fex_wl_proxy_marshal_array(proxy, opcode, args, interface, version, flags);
 }
 
 // See wayland-util.h for documentation on protocol message signatures
@@ -46,8 +251,12 @@ static void WaylandFinalizeHostTrampolineForGuestListener(void (*callback)()) {
 }
 
 extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_proxy *proxy,
-      guest_layout<void (**)(void)> callback_raw, void* data) {
+      guest_layout<void (**)(void)> callback_table_raw, void* data) {
   auto interface = get_proxy_interface(proxy);
+
+  assert_is_valid_host_interface(interface);
+
+  auto callback_table = callback_table_raw.force_get_host_pointer();
 
   for (int i = 0; i < interface->event_count; ++i) {
     auto signature_view = std::string_view { interface->events[i].signature };
@@ -55,12 +264,12 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
     // A leading number indicates the minimum protocol version
     uint32_t since_version = 0;
     auto [ptr, res] = std::from_chars(signature_view.begin(), signature_view.end(), since_version, 10);
-    std::string signature { ptr, &*signature_view.end() };
+    auto signature = std::string { signature_view.substr(ptr - signature_view.begin()) };
 
     // ? just indicates that the argument may be null, so it doesn't change the signature
     signature.erase(std::remove(signature.begin(), signature.end(), '?'), signature.end());
 
-    auto callback = reinterpret_cast<void(*)()>(uintptr_t { callback_raw.get_pointer()[i].data });
+    auto callback = callback_table[i];
 
     if (signature == "") {
       // E.g. xdg_toplevel::close
@@ -162,15 +371,15 @@ extern "C" int fexfn_impl_libwayland_client_wl_proxy_add_listener(struct wl_prox
   }
 
   // Pass the original function pointer table to the host wayland library. This ensures the table is valid until the listener is unregistered.
-  return fexldr_ptr_libwayland_client_wl_proxy_add_listener(proxy,
-                                                            reinterpret_cast<void(**)(void)>(callback_raw.get_pointer()),
-                                                            data);
+  return fexldr_ptr_libwayland_client_wl_proxy_add_listener(proxy, callback_table, data);
 }
 
-wl_interface* fexfn_impl_libwayland_client_fex_wl_exchange_interface_pointer(wl_interface* guest_interface, char const* name) {
-  auto host_interface = reinterpret_cast<wl_interface*>(dlsym(fexldr_ptr_libwayland_client_so, (std::string { name } + "_interface").c_str()));
+void fexfn_impl_libwayland_client_fex_wl_exchange_interface_pointer(guest_layout<wl_interface*> guest_interface_raw, const char* name) {
+  auto& guest_interface = *guest_interface_raw.get_pointer();
+  auto& host_interface = guest_to_host_interface[reinterpret_cast<guest_layout<const wl_interface>*>(&guest_interface)];
+  host_interface = reinterpret_cast<wl_interface*>(dlsym(fexldr_ptr_libwayland_client_so, (std::string { name } + "_interface").c_str()));
   if (!host_interface) {
-    fprintf(stderr, "Could not find host interface corresponding to %p (%s)\n", guest_interface, name);
+    fprintf(stderr, "Could not find host interface corresponding to %p (%s)\n", &guest_interface, name);
     std::abort();
   }
 
@@ -178,23 +387,34 @@ wl_interface* fexfn_impl_libwayland_client_fex_wl_exchange_interface_pointer(wl_
   // them into the rodata section of the application itself instead of the
   // library. To copy the host information to them on startup, we must
   // temporarily disable write-protection on this data hence.
-  auto page_begin = reinterpret_cast<uintptr_t>(guest_interface) & ~uintptr_t { 0xfff };
+  auto page_begin = reinterpret_cast<uintptr_t>(guest_interface_raw.force_get_host_pointer()) & ~uintptr_t { 0xfff };
   if (0 != mprotect((void*)page_begin, 0x1000, PROT_READ | PROT_WRITE)) {
     fprintf(stderr, "ERROR: %s\n", strerror(errno));
     std::abort();
   }
 
-#ifdef IS_32BIT_THUNK
-// Requires struct repacking for wl_interface
-#error Not implemented
+#ifndef IS_32BIT_THUNK
+  memcpy(&guest_interface, host_interface, sizeof(wl_interface));
 #else
-  memcpy(guest_interface, host_interface, sizeof(wl_interface));
+  guest_interface = to_guest(to_host_layout(*host_interface));
+
+  // NOTE: These arrays are complements to global symbols in the guest, so we
+  //       never explicitly free this memory
+  guest_interface.data.methods.data = (uintptr_t)new guest_layout<wl_message>[host_interface->method_count];
+  for (int i = 0; i < host_interface->method_count; ++i) {
+    guest_interface.data.methods.get_pointer()[i] = to_guest(to_host_layout(host_interface->methods[i]));
+    guest_interface.data.methods.get_pointer()[i].data.types = to_guest(to_host_layout(host_interface->methods[i].types));
+  }
+
+  guest_interface.data.events.data = (uintptr_t)new guest_layout<wl_message>[host_interface->event_count];
+  for (int i = 0; i < host_interface->event_count; ++i) {
+    guest_interface.data.events.get_pointer()[i] = to_guest(to_host_layout(host_interface->events[i]));
+    guest_interface.data.events.get_pointer()[i].data.types = to_guest(to_host_layout(host_interface->events[i].types));
+  }
 #endif
 
 // TODO: Disabled until we ensure the interface data is indeed stored in rodata
 //  mprotect((void*)page_begin, 0x1000, PROT_READ);
-
-  return host_interface;
 }
 
 void fexfn_impl_libwayland_client_fex_wl_get_method_signature(wl_proxy* proxy, uint32_t opcode, char* out) {

--- a/ThunkLibs/libwayland-client/libwayland-client_interface.cpp
+++ b/ThunkLibs/libwayland-client/libwayland-client_interface.cpp
@@ -51,6 +51,7 @@ template<> struct fex_gen_param<wl_proxy_add_listener, 1, void(**)()> : fexgen::
 template<> struct fex_gen_param<wl_proxy_add_listener, 2, void*> : fexgen::assume_compatible_data_layout {};
 template<> struct fex_gen_config<wl_proxy_create> {};
 template<> struct fex_gen_config<wl_proxy_create_wrapper> {};
+template<> struct fex_gen_config<wl_proxy_get_listener> {};
 template<> struct fex_gen_config<wl_proxy_get_tag> {};
 template<> struct fex_gen_config<wl_proxy_get_user_data> {};
 template<> struct fex_gen_config<wl_proxy_get_version> {};

--- a/ThunkLibs/libwayland-client/libwayland-client_interface.cpp
+++ b/ThunkLibs/libwayland-client/libwayland-client_interface.cpp
@@ -44,11 +44,13 @@ template<> struct fex_gen_config<wl_display_dispatch> {};
 template<> struct fex_gen_config<wl_display_dispatch_pending> {};
 template<> struct fex_gen_config<wl_display_dispatch_queue> {};
 template<> struct fex_gen_config<wl_display_dispatch_queue_pending> {};
+template<> struct fex_gen_config<wl_display_get_error> {};
 template<> struct fex_gen_config<wl_display_prepare_read> {};
 template<> struct fex_gen_config<wl_display_prepare_read_queue> {};
 template<> struct fex_gen_config<wl_display_read_events> {};
 template<> struct fex_gen_config<wl_display_roundtrip> {};
 template<> struct fex_gen_config<wl_display_roundtrip_queue> {};
+template<> struct fex_gen_config<wl_display_connect_to_fd> {};
 template<> struct fex_gen_config<wl_display_get_fd> {};
 
 template<> struct fex_gen_config<wl_event_queue_destroy> {};
@@ -61,6 +63,8 @@ template<> struct fex_gen_param<wl_proxy_add_listener, 2, void*> : fexgen::assum
 template<> struct fex_gen_config<wl_proxy_create> : fexgen::custom_host_impl {};
 template<> struct fex_gen_param<wl_proxy_create, 1, const wl_interface*> : fexgen::ptr_passthrough {};
 template<> struct fex_gen_config<wl_proxy_create_wrapper> {};
+template<> struct fex_gen_config<wl_proxy_get_class> {};
+template<> struct fex_gen_config<wl_proxy_get_id> {};
 template<> struct fex_gen_config<wl_proxy_get_listener> {};
 template<> struct fex_gen_config<wl_proxy_get_tag> {};
 template<> struct fex_gen_config<wl_proxy_get_user_data> {};
@@ -73,6 +77,12 @@ template<> struct fex_gen_config<wl_proxy_wrapper_destroy> {};
 
 template<> struct fex_gen_config<wl_proxy_marshal_array> : fexgen::custom_host_impl {};
 template<> struct fex_gen_param<wl_proxy_marshal_array, 2, wl_argument*> : fexgen::ptr_passthrough {};
+template<> struct fex_gen_config<wl_proxy_marshal_array_constructor> : fexgen::custom_host_impl {};
+template<> struct fex_gen_param<wl_proxy_marshal_array_constructor, 2, wl_argument*> : fexgen::ptr_passthrough {};
+template<> struct fex_gen_param<wl_proxy_marshal_array_constructor, 3, const wl_interface*> : fexgen::ptr_passthrough {};
+template<> struct fex_gen_config<wl_proxy_marshal_array_constructor_versioned> : fexgen::custom_host_impl {};
+template<> struct fex_gen_param<wl_proxy_marshal_array_constructor_versioned, 2, wl_argument*> : fexgen::ptr_passthrough {};
+template<> struct fex_gen_param<wl_proxy_marshal_array_constructor_versioned, 3, const wl_interface*> : fexgen::ptr_passthrough {};
 // wl_proxy_marshal_array_flags is only available starting from Wayland 1.19.91
 #if WAYLAND_VERSION_MAJOR * 10000 + WAYLAND_VERSION_MINOR * 100 + WAYLAND_VERSION_MICRO >= 11991
 template<> struct fex_gen_config<wl_proxy_marshal_array_flags> : fexgen::custom_host_impl {};

--- a/ThunkLibs/libwayland-client/libwayland-client_interface.cpp
+++ b/ThunkLibs/libwayland-client/libwayland-client_interface.cpp
@@ -69,3 +69,14 @@ template<> struct fex_gen_config<wl_proxy_marshal_array_flags> {};
 // Guest notifies host about its interface. Host returns its corresponding interface pointer
 wl_interface* fex_wl_exchange_interface_pointer(wl_interface*, const char* name);
 template<> struct fex_gen_config<fex_wl_exchange_interface_pointer> : fexgen::custom_host_impl {};
+
+// This is equivalent to reading proxy->interface->methods[opcode].signature on 64-bit.
+// On 32-bit, the data layout differs between host and guest however, so we let the host extract the data.
+void fex_wl_get_method_signature(wl_proxy*, uint32_t opcode, char*);
+template<> struct fex_gen_config<fex_wl_get_method_signature> : fexgen::custom_host_impl {};
+int fex_wl_get_interface_event_count(wl_proxy*);
+template<> struct fex_gen_config<fex_wl_get_interface_event_count> : fexgen::custom_host_impl {};
+void fex_wl_get_interface_event_name(wl_proxy*, int, char*);
+template<> struct fex_gen_config<fex_wl_get_interface_event_name> : fexgen::custom_host_impl {};
+void fex_wl_get_interface_event_signature(wl_proxy*, int, char*);
+template<> struct fex_gen_config<fex_wl_get_interface_event_signature> : fexgen::custom_host_impl {};


### PR DESCRIPTION
## Overview

Finally, the first real 32-bit library we can forward to the 64-bit host, moving us up to Phase 3 of the [Library Forwarding Roadmap](https://gist.github.com/neobrain/3812c111a2da57bfd8376dd21d61a886):
|                          | X11 (64-bit) | Wayland (64-bit) | Wayland (32-bit) | X11 (32-bit) |
| ------------------------ | ------------ | ---------------- | ---------------- |------------- |
| no thunks            | ☑️ 2022      | ☑️ 2022         | ☑️ 2022          | ☑️ 2022      |
| only Wayland thunks  | N/A          | ☑️ Phase 1      | ✅Phase 3          | N/A           |
| Vulkan               | ☑️ 2022      | ☑️ Phase 1      | Phase 4          | Phase 7       |
| zink on Vulkan       | ☑️ Phase 2   | ☑️ Phase 2      | Phase 4          | Phase 7       |
| OpenGL               | ☑️ 2022      | Phase 5         | Phase 6          | Phase 7       |

To enable this support, the `thunkgen` features added recently are coming together:
* **Opaque types**: `wl_proxy` is always created host-side and the guest only passes around the pointer. (Internally, we need to peek into implementation details to parse message signatures, but that doesn't concern `thunkgen`.)
* **Automatic struct repacking** (`wl_array`)
* **Customized struct repacking** (to handle the cyclic reference of `wl_interface` and`wl_message`, which even includes an array-of-pointers)
* **`ptr_passthrough`** and **`emit_layout_wrappers`** annotations (to send `guest_layout<wl_interface>` across architecture boundaries and trigger repacking manually, without compromising data layout compatibility checks elsewhere)

Additionally, a few new API functions are added to facilitate testing of this branch by making 32-bit Super Meat Boy and zink work.

## Testing

These configurations are confirmed to work when forwarding 32-bit Wayland:
* vkcube (via x86 Vulkan)
* Super Meat Boy (via x86 GL)
* Super Meat Boy (via x86 zink+Vulkan)

## Impact

The changes here are almost exclusively restricted to Wayland. Other than minor cleanups, the 64-bit wrapper should be unaffected.

## Future

Functioning Wayland forwarding paves the way for 32-bit Vulkan, which is much easier to test with working window system integration.
