### PR TITLE
Syscalls: Fix SourcecodeMap generation for GDB JIT integration

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -975,7 +975,7 @@ fextl::unique_ptr<FEXCore::HLE::SourcecodeMap> SyscallHandler::GenerateMap(const
     fextl::istringstream Stream(SourceData);
 
     constexpr int USER_PERMS = S_IRWXU | S_IRWXG | S_IRWXO;
-    int IndexStream = ::open(GuestSourceFile.c_str(), O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC, USER_PERMS);
+    int IndexStream = ::open(GuestIndexFile.c_str(), O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, USER_PERMS);
 
     if (IndexStream == -1) {
       LogMan::Msg::DFmt("GenerateMap: Failed to open '{}' for writing", GuestIndexFile);


### PR DESCRIPTION
This fixes a regression from 9dd715573, which accidentally changed the filename and set up incorrect file opening flags.

For personal reference, it seems that Ubuntu's `gdb` package enables assertions that break with FEX's GDBJITReader, however it's working fine when building gdb from source with the default configuration.