### PR TITLE
Library Forwarding: Fix accidental data copying when converting from host to guest layout

### DIFF
--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -368,7 +368,7 @@ T* unwrap_host(repack_wrapper<T*, T2>& val) {
 
 template<typename T>
 struct host_to_guest_convertible {
-  const host_layout<T> from;
+  const host_layout<T>& from;
 
   // Conversion from host to guest layout for non-pointers
   operator guest_layout<T>() const requires(!std::is_pointer_v<T>) {


### PR DESCRIPTION
The converted `host_layout` object may be referenced by a pointer, so taking a copy would produce stale pointers. This is a regression from 28ae84cf60d7d7d25bee8f348791c8d8ad61098f.

Fixes a crash during startup of Wayland applications in Debug mode. (Release/RelWithDebInfo builds likely optimized the copy away.)