### PR TITLE
Arm64: Stop moving source in atomic swap

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/AtomicOps.cpp
@@ -310,8 +310,7 @@ DEF_OP(AtomicSwap) {
     OpSize == 1 ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
 
   if (CTX->HostFeatures.SupportsAtomics) {
-    mov(EmitSize, TMP2, Src);
-    ldswpal(SubEmitSize, TMP2, GetReg(Node), MemSrc);
+    ldswpal(SubEmitSize, Src, GetReg(Node), MemSrc);
   }
   else {
     ARMEmitter::BackwardLabel LoopTop;

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -316,37 +316,33 @@
       ]
     },
     "xchg byte [rax], cl": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": "0x86",
       "ExpectedArm64ASM": [
-        "mov w1, w5",
-        "swpalb w1, w20, [x4]",
+        "swpalb w5, w20, [x4]",
         "bfxil x5, x20, #0, #8"
       ]
     },
     "xchg word [rax], cx": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": "0x87",
       "ExpectedArm64ASM": [
-        "mov w1, w5",
-        "swpalh w1, w20, [x4]",
+        "swpalh w5, w20, [x4]",
         "bfxil x5, x20, #0, #16"
       ]
     },
     "xchg dword [rax], ecx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": "0x87",
       "ExpectedArm64ASM": [
-        "mov w1, w5",
-        "swpal w1, w5, [x4]"
+        "swpal w5, w5, [x4]"
       ]
     },
     "xchg qword [rax], rcx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": "0x87",
       "ExpectedArm64ASM": [
-        "mov x1, x5",
-        "swpal x1, x5, [x4]"
+        "swpal x5, x5, [x4]"
       ]
     },
     "xadd byte [rax], bl": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -1976,11 +1976,10 @@
       ]
     },
     "xchg [rax], cl": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": "0x86",
       "ExpectedArm64ASM": [
-        "mov w1, w5",
-        "swpalb w1, w20, [x4]",
+        "swpalb w5, w20, [x4]",
         "bfxil x5, x20, #0, #8"
       ]
     },
@@ -1995,11 +1994,10 @@
       ]
     },
     "xchg [rax], cx": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": "0x87",
       "ExpectedArm64ASM": [
-        "mov w1, w5",
-        "swpalh w1, w20, [x4]",
+        "swpalh w5, w20, [x4]",
         "bfxil x5, x20, #0, #16"
       ]
     },
@@ -2013,11 +2011,10 @@
       ]
     },
     "xchg [rax], ecx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": "0x87",
       "ExpectedArm64ASM": [
-        "mov w1, w5",
-        "swpal w1, w5, [x4]"
+        "swpal w5, w5, [x4]"
       ]
     },
     "xchg rbx, rcx": {
@@ -2030,11 +2027,10 @@
       ]
     },
     "xchg [rax], rcx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": "0x87",
       "ExpectedArm64ASM": [
-        "mov x1, x5",
-        "swpal x1, x5, [x4]"
+        "swpal x5, x5, [x4]"
       ]
     },
     "mov [rax], bl": {


### PR DESCRIPTION
ldswpal doesn't overwrite the source register and only reads the bits
required for the sized operation.
Not sure exactly why we were doing a copy here.

Removing it means improving Skyrim's hottest code block, as seen in https://github.com/FEX-Emu/FEX/issues/3472