### PR TITLE
WOW64 backend code invalidation fixes

### DIFF
--- a/Source/Windows/Common/InvalidationTracker.cpp
+++ b/Source/Windows/Common/InvalidationTracker.cpp
@@ -2,6 +2,7 @@
 
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/TypeDefines.h>
+#include <FEXCore/Utils/SignalScopeGuards.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Debug/InternalThreadState.h>
 #include "InvalidationTracker.h"
@@ -9,13 +10,19 @@
 #include <winternl.h>
 
 namespace FEX::Windows {
-void InvalidationTracker::HandleMemoryProtectionNotification(FEXCore::Core::InternalThreadState* Thread, uint64_t Address, uint64_t Size,
-                                                             ULONG Prot) {
+InvalidationTracker::InvalidationTracker(FEXCore::Context::Context& CTX, const std::unordered_map<DWORD, FEXCore::Core::InternalThreadState*>& Threads)
+  : CTX {CTX}
+  , Threads {Threads} {}
+
+void InvalidationTracker::HandleMemoryProtectionNotification(uint64_t Address, uint64_t Size, ULONG Prot) {
   const auto AlignedBase = Address & FEXCore::Utils::FEX_PAGE_MASK;
   const auto AlignedSize = (Address - AlignedBase + Size + FEXCore::Utils::FEX_PAGE_SIZE - 1) & FEXCore::Utils::FEX_PAGE_MASK;
 
   if (Prot & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE)) {
-    Thread->CTX->InvalidateGuestCodeRange(Thread, AlignedBase, AlignedSize);
+    std::scoped_lock Lock(CTX.GetCodeInvalidationMutex());
+    for (auto Thread : Threads) {
+      CTX.InvalidateGuestCodeRange(Thread.second, AlignedBase, AlignedSize);
+    }
   }
 
   if (Prot & PAGE_EXECUTE_READWRITE) {
@@ -28,7 +35,7 @@ void InvalidationTracker::HandleMemoryProtectionNotification(FEXCore::Core::Inte
   }
 }
 
-void InvalidationTracker::InvalidateContainingSection(FEXCore::Core::InternalThreadState* Thread, uint64_t Address, bool Free) {
+void InvalidationTracker::InvalidateContainingSection(uint64_t Address, bool Free) {
   MEMORY_BASIC_INFORMATION Info;
   if (NtQueryVirtualMemory(NtCurrentProcess(), reinterpret_cast<void*>(Address), MemoryBasicInformation, &Info, sizeof(Info), nullptr)) {
     return;
@@ -36,7 +43,13 @@ void InvalidationTracker::InvalidateContainingSection(FEXCore::Core::InternalThr
 
   const auto SectionBase = reinterpret_cast<uint64_t>(Info.AllocationBase);
   const auto SectionSize = reinterpret_cast<uint64_t>(Info.BaseAddress) + Info.RegionSize - reinterpret_cast<uint64_t>(Info.AllocationBase);
-  Thread->CTX->InvalidateGuestCodeRange(Thread, SectionBase, SectionSize);
+
+  {
+    std::scoped_lock Lock(CTX.GetCodeInvalidationMutex());
+    for (auto Thread : Threads) {
+      CTX.InvalidateGuestCodeRange(Thread.second, SectionBase, SectionSize);
+    }
+  }
 
   if (Free) {
     std::scoped_lock Lock(RWXIntervalsLock);
@@ -44,10 +57,16 @@ void InvalidationTracker::InvalidateContainingSection(FEXCore::Core::InternalThr
   }
 }
 
-void InvalidationTracker::InvalidateAlignedInterval(FEXCore::Core::InternalThreadState* Thread, uint64_t Address, uint64_t Size, bool Free) {
+void InvalidationTracker::InvalidateAlignedInterval(uint64_t Address, uint64_t Size, bool Free) {
   const auto AlignedBase = Address & FEXCore::Utils::FEX_PAGE_MASK;
   const auto AlignedSize = (Address - AlignedBase + Size + FEXCore::Utils::FEX_PAGE_SIZE - 1) & FEXCore::Utils::FEX_PAGE_MASK;
-  Thread->CTX->InvalidateGuestCodeRange(Thread, AlignedBase, AlignedSize);
+
+  {
+    std::scoped_lock Lock(CTX.GetCodeInvalidationMutex());
+    for (auto Thread : Threads) {
+      CTX.InvalidateGuestCodeRange(Thread.second, AlignedBase, AlignedSize);
+    }
+  }
 
   if (Free) {
     std::scoped_lock Lock(RWXIntervalsLock);
@@ -75,7 +94,7 @@ void InvalidationTracker::ReprotectRWXIntervals(uint64_t Address, uint64_t Size)
   } while (Address < End);
 }
 
-bool InvalidationTracker::HandleRWXAccessViolation(FEXCore::Core::InternalThreadState* Thread, uint64_t FaultAddress) {
+bool InvalidationTracker::HandleRWXAccessViolation(uint64_t FaultAddress) {
   const bool NeedsInvalidate = [&](uint64_t Address) {
     std::unique_lock Lock(RWXIntervalsLock);
     const bool Enclosed = RWXIntervals.Query(Address).Enclosed;
@@ -93,7 +112,10 @@ bool InvalidationTracker::HandleRWXAccessViolation(FEXCore::Core::InternalThread
 
   if (NeedsInvalidate) {
     // RWXIntervalsLock cannot be held during invalidation
-    Thread->CTX->InvalidateGuestCodeRange(Thread, FaultAddress & FEXCore::Utils::FEX_PAGE_MASK, FEXCore::Utils::FEX_PAGE_SIZE);
+    std::scoped_lock Lock(CTX.GetCodeInvalidationMutex());
+    for (auto Thread : Threads) {
+      CTX.InvalidateGuestCodeRange(Thread.second, FaultAddress & FEXCore::Utils::FEX_PAGE_MASK, FEXCore::Utils::FEX_PAGE_SIZE);
+    }
     return true;
   }
   return false;

--- a/Source/Windows/Common/InvalidationTracker.h
+++ b/Source/Windows/Common/InvalidationTracker.h
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: MIT
-// FIXME TODO put in cpp
 #pragma once
 
 #include "IntervalList.h"
 #include <mutex>
+#include <unordered_map>
 
 namespace FEXCore::Core {
 struct InternalThreadState;
+}
+
+namespace FEXCore::Context {
+class Context;
 }
 
 namespace FEX::Windows {
@@ -15,14 +19,17 @@ namespace FEX::Windows {
  */
 class InvalidationTracker {
 public:
-  void HandleMemoryProtectionNotification(FEXCore::Core::InternalThreadState* Thread, uint64_t Address, uint64_t Size, ULONG Prot);
-  void InvalidateContainingSection(FEXCore::Core::InternalThreadState* Thread, uint64_t Address, bool Free);
-  void InvalidateAlignedInterval(FEXCore::Core::InternalThreadState* Thread, uint64_t Address, uint64_t Size, bool Free);
+  InvalidationTracker(FEXCore::Context::Context& CTX, const std::unordered_map<DWORD, FEXCore::Core::InternalThreadState*>& Threads);
+  void HandleMemoryProtectionNotification(uint64_t Address, uint64_t Size, ULONG Prot);
+  void InvalidateContainingSection(uint64_t Address, bool Free);
+  void InvalidateAlignedInterval(uint64_t Address, uint64_t Size, bool Free);
   void ReprotectRWXIntervals(uint64_t Address, uint64_t Size);
-  bool HandleRWXAccessViolation(FEXCore::Core::InternalThreadState* Thread, uint64_t FaultAddress);
+  bool HandleRWXAccessViolation(uint64_t FaultAddress);
 
 private:
   IntervalList<uint64_t> RWXIntervals;
   std::mutex RWXIntervalsLock;
+  FEXCore::Context::Context& CTX;
+  const std::unordered_map<DWORD, FEXCore::Core::InternalThreadState*>& Threads;
 };
 } // namespace FEX::Windows

--- a/Source/Windows/Defs/ntdll.def
+++ b/Source/Windows/Defs/ntdll.def
@@ -8,7 +8,5 @@ EXPORTS
   NtSuspendThread
   NtGetContextThread
   NtContinue
-  NtQueryVirtualMemory
-  NtProtectVirtualMemory
   __wine_dbg_output
   __wine_unix_call


### PR DESCRIPTION
- An invalidation event on one thread will now invalidate the cache across all threads.
- The entire section is now invalidated on section unmap events, rather than just the region of the section that contained the unmap address - this fixes msacm32 setup in wine.