### PR TITLE
Remove some x86 leftovers

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -6,12 +6,11 @@
         "Default": "FEXCore::Config::ConfigCore::CONFIG_IRJIT",
         "TextDefault": "irjit",
         "ShortArg": "c",
-        "Choices": [ "irjit", "host" ],
+        "Choices": [ "irjit" ],
         "ArgumentHandler": "CoreHandler",
         "Desc": [
           "Which CPU core to use",
-          "host only exists on x86_64",
-          "[irjit, host]"
+          "[irjit]"
         ]
       },
       "Multiblock": {
@@ -545,4 +544,3 @@
     }
   }
 }
-

--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -22,11 +22,6 @@ namespace Handler {
     if (Value == "irjit") {
       return "0";
     }
-#ifdef _M_X86_64
-    else if (Value == "host") {
-      return "1";
-    }
-#endif
     return "0";
   }
 

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 # FEX - Fast x86 emulation frontend
 FEX allows you to run x86 and x86-64 binaries on an AArch64 host, similar to qemu-user and box86.
 It has native support for a rootfs overlay, so you don't need to chroot, as well as some thunklibs so it can forward things like GL to the host.
-FEX presents a Linux 5.0 interface to the guest, and supports both AArch64 and x86-64 as hosts.
+FEX presents a Linux 5.0 interface to the guest.
 FEX is very much work in progress, so expect things to change.
 
 
@@ -20,11 +20,11 @@ Ubuntu PPA is updated with our monthly releases.
 Please see [Building FEX](#building-fex).
 
 ## Getting Started
-FEX has been tested to build and run on ARMv8.0, ARMv8.1+, and x86-64(AVX or newer) hardware.
-ARMv7 and older x86 hardware will not work.
+FEX has been tested to build and run on ARMv8.0 and ARMv8.1+ hardware.
+ARMv7 and x86/x86-64 hardware will not work.
 Expected operating system usage is Linux. FEX has been tested with Ubuntu 20.04, 20.10, and 21.04. Also Arch Linux.
 
-On AArch64 hosts the user **MUST** have an x86-64 RootFS [Creating a RootFS](#RootFS-Generation).
+Users **MUST** have an x86-64 RootFS [Creating a RootFS](#RootFS-Generation).
 
 ### Navigating the Source
 See the [Source Outline](docs/SourceOutline.md) for more information.
@@ -33,7 +33,7 @@ See the [Source Outline](docs/SourceOutline.md) for more information.
 Follow the guide on the official FEX-Emu Wiki [here](https://wiki.fex-emu.com/index.php/Development:Setting_up_FEX).
 
 ### RootFS generation
-AArch64 hosts require a rootfs for running applications.
+Hosts require a rootfs for running applications.
 Follow the guide on the wiki page for seeing how to set up the rootfs from scratch
 https://wiki.fex-emu.com/index.php/Development:Setting_up_RootFS
 


### PR DESCRIPTION
As far as I know the x86 hosts are no longer supported, there is an x86 specific option (that crashes FEX on x86 with `terminate called after throwing an instance of 'std::bad_function_call'`) and an old description in readme. This PR cleans it up a bit.

The CONFIG_IRJIT isn't completely removed, but I actually think that it could be removed. That will mean removing the CustomCPUFactory concept (I guess) which might not be ideal. For now removing an option to use the unused choice might be okay.

I also noticed that there are some _M_X86_64 defines that hide x86 specific code, should they go as well? Or maybe everything that isn't in FEXCore should keep the #ifdef _M_X86_64?