### PR TITLE
Implement small TSC scaling

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -115,6 +115,13 @@
           "\toff: Default CPU features queried from CPU features",
           "\t{enable,disable}sha: Will force enable or disable sha even if the host doesn't support it"
         ]
+      },
+      "SmallTSCScale": {
+        "Type": "bool",
+        "Default": "true",
+        "Desc": [
+          "Scales the cycle counter on systems that have low frequencies."
+        ]
       }
     },
     "Emulation": {

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -74,6 +74,8 @@ namespace FEXCore::Context {
   };
 
   using BlockDelinkerFunc = void(*)(FEXCore::Core::CpuStateFrame *Frame, FEXCore::Context::ExitFunctionLinkData *Record);
+  constexpr uint32_t TSC_SCALE = 128;
+  constexpr uint32_t TSC_SCALE_MAXIMUM = 1'000'000'000; ///< 1Ghz
 
   class ContextImpl final : public FEXCore::Context::Context {
     public:
@@ -230,6 +232,7 @@ namespace FEXCore::Context {
       FEX_CONFIG_OPT(x87ReducedPrecision, X87REDUCEDPRECISION);
       FEX_CONFIG_OPT(DisableTelemetry, DISABLETELEMETRY);
       FEX_CONFIG_OPT(DisableVixlIndirectCalls, DISABLE_VIXL_INDIRECT_RUNTIME_CALLS);
+      FEX_CONFIG_OPT(SmallTSCScale, SMALLTSCSCALE);
     } Config;
 
 

--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -98,7 +98,7 @@ constexpr uint32_t FAMILY_IDENTIFIER =
 #endif
 
 #ifdef _M_ARM_64
-static uint32_t GetCycleCounterFrequency() {
+uint32_t GetCycleCounterFrequency() {
   uint64_t Result{};
   __asm("mrs %[Res], CNTFRQ_EL0"
       : [Res] "=r" (Result));
@@ -349,7 +349,7 @@ void CPUIDEmu::SetupHostHybridFlag() {
 }
 
 #else
-static uint32_t GetCycleCounterFrequency() {
+uint32_t GetCycleCounterFrequency() {
   return 0;
 }
 
@@ -803,7 +803,7 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_15h(uint32_t Leaf) const {
   uint32_t FrequencyHz = GetCycleCounterFrequency();
   if (FrequencyHz) {
     Res.eax = 1;
-    Res.ebx = 1;
+    Res.ebx = CTX->Config.SmallTSCScale() ? FEXCore::Context::TSC_SCALE : 1;
     Res.ecx = FrequencyHz;
   }
   return Res;

--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -14,6 +14,8 @@ namespace Context {
   class ContextImpl;
 }
 
+uint32_t GetCycleCounterFrequency();
+
 // Debugging define to switch what family of CPU we execute as.
 // Might be useful if an application makes an assumption about a CPU.
 // #define CPUID_AMD
@@ -115,6 +117,7 @@ private:
   bool Hybrid{};
   uint32_t Cores{};
   FEX_CONFIG_OPT(HideHypervisorBit, HIDEHYPERVISORBIT);
+  FEX_CONFIG_OPT(SmallTSCScale, SMALLTSCSCALE);
 
   // XFEATURE_ENABLED_MASK
   // Mask that configures what features are enabled on the CPU.

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -99,6 +99,10 @@ namespace FEXCore::Context {
       Symbols.InitFile();
     }
 
+    if (FEXCore::GetCycleCounterFrequency() >= FEXCore::Context::TSC_SCALE_MAXIMUM) {
+      Config.SmallTSCScale = false;
+    }
+
     // Track atomic TSO emulation configuration.
     UpdateAtomicTSOEmulationConfig();
   }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3591,12 +3591,31 @@ void OpDispatchBuilder::SGDTOp(OpcodeArgs) {
   _StoreMemAutoTSO(GPRClass, GDTStoreSize, _Add(OpSize::i64Bit, DestAddress, _Constant(2)), _Constant(GDTAddress));
 }
 
-void OpDispatchBuilder::RDTSCOp(OpcodeArgs) {
+
+OpDispatchBuilder::CycleCounterPair OpDispatchBuilder::CycleCounter() {
+  OrderedNode *CounterLow{};
+  OrderedNode *CounterHigh{};
   auto Counter = _CycleCounter();
-  auto CounterLow = _Bfe(OpSize::i64Bit, 32, 0, Counter);
-  auto CounterHigh = _Bfe(OpSize::i64Bit, 32, 32, Counter);
-  StoreGPRRegister(X86State::REG_RAX, CounterLow);
-  StoreGPRRegister(X86State::REG_RDX, CounterHigh);
+  if (CTX->Config.SmallTSCScale()) {
+    const auto ShiftAmount = FEXCore::ilog2(FEXCore::Context::TSC_SCALE);
+    CounterLow = _Lshl(OpSize::i32Bit, Counter, _Constant(ShiftAmount));
+    CounterHigh = _Lshr(OpSize::i64Bit, Counter, _Constant(32 - ShiftAmount));
+  }
+  else {
+    CounterLow = _Bfe(OpSize::i64Bit, 32, 0, Counter);
+    CounterHigh = _Bfe(OpSize::i64Bit, 32, 32, Counter);
+  }
+
+  return {
+    .CounterLow = CounterLow,
+    .CounterHigh = CounterHigh,
+  };
+}
+
+void OpDispatchBuilder::RDTSCOp(OpcodeArgs) {
+  auto Counter = CycleCounter();
+  StoreGPRRegister(X86State::REG_RAX, Counter.CounterLow);
+  StoreGPRRegister(X86State::REG_RDX, Counter.CounterHigh);
 }
 
 void OpDispatchBuilder::INCOp(OpcodeArgs) {
@@ -5505,13 +5524,12 @@ void OpDispatchBuilder::RDTSCPOp(OpcodeArgs) {
   //  - Explicitly use an LFENCE after RDTSCP if you want to block this behaviour
 
   _Fence({FEXCore::IR::Fence_Load});
-  auto Counter = _CycleCounter();
-  auto CounterLow = _Bfe(OpSize::i64Bit, 32, 0, Counter);
-  auto CounterHigh = _Bfe(OpSize::i64Bit, 32, 32, Counter);
+  auto Counter = CycleCounter();
+
   auto ID = _ProcessorID();
-  StoreGPRRegister(X86State::REG_RAX, CounterLow);
+  StoreGPRRegister(X86State::REG_RAX, Counter.CounterLow);
   StoreGPRRegister(X86State::REG_RCX, ID);
-  StoreGPRRegister(X86State::REG_RDX, CounterHigh);
+  StoreGPRRegister(X86State::REG_RDX, Counter.CounterHigh);
 }
 
 void OpDispatchBuilder::CRC32(OpcodeArgs) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -352,6 +352,11 @@ public:
   void PUSHFOp(OpcodeArgs);
   void POPFOp(OpcodeArgs);
 
+  struct CycleCounterPair {
+    OrderedNode *CounterLow;
+    OrderedNode *CounterHigh;
+  };
+  CycleCounterPair CycleCounter();
   void RDTSCOp(OpcodeArgs);
   void INCOp(OpcodeArgs);
   void DECOp(OpcodeArgs);

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -79,8 +79,8 @@
       "ExpectedArm64ASM": [
         "dmb ld",
         "mrs x20, S3_3_c14_c0_2",
-        "mov w4, w20",
-        "lsr x6, x20, #32",
+        "lsl w4, w20, #7",
+        "lsr x6, x20, #25",
         "mrs x0, nzcv",
         "str w0, [x28, #728]",
         "str x8, [x28, #40]",

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -243,8 +243,8 @@
       "Comment": "0x0f 0x31",
       "ExpectedArm64ASM": [
         "mrs x20, S3_3_c14_c0_2",
-        "mov w4, w20",
-        "lsr x6, x20, #32"
+        "lsl w4, w20, #7",
+        "lsr x6, x20, #25"
       ]
     },
     "cmovo ax, bx": {

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -79,8 +79,8 @@
       "ExpectedArm64ASM": [
         "dmb ld",
         "mrs x20, S3_3_c14_c0_2",
-        "mov w4, w20",
-        "lsr x6, x20, #32",
+        "lsl w4, w20, #7",
+        "lsr x6, x20, #25",
         "mrs x0, nzcv",
         "str w0, [x28, #728]",
         "str x8, [x28, #40]",


### PR DESCRIPTION
Games engines are expecting >1Ghz cycle counters. Scale them to work around the issue.

Resolves the excessive busy waiting in Unreal Engine 5 games.