### PR TITLE
OpcodeDispatcher: eliminate branch in cmpxchg pair

### DIFF
--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -80,7 +80,7 @@
       ]
     },
     "dxvk hotblock from MGRR": {
-      "ExpectedInstructionCount": 43,
+      "ExpectedInstructionCount": 42,
       "Comment": [
         "Hottest block in Metal Gear Rising: Revengeance render thread"
       ],
@@ -141,9 +141,8 @@
         "cset x22, eq",
         "msr nzcv, x21",
         "rmif x22, #62, #nZcv",
-        "cbnz x22, #+0xc",
-        "mov w4, w20",
-        "mov w6, w12"
+        "csel x4, x20, x4, ne",
+        "csel x6, x12, x6, ne"
       ]
     },
     "Psychonauts matrix swizzle": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -644,7 +644,7 @@
       ]
     },
     "cmpxchg8b [rbp]": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 24,
       "Comment": "GROUP9 0x0F 0xC7 /1",
       "ExpectedArm64ASM": [
         "add x20, x9, #0x0 (0)",
@@ -669,13 +669,12 @@
         "cset x22, eq",
         "msr nzcv, x21",
         "rmif x22, #62, #nZcv",
-        "cbnz x22, #+0xc",
-        "mov x4, x20",
-        "mov x6, x30"
+        "csel x4, x20, x4, ne",
+        "csel x6, x30, x6, ne"
       ]
     },
     "cmpxchg16b [rbp]": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 20,
       "Comment": "GROUP9 0x0F 0xC7 /1",
       "ExpectedArm64ASM": [
         "add x20, x9, #0x0 (0)",
@@ -696,9 +695,8 @@
         "cset x22, eq",
         "msr nzcv, x21",
         "rmif x22, #62, #nZcv",
-        "cbnz x22, #+0xc",
-        "mov x4, x20",
-        "mov x6, x30"
+        "csel x4, x20, x4, ne",
+        "csel x6, x30, x6, ne"
       ]
     },
     "rdrand ax": {

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -776,7 +776,7 @@
       ]
     },
     "cmpxchg8b [rbp]": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 24,
       "Comment": "GROUP9 0x0F 0xC7 /1",
       "ExpectedArm64ASM": [
         "add x20, x9, #0x0 (0)",
@@ -801,13 +801,12 @@
         "cset x22, eq",
         "bfi w21, w22, #30, #1",
         "msr nzcv, x21",
-        "cbnz x22, #+0xc",
-        "mov x4, x20",
-        "mov x6, x30"
+        "csel x4, x20, x4, ne",
+        "csel x6, x30, x6, ne"
       ]
     },
     "cmpxchg16b [rbp]": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 20,
       "Comment": "GROUP9 0x0F 0xC7 /1",
       "ExpectedArm64ASM": [
         "add x20, x9, #0x0 (0)",
@@ -828,9 +827,8 @@
         "cset x22, eq",
         "bfi w21, w22, #30, #1",
         "msr nzcv, x21",
-        "cbnz x22, #+0xc",
-        "mov x4, x20",
-        "mov x6, x30"
+        "csel x4, x20, x4, ne",
+        "csel x6, x30, x6, ne"
       ]
     },
     "rdrand ax": {


### PR DESCRIPTION
    In the old case:
    
    * if we take the branch, 1 instruction
    * if we don't take the branch, 3 instruction
    * branch predictor fun
    * 3 instructions of icache pressure
    
    In the new case:
    
    * unconditionally 2 instructions
    * no branch predictor dependence
    * 2 instructions of icache pressure
    
    This should not be non-neglibly worse, and it simplifies things for RA.
