### PR TITLE
Thunks: Disable 32-bit thunks unless a config option is set

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -137,6 +137,8 @@ jobs:
     - name: FEXLinuxTests
       working-directory: ${{runner.workspace}}/build
       shell: bash
+      env:
+        FEX_THUNKS32BITENABLED: "1"
       run: cmake --build . --config $BUILD_TYPE --target fex_linux_tests_all
 
     - name: FEXLinuxTests Results move

--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -185,6 +185,15 @@
           "\teg: $XDG_DATA_HOME/.fex-emu/ThunkConfigs/<ThunkConfig name>"
         ]
       },
+      "Thunks32BitEnabled": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Enables support for 32-bit thunking",
+          "This feature is currently not fully supported.",
+          "Only enable this if you know what you're doing"
+        ]
+      },
       "Env": {
         "Type": "strarray",
         "Default": "",


### PR DESCRIPTION
This will be necessary before #3487 is merged.
Once #3487 is merged then 32-bit Vulkan thunk libraries is built which results in crashing in every 32-bit vulkan/dxvk game.

Explicitly disable the thunking until this config option is set. Once X11 is as stable on 32-bit as 64-bit then this option can get removed.

For testing purposes it's easy to set the environment variable `FEX_THUNKS32BITENABLED=1`