### PR TITLE
Removes steamwebhelper config

### DIFF
--- a/Data/AppConfig/steamwebhelper.json
+++ b/Data/AppConfig/steamwebhelper.json
@@ -1,5 +1,0 @@
-{
-  "Config": {
-    "AdditionalArguments": "--no-sandbox"
-  }
-}


### PR DESCRIPTION
Fixes #3479

As of the Steam update on Feb 29 2024, this is no longer necessary and actually causes steamwebhelper to abort.

Steam has started using SLR to launch steamwebhelper, which already passes in --no-sandbox. Adding this argument twice seemingly breaks the application since it starts complaining that it doesn't understand the argument and closes with a SIGABRT.

With this removed Steam starts working again.