### PR TITLE
Library Forwarding: Don't map float/double to fixed-size integers

### DIFF
--- a/ThunkLibs/Generator/data_layout.cpp
+++ b/ThunkLibs/Generator/data_layout.cpp
@@ -191,10 +191,10 @@ static std::array<uint8_t, 32> GetSha256(const std::string& function_name) {
 };
 
 std::string GetTypeNameWithFixedSizeIntegers(clang::ASTContext& context, clang::QualType type) {
-    if (type->isBuiltinType()) {
+    if (type->isBuiltinType() && type->isIntegerType()) {
         auto size = context.getTypeSize(type);
         return fmt::format("uint{}_t", size);
-    } else if (type->isPointerType() && type->getPointeeType()->isBuiltinType() && context.getTypeSize(type->getPointeeType()) > 8) {
+    } else if (type->isPointerType() && type->getPointeeType()->isBuiltinType() && type->getPointeeType()->isIntegerType() && context.getTypeSize(type->getPointeeType()) > 8) {
         // TODO: Also apply this path to char-like types
         auto size = context.getTypeSize(type->getPointeeType());
         return fmt::format("uint{}_t*", size);

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -551,10 +551,10 @@ void GenerateThunkLibsAction::OnAnalysisComplete(clang::ASTContext& context) {
             }
 
             auto get_guest_type_name = [this](clang::QualType type) {
-                if (type->isBuiltinType() && !type->isFloatingType()) {
+                if (type->isBuiltinType() && type->isIntegerType()) {
                     auto size = guest_abi.at(type.getUnqualifiedType().getAsString()).get_if_simple_or_struct()->size_bits;
                     return get_fixed_size_int_name(type.getTypePtr(), size);
-                } else if (type->isPointerType() && type->getPointeeType()->isIntegerType() && !type->getPointeeType()->isEnumeralType() && !type->getPointeeType()->isVoidType()) {
+                } else if (type->isPointerType() && type->getPointeeType()->isBuiltinType() && type->getPointeeType()->isIntegerType() && !type->getPointeeType()->isVoidType()) {
                     auto size = guest_abi.at(type->getPointeeType().getUnqualifiedType().getAsString()).get_if_simple_or_struct()->size_bits;
                     return fmt::format("{}{}*", type->getPointeeType().isConstQualified() ? "const " : "", get_fixed_size_int_name(type->getPointeeType().getTypePtr(), size));
                 } else {


### PR DESCRIPTION
d04c94f unintentionally changed behavior on 64-bit applications: In particular, the apitraces attached to https://github.com/FEX-Emu/FEX/pull/3488#issuecomment-1989642375 show that the LOD bias passed to `glTexParameterf` differs before and after the change:
```diff
< 12916 glTexParameterf(target = GL_TEXTURE_2D, pname = GL_TEXTURE_LOD_BIAS, param = 0)
> 12916 glTexParameterf(target = GL_TEXTURE_2D, pname = GL_TEXTURE_LOD_BIAS, param = -4184224)
```

It turns out GetTypeNameWithFixedSizeIntegers erroneously mapped float/double types to fixed-size integers, which led to wrong semantics (presumably bitcasting followed by rounding conversion, instead of plain copying). This mapping was done consistently for both host and guest, so this issue escaped my initial attempt at finding differences.

By fixing GetTypeNameWithFixedSizeIntegers, `thunkgen` now emits `GuestWrapperForHostFunction<void(uint32_t, uint32_t, float), uint32_t, uint32_t, float>::Call` for glTexParameterf, where previously the `float`s would have been replaced by `uint32_t`. Similar type checks have been updated to use `builtin && integer` for consistency without functional change.

Fixes #3455.
Supersedes #3488.
