### PR TITLE
Adds a unittest for a bug from #3421

### DIFF
--- a/unittests/32Bit_ASM/FEX_bugs/SignExtendBug.asm
+++ b/unittests/32Bit_ASM/FEX_bugs/SignExtendBug.asm
@@ -1,0 +1,20 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344"
+  },
+  "MemoryRegions": {
+    "0xf0000000": "4096"
+  },
+  "MemoryData": {
+    "0xf0000000": "0x41424344"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; Ensures that zero extension of addresses are adhered to.
+lea eax, [0xf000_0000]
+mov eax, [ds:eax]
+
+hlt


### PR DESCRIPTION
When the source arguments for LoadMem/StoreMem have bit 31 set then they are incorrectly sign extending in some instances.

Detected this when testing #3421 but I don't have a proper fix for it.