### PR TITLE
Revert "Library Forwarding/gen: Map integers to fixed-size equivalents on guest"

### DIFF
--- a/ThunkLibs/Generator/analysis.h
+++ b/ThunkLibs/Generator/analysis.h
@@ -199,15 +199,3 @@ inline std::string get_type_name(const clang::ASTContext& context, const clang::
     }
     return type_name;
 }
-
-inline std::string get_fixed_size_int_name(bool is_signed, int size) {
-    return (!is_signed ? "u" : "") + std::string { "int" } + std::to_string(size) + "_t";
-}
-
-inline std::string get_fixed_size_int_name(const clang::Type* type, int size) {
-    return get_fixed_size_int_name(type->isSignedIntegerType(), size);
-}
-
-inline std::string get_fixed_size_int_name(const clang::Type* type, const clang::ASTContext& context) {
-    return get_fixed_size_int_name(type, context.getTypeSize(type));
-}

--- a/ThunkLibs/Generator/data_layout.cpp
+++ b/ThunkLibs/Generator/data_layout.cpp
@@ -87,7 +87,6 @@ std::unordered_map<const clang::Type*, TypeInfo> ComputeDataLayout(const clang::
                 .array_size = array_size,
                 .is_function_pointer = field_type->isFunctionPointerType(),
                 .is_integral = field->getType()->isIntegerType(),
-                .is_signed_integer = field->getType()->isSignedIntegerType(),
             };
 
             // TODO: Process types in dependency-order. Currently we skip this
@@ -151,28 +150,8 @@ ABI GetStableLayout(const clang::ASTContext& context, const std::unordered_map<c
 
     for (auto [type, type_info] : data_layout) {
         auto type_name = get_type_name(context, type);
-        if (auto struct_info = type_info.get_if_struct()) {
-            for (auto& member : struct_info->members) {
-                if (member.is_integral) {
-                    // Map member types to fixed-size integers
-                    auto alt_type_name = get_fixed_size_int_name(member.is_signed_integer, member.size_bits);
-                    auto alt_type_info = SimpleTypeInfo {
-                        .size_bits = member.size_bits,
-                        .alignment_bits = context.getTypeAlign(context.getIntTypeForBitwidth(member.size_bits, member.is_signed_integer)),
-                    };
-                    stable_layout.insert(std::pair { alt_type_name, alt_type_info });
-                    member.type_name = std::move(alt_type_name);
-                }
-            }
-        }
-
-        auto [it, inserted] = stable_layout.insert(std::pair { type_name, std::move(type_info) });
-        if (type->isIntegerType()) {
-            auto alt_type_name = get_fixed_size_int_name(type, context);
-            stable_layout.insert(std::pair { std::move(alt_type_name), type_info });
-        }
-
-        if (!inserted && it->second != type_info && !type->isIntegerType()) {
+        auto [it, inserted] = stable_layout.insert(std::pair { type_name, type_info });
+        if (!inserted && it->second != type_info) {
             throw std::runtime_error("Duplicate type information: Tried to re-register type \"" + type_name + "\"");
         }
     }
@@ -190,19 +169,6 @@ static std::array<uint8_t, 32> GetSha256(const std::string& function_name) {
     return sha256;
 };
 
-std::string GetTypeNameWithFixedSizeIntegers(clang::ASTContext& context, clang::QualType type) {
-    if (type->isBuiltinType()) {
-        auto size = context.getTypeSize(type);
-        return fmt::format("uint{}_t", size);
-    } else if (type->isPointerType() && type->getPointeeType()->isBuiltinType() && context.getTypeSize(type->getPointeeType()) > 8) {
-        // TODO: Also apply this path to char-like types
-        auto size = context.getTypeSize(type->getPointeeType());
-        return fmt::format("uint{}_t*", size);
-    } else {
-        return type.getAsString();
-    }
-}
-
 void AnalyzeDataLayoutAction::OnAnalysisComplete(clang::ASTContext& context) {
     type_abi = GetStableLayout(context, ComputeDataLayout(context, types));
 
@@ -215,11 +181,9 @@ void AnalyzeDataLayoutAction::OnAnalysisComplete(clang::ASTContext& context) {
         auto cb_sha256 = GetSha256("fexcallback_" + mangled_name);
         FuncPtrInfo info = { cb_sha256 };
 
-        // TODO: Also apply GetTypeNameWithFixedSizeIntegers here
         info.result = func_type->getReturnType().getAsString();
-
         for (auto arg : func_type->getParamTypes()) {
-            info.args.push_back(GetTypeNameWithFixedSizeIntegers(context, arg));
+            info.args.push_back(arg.getAsString());
         }
         type_abi.thunked_funcptrs[funcptr_id] = std::move(info);
     }
@@ -255,9 +219,7 @@ TypeCompatibility DataLayoutCompareAction::GetTypeCompatibility(
     }
 
     auto type_name = get_type_name(context, type);
-    // Look up the same type name in the guest map,
-    // unless it's an integer (which is mapped to fixed-size uintX_t types)
-    auto guest_info = guest_abi.at(!type->isIntegerType() ? type_name : get_fixed_size_int_name(type, context));
+    auto& guest_info = guest_abi.at(type_name);
     auto& host_info = host_abi.at(type->isBuiltinType() ? type : context.getCanonicalType(type));
 
     const bool is_32bit = (guest_abi.pointer_size == 4);

--- a/ThunkLibs/Generator/data_layout.h
+++ b/ThunkLibs/Generator/data_layout.h
@@ -30,7 +30,6 @@ struct StructInfo : SimpleTypeInfo {
         std::optional<uint64_t> array_size;
         bool is_function_pointer;
         bool is_integral;
-        bool is_signed_integer;
 
         bool operator==(const MemberInfo& other) const {
             return  size_bits == other.size_bits &&
@@ -100,17 +99,6 @@ ComputeDataLayout(const clang::ASTContext& context, const std::unordered_map<con
 // Convert the output of ComputeDataLayout to a format that isn't tied to a libclang session.
 // As a consequence, type information is indexed by type name instead of clang::Type.
 ABI GetStableLayout(const clang::ASTContext& context, const std::unordered_map<const clang::Type*, TypeInfo>& data_layout);
-
-/**
- * Returns the type of the given name, but replaces any mentions of integer
- * types with fixed-size equivalents.
- *
- * Examples:
- * - int -> int32_t
- * - unsigned long long* -> uint64_t*
- * - MyStruct -> MyStruct (no change)
- */
-std::string GetTypeNameWithFixedSizeIntegers(clang::ASTContext&, clang::QualType);
 
 enum class TypeCompatibility {
     Full,       // Type has matching data layout across architectures

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -190,10 +190,7 @@ void GenerateThunkLibsAction::EmitLayoutWrappers(
         } else {
             fmt::print(file, "  struct type {{\n");
             for (auto& member : guest_abi.at(struct_name).get_if_struct()->members) {
-                fmt::print( file, "    guest_layout<{}{}> {};\n",
-                            member.type_name,
-                            member.array_size ? fmt::format("[{}]", member.array_size.value()) : "",
-                            member.member_name);
+                fmt::print(file, "    guest_layout<{}> {};\n", member.type_name, member.member_name);
             }
             fmt::print(file, "  }};\n");
         }
@@ -550,18 +547,6 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
                 }
             }
 
-            auto get_guest_type_name = [this](clang::QualType type) {
-                if (type->isBuiltinType() && !type->isFloatingType()) {
-                    auto size = guest_abi.at(type.getUnqualifiedType().getAsString()).get_if_simple_or_struct()->size_bits;
-                    return get_fixed_size_int_name(type.getTypePtr(), size);
-                } else if (type->isPointerType() && type->getPointeeType()->isIntegerType() && !type->getPointeeType()->isEnumeralType() && !type->getPointeeType()->isVoidType()) {
-                    auto size = guest_abi.at(type->getPointeeType().getUnqualifiedType().getAsString()).get_if_simple_or_struct()->size_bits;
-                    return fmt::format("{}{}*", type->getPointeeType().isConstQualified() ? "const " : "", get_fixed_size_int_name(type->getPointeeType().getTypePtr(), size));
-                } else {
-                    return type.getUnqualifiedType().getAsString();
-                }
-            };
-
             // Forward declarations for user-provided implementations
             if (thunk.custom_host_impl) {
                 file << "static auto fexfn_impl_" << libname << "_" << function_name << "(";
@@ -571,7 +556,7 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
                     file << (idx == 0 ? "" : ", ");
 
                     if (thunk.param_annotations[idx].is_passthrough) {
-                        fmt::print(file, "guest_layout<{}> a_{}", get_guest_type_name(type), idx);
+                        fmt::print(file, "guest_layout<{}> a_{}", type.getAsString(), idx);
                     } else {
                         file << format_decl(type, fmt::format("a_{}", idx));
                     }
@@ -604,10 +589,10 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
                 file << "struct __attribute__((packed)) " << struct_name << " {\n";
 
                 for (std::size_t idx = 0; idx < thunk.param_types.size(); ++idx) {
-                    fmt::print(file, "  guest_layout<{}> a_{};\n", get_guest_type_name(thunk.param_types[idx]), idx);
+                    fmt::print(file, "  guest_layout<{}> a_{};\n", get_type_name(context, thunk.param_types[idx].getTypePtr()), idx);
                 }
                 if (!thunk.return_type->isVoidType()) {
-                    fmt::print(file, "  guest_layout<{}> rv;\n", get_guest_type_name(thunk.return_type));
+                    fmt::print(file, "  guest_layout<{}> rv;\n", get_type_name(context, thunk.return_type.getTypePtr()));
                 } else if (thunk.param_types.size() == 0) {
                     // Avoid "empty struct has size 0 in C, size 1 in C++" warning
                     file << "    char force_nonempty;\n";
@@ -727,17 +712,14 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
         for (auto& host_funcptr_entry : thunked_funcptrs) {
             auto& [type, param_annotations] = host_funcptr_entry.second;
             auto func_type = type->getAs<clang::FunctionProtoType>();
+            std::string mangled_name = clang::QualType { type, 0 }.getAsString();
             FuncPtrInfo info = { };
 
-            // TODO: Use GetTypeNameWithFixedSizeIntegers
             info.result = func_type->getReturnType().getAsString();
 
-            // NOTE: In guest contexts, integer types must be mapped to
-            //       fixed-size equivalents. Since this is a host context, this
-            //       isn't strictly necessary here, but it makes matching up
-            //       guest_layout/host_layout constructors easier.
+            // TODO: Use guest-sizes for integer types
             for (auto arg : func_type->getParamTypes()) {
-                info.args.push_back(GetTypeNameWithFixedSizeIntegers(context, arg));
+                info.args.push_back(arg.getAsString());
             }
 
             std::string annotations;

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -450,7 +450,7 @@ TEST_CASE_METHOD(Fixture, "FunctionPointerViaType") {
             hasInitializer(hasDescendant(declRefExpr(to(cxxMethodDecl(hasName("Call"), ofClass(hasName("GuestWrapperForHostFunction"))).bind("funcptr")))))
             )).check_binding("funcptr", +[](const clang::CXXMethodDecl* decl) {
                 auto parent = llvm::cast<clang::ClassTemplateSpecializationDecl>(decl->getParent());
-                return parent->getTemplateArgs().get(0).getAsType().getAsString() == "int (unsigned char, unsigned char)";
+                return parent->getTemplateArgs().get(0).getAsType().getAsString() == "int (char, char)";
             }));
 }
 
@@ -529,9 +529,9 @@ TEST_CASE_METHOD(Fixture, "MultipleParameters") {
             parameterCountIs(1),
             hasParameter(0, hasType(pointerType(pointee(hasUnqualifiedDesugaredType(
                 recordType(hasDeclaration(decl(
-                    has(fieldDecl(hasType(asString("guest_layout<int32_t>")))),
-                    has(fieldDecl(hasType(asString("guest_layout<uint8_t>")))),
-                    has(fieldDecl(hasType(asString("guest_layout<uint64_t>")))),
+                    has(fieldDecl(hasType(asString("guest_layout<int>")))),
+                    has(fieldDecl(hasType(asString("guest_layout<char>")))),
+                    has(fieldDecl(hasType(asString("guest_layout<unsigned long>")))),
                     has(fieldDecl(hasType(asString("guest_layout<" CLANG_STRUCT_PREFIX "TestStruct>"))))
                     ))))))))
             )));
@@ -646,9 +646,9 @@ TEST_CASE_METHOD(Fixture, "LayoutWrappers") {
                   hasAnyTemplateArgument(refersToType(asString("struct A"))),
                   // The member "data" exists and is defined to a struct...
                   has(fieldDecl(hasName("data"), hasType(hasCanonicalType(hasDeclaration(decl(
-                      // ... the members of which also use guest_layout (with fixed-size integers)
-                      has(fieldDecl(hasName("a"), hasType(asString("guest_layout<int32_t>")))),
-                      has(fieldDecl(hasName("b"), hasType(asString("guest_layout<int32_t>"))))
+                      // ... the members of which also use guest_layout
+                      has(fieldDecl(hasName("a"), hasType(asString("guest_layout<int>")))),
+                      has(fieldDecl(hasName("b"), hasType(asString("guest_layout<int>"))))
                       ))))))
             )));
         CHECK_THAT(output, guest_converter_defined);
@@ -695,7 +695,7 @@ TEST_CASE_METHOD(Fixture, "LayoutWrappers") {
                   has(fieldDecl(hasName("data"), hasType(hasCanonicalType(hasDeclaration(decl(
                       // ... the members of which also use guest_layout
                       has(fieldDecl(hasName("a"), hasType(asString("guest_layout<" CLANG_STRUCT_PREFIX "B *>")))),
-                      has(fieldDecl(hasName("b"), hasType(asString("guest_layout<int32_t>"))))
+                      has(fieldDecl(hasName("b"), hasType(asString("guest_layout<int>"))))
                       ))))))
             )));
         CHECK_THAT(output, guest_converter_defined);


### PR DESCRIPTION
This reverts commit d04c94fe802a09288a24ea68c7f951474bb0235a.

This isn't necessarily expected to be merged but instead opening a discussion about why this is breaking rendering with thunking enabled.

In particular this revert fixes "Broforce". Before the revert the game looked like it was rendering with a bad anaglyph 3D renderer.

This might also be related to #3455 but I haven't had a chance to retest it.

This could be related to sign/zero extension semantics being different between AArch64 and x86?

Original commit comes from PR #3392