### PR TITLE
Reformat until fixed-point

### DIFF
--- a/FEXCore/include/FEXCore/Utils/SignalScopeGuards.h
+++ b/FEXCore/include/FEXCore/Utils/SignalScopeGuards.h
@@ -239,8 +239,8 @@ static auto GuardSignalDeferringSectionWithFallback(MutexType& mutex, FEXCore::C
                           :
                           ExtraGuard {ScopedSignalMasker {Mask}}
 #else
-                           :
-                           ExtraGuard {}
+                          :
+                          ExtraGuard {}
 #endif
   };
   scope_guard.lock = LockType<MutexType> {mutex};

--- a/Source/Tools/CommonTools/Linux/Utils/ELFContainer.h
+++ b/Source/Tools/CommonTools/Linux/Utils/ELFContainer.h
@@ -84,7 +84,7 @@ public:
     return DynamicLinker;
   }
 
-  const fextl::vector<char const*>* GetNecessaryLibs() const {
+  const fextl::vector<const char*>* GetNecessaryLibs() const {
     return &NecessaryLibs;
   }
 

--- a/unittests/ThunkLibs/generator.cpp
+++ b/unittests/ThunkLibs/generator.cpp
@@ -637,15 +637,14 @@ TEST_CASE_METHOD(Fixture, "LayoutWrappers") {
                              "template<typename> struct fex_gen_type {};\n"
                              "template<> struct fex_gen_type<A> : fexgen::emit_layout_wrappers {};\n";
     const auto output = run_thunkgen_host(struct_def, code, guest_abi);
-    CHECK_THAT(output,
-               matches(classTemplateSpecializationDecl(
-                 hasName("guest_layout"), hasAnyTemplateArgument(refersToType(recordType(hasDeclaration(recordDecl(hasName("A")))))),
-                 // The member "data" exists and is defined to a struct...
-                 has(fieldDecl(hasName("data"), hasType(hasCanonicalType(hasDeclaration(decl(
-                                                  // ... the members of which also use guest_layout
-                                                  has(fieldDecl(hasName("a"), hasType(asString("guest_layout<" CLANG_STRUCT_PREFIX "B "
-                                                                                                                                   "*>")))),
-                                                  has(fieldDecl(hasName("b"), hasType(asString("guest_layout<int32_t>")))))))))))));
+    CHECK_THAT(output, matches(classTemplateSpecializationDecl(
+                         hasName("guest_layout"), hasAnyTemplateArgument(refersToType(recordType(hasDeclaration(recordDecl(hasName("A")))))),
+                         // The member "data" exists and is defined to a struct...
+                         has(fieldDecl(hasName("data"), hasType(hasCanonicalType(hasDeclaration(decl(
+                                                          // ... the members of which also use guest_layout
+                                                          has(fieldDecl(hasName("a"), hasType(asString("guest_layout<" CLANG_STRUCT_PREFIX "B "
+                                                                                                       "*>")))),
+                                                          has(fieldDecl(hasName("b"), hasType(asString("guest_layout<int32_t>")))))))))))));
     CHECK_THAT(output, guest_converter_defined);
 
     CHECK_THAT(output, host_layout_is_trivial);

--- a/unittests/Utilities/DeleteOldSHMRegions.cpp
+++ b/unittests/Utilities/DeleteOldSHMRegions.cpp
@@ -13,9 +13,11 @@ static bool ctime_is_old(uint64_t ctime) {
 }
 
 int main() {
-  // key      shmid perms                  size  cpid  lpid nattch   uid   gid  cuid  cgid      atime      dtime      ctime rss swap
-  //	 0     360448   777                  4096 165187 165187      0  1002  1002  1002  1002 1679659857 1679659857 1679659857 4096 0 	 0 32769
-  //777                  4096 153814 153814      0  1002  1002  1002  1002 1676490841 1676490841 1676490841                     0 4096
+  // clang-format off
+  // key      shmid perms                  size  cpid  lpid nattch   uid   gid  cuid  cgid      atime      dtime      ctime                   rss                  swap
+  //	 0     360448   777                  4096 165187 165187      0  1002  1002  1002  1002 1679659857 1679659857 1679659857                  4096                     0
+  //	 0      32769   777                  4096 153814 153814      0  1002  1002  1002  1002 1676490841 1676490841 1676490841                     0                  4096
+  // clang-format on
   std::ifstream fs {"/proc/sysvipc/shm", std::fstream::binary};
   std::string Line;
 


### PR DESCRIPTION
Followup to 2b4ec88daebd35fefb5bf5c73d7fc2b4155771ed. Some files needed a couple of calls to clang-format 16.0.6 to reach a fixed point.