### PR TITLE
Arm64Emitter: Introduce ARM64EC SRA mappings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,11 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64|^arm64|^armv8\.*")
   add_definitions(-D_M_ARM_64=1)
 endif()
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm64ec")
+  set(_M_ARM_64EC 1)
+  add_definitions(-D_M_ARM_64EC=1)
+endif()
+
 if (ENABLE_CCACHE)
   find_program(CCACHE_PROGRAM ccache)
   if(CCACHE_PROGRAM)

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -37,17 +37,37 @@ namespace FEXCore::CPU {
 // Contains the address to the currently available CPU state
 constexpr auto STATE = FEXCore::ARMEmitter::XReg::x28;
 
+#ifndef _M_ARM_64EC
 // GPR temporaries. Only x3 can be used across spill boundaries
 // so if these ever need to change, be very careful about that.
 constexpr auto TMP1 = FEXCore::ARMEmitter::XReg::x0;
 constexpr auto TMP2 = FEXCore::ARMEmitter::XReg::x1;
 constexpr auto TMP3 = FEXCore::ARMEmitter::XReg::x2;
 constexpr auto TMP4 = FEXCore::ARMEmitter::XReg::x3;
-constexpr bool TMP_ABIARGS = true; // TMP{1-4} map to ABI arguments 0-3
+constexpr bool TMP_ABIARGS = true;
+
+// We pin r26/r27 as PF/AF respectively, this is internal FEX ABI.
+constexpr auto REG_PF = FEXCore::ARMEmitter::Reg::r26;
+constexpr auto REG_AF = FEXCore::ARMEmitter::Reg::r27;
 
 // Vector temporaries
 constexpr auto VTMP1 = FEXCore::ARMEmitter::VReg::v0;
 constexpr auto VTMP2 = FEXCore::ARMEmitter::VReg::v1;
+#else
+constexpr auto TMP1 = FEXCore::ARMEmitter::XReg::x10;
+constexpr auto TMP2 = FEXCore::ARMEmitter::XReg::x11;
+constexpr auto TMP3 = FEXCore::ARMEmitter::XReg::x12;
+constexpr auto TMP4 = FEXCore::ARMEmitter::XReg::x13;
+constexpr bool TMP_ABIARGS = false;
+
+// We pin r11/r12 as PF/AF respectively for arm64ec, as r26/r27 are used for SRA.
+constexpr auto REG_PF = FEXCore::ARMEmitter::Reg::r9;
+constexpr auto REG_AF = FEXCore::ARMEmitter::Reg::r24;
+
+// Vector temporaries
+constexpr auto VTMP1 = FEXCore::ARMEmitter::VReg::v16;
+constexpr auto VTMP2 = FEXCore::ARMEmitter::VReg::v17;
+#endif
 
 // Predicate register temporaries (used when AVX support is enabled)
 // PRED_TMP_16B indicates a predicate register that indicates the first 16 bytes set to 1.
@@ -55,9 +75,6 @@ constexpr auto VTMP2 = FEXCore::ARMEmitter::VReg::v1;
 constexpr FEXCore::ARMEmitter::PRegister PRED_TMP_16B = FEXCore::ARMEmitter::PReg::p6;
 constexpr FEXCore::ARMEmitter::PRegister PRED_TMP_32B = FEXCore::ARMEmitter::PReg::p7;
 
-// We pin r26/r27 as PF/AF respectively, this is internal FEX ABI.
-constexpr auto REG_PF = FEXCore::ARMEmitter::Reg::r26;
-constexpr auto REG_AF = FEXCore::ARMEmitter::Reg::r27;
 
 // This class contains common emitter utility functions that can
 // be used by both Arm64 JIT and ARM64 Dispatcher


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/cpp/build/arm64ec-windows-abi-conventions?view=msvc-170 note that since mm registers are volatile there is no need to match the mapping for them when in JIT, so they can be used as scratch regs.
Disallowed regs are also wiped on context switches, so they cannot be taken advantage of to e.g. avoid spilling.