### PR TITLE
Telemetry: Rename old file instead of copying

### DIFF
--- a/FEXCore/Source/Utils/Telemetry.cpp
+++ b/FEXCore/Source/Utils/Telemetry.cpp
@@ -61,11 +61,11 @@ namespace FEXCore::Telemetry {
     auto DataDirectory = Config::GetDataDirectory();
     DataDirectory += "Telemetry/" + ApplicationName + ".telem";
 
-    if (FHU::Filesystem::Exists(DataDirectory)) {
-      // If the file exists, retain a single backup
-      auto Backup = DataDirectory + ".1";
-      FHU::Filesystem::CopyFile(DataDirectory, Backup, FHU::Filesystem::CopyOptions::OVERWRITE_EXISTING);
-    }
+    // Retain a single backup if the telemetry already existed.
+    auto Backup = DataDirectory + ".bck";
+
+    // Failure on rename is okay.
+    (void)FHU::Filesystem::RenameFile(DataDirectory, Backup);
 
     auto File = FEXCore::File::File(DataDirectory.c_str(),
          FEXCore::File::FileModes::WRITE |


### PR DESCRIPTION
Since we do an immediate overwrite of the file we are copying, we can instead do a rename. Failure on rename is fine, will either mean the telemetry file didn't exist initially, or some other permission error so the telemetry will get lost regardless.

Basic renaming is also faster which is a nice benefit:
- renameat syscall: 0.000179 seconds

Old exist check + copy (sequence of syscalls):
- faccessat: 0.000027 s
- faccessat: 0.000011 s (directory cached in kernel now?)
- openat: 0.000016 s
- openat: 0.000104 s
- newfstatat: 0.000007 s
- fchmod: 0.000010 s
- sendfile: 0.000049 s
- close: 0.000065 s
- close: 0.000005 s
Total: 0.000294 s