### PR TITLE
DebugData: Remove header

### DIFF
--- a/FEXCore/Source/Interface/Core/DebugData.h
+++ b/FEXCore/Source/Interface/Core/DebugData.h
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: MIT
-#pragma once
-#include <stdint.h>
-
-namespace FEXCore::CPU {
-}


### PR DESCRIPTION
This isn't included or used anywhere, so it can be removed.