### PR TITLE
LookupCache: Track ARM64EC page state in the code cache

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -777,6 +777,14 @@ namespace FEXCore::Context {
     FEXCORE_PROFILE_SCOPED("CompileBlock");
     auto Thread = Frame->Thread;
 
+#ifdef _M_ARM_64EC
+    // If the target PC is EC code, mark it in the L2 and return straight to the dispatcher
+    // so it can handle the call/return.
+    if (Thread->LookupCache->CheckPageEC(GuestRIP)) {
+      return GuestRIP;
+    }
+#endif
+
     // Invalidate might take a unique lock on this, to guarantee that during invalidation no code gets compiled
     auto lk = GuardSignalDeferringSection<std::shared_lock>(CodeInvalidationMutex, Thread);
 

--- a/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/FEXCore/Source/Interface/Core/LookupCache.h
@@ -13,6 +13,9 @@
 #include <stddef.h>
 #include <utility>
 #include <mutex>
+#ifdef _M_ARM_64EC
+#include <winnt.h>
+#endif
 
 namespace FEXCore {
 
@@ -67,6 +70,24 @@ public:
     // Failed to find
     return 0;
   }
+
+#ifdef _M_ARM_64EC
+  bool CheckPageEC(uint64_t Address) {
+    if (!RtlIsEcCode(Address)) {
+        return false;
+    }
+
+    std::lock_guard<std::recursive_mutex> lk(WriteLock);
+
+    // Mark L2 entry for this page as EC by setting the LSB, this can then be
+    // checked by the dispatcher to see if it needs to perform a call/return to
+    // EC code.
+    const auto PageIndex = (Address & (VirtualMemSize -1)) >> 12;
+    const auto Pointers = reinterpret_cast<uintptr_t*>(PagePointer);
+    Pointers[PageIndex] |= 1;
+    return true;
+  }
+#endif
 
   fextl::map<uint64_t, fextl::vector<uint64_t>> CodePages;
 


### PR DESCRIPTION
Rather than checking the actual EC bitmap in the dispatcher (~6 instrs), this indirection through the code cache allows just 1 instr for the hot path of calling repeated EC code/x64 code.