### PR TITLE
Linux: More safe stack cleanup for clone

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -38,9 +38,11 @@ $end_info$
 #define SYSCALL_ARCH_NAME Arm64
 #endif
 
+#include "LinuxSyscalls/x64/SyscallsEnum.h"
+
 #define CONCAT_(a, b) a ## b
 #define CONCAT(a, b) CONCAT_(a, b)
-#define SYSCALL_DEF(name) ( SYSCALL_ARCH_NAME::CONCAT(CONCAT(SYSCALL_, SYSCALL_ARCH_NAME), _##name))
+#define SYSCALL_DEF(name) ( HLE::SYSCALL_ARCH_NAME::CONCAT(CONCAT(SYSCALL_, SYSCALL_ARCH_NAME), _##name))
 
 // #define DEBUG_STRACE
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.h
@@ -20,8 +20,10 @@ namespace FEX::LinuxEmulation::Threads {
    * Will not free the memory immediately, instead saving for reuse temporarily to solve race conditions on stack usage while stack tears down.
    *
    * @param Ptr The stack base from `AllocateStackObject`
+   * @param Status The status to pass to the exit syscall.
    */
-  void DeallocateStackObject(void *Ptr);
+  [[noreturn]]
+  void DeallocateStackObjectAndExit(void *Ptr, int Status);
 
   /**
    * @brief Registers thread creation handlers with FEXCore.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
@@ -30,8 +30,6 @@ struct InternalThreadState;
 }
 
 namespace FEX::HLE::x64 {
-#include "SyscallsEnum.h"
-
 class x64SyscallHandler final : public FEX::HLE::SyscallHandler {
   public:
     x64SyscallHandler(FEXCore::Context::Context *ctx, FEX::HLE::SignalDelegator *_SignalDelegation);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/SyscallsEnum.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/SyscallsEnum.h
@@ -6,6 +6,7 @@ $end_info$
 */
 #pragma once
 
+namespace FEX::HLE::x64 {
 ///< Enum containing all x86-64 linux syscalls for the guest kernel version
 enum Syscalls_x64 {
   SYSCALL_x64_read = 0,
@@ -479,4 +480,4 @@ enum Syscalls_x64 {
   SYSCALL_x64_futex_time64 = ~0,
   SYSCALL_x64_sched_rr_get_interval_time64 = ~0,
 };
-
+}


### PR DESCRIPTION
Previously: Would keep one clone thread's stack active for teardown delaying.

With aggressive cloning and teardown, this was unsafe. Only reap the stack when told it is safe to do so.