### PR TITLE
Library Forwarding/vulkan: Fix query of vkCreateInstance function pointer

### DIFF
--- a/ThunkLibs/libvulkan/Host.cpp
+++ b/ThunkLibs/libvulkan/Host.cpp
@@ -39,7 +39,6 @@ static void DoSetupWithInstance(VkInstance instance) {
     }
 
     // Query pointers for functions customized below
-    (void*&)LDR_PTR(vkCreateInstance) = (void*)LDR_PTR(vkGetInstanceProcAddr)(instance, "vkCreateInstance");
     (void*&)LDR_PTR(vkCreateDevice) = (void*)LDR_PTR(vkGetInstanceProcAddr)(instance, "vkCreateDevice");
 
     // Only do this lookup once.


### PR DESCRIPTION
The Vulkan specification states that "global commands" like vkCreateInstance may only be queried with a NULL instance. Some implementations return null pointers otherwise.

Fixes #3519.