### PR TITLE
OpcodeDispatcher: Don't use AddShift with no shift

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4757,7 +4757,12 @@ OrderedNode *OpDispatchBuilder::LoadSource_WithOpSize(RegisterClassType Class, X
     if (!IsVSIB && Operand.Data.SIB.Index != FEXCore::X86State::REG_INVALID && Operand.Data.SIB.Base != FEXCore::X86State::REG_INVALID) {
       auto Base = LoadGPRRegister(Operand.Data.SIB.Base, GPRSize);
       auto Index = LoadGPRRegister(Operand.Data.SIB.Index, GPRSize);
-      Tmp = _AddShift(IR::SizeToOpSize(GPRSize), Base, Index, ShiftType::LSL, FEXCore::ilog2(Operand.Data.SIB.Scale));
+      if (Operand.Data.SIB.Scale == 1) {
+        Tmp = _Add(IR::SizeToOpSize(GPRSize), Base, Index);
+      }
+      else {
+        Tmp = _AddShift(IR::SizeToOpSize(GPRSize), Base, Index, ShiftType::LSL, FEXCore::ilog2(Operand.Data.SIB.Scale));
+      }
     }
     else {
       // NOTE: VSIB cannot have the index * scale portion calculated ahead of time,
@@ -5011,7 +5016,12 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
     if (Operand.Data.SIB.Index != FEXCore::X86State::REG_INVALID && Operand.Data.SIB.Base != FEXCore::X86State::REG_INVALID) {
       auto Base = LoadGPRRegister(Operand.Data.SIB.Base, GPRSize);
       auto Index = LoadGPRRegister(Operand.Data.SIB.Index, GPRSize);
-      Tmp = _AddShift(IR::SizeToOpSize(GPRSize), Base, Index, ShiftType::LSL, FEXCore::ilog2(Operand.Data.SIB.Scale));
+      if (Operand.Data.SIB.Scale == 1) {
+        Tmp = _Add(IR::SizeToOpSize(GPRSize), Base, Index);
+      }
+      else {
+        Tmp = _AddShift(IR::SizeToOpSize(GPRSize), Base, Index, ShiftType::LSL, FEXCore::ilog2(Operand.Data.SIB.Scale));
+      }
     }
     else {
       if (Operand.Data.SIB.Index != FEXCore::X86State::REG_INVALID) {

--- a/unittests/32Bit_ASM/FEX_bugs/SignExtendBug.asm
+++ b/unittests/32Bit_ASM/FEX_bugs/SignExtendBug.asm
@@ -1,7 +1,8 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "RAX": "0x41424344"
+    "RAX": "0x41424344",
+    "RBX": "0x41424344"
   },
   "MemoryRegions": {
     "0xf0000000": "4096"
@@ -16,5 +17,14 @@
 ; Ensures that zero extension of addresses are adhered to.
 lea eax, [0xf000_0000]
 mov eax, [ds:eax]
+
+; Ensures that zext occurs correctly with two registers that have the sign bit set.
+mov ebx, 0xffff_ffff
+mov ecx, 0xf000_0001
+
+; Break the block so it can't optimize through.
+jmp .test
+.test:
+mov ebx, [ebx+ecx]
 
 hlt

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -169,7 +169,7 @@
       ]
     },
     "Scalar vector add loop": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Saw this in bytemark"
       ],
@@ -181,11 +181,9 @@
         "cmp     rsi, rax"
       ],
       "ExpectedArm64ASM": [
-        "add x20, x16, x4",
-        "ldr q16, [x20]",
+        "ldr q16, [x16, x4, sxtx]",
         "add v16.2d, v16.2d, v17.2d",
-        "add x20, x16, x4",
-        "str q16, [x20]",
+        "str q16, [x16, x4, sxtx]",
         "add x4, x4, #0x10 (16)",
         "eor w27, w10, w4",
         "subs x26, x10, x4",


### PR DESCRIPTION
This accidentally removed optimizations elsewhere that was only checking
for Add.

Adds a unit test that gets unveiled with this that #3421 ends up breaking.