### PR TITLE
FEXCore: Moves CodeLoader to frontend

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -29,7 +29,6 @@ $end_info$
 #include "Utils/Allocator/HostAllocator.h"
 
 #include <FEXCore/Config/Config.h>
-#include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/CPUBackend.h>

--- a/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -5,10 +5,6 @@
 
 #include <FEXCore/IR/IR.h>
 
-namespace FEXCore {
-  class CodeLoader;
-}
-
 namespace FEXCore::IR {
   struct AOTIRCacheEntry;
 }
@@ -74,7 +70,6 @@ namespace FEXCore::HLE {
     virtual FEXCore::IR::SyscallFlags GetSyscallFlags(uint64_t Syscall) const { return FEXCore::IR::SyscallFlags::DEFAULT; }
 
     SyscallOSABI GetOSABI() const { return OSABI; }
-    virtual FEXCore::CodeLoader *GetCodeLoader() const { return nullptr; }
     virtual void MarkGuestExecutableRange(FEXCore::Core::InternalThreadState *Thread, uint64_t Start, uint64_t Length) { }
     virtual AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState *Thread, uint64_t GuestAddr) = 0;
 

--- a/Source/Tools/CommonTools/CodeLoader.h
+++ b/Source/Tools/CommonTools/CodeLoader.h
@@ -6,10 +6,11 @@
 #include <cstdint>
 #include <functional>
 
-namespace FEXCore {
-namespace IR {
+namespace FEXCore::IR {
 class IREmitter;
 }
+
+namespace FEX {
 
 /**
  * @brief Code loader class so the CPU backend can load code in a generic fashion
@@ -45,6 +46,5 @@ public:
 
   virtual uint64_t GetBaseOffset() const { return 0; }
 };
-
 
 }

--- a/Source/Tools/CommonTools/HarnessHelpers.h
+++ b/Source/Tools/CommonTools/HarnessHelpers.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include "CodeLoader.h"
 #include "Common/Config.h"
 
 #include <array>
@@ -9,7 +10,6 @@
 #include <cstring>
 #include <fcntl.h>
 
-#include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Utils/Allocator.h>
@@ -369,7 +369,7 @@ namespace FEX::HarnessHelper {
     ConfigStructBase BaseConfig;
   };
 
-  class HarnessCodeLoader final : public FEXCore::CodeLoader {
+  class HarnessCodeLoader final : public FEX::CodeLoader {
   public:
 
     HarnessCodeLoader(fextl::string const &Filename, fextl::string const &ConfigFilename) {

--- a/Source/Tools/FEXLoader/ELFCodeLoader.h
+++ b/Source/Tools/FEXLoader/ELFCodeLoader.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ArchHelpers/UContext.h"
+#include "CodeLoader.h"
 #include "Common/Config.h"
 #include "Common/FDUtils.h"
 #include "FEXCore/Utils/Allocator.h"
@@ -17,7 +18,6 @@
 #include <cstring>
 #include <random>
 
-#include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Utils/MathUtils.h>
 #include <FEXCore/Core/X86Enums.h>
@@ -41,7 +41,7 @@
 #define PAGE_OFFSET(x) ((x) & 4095)
 #define PAGE_ALIGN(x) (((x) + 4095) & ~(uintptr_t)(4095))
 
-class ELFCodeLoader final : public FEXCore::CodeLoader {
+class ELFCodeLoader final : public FEX::CodeLoader {
   ELFParser MainElf;
   ELFParser InterpElf;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -6,12 +6,13 @@ desc: Emulated /proc/cpuinfo, version, osrelease, etc
 $end_info$
 */
 
+#include "CodeLoader.h"
+
 #include "Common/FDUtils.h"
 #include "LinuxSyscalls/Syscalls.h"
 #include "LinuxSyscalls/EmulatedFiles/EmulatedFiles.h"
 
 #include <FEXCore/Config/Config.h>
-#include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CPUID.h>
 #include <FEXCore/Utils/CPUInfo.h>

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -6,6 +6,8 @@ desc: Provides a gdb interface to the guest state
 $end_info$
 */
 
+#include "CodeLoader.h"
+
 #include "LinuxSyscalls/NetStream.h"
 
 #include <cstdlib>
@@ -16,7 +18,6 @@ $end_info$
 
 #include <Common/FEXServerClient.h>
 #include <FEXCore/Config/Config.h>
-#include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/SignalDelegator.h>

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -7,6 +7,8 @@ desc: Glue logic, brk allocations
 $end_info$
 */
 
+#include "CodeLoader.h"
+
 #include "Linux/Utils/ELFContainer.h"
 #include "Linux/Utils/ELFParser.h"
 
@@ -23,7 +25,6 @@ $end_info$
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CoreState.h>
-#include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/HLE/Linux/ThreadManagement.h>
 #include <FEXCore/HLE/SyscallHandler.h>

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -46,8 +46,11 @@ $end_info$
 
 // #define DEBUG_STRACE
 
-namespace FEXCore {
+namespace FEX {
   class CodeLoader;
+}
+
+namespace FEXCore {
   namespace Context {
     class Context;
   }
@@ -243,8 +246,8 @@ public:
   uint64_t HandleBRK(FEXCore::Core::CpuStateFrame *Frame, void *Addr);
 
   FEX::HLE::FileManager FM;
-  FEXCore::CodeLoader *GetCodeLoader() const override { return LocalLoader; }
-  void SetCodeLoader(FEXCore::CodeLoader *Loader) { LocalLoader = Loader; }
+  FEX::CodeLoader *GetCodeLoader() const { return LocalLoader; }
+  void SetCodeLoader(FEX::CodeLoader *Loader) { LocalLoader = Loader; }
   FEX::HLE::SignalDelegator *GetSignalDelegator() { return SignalDelegation; }
 
   FEX_CONFIG_OPT(IsInterpreter, IS_INTERPRETER);
@@ -334,7 +337,7 @@ private:
 
   std::mutex FutexMutex;
   std::mutex SyscallMutex;
-  FEXCore::CodeLoader *LocalLoader{};
+  FEX::CodeLoader *LocalLoader{};
   bool NeedToCheckXID{true};
 
   #ifdef DEBUG_STRACE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -5,7 +5,8 @@ tags: LinuxSyscalls|syscalls-shared
 $end_info$
 */
 
-#include "FEXCore/IR/IR.h"
+#include "CodeLoader.h"
+
 #include "LinuxSyscalls/SignalDelegator.h"
 #include "LinuxSyscalls/Syscalls.h"
 #include "LinuxSyscalls/Syscalls/Thread.h"
@@ -15,7 +16,6 @@ $end_info$
 #include "LinuxSyscalls/x32/Thread.h"
 
 #include <FEXCore/Core/Context.h>
-#include <FEXCore/Core/CodeLoader.h>
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/IR/IR.h>


### PR DESCRIPTION
FEXCore no longer has a need for this since a bunch of related code was already moved to the frontend. Move the CodeLoader now.