### PR TITLE
IR: Remove VectorZero

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -794,31 +794,6 @@ DEF_OP(VFCMPScalarInsert) {
   VFScalarOperation(IROp->Size, ElementSize, Op->ZeroUpperBits, Funcs[FEXCore::ToUnderlying(Op->Op)], Dst, Vector1, Vector2);
 }
 
-DEF_OP(VectorZero) {
-  const auto OpSize = IROp->Size;
-  const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
-
-  const auto Dst = GetVReg(Node);
-
-  if (HostSupportsSVE256 && Is256Bit) {
-    mov_imm(ARMEmitter::SubRegSize::i64Bit, Dst.Z(), 0);
-  } else {
-    switch (OpSize) {
-      case 8: {
-        movi(ARMEmitter::SubRegSize::i64Bit, Dst.D(), 0);
-        break;
-      }
-      case 16: {
-        movi(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), 0);
-        break;
-      }
-      default:
-        LOGMAN_MSG_A_FMT("Unknown Op Size: {}", OpSize);
-        break;
-    }
-  }
-}
-
 DEF_OP(VectorImm) {
   const auto Op = IROp->C<IR::IROp_VectorImm>();
   const auto OpSize = IROp->Size;

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1647,13 +1647,6 @@
         "DestSize": "RegisterSize"
       },
 
-      "FPR = VectorZero u8:#RegisterSize": {
-        "Desc": ["Generates a vector zero",
-                 "Useful to generate a zero vector without any previous dependencies"
-                ],
-        "DestSize": "RegisterSize"
-      },
-
       "FPR = VectorImm u8:#RegisterSize, u8:#ElementSize, u8:$Immediate, u8:$ShiftAmount{0}": {
         "Desc": ["Generates a vector with each element containg the immediate zexted"
                 ],


### PR DESCRIPTION
We have LoadNamedVectorConstant that now performs this behavior while also being more flexible.