### PR TITLE
IoctlEmulation: Add missing nouveau ioctl

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/IoctlEmulation.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/IoctlEmulation.cpp
@@ -360,6 +360,8 @@ namespace FEX::HLE::x32 {
 #define _CUSTOM_META_OFFSET(name, ioctl_num, offset)
       // DRM
 #include "LinuxSyscalls/x32/Ioctl/nouveau_drm.inl"
+        // Let's hope NVIF is arch agnostic.
+        case DRM_COMMAND_BASE + DRM_NOUVEAU_NVIF:
         {
           uint64_t Result = ::ioctl(fd, cmd, args);
           SYSCALL_ERRNO();


### PR DESCRIPTION
The NVIF ioctl isn't publicly described in the nouveau headers and it is required for anything to work with Nouveau.

Pass the ioctl command through without modification and hope that this ioctl is architecture agnostic.

Gets NVK working with FEX on 32-bit.
![Screenshot 2024-03-05 15-11-37](https://github.com/FEX-Emu/FEX/assets/1018829/5d669d54-dccc-4f8c-a4c2-aca6c7240440)
