### PR TITLE
Update xxhash to v0.8.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,7 +41,7 @@
 	url = https://github.com/FEX-Emu/drm-headers.git
 [submodule "External/xxhash"]
 	path = External/xxhash
-	url = https://github.com/FEX-Emu/xxHash.git
+	url = https://github.com/Cyan4973/xxHash.git
 [submodule "External/Catch2"]
 	path = External/Catch2
 	url = https://github.com/catchorg/Catch2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,8 +237,10 @@ endif()
 find_package(PkgConfig REQUIRED)
 find_package(Python 3.0 REQUIRED COMPONENTS Interpreter)
 
-add_subdirectory(External/xxhash/)
-include_directories(External/xxhash/)
+set(XXHASH_BUNDLED_MODE TRUE)
+set(XXHASH_BUILD_XXHSUM FALSE)
+set(BUILD_SHARED_LIBS OFF)
+add_subdirectory(External/xxhash/cmake_unofficial/)
 
 add_definitions(-Wno-trigraphs)
 add_definitions(-DGLOBAL_DATA_DIRECTORY="${DATA_DIRECTORY}/")

--- a/FEXCore/Source/CMakeLists.txt
+++ b/FEXCore/Source/CMakeLists.txt
@@ -194,7 +194,7 @@ endif()
 # Some defines for the softfloat library
 list(APPEND DEFINES "-DSOFTFLOAT_BUILTIN_CLZ")
 
-set (LIBS fmt::fmt vixl xxhash FEXHeaderUtils)
+set (LIBS fmt::fmt vixl xxHash::xxhash FEXHeaderUtils)
 
 if (NOT MINGW_BUILD)
   list (APPEND LIBS dl)

--- a/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
+++ b/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SRCS Main.cpp
   XXFileHash.cpp)
 
 add_executable(${NAME} ${SRCS})
-list(APPEND LIBS FEXCore Common)
+list(APPEND LIBS FEXCore Common xxHash::xxhash)
 
 target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/Source/)
 


### PR DESCRIPTION
Update xxhash to v0.8.2

Switches to using upstream cmake files. Which means we don't need to use our own fork now.

There has been some good ARM ASIMD/SVE optimizations since our last update. I have also seen some additional changes merged, so when they do a version bump we should probably update again.