### PR TITLE
Library Forwarding: Fix issues with libGL's fake X11 dependency

### DIFF
--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -182,8 +182,10 @@ if (BITNESS EQUAL 64)
   add_guest_lib(GL "libGL.so.1")
 
   # libGL must pull in libX11.so, so generate a placeholder libX11.so to link against
-  add_library(X11 SHARED ../libX11/libX11_NativeGuest.cpp)
-  target_link_libraries(GL-guest PRIVATE X11)
+  add_library(PlaceholderX11 SHARED ../libX11/libX11_NativeGuest.cpp)
+  target_link_options(PlaceholderX11 PRIVATE "LINKER:-soname,libX11.so.6")
+  set_target_properties(PlaceholderX11 PROPERTIES NO_SONAME ON)
+  target_link_libraries(GL-guest PRIVATE PlaceholderX11)
 
   # disabled for now, headers are platform specific
   # find_package(SDL2 REQUIRED)


### PR DESCRIPTION
The library's soname is changed to libX11.so.6 and the CMake target is
renamed to libPlaceholderX11. This fixes two issues:
* Steam and mangohud can't find libX11 during startup if the library doesn't include a version suffix.
* Calling the CMake target libX11 overrode the true host X11 library used by unrelated targets (such as FEXConfig), which could cause link errors