### PR TITLE
CPUID: Enable enhanced rep movs in more situations

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -595,7 +595,8 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_07h(uint32_t Leaf) const {
     // Disable Enhanced REP MOVS when TSO is enabled.
     // vcruntime140 memmove will use `rep movsb` in this case which completely destroys perf in Hades(appId 1145360)
     // This is due to LRCPC performance on Cortex being abysmal.
-    const uint32_t SupportsEnhancedREPMOVS = CTX->SoftwareTSORequired() ? 0 : 1;
+    // Only enable EnhancedREPMOVS if SoftwareTSO isn't required OR if MemcpySetTSO is not enabled.
+    const uint32_t SupportsEnhancedREPMOVS = CTX->SoftwareTSORequired() == false || MemcpySetTSOEnabled() == false;
 
     // Number of subfunctions
     Res.eax = 0x0;

--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -119,6 +119,7 @@ private:
   uint32_t Cores {};
   FEX_CONFIG_OPT(HideHypervisorBit, HIDEHYPERVISORBIT);
   FEX_CONFIG_OPT(SmallTSCScale, SMALLTSCSCALE);
+  FEX_CONFIG_OPT(MemcpySetTSOEnabled, MEMCPYSETTSOENABLED);
 
   // XFEATURE_ENABLED_MASK
   // Mask that configures what features are enabled on the CPU.


### PR DESCRIPTION
Instead of only enabling enhanced rep movs if software TSO is disabled, Enable it if software tso is disabled OR memcpysettso is disabled. This is because now we hit the fast path when memcpysettso is disabled alone but global TSO is disabled.

Retested Hades and performance was fine in this configuration.