### PR TITLE
Use SETF8/16 for 8/16-bit INC/DEC

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -311,6 +311,20 @@ DEF_OP(RmifNZCV) {
   rmif(GetReg(Op->Src.ID()).X(), Op->Rotate, Op->Mask);
 }
 
+DEF_OP(SetSmallNZV) {
+  auto Op = IROp->C<IR::IROp_SetSmallNZV>();
+  LOGMAN_THROW_A_FMT(CTX->HostFeatures.SupportsFlagM, "Unsupported flagm op");
+
+  const uint8_t OpSize = IROp->Size;
+  LOGMAN_THROW_AA_FMT(OpSize == 1 || OpSize == 2, "Unsupported {} size: {}", __func__, OpSize);
+
+  if (OpSize == 1) {
+    setf8(GetReg(Op->Src.ID()).W());
+  } else {
+    setf16(GetReg(Op->Src.ID()).W());
+  }
+}
+
 DEF_OP(AXFlag) {
   LOGMAN_THROW_A_FMT(CTX->HostFeatures.SupportsFlagM2, "Unsupported flagm2 op");
   axflag();

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -992,6 +992,14 @@
         "HasSideEffects": true,
         "DestSize": "Size"
       },
+      "SetSmallNZV OpSize:#Size, GPR:$Src": {
+        "Desc": ["Set NZV with a SETF instruction. Preserves CF."],
+        "HasSideEffects": true,
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit"
+        ]
+      },
       "CarryInvert": {
         "Desc": ["Invert carry flag in NZCV"],
         "HasSideEffects": true

--- a/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
@@ -183,6 +183,12 @@ DeadFlagCalculationEliminination::Classify(IROp_Header *IROp)
         .CanEliminate = true,
       };
 
+    case OP_SETSMALLNZV:
+      return {
+        .Write = FLAG_N | FLAG_Z | FLAG_V,
+        .CanEliminate = true,
+      };
+
     case OP_LOADNZCV:
       return {.Read = FLAG_NZCV};
 

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -1296,17 +1296,15 @@
       ]
     },
     "lock dec byte [rax]": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
-        "mov w20, #0x1",
-        "mov w21, #0xff",
-        "ldaddalb w21, w27, [x4]",
-        "cset w21, hs",
-        "lsl w0, w27, #24",
-        "cmp w0, w20, lsl #24",
+        "mov w20, #0xff",
+        "ldaddalb w20, w27, [x4]",
         "sub w26, w27, #0x1 (1)",
-        "rmif x21, #63, #nzCv"
+        "setf8 w26",
+        "bic w20, w27, w26",
+        "rmif x20, #7, #nzcV"
       ]
     },
     "lock not byte [rax]": {
@@ -1396,17 +1394,15 @@
       ]
     },
     "lock dec word [rax]": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
-        "mov w20, #0x1",
-        "mov w21, #0xffff",
-        "ldaddalh w21, w27, [x4]",
-        "cset w21, hs",
-        "lsl w0, w27, #16",
-        "cmp w0, w20, lsl #16",
+        "mov w20, #0xffff",
+        "ldaddalh w20, w27, [x4]",
         "sub w26, w27, #0x1 (1)",
-        "rmif x21, #63, #nzCv"
+        "setf16 w26",
+        "bic w20, w27, w26",
+        "rmif x20, #15, #nzcV"
       ]
     },
     "lock dec dword [rax]": {
@@ -1432,29 +1428,27 @@
       ]
     },
     "lock inc byte [rax]": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldaddalb w20, w27, [x4]",
-        "cset w21, hs",
-        "lsl w0, w27, #24",
-        "cmn w0, w20, lsl #24",
         "add w26, w27, #0x1 (1)",
-        "rmif x21, #63, #nzCv"
+        "setf8 w26",
+        "bic w20, w26, w27",
+        "rmif x20, #7, #nzcV"
       ]
     },
     "lock inc word [rax]": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldaddalh w20, w27, [x4]",
-        "cset w21, hs",
-        "lsl w0, w27, #16",
-        "cmn w0, w20, lsl #16",
         "add w26, w27, #0x1 (1)",
-        "rmif x21, #63, #nzCv"
+        "setf16 w26",
+        "bic w20, w26, w27",
+        "rmif x20, #15, #nzcV"
       ]
     },
     "lock inc dword [rax]": {

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -142,6 +142,47 @@
         "ands x26, x4, x5"
       ]
     },
+    "8-bit DEC consumed": {
+      "ExpectedInstructionCount": 14,
+      "x86Insts": [
+        "sub al, ah",
+        "dec al"
+      ],
+      "ExpectedArm64ASM": [
+        "lsr w20, w4, #8",
+        "lsl w0, w4, #24",
+        "cmp w0, w20, lsl #24",
+        "sub w20, w4, w20",
+        "cfinv",
+        "bfxil x4, x20, #0, #8",
+        "mov w20, #0x1",
+        "uxtb w27, w4",
+        "cset w21, hs",
+        "lsl w0, w27, #24",
+        "cmp w0, w20, lsl #24",
+        "sub w26, w27, #0x1 (1)",
+        "rmif x21, #63, #nzCv",
+        "bfxil x4, x26, #0, #8"
+      ]
+    },
+    "8-bit DEC dead": {
+      "ExpectedInstructionCount": 8,
+      "x86Insts": [
+        "sub al, ah",
+        "dec al",
+        "test al, al"
+      ],
+      "ExpectedArm64ASM": [
+        "lsr w20, w4, #8",
+        "sub w20, w4, w20",
+        "bfxil x4, x20, #0, #8",
+        "uxtb w20, w4",
+        "sub w20, w20, #0x1 (1)",
+        "bfxil x4, x20, #0, #8",
+        "mov x26, x4",
+        "cmn wzr, w26, lsl #24"
+      ]
+    },
     "Variable shift dead": {
       "ExpectedInstructionCount": 2,
       "x86Insts": [

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -143,7 +143,7 @@
       ]
     },
     "8-bit DEC consumed": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 12,
       "x86Insts": [
         "sub al, ah",
         "dec al"
@@ -155,13 +155,11 @@
         "sub w20, w4, w20",
         "cfinv",
         "bfxil x4, x20, #0, #8",
-        "mov w20, #0x1",
         "uxtb w27, w4",
-        "cset w21, hs",
-        "lsl w0, w27, #24",
-        "cmp w0, w20, lsl #24",
         "sub w26, w27, #0x1 (1)",
-        "rmif x21, #63, #nzCv",
+        "setf8 w26",
+        "bic w20, w27, w26",
+        "rmif x20, #7, #nzcV",
         "bfxil x4, x26, #0, #8"
       ]
     },

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -2388,44 +2388,38 @@
       ]
     },
     "inc al": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP3 0xfe /0",
       "ExpectedArm64ASM": [
-        "mov w20, #0x1",
         "uxtb w27, w4",
-        "cset w21, hs",
-        "lsl w0, w27, #24",
-        "cmn w0, w20, lsl #24",
         "add w26, w27, #0x1 (1)",
-        "rmif x21, #63, #nzCv",
+        "setf8 w26",
+        "bic w20, w26, w27",
+        "rmif x20, #7, #nzcV",
         "bfxil x4, x26, #0, #8"
       ]
     },
     "dec al": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP3 0xfe /1",
       "ExpectedArm64ASM": [
-        "mov w20, #0x1",
         "uxtb w27, w4",
-        "cset w21, hs",
-        "lsl w0, w27, #24",
-        "cmp w0, w20, lsl #24",
         "sub w26, w27, #0x1 (1)",
-        "rmif x21, #63, #nzCv",
+        "setf8 w26",
+        "bic w20, w27, w26",
+        "rmif x20, #7, #nzcV",
         "bfxil x4, x26, #0, #8"
       ]
     },
     "inc ax": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
-        "mov w20, #0x1",
         "uxth w27, w4",
-        "cset w21, hs",
-        "lsl w0, w27, #16",
-        "cmn w0, w20, lsl #16",
         "add w26, w27, #0x1 (1)",
-        "rmif x21, #63, #nzCv",
+        "setf16 w26",
+        "bic w20, w26, w27",
+        "rmif x20, #15, #nzcV",
         "bfxil x4, x26, #0, #16"
       ]
     },
@@ -2452,16 +2446,14 @@
       ]
     },
     "dec ax": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 6,
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
-        "mov w20, #0x1",
         "uxth w27, w4",
-        "cset w21, hs",
-        "lsl w0, w27, #16",
-        "cmp w0, w20, lsl #16",
         "sub w26, w27, #0x1 (1)",
-        "rmif x21, #63, #nzCv",
+        "setf16 w26",
+        "bic w20, w27, w26",
+        "rmif x20, #15, #nzcV",
         "bfxil x4, x26, #0, #16"
       ]
     },


### PR DESCRIPTION
This isn't as useful as you'd like, since the definition of SETF seems to be broken (due to a fundamental misunderstanding at Arm about how OF works?). But it's still a win in this one case.