### PR TITLE
OpcodeDispatcher: Implement rdpid

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -694,7 +694,7 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_07h(uint32_t Leaf) const {
       (0 << 19) | // MPX MAWAU
       (0 << 20) | // MPX MAWAU
       (0 << 21) | // MPX MAWAU
-      (0 << 22) | // RDPID Read Processor ID
+      (1 << 22) | // RDPID Read Processor ID
       (0 << 23) | // Reserved
       (0 << 24) | // Reserved
       (0 << 25) | // CLDEMOTE

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5426,6 +5426,10 @@ void OpDispatchBuilder::RDTSCPOp(OpcodeArgs) {
   StoreGPRRegister(X86State::REG_RDX, Counter.CounterHigh);
 }
 
+void OpDispatchBuilder::RDPIDOp(OpcodeArgs) {
+  StoreResult(GPRClass, Op, _ProcessorID(), -1);
+}
+
 void OpDispatchBuilder::CRC32(OpcodeArgs) {
   const uint8_t GPRSize = CTX->GetGPRSize();
 
@@ -6572,6 +6576,8 @@ constexpr uint16_t PF_F2 = 3;
     {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_F3, 1), 1, &OpDispatchBuilder::CMPXCHGPairOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_66, 1), 1, &OpDispatchBuilder::CMPXCHGPairOp},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_F2, 1), 1, &OpDispatchBuilder::CMPXCHGPairOp},
+
+    {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_F3, 7), 1, &OpDispatchBuilder::RDPIDOp},
 
     // GROUP 12
     {OPD(FEXCore::X86Tables::TYPE_GROUP_12, PF_NONE, 2), 1, &OpDispatchBuilder::PSRLI<2>},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -867,6 +867,7 @@ public:
   void StoreFenceOrCLFlush(OpcodeArgs);
   void CLZeroOp(OpcodeArgs);
   void RDTSCPOp(OpcodeArgs);
+  void RDPIDOp(OpcodeArgs);
 
   void PSADBW(OpcodeArgs);
 

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
@@ -162,7 +162,7 @@ std::array<X86InstInfo, MAX_INST_SECOND_GROUP_TABLE_SIZE> SecondInstGroupOps = [
     {OPD(TYPE_GROUP_9, PF_F3, 4), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_F3, 5), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_F3, 6), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
-    {OPD(TYPE_GROUP_9, PF_F3, 7), 1, X86InstInfo{"RDPID",      TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
+    {OPD(TYPE_GROUP_9, PF_F3, 7), 1, X86InstInfo{"RDPID",      TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_REG_ONLY, 0, nullptr}},
 
     {OPD(TYPE_GROUP_9, PF_66, 0), 1, X86InstInfo{"",           TYPE_INVALID, FLAGS_NONE,     0, nullptr}},
     {OPD(TYPE_GROUP_9, PF_66, 1), 1, X86InstInfo{"CMPXCHG8B/16B", TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_MEM_ONLY, 0, nullptr}},

--- a/unittests/ASM/Disabled_Tests_Simulator
+++ b/unittests/ASM/Disabled_Tests_Simulator
@@ -86,3 +86,6 @@ Test_VEX/vroundss.asm
 
 # Simulator doesn't support cycle counter reading
 Test_TwoByte/0F_31.asm
+
+# Simulator doesn't support executing a syscall
+Test_Secondary/09_F3_07.asm

--- a/unittests/ASM/Secondary/09_F3_07.asm
+++ b/unittests/ASM/Secondary/09_F3_07.asm
@@ -1,0 +1,17 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "1"
+  }
+}
+%endif
+
+mov rax, 0
+mov rbx, 0x4142434445464748
+mov rcx, 0x4142434445464748
+rdpid ebx
+
+cmp rbx, rcx
+setne al
+
+hlt

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -921,6 +921,54 @@
         "msr nzcv, x20"
       ]
     },
+    "rdpid eax": {
+      "ExpectedInstructionCount": 18,
+      "Comment": "GROUP9 0xF3 0x0F 0xC7 /7",
+      "ExpectedArm64ASM": [
+        "mrs x0, nzcv",
+        "str w0, [x28, #728]",
+        "str x8, [x28, #40]",
+        "mov w0, #0x100",
+        "str x0, [x28, #1056]",
+        "sub sp, sp, #0x10 (16)",
+        "mov w8, #0xa8",
+        "mov x0, sp",
+        "add x1, sp, #0x4 (4)",
+        "svc #0x0",
+        "ldp w0, w1, [sp]",
+        "sub sp, sp, #0x10 (16)",
+        "ldr w8, [x28, #728]",
+        "msr nzcv, x8",
+        "ldr x8, [x28, #40]",
+        "str xzr, [x28, #1056]",
+        "orr x20, x0, x1, lsl #12",
+        "mov w4, w20"
+      ]
+    },
+    "rdpid rax": {
+      "ExpectedInstructionCount": 18,
+      "Comment": "GROUP9 0xF3 0x0F 0xC7 /7",
+      "ExpectedArm64ASM": [
+        "mrs x0, nzcv",
+        "str w0, [x28, #728]",
+        "str x8, [x28, #40]",
+        "mov w0, #0x100",
+        "str x0, [x28, #1056]",
+        "sub sp, sp, #0x10 (16)",
+        "mov w8, #0xa8",
+        "mov x0, sp",
+        "add x1, sp, #0x4 (4)",
+        "svc #0x0",
+        "ldp w0, w1, [sp]",
+        "sub sp, sp, #0x10 (16)",
+        "ldr w8, [x28, #728]",
+        "msr nzcv, x8",
+        "ldr x8, [x28, #40]",
+        "str xzr, [x28, #1056]",
+        "orr x20, x0, x1, lsl #12",
+        "mov w4, w20"
+      ]
+    },
     "psrlw mm0, 0": {
       "ExpectedInstructionCount": 0,
       "Type": "MMX",


### PR DESCRIPTION
Missed this instruction when implementing rdtscp. Returns the same ID result in to register just like rdtscp, but without the cycle counter results. Doesn't touch any flags just like rdtscp.