### PR TITLE
FEXCore: Expose AbsoluteLoopTopAddress to the frontend

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -277,6 +277,7 @@ namespace FEXCore::Context {
       .DispatcherBegin = Dispatcher->Start,
       .DispatcherEnd = Dispatcher->End,
 
+      .AbsoluteLoopTopAddress = Dispatcher->AbsoluteLoopTopAddress,
       .AbsoluteLoopTopAddressFillSRA = Dispatcher->AbsoluteLoopTopAddressFillSRA,
       .SignalHandlerReturnAddress = Dispatcher->SignalHandlerReturnAddress,
       .SignalHandlerReturnAddressRT = Dispatcher->SignalHandlerReturnAddressRT,

--- a/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -55,6 +55,7 @@ namespace Core {
       uint64_t DispatcherEnd;
 
       // Dispatcher entrypoint.
+      uint64_t AbsoluteLoopTopAddress{};
       uint64_t AbsoluteLoopTopAddressFillSRA{};
 
       // Signal return pointers.


### PR DESCRIPTION
ARM64EC has a shared SRA mapping between ARM64 and X64 code, so there needs to be a public way to enter the dispatcher without refilling SRA from the in-memory context structure to avoid a needless roundtrip.