### PR TITLE
Linux: Make sure to destroy thread object when thread shuts down

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -53,6 +53,7 @@ namespace FEX::HLE {
     auto Thread = Handler->Thread;
     FEXCore::Allocator::free(Handler);
     CTX->ExecutionThread(Thread);
+    FEX::HLE::_SyscallHandler->TM.DestroyThread(Thread);
     return nullptr;
   }
 


### PR DESCRIPTION
This fixes a fairly large memory leak.