### PR TITLE
AppConfig: Disable libGL forwarding for steamwebhelper

### DIFF
--- a/Data/AppConfig/steamwebhelper.json
+++ b/Data/AppConfig/steamwebhelper.json
@@ -1,0 +1,6 @@
+{
+  "Comment": "Bypasses libGL's glX and instead sends GLX requests directly via xcb",
+  "ThunksDB": {
+    "GL": 0
+  }
+}


### PR DESCRIPTION
This app bypasses the glX functions exported by libGL and instead sends GLX requests directly via xcb. FEX won't support forwarding this usage pattern in the foreseeable future.