### PR TITLE
OpcodeDispatcher: Fixes 32-bit mode LOOP RCX register usage 

### DIFF
--- a/unittests/32Bit_ASM/FEX_bugs/LoopAddressSizeCheck.asm
+++ b/unittests/32Bit_ASM/FEX_bugs/LoopAddressSizeCheck.asm
@@ -1,0 +1,27 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000000000001",
+    "RBX": "0x0000000000010001"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; FEX-Emu had a bug where a16 loop instructions weren't treating the input RCX register as 16-bit.
+; Effectively always treating it as 32-bit.
+; Little test that operates at 16-bit and 32-bit sizes to ensure it is correctly handled.
+mov eax, 0
+mov ebx, 0
+mov ecx, 0x0001_0001
+
+.test:
+inc eax
+a16 loop .test
+
+mov ecx, 0x0001_0001
+.test2:
+inc ebx
+a32 loop .test2
+
+hlt

--- a/unittests/ASM/FEX_bugs/LoopAddressSizeCheck.asm
+++ b/unittests/ASM/FEX_bugs/LoopAddressSizeCheck.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000000010001",
+    "RBX": "0x0000000000000001"
+  }
+}
+%endif
+
+; FEX-Emu had a bug in the 32-bit implementation of LOOP where it didn't handle 16-bit RCX correctly.
+; For test coverage on the 64-bit side, ensure that both 64-bit and 32-bit operation works correctly.
+mov rax, 0
+mov rbx, 0
+mov rcx, 0x0001_0001
+
+.test:
+inc rax
+a64 loop .test
+
+mov rcx, 0x1_0000_0001
+.test2:
+inc rbx
+a32 loop .test2
+
+hlt


### PR DESCRIPTION
In 64-bit mode, the LOOP instruction's RCX register usage is 64-bit or
32-bit.
In 32-bit mode, the LOOP instruction's RCX register usage is 32-bit or
16-bit.

FEX wasn't handling the 16-bit case at all which was causing the LOOP
instruction to effectively always operate at 32-bit size. Now this is
correctly supported, and it also stops treating the operation as 64-bit.