### PR TITLE
Enable jemalloc for ARM64EC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,9 @@ endif()
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm64ec")
   set(_M_ARM_64EC 1)
   add_definitions(-D_M_ARM_64EC=1)
+
+  # Required as FEX is not allowed to lock the CRT heap lock during compilation or callbacks
+  set(ENABLE_JEMALLOC TRUE)
 endif()
 
 if (ENABLE_CCACHE)

--- a/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
+++ b/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
@@ -90,7 +90,18 @@ namespace FEXCore::Allocator {
 #endif
 
   // Memory allocation routines aliased to jemalloc functions.
-#ifdef _WIN32
+#ifdef ENABLE_JEMALLOC
+  inline void *malloc(size_t size) { return ::je_malloc(size); }
+  inline void *calloc(size_t n, size_t size) { return ::je_calloc(n, size); }
+  inline void *memalign(size_t align, size_t s) { return ::je_memalign(align, s); }
+  inline void *valloc(size_t size) { return ::je_valloc(size); }
+  inline int posix_memalign(void** r, size_t a, size_t s) { return ::je_posix_memalign(r, a, s); }
+  inline void *realloc(void* ptr, size_t size) { return ::je_realloc(ptr, size); }
+  inline void free(void* ptr) { return ::je_free(ptr); }
+  inline size_t malloc_usable_size(void *ptr) { return ::je_malloc_usable_size(ptr); }
+  inline void *aligned_alloc(size_t a, size_t s) { return ::je_aligned_alloc(a, s); }
+  inline void aligned_free(void* ptr) { return ::je_free(ptr); }
+#elif defined(_WIN32)
   inline void *malloc(size_t size) { return ::malloc(size); }
   inline void *calloc(size_t n, size_t size) { return ::calloc(n, size); }
   inline void *memalign(size_t align, size_t s) { return ::_aligned_malloc(s, align); }
@@ -110,17 +121,6 @@ namespace FEXCore::Allocator {
   inline size_t malloc_usable_size(void *ptr) { return ::_msize(ptr); }
   inline void *aligned_alloc(size_t a, size_t s) { return ::_aligned_malloc(s, a); }
   inline void aligned_free(void* ptr) { return ::_aligned_free(ptr); }
-#elif defined(ENABLE_JEMALLOC)
-  inline void *malloc(size_t size) { return ::je_malloc(size); }
-  inline void *calloc(size_t n, size_t size) { return ::je_calloc(n, size); }
-  inline void *memalign(size_t align, size_t s) { return ::je_memalign(align, s); }
-  inline void *valloc(size_t size) { return ::je_valloc(size); }
-  inline int posix_memalign(void** r, size_t a, size_t s) { return ::je_posix_memalign(r, a, s); }
-  inline void *realloc(void* ptr, size_t size) { return ::je_realloc(ptr, size); }
-  inline void free(void* ptr) { return ::je_free(ptr); }
-  inline size_t malloc_usable_size(void *ptr) { return ::je_malloc_usable_size(ptr); }
-  inline void *aligned_alloc(size_t a, size_t s) { return ::je_aligned_alloc(a, s); }
-  inline void aligned_free(void* ptr) { return ::je_free(ptr); }
 #else
   inline void *malloc(size_t size) { return ::malloc(size); }
   inline void *calloc(size_t n, size_t size) { return ::calloc(n, size); }


### PR DESCRIPTION
Since FEX shares msvcrt with the guest on ARM64EC, FEX code can called into with the crt heap lock locked e.g by a system call callback inside of malloc. To avoid deadlocking in such scenarios jemalloc is used instead of msvcrt malloc.