### PR TITLE
GDBServer fixes

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -407,7 +407,6 @@ private:
   IR::AOTIRCaptureCache IRCaptureCache;
   fextl::unique_ptr<FEXCore::CodeSerialize::CodeObjectSerializeService> CodeObjectCacheService;
 
-  bool StartPaused = false;
   bool IsMemoryShared = false;
   bool SupportsHardwareTSO = false;
   bool AtomicTSOEmulationEnabled = true;

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -311,8 +311,6 @@ bool ContextImpl::InitCore() {
   if (Config.GdbServer) {
     // If gdbserver is enabled then this needs to be enabled.
     Config.NeedsPendingInterruptFaultCheck = true;
-    // FEX needs to start paused when gdb is enabled.
-    StartPaused = true;
   }
 
   return true;
@@ -867,7 +865,7 @@ void ContextImpl::ExecutionThread(FEXCore::Core::InternalThreadState* Thread) {
   // Now notify the thread that we are initialized
   Thread->ThreadWaiting.NotifyAll();
 
-  if (StartPaused || Thread->StartPaused) {
+  if (Thread->StartPaused) {
     // Parent thread doesn't need to wait to run
     Thread->StartRunning.Wait();
   }

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -543,7 +543,7 @@ int main(int argc, char** argv, char** const envp) {
       FEX::AOT::AOTGenSection(CTX.get(), Section);
     }
   } else {
-    CTX->RunUntilExit(ParentThread);
+    SyscallHandler->TM.RunPrimaryThread(CTX.get(), ParentThread);
   }
 
   if (AOTEnabled) {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -17,6 +17,7 @@ $end_info$
 #include <optional>
 
 #include <Common/FEXServerClient.h>
+#include <Common/StringUtil.h>
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CoreState.h>
@@ -197,6 +198,8 @@ static fextl::string getThreadName(uint32_t ThreadID) {
   const auto ThreadFile = fextl::fmt::format("/proc/{}/task/{}/comm", getpid(), ThreadID);
   fextl::string ThreadName;
   FEXCore::FileLoading::LoadFile(ThreadName, ThreadFile);
+  // Trim out the potential newline, breaks GDB if it exists.
+  FEX::StringUtil::trim(ThreadName);
   return ThreadName;
 }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -157,6 +157,7 @@ GdbServer::GdbServer(FEXCore::Context::Context* ctx, FEX::HLE::SignalDelegator* 
         return false;
       }
 
+      this->SyscallHandler->TM.Pausing(Thread);
       this->ThreadBreakEventInfo.HostPC = ArchHelpers::Context::GetPc(ucontext);
       this->ThreadBreakEventInfo.Thread = Thread;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.h
@@ -54,6 +54,11 @@ private:
   void SendACK(std::ostream& stream, bool NACK);
 
   Event ThreadBreakEvent {};
+  struct ThreadBreakEventInfoStruct {
+    uint64_t HostPC {};
+    FEXCore::Core::InternalThreadState* Thread {};
+  };
+  ThreadBreakEventInfoStruct ThreadBreakEventInfo {};
   void WaitForThreadWakeup();
 
   struct HandledPacketType {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.h
@@ -37,6 +37,7 @@ public:
 
 private:
   void Break(int signal);
+  void BreakThread(FEXCore::Core::InternalThreadState* Thread, int signal);
 
   void OpenListenSocket();
   void CloseListenSocket();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -120,7 +120,6 @@ public:
   void Pausing(FEXCore::Core::InternalThreadState* Thread);
 
   void WaitForIdle();
-  void WaitForIdleWithTimeout();
   void WaitForThreadsToRun();
 
   void SleepThread(FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -162,6 +162,8 @@ public:
   }
 
 private:
+  FEX_CONFIG_OPT(GdbServer, GDBSERVER);
+
   FEXCore::Context::Context* CTX;
   FEX::HLE::SignalDelegator* SignalDelegation;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -117,6 +117,7 @@ public:
   void Run();
   void Step();
   void Stop(bool IgnoreCurrentThread = false);
+  void Pausing(FEXCore::Core::InternalThreadState* Thread);
 
   void WaitForIdle();
   void WaitForIdleWithTimeout();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -173,7 +173,6 @@ private:
   // Thread idling support.
   bool Running {};
   std::mutex IdleWaitMutex;
-  std::condition_variable IdleWaitCV;
   std::atomic<uint32_t> IdleWaitRefCount {};
 
   void HandleThreadDeletion(FEXCore::Core::InternalThreadState* Thread);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -111,6 +111,8 @@ public:
   void StopThread(FEXCore::Core::InternalThreadState* Thread);
   void RunThread(FEXCore::Core::InternalThreadState* Thread);
 
+  void RunPrimaryThread(FEXCore::Context::Context* CTX, FEXCore::Core::InternalThreadState* Thread);
+
   void Pause();
   void Run();
   void Step();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -94,21 +94,6 @@ void ThreadManager::Run() {
   }
 }
 
-void ThreadManager::WaitForIdleWithTimeout() {
-  std::unique_lock<std::mutex> lk(IdleWaitMutex);
-  bool WaitResult = IdleWaitCV.wait_for(lk, std::chrono::milliseconds(1500), [this] { return IdleWaitRefCount.load() == 0; });
-
-  if (!WaitResult) {
-    // The wait failed, this will occur if we stepped in to a syscall
-    // That's okay, we just need to pause the threads manually
-    NotifyPause();
-  }
-
-  // We have sent every thread a pause signal
-  // Now wait again because they /will/ be going to sleep
-  WaitForIdle();
-}
-
 void ThreadManager::WaitForThreadsToRun() {
   size_t NumThreads {};
   {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -66,7 +66,9 @@ void ThreadManager::NotifyPause() {
   // Tell all the threads that they should pause
   std::lock_guard lk(ThreadCreationMutex);
   for (auto& Thread : Threads) {
-    SignalDelegation->SignalThread(Thread, FEXCore::Core::SignalEvent::Pause);
+    if (Thread->RunningEvents.Running.load()) {
+      SignalDelegation->SignalThread(Thread, FEXCore::Core::SignalEvent::Pause);
+    }
   }
 }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -38,6 +38,10 @@ void ThreadManager::RunPrimaryThread(FEXCore::Context::Context* CTX, FEXCore::Co
   Thread->ThreadManager.TID = FHU::Syscalls::gettid();
   Thread->ThreadManager.PID = ::getpid();
 
+  if (GdbServer()) {
+    Thread->StartRunning.Wait();
+  }
+
   ++IdleWaitRefCount;
   CTX->RunUntilExit(Thread);
 }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -75,6 +75,11 @@ void ThreadManager::Pause() {
   WaitForIdle();
 }
 
+void ThreadManager::Pausing(FEXCore::Core::InternalThreadState* Thread) {
+  Thread->RunningEvents.Running.store(false);
+  --IdleWaitRefCount;
+}
+
 void ThreadManager::Run() {
   // Spin up all the threads
   std::lock_guard lk(ThreadCreationMutex);


### PR DESCRIPTION
This gets gdbserver working for simpler cases again. Some of the work is working around #3535 not being complete since some of the thread state management is still split between FEXCore and the frontend.

I'm still working on fixing that code, but until then lets at least get gdbserver working again so we can get x86 debugging.