### PR TITLE
FEXCore: Adds more TSO control levers

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -392,6 +392,21 @@
           "Highly likely to break any multithreaded application if disabled."
         ]
       },
+      "VectorTSOEnabled": {
+        "Type": "bool",
+        "Default": "true",
+        "Desc": [
+          "When TSO emulation is enabled, controls if vector loadstores should also be atomic."
+        ]
+      },
+      "MemcpySetTSOEnabled": {
+        "Type": "bool",
+        "Default": "true",
+        "Desc": [
+          "When TSO emulation is enabled, controls if memcpy and memset should also be atomic.",
+          "Only affects REP MOVS and REP STOS instructions"
+        ]
+      },
       "TSOAutoMigration": {
         "Type": "bool",
         "Default": "true",

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -56,6 +56,8 @@ public:
 
 private:
   FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
+  FEX_CONFIG_OPT(VectorTSOEnabled, VECTORTSOENABLED);
+  FEX_CONFIG_OPT(MemcpySetTSOEnabled, MEMCPYSETTSOENABLED);
 
   const bool HostSupportsSVE128{};
   const bool HostSupportsSVE256{};

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -547,10 +547,42 @@ namespace {
   void FillHackConfig() {
     if (ImGui::BeginTabItem("Hacks")) {
       auto Value = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED);
+      auto VectorTSO = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_VECTORTSOENABLED);
+      auto MemcpyTSO = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_MEMCPYSETTSOENABLED);
+
       bool TSOEnabled = Value.has_value() && **Value == "1";
+      bool VectorTSOEnabled = VectorTSO.has_value() && **VectorTSO == "1";
+      bool MemcpyTSOEnabled = MemcpyTSO.has_value() && **MemcpyTSO == "1";
+
       if (ImGui::Checkbox("TSO Enabled", &TSOEnabled)) {
         LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED, TSOEnabled ? "1" : "0");
         ConfigChanged = true;
+      }
+
+      if (TSOEnabled) {
+        if (ImGui::TreeNodeEx("TSO sub-options", ImGuiTreeNodeFlags_Leaf)) {
+          if (ImGui::Checkbox("Vector TSO Enabled", &VectorTSOEnabled)) {
+            LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_VECTORTSOENABLED, VectorTSOEnabled ? "1" : "0");
+            ConfigChanged = true;
+          }
+          if (ImGui::IsItemHovered()) {
+            ImGui::BeginTooltip();
+            ImGui::Text("Disables TSO emulation on vector load/store instructions");
+            ImGui::EndTooltip();
+          }
+
+          if (ImGui::Checkbox("Memcpy TSO Enabled", &MemcpyTSOEnabled)) {
+            LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_MEMCPYSETTSOENABLED, MemcpyTSOEnabled ? "1" : "0");
+            ConfigChanged = true;
+          }
+          if (ImGui::IsItemHovered()) {
+            ImGui::BeginTooltip();
+            ImGui::Text("Disables TSO emulation on memcpy/memset instructions");
+            ImGui::EndTooltip();
+          }
+
+          ImGui::TreePop();
+        }
       }
 
       Value = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_PARANOIDTSO);


### PR DESCRIPTION
Lets use control vector loadstores and memcpy/memset TSO visibility. This just gives us a bit more configuration rather than TSO off or on.

![Image_2024-03-26_02-49-34](https://github.com/FEX-Emu/FEX/assets/1018829/465b74ee-2c98-4920-a658-e5c85c508894)
