### PR TITLE
CMake: Define _M_ARM_64EC when building for ARM64EC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,11 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64|^arm64|^armv8\.*")
   add_definitions(-D_M_ARM_64=1)
 endif()
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm64ec")
+  set(_M_ARM_64EC 1)
+  add_definitions(-D_M_ARM_64EC=1)
+endif()
+
 if (ENABLE_CCACHE)
   find_program(CCACHE_PROGRAM ccache)
   if(CCACHE_PROGRAM)


### PR DESCRIPTION
Note that this explicitly differs from the Windows define _M_ARM64EC, in the same way that Windows defines _M_ARM64 but FEX defines  _M_ARM_64. Matching the windows define ends up confusing CMake which expects MSVC to be used in such cases