### PR TITLE
OpcodeDispatcher: Implement support for SMSW

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -423,6 +423,7 @@ public:
   void EnterOp(OpcodeArgs);
 
   void SGDTOp(OpcodeArgs);
+  void SMSWOp(OpcodeArgs);
 
   // SSE
   void MOVLPOp(OpcodeArgs);

--- a/unittests/32Bit_ASM/Secondary/07_XX_04.asm
+++ b/unittests/32Bit_ASM/Secondary/07_XX_04.asm
@@ -1,0 +1,39 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000080050033",
+    "RBX": "0x0000000041420033",
+    "RCX": "0x0000000041420033",
+    "RDX": "0x0000000041420033",
+    "RDI": "0x0000000080050033",
+    "RSP": "0x0000000080050033",
+    "RBP": "0x0000000041420033"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+mov eax, 0x41424344
+mov ebx, 0x41424344
+mov ecx, 0x41424344
+mov edx, 0x41424344
+mov esi, 0xe000_0000
+mov [esi], edx
+
+mov edi, 0x41424344
+mov esp, 0x41424344
+mov ebp, 0x41424344
+
+smsw eax
+smsw bx
+
+smsw [esi]
+mov ecx, [esi]
+
+o16 smsw dx
+repe smsw edi
+repne smsw esp
+
+o16 smsw bp
+
+hlt

--- a/unittests/ASM/Secondary/07_XX_04.asm
+++ b/unittests/ASM/Secondary/07_XX_04.asm
@@ -1,0 +1,47 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000080050033",
+    "RBX": "0x4142434480050033",
+    "RCX": "0x4142434445460033",
+    "RDX": "0x4142434445460033",
+    "RDI": "0x0000000080050033",
+    "RSP": "0x0000000080050033",
+    "RBP": "0x0000000080050033",
+    "R8":  "0x4142434445460033",
+    "R9":  "0x4142434445460033",
+    "R10": "0x4142434445460033"
+  }
+}
+%endif
+
+mov rax, 0x4142434445464748
+mov rbx, 0x4142434445464748
+mov rcx, 0x4142434445464748
+mov rdx, 0x4142434445464748
+mov rsi, 0xe000_0000
+mov [rsi], rdx
+
+mov rdi, 0x4142434445464748
+mov rsp, 0x4142434445464748
+mov rbp, 0x4142434445464748
+mov r8, 0x4142434445464748
+mov r9, 0x4142434445464748
+mov r10, 0x4142434445464748
+
+smsw rax
+smsw ebx
+smsw cx
+
+smsw [rsi]
+mov rdx, [rsi]
+
+o16 smsw rdi
+repe smsw rsp
+repne smsw rbp
+
+o16 smsw r8w
+repe smsw r9w
+repne smsw r10w
+
+hlt


### PR DESCRIPTION
Found out that Far Cry uses this instruction and it is viable to use in CPL-3. This only returns constant data but its behaviour is a little quirky.

This instruction has a weird behaviour that the 32-bit operation does an insert in to the 64-bit destination, which might be an Intel versus AMD behaviour. I don't have an Intel machine available to test if that theory is true although. This assumption would match similar behaviour where segment registers are inserted instead of zext.

Gets the game farther but then it crashes in a `___ascii_strnicmp` function where the arguments end up being `___ascii_strnicmp(nullptr, "Color", 5);`.