### PR TITLE
Fixes zero register flag generation

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5138,8 +5138,9 @@ void OpDispatchBuilder::ALUOpImpl(OpcodeArgs, FEXCore::IR::IROps ALUIROp, FEXCor
     Op->Dest.IsGPR() && Op->Src[SrcIdx].IsGPR() &&
     Op->Dest.Data.GPR == Op->Src[SrcIdx].Data.GPR) {
 
-    StoreResult(GPRClass, Op, _Constant(0), -1);
-    ZeroNZCV();
+    auto Result = _Constant(0);
+    StoreResult(GPRClass, Op, Result, -1);
+    GenerateFlags_Logical(Op, Result, Result, Result);
     return;
   }
 

--- a/unittests/ASM/FEX_bugs/xor_flags.asm
+++ b/unittests/ASM/FEX_bugs/xor_flags.asm
@@ -1,0 +1,17 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000000004600"
+  }
+}
+%endif
+
+; FEX had a bug where an optimization for canonical zeroing of a register would fail to set flags correctly.
+; This broke `Metal Gear Rising: Revengeance`. The title screen geometry was broken.
+
+mov rax, 0
+mov rbx, 0
+sahf
+xor rbx, rbx
+lahf
+hlt


### PR DESCRIPTION
Fixes 140976d322dc5e26c129d1e6448f25f6b2378341

Adds a unit test to ensure it keeps working.

Before fix:
![Screenshot 2024-02-24 15-33-39](https://github.com/FEX-Emu/FEX/assets/1018829/444b578e-4c03-4865-a606-13efa01345f3)

After fix:
![Screenshot 2024-02-24 16-34-35](https://github.com/FEX-Emu/FEX/assets/1018829/8712ed54-91ee-434d-b433-3b6ce5cd76f4)
