### PR TITLE
Moves SignalDelegator TLS tracking to the frontend

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -348,7 +348,6 @@ namespace FEXCore::Context {
     Thread->ThreadManager.TID = FHU::Syscalls::gettid();
     Thread->ThreadManager.PID = ::getpid();
 
-    SignalDelegation->RegisterTLSState(Thread);
     if (ThunkHandler) {
       ThunkHandler->RegisterTLSState(Thread);
     }
@@ -428,7 +427,6 @@ namespace FEXCore::Context {
 #ifndef _WIN32
       Alloc::OSAllocator::UninstallTLSData(Thread);
 #endif
-      SignalDelegation->UninstallTLSState(Thread);
     }
 
     FEXCore::Allocator::VirtualFree(reinterpret_cast<void*>(Thread->CurrentFrame->State.DeferredSignalFaultAddress), 4096);
@@ -915,7 +913,6 @@ namespace FEXCore::Context {
 #ifndef _WIN32
     Alloc::OSAllocator::UninstallTLSData(Thread);
 #endif
-    SignalDelegation->UninstallTLSState(Thread);
   }
 
   static void InvalidateGuestThreadCodeRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) {

--- a/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -39,14 +39,6 @@ namespace Core {
   public:
     virtual ~SignalDelegator() = default;
 
-    /**
-     * @brief Registers an emulated thread's object to a TLS object
-     *
-     * Required to know which thread has received the signal when it occurs
-     */
-    virtual void RegisterTLSState(FEXCore::Core::InternalThreadState *Thread) = 0;
-    virtual void UninstallTLSState(FEXCore::Core::InternalThreadState *Thread) = 0;
-
     struct SignalDelegatorConfig {
       bool SupportsAVX{};
 

--- a/Source/Tools/CommonTools/DummyHandlers.h
+++ b/Source/Tools/CommonTools/DummyHandlers.h
@@ -32,8 +32,8 @@ class DummySignalDelegator final : public FEXCore::SignalDelegator, public FEXCo
   }
 
   protected:
-    void RegisterTLSState(FEXCore::Core::InternalThreadState *Thread) override;
-    void UninstallTLSState(FEXCore::Core::InternalThreadState *Thread) override;
+    void RegisterTLSState(FEXCore::Core::InternalThreadState *Thread);
+    void UninstallTLSState(FEXCore::Core::InternalThreadState *Thread);
 
   private:
     FEXCore::Core::InternalThreadState *GetTLSThread();

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -484,6 +484,7 @@ int main(int argc, char **argv, char **const envp) {
 
   auto ParentThread = SyscallHandler->TM.CreateThread(Loader.DefaultRIP(), Loader.GetStackPointer());
   SyscallHandler->TM.TrackThread(ParentThread);
+  SignalDelegation->RegisterTLSState(ParentThread);
 
   // Pass in our VDSO thunks
   CTX->AppendThunkDefinitions(FEX::VDSO::GetVDSOThunkDefinitions());
@@ -561,6 +562,7 @@ int main(int argc, char **argv, char **const envp) {
 
   auto ProgramStatus = ParentThread->StatusCode;
 
+  SignalDelegation->UninstallTLSState(ParentThread);
   CTX->DestroyThread(ParentThread);
 
   DebugServer.reset();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -54,8 +54,8 @@ namespace FEX::HLE {
     // Called from the signal trampoline function.
     void HandleSignal(int Signal, void *Info, void *UContext);
 
-    void RegisterTLSState(FEXCore::Core::InternalThreadState *Thread) override;
-    void UninstallTLSState(FEXCore::Core::InternalThreadState *Thread) override;
+    void RegisterTLSState(FEXCore::Core::InternalThreadState *Thread);
+    void UninstallTLSState(FEXCore::Core::InternalThreadState *Thread);
 
     /**
      * @brief Registers a signal handler for the host to handle a signal

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -52,7 +52,9 @@ namespace FEX::HLE {
     auto CTX = Handler->CTX;
     auto Thread = Handler->Thread;
     FEXCore::Allocator::free(Handler);
+    FEX::HLE::_SyscallHandler->GetSignalDelegator()->RegisterTLSState(Thread);
     CTX->ExecutionThread(Thread);
+    FEX::HLE::_SyscallHandler->GetSignalDelegator()->UninstallTLSState(Thread);
     FEX::HLE::_SyscallHandler->TM.DestroyThread(Thread);
     return nullptr;
   }
@@ -221,9 +223,13 @@ namespace FEX::HLE {
       FEX::HLE::_SyscallHandler->TM.TrackThread(Thread);
     }
 
+    FEX::HLE::_SyscallHandler->GetSignalDelegator()->RegisterTLSState(Thread);
+
     // Start exuting the thread directly
     // Our host clone starts in a new stack space, so it can't return back to the JIT space
     CTX->ExecutionThread(Thread);
+
+    FEX::HLE::_SyscallHandler->GetSignalDelegator()->UninstallTLSState(Thread);
 
     // The rest of the context remains as is and the thread will continue executing
     return Thread->StatusCode;

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -309,6 +309,7 @@ int main(int argc, char **argv, char **const envp) {
       return 1;
     }
     auto ParentThread = CTX->CreateThread(Loader.DefaultRIP(), Loader.GetStackPointer());
+    SignalDelegation->RegisterTLSState(ParentThread);
 
     if (!ParentThread) {
       return 1;
@@ -324,6 +325,7 @@ int main(int argc, char **argv, char **const envp) {
 
     SyscallHandler.reset();
 
+    SignalDelegation->UninstallTLSState(ParentThread);
     CTX->DestroyThread(ParentThread, true);
   }
 #ifndef _WIN32


### PR DESCRIPTION
FEXCore doesn't need track the TLS state of the SignalDelegator, this is a frontend concept.

Removes the tracking from the backend and keeps it in the frontend.