### PR TITLE
FEXLoader: Allocate the second 4GB of virtual memory when executing 32-bit

### DIFF
--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -297,6 +297,12 @@ namespace FEXCore::Allocator {
         if (c == ' ') {
           STEAL_LOG("[%d] ParseEnd; RegionBegin: %016lX RegionEnd: %016lX\n", __LINE__, RegionBegin, RegionEnd);
 
+          if (RegionEnd >= End) {
+            // Early return if we are completely beyond the allocation space.
+            close(MapsFD);
+            return Regions;
+          }
+
           State = ScanEnd;
 
           // If the previous map's ending and the region we just parsed overlap the stack then we need to save the stack mapping.


### PR DESCRIPTION
Spurred on by https://github.com/FEX-Emu/FEX/pull/3421. To ensure that applications don't take advantage of
small address wrap around, allocate the second 4GB of virtual memory.

Some context. Linux always reserves the first 16KB of virtual address
space (unless you tinker with some settings which nobody should do).

Example of 32-bit code:
lea eax, [0xffff_0000]
mov ebx, [eax + 0x1_0000]

The address calculated by the mov will wrap around to 0x0 which will
result in SIGSEGV. If FEX messes up zero extensions then it would try to
access 0x1_0000_0000 instead.

This could result in a 32-bit application potentially accessing some FEX
memory instead of crashing.
Add this safety net which will still SIGSEGV and we will be able to see
the crash.