### PR TITLE
InstcountCI: Adds addressing limitations to instcountci

### DIFF
--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -1,0 +1,860 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256",
+      "RPRES",
+      "AFP"
+    ]
+  },
+  "Comment": [
+    "Instructions that explicitly push against the limits of ARM's loadstore instructions"
+  ],
+  "Instructions": {
+    "movzx rax, byte [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "mov w20, w20",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx rax, byte [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx rax, byte [ecx + 255]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0xff (255)",
+        "mov w20, w20",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx rax, byte [ecx + 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx rax, byte [ecx + 4095]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0xfff (4095)",
+        "mov w20, w20",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx rax, byte [ecx + 4096]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x1000 (4096)",
+        "mov w20, w20",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx rax, word [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "mov w20, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx rax, word [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx rax, word [ecx + 255]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0xff (255)",
+        "mov w20, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx rax, word [ecx + 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx rax, word [ecx + 8190]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1ffe",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx rax, word [ecx + 8191]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1fff",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx rax, word [ecx + 8192]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x2000 (8192)",
+        "mov w20, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "mov w20, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 255]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0xff (255)",
+        "mov w20, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 16380]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffc",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 16381]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffd",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 16382]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffe",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 16383]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3fff",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 16384]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x4000 (16384)",
+        "mov w20, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 255]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0xff (255)",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 32760]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff8",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 32761]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff9",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 32762]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ffa",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 32763]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ffb",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 32764]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ffc",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 32765]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ffd",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 32766]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ffe",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 32767]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7fff",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [ecx + 32768]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x8000 (32768)",
+        "mov w20, w20",
+        "ldr x4, [x20]"
+      ]
+    },
+    "movzx rax, byte [rcx - 257]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx rax, byte [rcx - 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx rax, byte [rcx + 255]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldrb w4, [x5, #255]"
+      ]
+    },
+    "movzx rax, byte [rcx + 256]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldrb w4, [x5, #256]"
+      ]
+    },
+    "movzx rax, byte [rcx + 4095]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldrb w4, [x5, #4095]"
+      ]
+    },
+    "movzx rax, byte [rcx + 4096]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1000",
+        "ldrb w4, [x5, x20, sxtx]"
+      ]
+    },
+    "movzx rax, word [rcx - 257]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx rax, word [rcx - 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx rax, word [rcx + 255]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldurh w4, [x5, #255]"
+      ]
+    },
+    "movzx rax, word [rcx + 256]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldrh w4, [x5, #256]"
+      ]
+    },
+    "movzx rax, word [rcx + 8190]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldrh w4, [x5, #8190]"
+      ]
+    },
+    "movzx rax, word [rcx + 8191]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1fff",
+        "ldrh w4, [x5, x20, sxtx]"
+      ]
+    },
+    "movzx rax, word [rcx + 8192]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x2000",
+        "ldrh w4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov eax, dword [rcx - 257]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [rcx - 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [rcx + 255]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldur w4, [x5, #255]"
+      ]
+    },
+    "mov eax, dword [rcx + 256]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr w4, [x5, #256]"
+      ]
+    },
+    "mov eax, dword [rcx + 16380]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr w4, [x5, #16380]"
+      ]
+    },
+    "mov eax, dword [rcx + 16381]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffd",
+        "ldr w4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov eax, dword [rcx + 16382]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffe",
+        "ldr w4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov eax, dword [rcx + 16383]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3fff",
+        "ldr w4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov eax, dword [rcx + 16384]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x4000",
+        "ldr w4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov rax, qword [rcx - 257]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [rcx - 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "ldr x4, [x20]"
+      ]
+    },
+    "mov rax, qword [rcx + 255]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldur x4, [x5, #255]"
+      ]
+    },
+    "mov rax, qword [rcx + 256]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr x4, [x5, #256]"
+      ]
+    },
+    "mov rax, qword [rcx + 32760]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr x4, [x5, #32760]"
+      ]
+    },
+    "mov rax, qword [rcx + 32761]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff9",
+        "ldr x4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov rax, qword [rcx + 32762]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ffa",
+        "ldr x4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov rax, qword [rcx + 32763]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ffb",
+        "ldr x4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov rax, qword [rcx + 32764]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ffc",
+        "ldr x4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov rax, qword [rcx + 32765]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ffd",
+        "ldr x4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov rax, qword [rcx + 32766]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ffe",
+        "ldr x4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov rax, qword [rcx + 32767]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7fff",
+        "ldr x4, [x5, x20, sxtx]"
+      ]
+    },
+    "mov rax, qword [rcx + 32768]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x8000",
+        "ldr x4, [x5, x20, sxtx]"
+      ]
+    },
+    "movss xmm0, [rcx + 16379]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffb",
+        "ldr s16, [x5, x20, sxtx]"
+      ]
+    },
+    "movss xmm0, [rcx + 16380]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr s16, [x5, #16380]"
+      ]
+    },
+    "movss xmm0, [rcx + 16381]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffd",
+        "ldr s16, [x5, x20, sxtx]"
+      ]
+    },
+    "movss xmm0, [rcx - 257]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [rcx - 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [rcx + 255]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldur s16, [x5, #255]"
+      ]
+    },
+    "movss xmm0, [rcx + 256]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr s16, [x5, #256]"
+      ]
+    },
+    "movsd xmm0, [rcx + 32759]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff7",
+        "ldr d16, [x5, x20, sxtx]"
+      ]
+    },
+    "movsd xmm0, [rcx + 32760]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr d16, [x5, #32760]"
+      ]
+    },
+    "movsd xmm0, [rcx + 32761]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff9",
+        "ldr d16, [x5, x20, sxtx]"
+      ]
+    },
+    "movsd xmm0, [rcx - 257]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [rcx - 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [rcx + 255]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldur d16, [x5, #255]"
+      ]
+    },
+    "movsd xmm0, [rcx + 256]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr d16, [x5, #256]"
+      ]
+    },
+    "movq xmm0, [rcx + 65519]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffef",
+        "ldr d16, [x5, x20, sxtx]"
+      ]
+    },
+    "movq xmm0, [rcx + 65520]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfff0",
+        "ldr d16, [x5, x20, sxtx]"
+      ]
+    },
+    "movq xmm0, [rcx + 65521]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfff1",
+        "ldr d16, [x5, x20, sxtx]"
+      ]
+    },
+    "movq xmm0, [rcx - 257]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [rcx - 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [rcx + 255]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldur d16, [x5, #255]"
+      ]
+    },
+    "movq xmm0, [rcx + 256]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr d16, [x5, #256]"
+      ]
+    },
+    "movss xmm0, [ecx + 16379]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffb",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx + 16380]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffc",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx + 16381]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffd",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "mov w20, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx + 255]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0xff (255)",
+        "mov w20, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx + 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx + 32759]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff7",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx + 32760]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff8",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx + 32761]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff9",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx + 255]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0xff (255)",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx + 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx + 65519]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffef",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx + 65520]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfff0",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx + 65521]": {
+      "ExpectedInstructionCount": 4,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfff1",
+        "add x20, x5, x20",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx + 255]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0xff (255)",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx + 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "add x20, x5, #0x100 (256)",
+        "mov w20, w20",
+        "ldr d16, [x20]"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -1,0 +1,345 @@
+{
+  "Features": {
+    "Bitness": 32,
+    "EnabledHostFeatures": [],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256",
+      "RPRES",
+      "AFP"
+    ]
+  },
+  "Comment": [
+    "Instructions that explicitly push against the limits of ARM's loadstore instructions"
+  ],
+  "Instructions": {
+    "movzx eax, byte [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfffffeff",
+        "add w20, w5, w20",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx eax, byte [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffffff00",
+        "add w20, w5, w20",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx eax, byte [ecx + 255]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0xff (255)",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx eax, byte [ecx + 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0x100 (256)",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx eax, byte [ecx + 4095]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0xfff (4095)",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx eax, byte [ecx + 4096]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0x1000 (4096)",
+        "ldrb w4, [x20]"
+      ]
+    },
+    "movzx eax, word [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfffffeff",
+        "add w20, w5, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx eax, word [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffffff00",
+        "add w20, w5, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx eax, word [ecx + 255]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0xff (255)",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx eax, word [ecx + 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0x100 (256)",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx eax, word [ecx + 8190]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1ffe",
+        "add w20, w5, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx eax, word [ecx + 8191]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x1fff",
+        "add w20, w5, w20",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "movzx eax, word [ecx + 8192]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0x2000 (8192)",
+        "ldrh w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfffffeff",
+        "add w20, w5, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffffff00",
+        "add w20, w5, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 255]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0xff (255)",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0x100 (256)",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 16380]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffc",
+        "add w20, w5, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 16381]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffd",
+        "add w20, w5, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 16382]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffe",
+        "add w20, w5, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 16383]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3fff",
+        "add w20, w5, w20",
+        "ldr w4, [x20]"
+      ]
+    },
+    "mov eax, dword [ecx + 16384]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0x4000 (16384)",
+        "ldr w4, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx + 16379]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffb",
+        "add w20, w5, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx + 16380]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffc",
+        "add w20, w5, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx + 16381]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x3ffd",
+        "add w20, w5, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfffffeff",
+        "add w20, w5, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffffff00",
+        "add w20, w5, w20",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx + 255]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0xff (255)",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movss xmm0, [ecx + 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0x100 (256)",
+        "ldr s16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx + 32759]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff7",
+        "add w20, w5, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx + 32760]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff8",
+        "add w20, w5, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx + 32761]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff9",
+        "add w20, w5, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfffffeff",
+        "add w20, w5, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffffff00",
+        "add w20, w5, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx + 255]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0xff (255)",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movsd xmm0, [ecx + 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0x100 (256)",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx + 65519]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffef",
+        "add w20, w5, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx + 65520]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfff0",
+        "add w20, w5, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx + 65521]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfff1",
+        "add w20, w5, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx - 257]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xfffffeff",
+        "add w20, w5, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx - 256]": {
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "mov w20, #0xffffff00",
+        "add w20, w5, w20",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx + 255]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0xff (255)",
+        "ldr d16, [x20]"
+      ]
+    },
+    "movq xmm0, [ecx + 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add w20, w5, #0x100 (256)",
+        "ldr d16, [x20]"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Spurred on by #3421

This does a bunch of GPR and vector loads to showcase addressing limitations between ARM and x86.

Tests:
- 8/16/32/64-bit GPR loads
   - Both 32-bit and 64-bit addressing modes
- 32/64/128-bit Vector loads
   - Both 32-bit and 64-bit addressing modes
- Duplicate the tests for 32-bit addressing mode with a 32-bit process
   - Since it should change behaviour.

Untested:
- 8/16-bit vector loadstores since those don't exist on x86
   - 16-bit x87 integer load exists but that doesn't go through a vector load in FEX.