### PR TITLE
Externals: Update Catch2 to v3.5.3

### DIFF
--- a/FEXCore/unittests/APITests/FileLoading.cpp
+++ b/FEXCore/unittests/APITests/FileLoading.cpp
@@ -1,5 +1,5 @@
 #include <FEXCore/Utils/FileLoading.h>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("LoadFile-Doesn'tExist") {
   fextl::string MapsFile;

--- a/FEXCore/unittests/APITests/FutexSpinTest.cpp
+++ b/FEXCore/unittests/APITests/FutexSpinTest.cpp
@@ -1,5 +1,5 @@
 #include "Utils/SpinWaitLock.h"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <chrono>
 #include <thread>
 

--- a/FEXCore/unittests/APITests/ILog2.cpp
+++ b/FEXCore/unittests/APITests/ILog2.cpp
@@ -1,5 +1,6 @@
 #include <FEXCore/Utils/MathUtils.h>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
 
 TEST_CASE("ILog2") {
   auto i = GENERATE(range(0, 64));

--- a/FEXCore/unittests/Emitter/ALU_Tests.cpp
+++ b/FEXCore/unittests/Emitter/ALU_Tests.cpp
@@ -1,6 +1,6 @@
 #include "TestDisassembler.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <fcntl.h>
 
 using namespace FEXCore::ARMEmitter;
@@ -450,7 +450,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ALU: Bitfield") {
 
   TEST_SINGLE(bfxil(Size::i32Bit, Reg::r29, Reg::r28, 4, 3),  "bfxil w29, w28, #4, #3");
   TEST_SINGLE(bfxil(Size::i32Bit, Reg::r29, Reg::r28, 27, 3), "bfxil w29, w28, #27, #3");
-  
+
   TEST_SINGLE(bfxil(Size::i64Bit, Reg::r29, Reg::r28, 4, 3),  "bfxil x29, x28, #4, #3");
   TEST_SINGLE(bfxil(Size::i64Bit, Reg::r29, Reg::r28, 57, 3), "bfxil x29, x28, #57, #3");
 

--- a/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -1,6 +1,6 @@
 #include "TestDisassembler.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <fcntl.h>
 
 using namespace FEXCore::ARMEmitter;

--- a/FEXCore/unittests/Emitter/Branch_Tests.cpp
+++ b/FEXCore/unittests/Emitter/Branch_Tests.cpp
@@ -1,6 +1,6 @@
 #include "TestDisassembler.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <fcntl.h>
 
 using namespace FEXCore::ARMEmitter;

--- a/FEXCore/unittests/Emitter/Loadstore_Tests.cpp
+++ b/FEXCore/unittests/Emitter/Loadstore_Tests.cpp
@@ -1,6 +1,6 @@
 #include "TestDisassembler.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <fcntl.h>
 
 using namespace FEXCore::ARMEmitter;

--- a/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -1,6 +1,6 @@
 #include "TestDisassembler.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <fcntl.h>
 
 using namespace FEXCore::ARMEmitter;
@@ -1177,7 +1177,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec vector by element 
   TEST_SINGLE(inch(ZReg::z30, PredicatePattern::SVE_POW2 , 1),  "inch z30.h, pow2");
   TEST_SINGLE(inch(ZReg::z30, PredicatePattern::SVE_VL256, 7),  "inch z30.h, vl256, mul #7");
   TEST_SINGLE(inch(ZReg::z30, PredicatePattern::SVE_ALL  , 16), "inch z30.h, all, mul #16");
-  
+
   TEST_SINGLE(dech(ZReg::z30, PredicatePattern::SVE_POW2 , 1),  "dech z30.h, pow2");
   TEST_SINGLE(dech(ZReg::z30, PredicatePattern::SVE_VL256, 7),  "dech z30.h, vl256, mul #7");
   TEST_SINGLE(dech(ZReg::z30, PredicatePattern::SVE_ALL  , 16), "dech z30.h, all, mul #16");
@@ -1185,7 +1185,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec vector by element 
   TEST_SINGLE(incw(ZReg::z30, PredicatePattern::SVE_POW2 , 1),  "incw z30.s, pow2");
   TEST_SINGLE(incw(ZReg::z30, PredicatePattern::SVE_VL256, 7),  "incw z30.s, vl256, mul #7");
   TEST_SINGLE(incw(ZReg::z30, PredicatePattern::SVE_ALL  , 16), "incw z30.s, all, mul #16");
-  
+
   TEST_SINGLE(decw(ZReg::z30, PredicatePattern::SVE_POW2 , 1),  "decw z30.s, pow2");
   TEST_SINGLE(decw(ZReg::z30, PredicatePattern::SVE_VL256, 7),  "decw z30.s, vl256, mul #7");
   TEST_SINGLE(decw(ZReg::z30, PredicatePattern::SVE_ALL  , 16), "decw z30.s, all, mul #16");
@@ -1193,7 +1193,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec vector by element 
   TEST_SINGLE(incd(ZReg::z30, PredicatePattern::SVE_POW2 , 1),  "incd z30.d, pow2");
   TEST_SINGLE(incd(ZReg::z30, PredicatePattern::SVE_VL256, 7),  "incd z30.d, vl256, mul #7");
   TEST_SINGLE(incd(ZReg::z30, PredicatePattern::SVE_ALL  , 16), "incd z30.d, all, mul #16");
-  
+
   TEST_SINGLE(decd(ZReg::z30, PredicatePattern::SVE_POW2 , 1),  "decd z30.d, pow2");
   TEST_SINGLE(decd(ZReg::z30, PredicatePattern::SVE_VL256, 7),  "decd z30.d, vl256, mul #7");
   TEST_SINGLE(decd(ZReg::z30, PredicatePattern::SVE_ALL  , 16), "decd z30.d, all, mul #16");
@@ -1203,7 +1203,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec register by elemen
   TEST_SINGLE(incb(XReg::x30, PredicatePattern::SVE_POW2 , 1),  "incb x30, pow2");
   TEST_SINGLE(incb(XReg::x30, PredicatePattern::SVE_VL256, 7),  "incb x30, vl256, mul #7");
   TEST_SINGLE(incb(XReg::x30, PredicatePattern::SVE_ALL  , 16), "incb x30, all, mul #16");
-  
+
   TEST_SINGLE(decb(XReg::x30, PredicatePattern::SVE_POW2 , 1),  "decb x30, pow2");
   TEST_SINGLE(decb(XReg::x30, PredicatePattern::SVE_VL256, 7),  "decb x30, vl256, mul #7");
   TEST_SINGLE(decb(XReg::x30, PredicatePattern::SVE_ALL  , 16), "decb x30, all, mul #16");
@@ -1211,7 +1211,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec register by elemen
   TEST_SINGLE(inch(XReg::x30, PredicatePattern::SVE_POW2 , 1),  "inch x30, pow2");
   TEST_SINGLE(inch(XReg::x30, PredicatePattern::SVE_VL256, 7),  "inch x30, vl256, mul #7");
   TEST_SINGLE(inch(XReg::x30, PredicatePattern::SVE_ALL  , 16), "inch x30, all, mul #16");
-  
+
   TEST_SINGLE(dech(XReg::x30, PredicatePattern::SVE_POW2 , 1),  "dech x30, pow2");
   TEST_SINGLE(dech(XReg::x30, PredicatePattern::SVE_VL256, 7),  "dech x30, vl256, mul #7");
   TEST_SINGLE(dech(XReg::x30, PredicatePattern::SVE_ALL  , 16), "dech x30, all, mul #16");
@@ -1219,7 +1219,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec register by elemen
   TEST_SINGLE(incw(XReg::x30, PredicatePattern::SVE_POW2 , 1),  "incw x30, pow2");
   TEST_SINGLE(incw(XReg::x30, PredicatePattern::SVE_VL256, 7),  "incw x30, vl256, mul #7");
   TEST_SINGLE(incw(XReg::x30, PredicatePattern::SVE_ALL  , 16), "incw x30, all, mul #16");
-  
+
   TEST_SINGLE(decw(XReg::x30, PredicatePattern::SVE_POW2 , 1),  "decw x30, pow2");
   TEST_SINGLE(decw(XReg::x30, PredicatePattern::SVE_VL256, 7),  "decw x30, vl256, mul #7");
   TEST_SINGLE(decw(XReg::x30, PredicatePattern::SVE_ALL  , 16), "decw x30, all, mul #16");
@@ -1227,7 +1227,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE inc/dec register by elemen
   TEST_SINGLE(incd(XReg::x30, PredicatePattern::SVE_POW2 , 1),  "incd x30, pow2");
   TEST_SINGLE(incd(XReg::x30, PredicatePattern::SVE_VL256, 7),  "incd x30, vl256, mul #7");
   TEST_SINGLE(incd(XReg::x30, PredicatePattern::SVE_ALL  , 16), "incd x30, all, mul #16");
-  
+
   TEST_SINGLE(decd(XReg::x30, PredicatePattern::SVE_POW2 , 1),  "decd x30, pow2");
   TEST_SINGLE(decd(XReg::x30, PredicatePattern::SVE_VL256, 7),  "decd x30, vl256, mul #7");
   TEST_SINGLE(decd(XReg::x30, PredicatePattern::SVE_ALL  , 16), "decd x30, all, mul #16");
@@ -1507,7 +1507,7 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE Permute Predicate") {
   TEST_SINGLE(rev(SubRegSize::i16Bit, PReg::p15, PReg::p14), "rev p15.h, p14.h");
   TEST_SINGLE(rev(SubRegSize::i32Bit, PReg::p15, PReg::p14), "rev p15.s, p14.s");
   TEST_SINGLE(rev(SubRegSize::i64Bit, PReg::p15, PReg::p14), "rev p15.d, p14.d");
-  
+
   TEST_SINGLE(punpklo(PReg::p15, PReg::p14), "punpklo p15.h, p14.b");
   TEST_SINGLE(punpkhi(PReg::p15, PReg::p14), "punpkhi p15.h, p14.b");
 
@@ -3469,15 +3469,15 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE floating-point multiply-ad
   // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalb z30.s, z29.h, z28.h");
   // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalb z30.s, z29.h, z28.h");
   // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalb z30.s, z29.h, z28.h");
-  
+
   // TEST_SINGLE(bfmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalt z30.s, z29.h, z28.h");
   // TEST_SINGLE(bfmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalt z30.s, z29.h, z28.h");
   // TEST_SINGLE(bfmlalt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlalt z30.s, z29.h, z28.h");
-  
+
   // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslb z30.s, z29.h, z28.h");
   // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslb z30.s, z29.h, z28.h");
   // TEST_SINGLE(bfmlalb(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslb z30.s, z29.h, z28.h");
-  
+
   // TEST_SINGLE(bfmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslt z30.s, z29.h, z28.h");
   // TEST_SINGLE(bfmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslt z30.s, z29.h, z28.h");
   // TEST_SINGLE(bfmlslt(SubRegSize::i32Bit, ZReg::z30, ZReg::z29, ZReg::z28), "bfmlslt z30.s, z29.h, z28.h");

--- a/FEXCore/unittests/Emitter/Scalar_Tests.cpp
+++ b/FEXCore/unittests/Emitter/Scalar_Tests.cpp
@@ -1,6 +1,6 @@
 #include "TestDisassembler.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <fcntl.h>
 
 using namespace FEXCore::ARMEmitter;

--- a/FEXCore/unittests/Emitter/System_Tests.cpp
+++ b/FEXCore/unittests/Emitter/System_Tests.cpp
@@ -1,6 +1,6 @@
 #include "TestDisassembler.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <fcntl.h>
 
 using namespace FEXCore::ARMEmitter;

--- a/unittests/APITests/Filesystem.cpp
+++ b/unittests/APITests/Filesystem.cpp
@@ -1,4 +1,5 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 #include <filesystem>
 #include <FEXHeaderUtils/Filesystem.h>
 

--- a/unittests/APITests/InterruptableConditionVariable.cpp
+++ b/unittests/APITests/InterruptableConditionVariable.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <chrono>
 #include <csetjmp>
 #include <FEXCore/Utils/InterruptableConditionVariable.h>

--- a/unittests/FEXLinuxTests/tests/fd/test_close_range.cpp
+++ b/unittests/FEXLinuxTests/tests/fd/test_close_range.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
 #include <unistd.h>

--- a/unittests/FEXLinuxTests/tests/signal/Syscall_state.32.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/Syscall_state.32.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <csetjmp>
 #include <unistd.h>
 #include <sys/syscall.h>

--- a/unittests/FEXLinuxTests/tests/signal/Syscall_state.64.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/Syscall_state.64.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <csetjmp>
 #include <unistd.h>
 #include <sys/syscall.h>

--- a/unittests/FEXLinuxTests/tests/signal/eflags_signal.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/eflags_signal.cpp
@@ -1,11 +1,12 @@
 #include <atomic>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <fstream>
+#include <functional>
+#include <optional>
+#include <signal.h>
+#include <thread>
 #include <sys/syscall.h>
 #include <linux/futex.h>
-#include <signal.h>
-#include <optional>
-#include <thread>
 
 #if __SIZEOF_POINTER__ == 4
 #define DO_ASM(x, y) \

--- a/unittests/FEXLinuxTests/tests/signal/invalid_hlt.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_hlt.cpp
@@ -1,6 +1,6 @@
 #include "invalid_util.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <atomic>
 #include <signal.h>

--- a/unittests/FEXLinuxTests/tests/signal/invalid_int.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_int.cpp
@@ -1,6 +1,6 @@
 #include "invalid_util.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <atomic>
 #include <signal.h>

--- a/unittests/FEXLinuxTests/tests/signal/invalid_int1.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_int1.cpp
@@ -1,6 +1,6 @@
 #include "invalid_util.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <atomic>
 #include <signal.h>

--- a/unittests/FEXLinuxTests/tests/signal/invalid_int3.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_int3.cpp
@@ -1,6 +1,6 @@
 #include "invalid_util.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <atomic>
 #include <signal.h>

--- a/unittests/FEXLinuxTests/tests/signal/invalid_ud2.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_ud2.cpp
@@ -1,6 +1,6 @@
 #include "invalid_util.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <atomic>
 #include <signal.h>

--- a/unittests/FEXLinuxTests/tests/signal/pthread_cancel.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/pthread_cancel.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <atomic>
 #include <errno.h>

--- a/unittests/FEXLinuxTests/tests/signal/signal_flags.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/signal_flags.cpp
@@ -1,6 +1,6 @@
 #include "invalid_util.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <atomic>
 #include <signal.h>

--- a/unittests/FEXLinuxTests/tests/signal/sigtest_no_defer.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/sigtest_no_defer.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <signal.h>
 #include <stdio.h>

--- a/unittests/FEXLinuxTests/tests/signal/sigtest_samask.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/sigtest_samask.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <signal.h>
 #include <stdio.h>

--- a/unittests/FEXLinuxTests/tests/signal/sigtest_siginfo.32.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/sigtest_siginfo.32.cpp
@@ -1,6 +1,6 @@
 #include "invalid_util.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <signal.h>
 #include <stdio.h>

--- a/unittests/FEXLinuxTests/tests/signal/sigtest_siginfo.64.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/sigtest_siginfo.64.cpp
@@ -1,6 +1,6 @@
 #include "invalid_util.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <signal.h>
 #include <stdio.h>

--- a/unittests/FEXLinuxTests/tests/signal/sigtest_sigmask.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/sigtest_sigmask.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <signal.h>
 #include <stdio.h>

--- a/unittests/FEXLinuxTests/tests/signal/synchronous-signal-block.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/synchronous-signal-block.cpp
@@ -19,7 +19,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 static jmp_buf jmpbuf;
 

--- a/unittests/FEXLinuxTests/tests/signal/timer-sigev-thread.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/timer-sigev-thread.cpp
@@ -1,6 +1,6 @@
 // Simple test of timer_create + SIGEV_THREAD, glibc implements it via SIG32
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/unittests/FEXLinuxTests/tests/smc/smc-1-dynamic.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-1-dynamic.cpp
@@ -13,7 +13,7 @@ char text_sym[16384] __attribute__((section(".text")));
 
 #include "smc-common.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("SMC: Changes in stack") {
   // stack, depends on -z execstack or mprotect

--- a/unittests/FEXLinuxTests/tests/smc/smc-2.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-2.cpp
@@ -4,7 +4,7 @@
 
 #include "smc-common.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("SMC: mmap") {
   auto code = (char *)mmap(0, 4096, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANON, 0, 0);

--- a/unittests/FEXLinuxTests/tests/smc/smc-mt-1.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-mt-1.cpp
@@ -3,7 +3,7 @@
 
   creates 10 threads
   each thread does an smc test 10 times
-  
+
 */
 #include <cstdio>
 #include <pthread.h>
@@ -11,7 +11,7 @@
 
 #include <atomic>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 std::atomic<int> result;
 std::atomic<bool> go;

--- a/unittests/FEXLinuxTests/tests/smc/smc-mt-2.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-mt-2.cpp
@@ -28,7 +28,7 @@
 
 #include <atomic>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 std::atomic<bool> ready_for_modification;
 std::atomic<bool> waiting_for_modification;

--- a/unittests/FEXLinuxTests/tests/smc/smc-shared-1.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-shared-1.cpp
@@ -4,7 +4,7 @@
 
 #include "smc-common.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("SMC: mmap_mremap") {
   auto code = (char *)mmap(0, 4096, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED | MAP_ANON, 0, 0);

--- a/unittests/FEXLinuxTests/tests/smc/smc-shared-2.cpp
+++ b/unittests/FEXLinuxTests/tests/smc/smc-shared-2.cpp
@@ -5,7 +5,7 @@
 
 #include "smc-common.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("SMC: mmap_fork") {
   auto code = (char *)mmap(0, 4096, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED | MAP_ANON, 0, 0);

--- a/unittests/FEXLinuxTests/tests/syscalls/syscalls_efault.cpp
+++ b/unittests/FEXLinuxTests/tests/syscalls/syscalls_efault.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
 #include <unistd.h>

--- a/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
+++ b/unittests/FEXLinuxTests/tests/thunks/thunk_testlib.cpp
@@ -4,7 +4,7 @@
 
 #include <stdexcept>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "../../../../ThunkLibs/libfex_thunk_test/api.h"
 

--- a/unittests/FEXLinuxTests/tests/vdso/vdso_test.cpp
+++ b/unittests/FEXLinuxTests/tests/vdso/vdso_test.cpp
@@ -10,7 +10,7 @@
 #include <time.h>
 #include <stdio.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using time_type = int (*) (time_t* tloc);
 time_type time_vdso = (time_type)::time;

--- a/unittests/ThunkLibs/abi.cpp
+++ b/unittests/ThunkLibs/abi.cpp
@@ -1,5 +1,5 @@
 #include <clang/Frontend/CompilerInstance.h>
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <data_layout.h>
 #include <interface.h>
@@ -8,6 +8,8 @@
 #include <fmt/format.h>
 
 #include <string_view>
+
+using Catch::Matchers::ContainsSubstring;
 
 // run_tool will leak memory when the ToolAction throws an exception, so
 // disable AddressSanitizer's leak detection
@@ -462,7 +464,7 @@ TEST_CASE_METHOD(Fixture, "DataLayout") {
                 "union B { int32_t a; uint32_t b; };\n"
                 "struct A { B a; };\n"
                 "template<> struct fex_gen_type<A> {};\n", guest_abi),
-                Catch::Contains("unannotated member") && Catch::Contains("union type"));
+                ContainsSubstring("unannotated member") && ContainsSubstring("union type"));
         }
 
         SECTION("with annotation") {
@@ -530,7 +532,7 @@ TEST_CASE_METHOD(Fixture, "DataLayoutPointers") {
             "struct B;\n"
             "struct A { B* a; };\n"
             "template<> struct fex_gen_type<A> {};\n", guest_abi),
-            Catch::Contains("incomplete type"));
+            ContainsSubstring("incomplete type"));
     }
 
     SECTION("Unannotated pointer to repackable type") {
@@ -630,7 +632,7 @@ TEST_CASE_METHOD(Fixture, "DataLayoutPointers") {
             "union B { int32_t a; uint32_t b; };\n"
             "struct A { B* a; };\n"
             "template<> struct fex_gen_type<A> {};\n", guest_abi),
-            Catch::Contains("unannotated member") && Catch::Contains("union type"));
+            ContainsSubstring("unannotated member") && ContainsSubstring("union type"));
     }
 
     SECTION("Pointer to union type with assume_compatible_data_layout annotation") {
@@ -735,7 +737,7 @@ TEST_CASE_METHOD(Fixture, "DataLayoutPointers") {
         INFO(FormatDataLayout(action->host_layout));
 
         REQUIRE(action->guest_layout->contains("A"));
-        CHECK_THROWS_WITH(action->GetTypeCompatibility("struct A"), Catch::Contains("recursive reference"));
+        CHECK_THROWS_WITH(action->GetTypeCompatibility("struct A"), ContainsSubstring("recursive reference"));
 
         // With annotation
         if (guest_abi == GuestABI::X86_64) {
@@ -766,8 +768,8 @@ TEST_CASE_METHOD(Fixture, "DataLayoutPointers") {
 
         REQUIRE(action->guest_layout->contains("A"));
         REQUIRE(action->guest_layout->contains("B"));
-        CHECK_THROWS_WITH(action->GetTypeCompatibility("struct A"), Catch::Contains("recursive reference"));
-        CHECK_THROWS_WITH(action->GetTypeCompatibility("struct B"), Catch::Contains("recursive reference"));
+        CHECK_THROWS_WITH(action->GetTypeCompatibility("struct A"), ContainsSubstring("recursive reference"));
+        CHECK_THROWS_WITH(action->GetTypeCompatibility("struct B"), ContainsSubstring("recursive reference"));
 
         // With annotation
         if (guest_abi == GuestABI::X86_64) {

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <clang/ASTMatchers/ASTMatchers.h>
 #include <clang/ASTMatchers/ASTMatchFinder.h>
@@ -122,7 +122,7 @@ public:
  * libclang ASTMatcher API.
  */
 template<typename ClangMatcher>
-class HasASTMatching : public Catch::MatcherBase<SourceWithAST> {
+class HasASTMatching : public Catch::Matchers::MatcherBase<SourceWithAST> {
     ClangMatcher matcher;
     MatchCallback callback;
 
@@ -733,7 +733,7 @@ TEST_CASE_METHOD(Fixture, "Mapping guest integers to fixed-size") {
         if (!ptr.empty() && guest_abi == GuestABI::X86_32 && !passthrough_guest_type) {
             // Guest points to a 32-bit integer, but the host to a 64-bit one.
             // This should be detected as a failure.
-            CHECK_THROWS_WITH(run_thunkgen_host("", code, guest_abi, true), Catch::Contains("initialization of 'host_layout", Catch::CaseSensitive::No));
+            CHECK_THROWS_WITH(run_thunkgen_host("", code, guest_abi, true), Catch::Matchers::ContainsSubstring("initialization of 'host_layout", Catch::CaseSensitive::No));
         } else {
             const auto output = run_thunkgen_host("", code, guest_abi);
             std::string expected_type = "guest_layout<";
@@ -868,7 +868,7 @@ TEST_CASE_METHOD(Fixture, "StructRepacking") {
             "struct A { B* a; };\n";
 
         // Unannotated
-        REQUIRE_THROWS_WITH(run_thunkgen_host(prelude, code, guest_abi), Catch::Contains("incomplete type"));
+        REQUIRE_THROWS_WITH(run_thunkgen_host(prelude, code, guest_abi), Catch::Matchers::ContainsSubstring("incomplete type"));
 
         // Annotated as opaque_type
         CHECK_NOTHROW(run_thunkgen_host(prelude,
@@ -887,7 +887,7 @@ TEST_CASE_METHOD(Fixture, "VoidPointerParameter") {
             "template<> struct fex_gen_config<func> {};\n";
         if (guest_abi == GuestABI::X86_32) {
             // TODO: Currently not considered an error
-//            CHECK_THROWS_WITH(run_thunkgen_host("", code, guest_abi, true), Catch::Contains("unsupported parameter type", Catch::CaseSensitive::No));
+//            CHECK_THROWS_WITH(run_thunkgen_host("", code, guest_abi, true), Catch::Matchers::ContainsSubstring("unsupported parameter type", Catch::CaseSensitive::No));
         } else {
             // Pointee data is assumed to be compatible on 64-bit
             CHECK_NOTHROW(run_thunkgen_host("", code, guest_abi));
@@ -920,7 +920,7 @@ TEST_CASE_METHOD(Fixture, "VoidPointerParameter") {
             "void func(A*);\n"
             "template<> struct fex_gen_config<func> {};\n";
         if (guest_abi == GuestABI::X86_32) {
-            CHECK_THROWS_WITH(run_thunkgen_host(prelude, code, guest_abi, true), Catch::Contains("unsupported parameter type", Catch::CaseSensitive::No));
+            CHECK_THROWS_WITH(run_thunkgen_host(prelude, code, guest_abi, true), Catch::Matchers::ContainsSubstring("unsupported parameter type", Catch::CaseSensitive::No));
         } else {
             CHECK_NOTHROW(run_thunkgen_host(prelude, code, guest_abi));
         }


### PR DESCRIPTION
This is a major version bump from Catch2 v2 to v3, enabling access to some new features but otherwise not changing anything dramatic.

(Also, yes, it's called Catch2 and the version is v3 🧐)