### PR TITLE
OpcodeDispatcher: Implement support for the various prefetch instructions

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/CodeEmitter/LoadstoreOps.inl
@@ -3762,7 +3762,12 @@ public:
     }
     else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
-        prfm(prfop, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        if ((MemSrc.MetaType.ImmType.Imm & 0b111) || MemSrc.MetaType.ImmType.Imm < 0) {
+          prfum<IndexType::OFFSET>(prfop, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
+        else {
+          prfm(prfop, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
+        }
       }
       else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -2419,6 +2419,47 @@ DEF_OP(CacheLineZero) {
   }
 }
 
+DEF_OP(Prefetch) {
+  auto Op = IROp->C<IR::IROp_Prefetch>();
+  const auto MemReg = GetReg(Op->Addr.ID());
+
+  // Access size is only ever handled as 8-byte. Even though it is accesssed as a cacheline.
+  const auto MemSrc = GenerateMemOperand(8, MemReg, Op->Offset, Op->OffsetType, Op->OffsetScale);
+
+  size_t LUT =
+    (Op->Stream ? 1 : 0) |
+    ((Op->CacheLevel - 1) << 1) |
+    (Op->ForStore ? 1U << 3 : 0);
+
+  constexpr static std::array<ARMEmitter::Prefetch, 14> PrefetchType = {
+    ARMEmitter::Prefetch::PLDL1KEEP,
+    ARMEmitter::Prefetch::PLDL1STRM,
+
+    ARMEmitter::Prefetch::PLDL2KEEP,
+    ARMEmitter::Prefetch::PLDL2STRM,
+
+    ARMEmitter::Prefetch::PLDL3KEEP,
+    ARMEmitter::Prefetch::PLDL3STRM,
+
+    // Gap of two.
+    // 0b0'11'0
+    ARMEmitter::Prefetch::PLDL1STRM,
+    // 0b0'11'1
+    ARMEmitter::Prefetch::PLDL1STRM,
+
+    ARMEmitter::Prefetch::PSTL1KEEP,
+    ARMEmitter::Prefetch::PSTL1STRM,
+
+    ARMEmitter::Prefetch::PSTL2KEEP,
+    ARMEmitter::Prefetch::PSTL2STRM,
+
+    ARMEmitter::Prefetch::PSTL3KEEP,
+    ARMEmitter::Prefetch::PSTL3STRM,
+  };
+
+  prfm(PrefetchType[LUT], MemSrc);
+}
+
 #undef DEF_OP
 }
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5439,6 +5439,12 @@ void OpDispatchBuilder::CLZeroOp(OpcodeArgs) {
   _CacheLineZero(DestMem);
 }
 
+template<bool ForStore, bool Stream, uint8_t Level>
+void OpDispatchBuilder::Prefetch(OpcodeArgs) {
+  OrderedNode *DestMem = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.LoadData = false});
+  Prefetch(ForStore, Stream, Level, DestMem);
+}
+
 void OpDispatchBuilder::RDTSCPOp(OpcodeArgs) {
   // RDTSCP is slightly different than RDTSC
   // IA32_TSC_AUX is returned in RCX
@@ -6648,13 +6654,36 @@ constexpr uint16_t PF_F2 = 3;
     {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_66, 7), 1, &OpDispatchBuilder::CLFLUSHOPT},
 
     // GROUP 16
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_NONE, 0), 8, &OpDispatchBuilder::NOPOp},
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F3, 0), 8, &OpDispatchBuilder::NOPOp},
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_66, 0), 8, &OpDispatchBuilder::NOPOp},
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F2, 0), 8, &OpDispatchBuilder::NOPOp},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_NONE, 0), 1, &OpDispatchBuilder::Prefetch<false, true, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_NONE, 1), 1, &OpDispatchBuilder::Prefetch<false, false, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_NONE, 2), 1, &OpDispatchBuilder::Prefetch<false, false, 2>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_NONE, 3), 1, &OpDispatchBuilder::Prefetch<false, false, 3>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_NONE, 4), 4, &OpDispatchBuilder::NOPOp},
+
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F3, 0), 1, &OpDispatchBuilder::Prefetch<false, true, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F3, 1), 1, &OpDispatchBuilder::Prefetch<false, false, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F3, 2), 1, &OpDispatchBuilder::Prefetch<false, false, 2>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F3, 3), 1, &OpDispatchBuilder::Prefetch<false, false, 3>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F3, 4), 4, &OpDispatchBuilder::NOPOp},
+
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_66, 0), 1, &OpDispatchBuilder::Prefetch<false, true, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_66, 1), 1, &OpDispatchBuilder::Prefetch<false, false, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_66, 2), 1, &OpDispatchBuilder::Prefetch<false, false, 2>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_66, 3), 1, &OpDispatchBuilder::Prefetch<false, false, 3>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_66, 4), 4, &OpDispatchBuilder::NOPOp},
+
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F2, 0), 1, &OpDispatchBuilder::Prefetch<false, true, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F2, 1), 1, &OpDispatchBuilder::Prefetch<false, false, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F2, 2), 1, &OpDispatchBuilder::Prefetch<false, false, 2>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F2, 3), 1, &OpDispatchBuilder::Prefetch<false, false, 3>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_16, PF_F2, 4), 4, &OpDispatchBuilder::NOPOp},
 
     // GROUP P
-    {OPD(FEXCore::X86Tables::TYPE_GROUP_P, PF_NONE, 0), 8, &OpDispatchBuilder::NOPOp},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_P, PF_NONE, 0), 1, &OpDispatchBuilder::Prefetch<false, false, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_P, PF_NONE, 1), 1, &OpDispatchBuilder::Prefetch<true, false, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_P, PF_NONE, 2), 1, &OpDispatchBuilder::Prefetch<true, false, 1>},
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_P, PF_NONE, 3), 5, &OpDispatchBuilder::NOPOp},
+
     {OPD(FEXCore::X86Tables::TYPE_GROUP_P, PF_F3, 0), 8, &OpDispatchBuilder::NOPOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_P, PF_66, 0), 8, &OpDispatchBuilder::NOPOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_P, PF_F2, 0), 8, &OpDispatchBuilder::NOPOp},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -2145,6 +2145,10 @@ private:
       return _LoadMem(Class, Size, ssa0, Invalid(), Align, MEM_OFFSET_SXTX, 1);
   }
 
+  OrderedNode* Prefetch(bool ForStore, bool Stream, uint8_t CacheLevel, OrderedNode *ssa0) {
+    return _Prefetch(ForStore, Stream, CacheLevel, ssa0, Invalid(), MEM_OFFSET_SXTX, 1);
+  }
+
   void InstallHostSpecificOpcodeHandlers();
 
   ///< Segment telemetry tracking

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -868,6 +868,9 @@ public:
   void CLZeroOp(OpcodeArgs);
   void RDTSCPOp(OpcodeArgs);
 
+  template<bool ForStore, bool Stream, uint8_t Level>
+  void Prefetch(OpcodeArgs);
+
   void PSADBW(OpcodeArgs);
 
   OrderedNode *BitwiseAtLeastTwo(OrderedNode *A, OrderedNode *B, OrderedNode *C);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -596,6 +596,15 @@
                  "Ensures the memory operations are globally visible"
                 ],
         "HasSideEffects": true
+      },
+      "Prefetch i1:$ForStore, i1:$Stream, i8:$CacheLevel, GPR:$Addr, GPR:$Offset, MemOffsetType:$OffsetType, u8:$OffsetScale": {
+        "Desc": ["Does a cacheline prefetch operation"
+                ],
+        "EmitValidation": [
+          "_CacheLevel > 0 && _CacheLevel < 4"
+        ],
+        "HasSideEffects": true,
+        "DestSize": "8"
       }
     },
     "Atomic": {

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -855,6 +855,71 @@
         "mov w20, w20",
         "ldr d16, [x20]"
       ]
+    },
+    "prefetch [rcx - 257]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x101 (257)",
+        "prfm pldl1keep, [x20]"
+      ]
+    },
+    "prefetch [rcx - 256]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "sub x20, x5, #0x100 (256)",
+        "prfm pldl1keep, [x20]"
+      ]
+    },
+    "prefetch [rcx + 255]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "prfum pldl1keep, [x5, #255]"
+      ]
+    },
+    "prefetch [rcx + 256]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "prfm pldl1keep, [x5, #256]"
+      ]
+    },
+    "prefetch [rcx + 32760]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "prfm pldl1keep, [x5, #32760]"
+      ]
+    },
+    "prefetch [rcx + 32761]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "mov w20, #0x7ff9",
+        "prfm pldl1keep, [x5, x20, sxtx]"
+      ]
+    },
+    "prefetch [rax + rcx*1]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "prfm pldl1keep, [x4, x5, sxtx]"
+      ]
+    },
+    "prefetch [rax + rcx*2]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #1",
+        "prfm pldl1keep, [x20]"
+      ]
+    },
+    "prefetch [rax + rcx*4]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #2",
+        "prfm pldl1keep, [x20]"
+      ]
+    },
+    "prefetch [rax + rcx*8]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "prfm pldl1keep, [x5, x4, sxtx #3]"
+      ]
     }
   }
 }

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -1639,36 +1639,40 @@
       ]
     },
     "prefetchnta [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUP16 0x0F 0x18 /0",
-        "NOP implementation"
+        "GROUP16 0x0F 0x18 /0"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pldl1strm, [x4]"
+      ]
     },
     "prefetcht0 [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUP16 0x0F 0x18 /1",
-        "NOP implementation"
+        "GROUP16 0x0F 0x18 /1"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pldl1keep, [x4]"
+      ]
     },
     "prefetcht1 [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUP16 0x0F 0x18 /2",
-        "NOP implementation"
+        "GROUP16 0x0F 0x18 /2"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pldl2keep, [x4]"
+      ]
     },
     "prefetcht2 [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUP16 0x0F 0x18 /3",
-        "NOP implementation"
+        "GROUP16 0x0F 0x18 /3"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pldl3keep, [x4]"
+      ]
     },
     "db 0x0f, 0x18, 0x20;": {
       "ExpectedInstructionCount": 0,
@@ -1680,29 +1684,32 @@
       "ExpectedArm64ASM": []
     },
     "db 0x0f, 0x0d, 0x00": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "GROUPP 0x0F 0x0D /0",
-        "prefetch_exclusive [rax]",
-        "NOP implementation"
+        "prefetch_exclusive [rax]"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pldl1keep, [x4]"
+      ]
     },
     "prefetchw [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUPP 0x0F 0x0D /1",
-        "NOP implementation"
+        "GROUPP 0x0F 0x0D /1"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pstl1keep, [x4]"
+      ]
     },
     "prefetchwt1 [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUPP 0x0F 0x0D /2",
-        "NOP implementation"
+        "GROUPP 0x0F 0x0D /2"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pstl1keep, [x4]"
+      ]
     }
   }
 }

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -1771,36 +1771,40 @@
       ]
     },
     "prefetchnta [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUP16 0x0F 0x18 /0",
-        "NOP implementation"
+        "GROUP16 0x0F 0x18 /0"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pldl1strm, [x4]"
+      ]
     },
     "prefetcht0 [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUP16 0x0F 0x18 /1",
-        "NOP implementation"
+        "GROUP16 0x0F 0x18 /1"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pldl1keep, [x4]"
+      ]
     },
     "prefetcht1 [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUP16 0x0F 0x18 /2",
-        "NOP implementation"
+        "GROUP16 0x0F 0x18 /2"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pldl2keep, [x4]"
+      ]
     },
     "prefetcht2 [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUP16 0x0F 0x18 /3",
-        "NOP implementation"
+        "GROUP16 0x0F 0x18 /3"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pldl3keep, [x4]"
+      ]
     },
     "db 0x0f, 0x18, 0x20;": {
       "ExpectedInstructionCount": 0,
@@ -1812,29 +1816,32 @@
       "ExpectedArm64ASM": []
     },
     "db 0x0f, 0x0d, 0x00": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "GROUPP 0x0F 0x0D /0",
-        "prefetch_exclusive [rax]",
-        "NOP implementation"
+        "prefetch_exclusive [rax]"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pldl1keep, [x4]"
+      ]
     },
     "prefetchw [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUPP 0x0F 0x0D /1",
-        "NOP implementation"
+        "GROUPP 0x0F 0x0D /1"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pstl1keep, [x4]"
+      ]
     },
     "prefetchwt1 [rax]": {
-      "ExpectedInstructionCount": 0,
+      "ExpectedInstructionCount": 1,
       "Comment": [
-        "GROUPP 0x0F 0x0D /2",
-        "NOP implementation"
+        "GROUPP 0x0F 0x0D /2"
       ],
-      "ExpectedArm64ASM": []
+      "ExpectedArm64ASM": [
+        "prfm pstl1keep, [x4]"
+      ]
     }
   }
 }


### PR DESCRIPTION
x86 has a few prefetch instructions.
- prefetch - One of two classic 3DNow! instructions
   - Prefetch in to L1 data cache
- prefetchw - One of two classic 3DNow! instructions
   - Implies prefetch in to L1 data cache
   - Prefetch cacheline with intent to write and exclusive ownership

- prefetchnta
   - Prefetch non-temporal data in respect to /all/ cache levels
   - Assumes inclusive caches?
- prefetch{t0,t1,t2}
   - Prefetch data with respect to each cache level
   - T0 = L1 and higher
   - T1 = L2 and higher
   - T2 = L3 and higher

**Some silly duplicates**
- prefetchwt1
   - Duplicate of prefetchw but explicitly L1 data cache
- prefetch_exclusive
   - Duplicate of prefetch

God Of War 2018 uses prefetchw as a hint for exclusive ownership of the
cacheline in some very aggressive spin-loops. Let's implement the
operations to help it along.