### PR TITLE
Allocator: Fixes compiling on Fedora 40

### DIFF
--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -8,6 +8,7 @@
 #include <FEXCore/fextl/memory_resource.h>
 #include <FEXHeaderUtils/Syscalls.h>
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <charconv>


### PR DESCRIPTION
This header was missing.

Either libstdc++14 or clang-18 changed includes and we were only getting this indirectly before.