### PR TITLE
FEXCore: Removes vestigial mman SMC checking

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -379,9 +379,8 @@
         "Desc": [
           "Checks code for modification before execution.",
           "\tnone: No checks",
-          "\tmtrack: Page tracking based invalidation",
-          "\tfull: Validate code before every run (slow)",
-          "\tmman: Invalidate on mmap, mprotect, munmap (deprecated, use mtrack)"
+          "\tmtrack: Page tracking based invalidation (default)",
+          "\tfull: Validate code before every run (slow)"
         ]
       },
       "TSOEnabled": {

--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -35,8 +35,6 @@ namespace Handler {
       return "1";
     else if (Value == "full")
       return "2";
-    else if (Value == "mman")
-      return "3";
     return "0";
   }
   static inline std::optional<fextl::string> CacheObjectCodeHandler(std::string_view Value) {
@@ -67,7 +65,6 @@ namespace Handler {
     CONFIG_SMC_NONE,
     CONFIG_SMC_MTRACK,
     CONFIG_SMC_FULL,
-    CONFIG_SMC_MMAN,
   };
 
   enum ConfigObjectCodeHandler {

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -568,7 +568,7 @@ namespace {
       }
 
       ImGui::Text("SMC Checks: ");
-      int SMCChecks = FEXCore::Config::CONFIG_SMC_MMAN;
+      int SMCChecks = FEXCore::Config::CONFIG_SMC_MTRACK;
 
       Value = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_SMCCHECKS);
       if (Value.has_value()) {
@@ -578,8 +578,6 @@ namespace {
           SMCChecks = FEXCore::Config::CONFIG_SMC_MTRACK;
         } else if (**Value == "2") {
           SMCChecks = FEXCore::Config::CONFIG_SMC_FULL;
-        } else if (**Value == "3") {
-          SMCChecks = FEXCore::Config::CONFIG_SMC_MMAN;
         }
       }
 
@@ -587,7 +585,6 @@ namespace {
       SMCChanged |= ImGui::RadioButton("None", &SMCChecks, FEXCore::Config::CONFIG_SMC_NONE); ImGui::SameLine();
       SMCChanged |= ImGui::RadioButton("MTrack (Default)", &SMCChecks, FEXCore::Config::CONFIG_SMC_MTRACK); ImGui::SameLine();
       SMCChanged |= ImGui::RadioButton("Full", &SMCChecks, FEXCore::Config::CONFIG_SMC_FULL);
-      SMCChanged |= ImGui::RadioButton("MMan (Deprecated)", &SMCChecks, FEXCore::Config::CONFIG_SMC_MMAN); ImGui::SameLine();
 
       if (SMCChanged) {
         LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_SMCCHECKS, std::to_string(SMCChecks));


### PR DESCRIPTION
This wasn't actually wired up to anything ever since some refactoring occured two years ago.