### PR TITLE
FEXCore: Remove DebugStore map

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -478,7 +478,6 @@ namespace FEXCore::Context {
 
     Thread->LookupCache->ClearCache();
     Thread->CPUBackend->ClearCache();
-    Thread->DebugStore.clear();
   }
 
   static void IRDumper(FEXCore::Core::InternalThreadState *Thread, IR::IREmitter *IREmitter, uint64_t GuestRIP, IR::RegisterAllocationData* RA) {
@@ -957,9 +956,6 @@ namespace FEXCore::Context {
         // Only the lookup cache is cleared here, so that old code can keep running until next compilation
         std::lock_guard<std::recursive_mutex> lkLookupCache(Thread->LookupCache->WriteLock);
         Thread->LookupCache->ClearCache();
-
-        // DebugStore also needs to be cleared
-        Thread->DebugStore.clear();
       }
     }
   }
@@ -975,7 +971,6 @@ namespace FEXCore::Context {
 
     std::lock_guard<std::recursive_mutex> lk(Thread->LookupCache->WriteLock);
 
-    Thread->DebugStore.erase(GuestRIP);
     Thread->LookupCache->Erase(Thread->CurrentFrame, GuestRIP);
   }
 

--- a/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/FEXCore/Source/Interface/Core/LookupCache.h
@@ -157,7 +157,7 @@ public:
   constexpr static size_t L1_ENTRIES = 1 * 1024 * 1024; // Must be a power of 2
   constexpr static size_t L1_ENTRIES_MASK = L1_ENTRIES - 1;
 
-  // This needs to be taken before reads or writes to L2, L3, CodePages, Thread::DebugStore,
+  // This needs to be taken before reads or writes to L2, L3, CodePages,
   // and before writes to L1. Concurrent access from a thread that this LookupCache doesn't belong to
   // may only happen during cross thread invalidation (::Erase).
   // All other operations must be done from the owning thread.

--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -10,7 +10,6 @@
 #include <FEXCore/Utils/InterruptableConditionVariable.h>
 #include <FEXCore/Utils/Threads.h>
 #include <FEXCore/fextl/memory.h>
-#include <FEXCore/fextl/robin_map.h>
 #include <FEXCore/fextl/vector.h>
 #include <FEXHeaderUtils/TypeDefines.h>
 
@@ -63,14 +62,6 @@ namespace FEXCore::Core {
     fextl::vector<FEXCore::CPU::Relocation> *Relocations;
   };
 
-  struct LocalIREntry {
-    uint64_t StartAddr;
-    uint64_t Length;
-    fextl::unique_ptr<FEXCore::IR::IRListView, FEXCore::IR::IRListViewDeleter> IR;
-    FEXCore::IR::RegisterAllocationData::UniquePtr RAData;
-    fextl::unique_ptr<FEXCore::Core::DebugData> DebugData;
-  };
-
   // Buffered JIT symbol tracking.
   struct JITSymbolBuffer {
     // Maximum buffer size to ensure we are a page in size.
@@ -114,8 +105,6 @@ namespace FEXCore::Core {
 
     fextl::unique_ptr<FEXCore::CPU::CPUBackend> CPUBackend;
     fextl::unique_ptr<FEXCore::LookupCache> LookupCache;
-
-    fextl::robin_map<uint64_t, LocalIREntry> DebugStore;
 
     fextl::unique_ptr<FEXCore::Frontend::Decoder> FrontendDecoder;
     fextl::unique_ptr<FEXCore::IR::PassManager> PassManager;


### PR DESCRIPTION
This hasn't been used and is blocking refactoring more code.