### PR TITLE
Arm64: Adds another TSO hack to disable half-barrier TSO

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -414,6 +414,14 @@
           "Only affects REP MOVS and REP STOS instructions"
         ]
       },
+      "HalfBarrierTSOEnabled": {
+        "Type": "bool",
+        "Default": "true",
+        "Desc": [
+          "When TSO emulation is enabled, controls if unaligned loads and stores should be backpatched to half-barrier atomics.",
+          "Can be dangerous due to aligned loadstores through the same code now become non-atomic."
+        ]
+      },
       "TSOAutoMigration": {
         "Type": "bool",
         "Default": "true",

--- a/FEXCore/Source/Utils/ArchHelpers/Arm64_stubs.cpp
+++ b/FEXCore/Source/Utils/ArchHelpers/Arm64_stubs.cpp
@@ -24,7 +24,7 @@ bool HandleAtomicMemOp(void* _ucontext, void* _info, uint32_t Instr) {
 }
 
 std::pair<bool, int32_t>
-HandleUnalignedAccess(FEXCore::Core::InternalThreadState* Thread, bool ParanoidTSO, uintptr_t ProgramCounter, uint64_t* GPRs) {
+HandleUnalignedAccess(FEXCore::Core::InternalThreadState* Thread, UnalignedHandlerType HandleType, uintptr_t ProgramCounter, uint64_t* GPRs) {
   ERROR_AND_DIE_FMT("HandleAtomicMemOp Not Implemented");
 }
 

--- a/FEXCore/include/FEXCore/Utils/ArchHelpers/Arm64.h
+++ b/FEXCore/include/FEXCore/Utils/ArchHelpers/Arm64.h
@@ -108,6 +108,15 @@ inline uint32_t GetRmReg(uint32_t Instr) {
   return (Instr >> RM_OFFSET) & REGISTER_MASK;
 }
 
+enum class UnalignedHandlerType {
+  ///< Don't backpatch code, instead handle inside SIGBUS handler.
+  Paranoid,
+  ///< Backpatch unaligned access to half-barrier based atomic.
+  HalfBarrier,
+  ///< Backpatch unaligned access to non-atomic.
+  NonAtomic,
+};
+
 /**
  * @brief On ARM64 handles an unaligned memory access that the JIT has done.
  *
@@ -123,5 +132,5 @@ inline uint32_t GetRmReg(uint32_t Instr) {
  */
 [[nodiscard]]
 FEX_DEFAULT_VISIBILITY std::pair<bool, int32_t>
-HandleUnalignedAccess(FEXCore::Core::InternalThreadState* Thread, bool ParanoidTSO, uintptr_t ProgramCounter, uint64_t* GPRs);
+HandleUnalignedAccess(FEXCore::Core::InternalThreadState* Thread, UnalignedHandlerType HandleType, uintptr_t ProgramCounter, uint64_t* GPRs);
 } // namespace FEXCore::ArchHelpers::Arm64

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -556,10 +556,12 @@ void FillHackConfig() {
     auto Value = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED);
     auto VectorTSO = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_VECTORTSOENABLED);
     auto MemcpyTSO = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_MEMCPYSETTSOENABLED);
+    auto HalfBarrierTSO = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_HALFBARRIERTSOENABLED);
 
     bool TSOEnabled = Value.has_value() && **Value == "1";
     bool VectorTSOEnabled = VectorTSO.has_value() && **VectorTSO == "1";
     bool MemcpyTSOEnabled = MemcpyTSO.has_value() && **MemcpyTSO == "1";
+    bool HalfBarrierTSOEnabled = HalfBarrierTSO.has_value() && **HalfBarrierTSO == "1";
 
     if (ImGui::Checkbox("TSO Enabled", &TSOEnabled)) {
       LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED, TSOEnabled ? "1" : "0");
@@ -585,6 +587,16 @@ void FillHackConfig() {
         if (ImGui::IsItemHovered()) {
           ImGui::BeginTooltip();
           ImGui::Text("Disables TSO emulation on memcpy/memset instructions");
+          ImGui::EndTooltip();
+        }
+
+        if (ImGui::Checkbox("Unaligned Half-Barrier TSO Enabled", &HalfBarrierTSOEnabled)) {
+          LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_HALFBARRIERTSOENABLED, HalfBarrierTSOEnabled ? "1" : "0");
+          ConfigChanged = true;
+        }
+        if (ImGui::IsItemHovered()) {
+          ImGui::BeginTooltip();
+          ImGui::Text("Disables half-barrier TSO emulation on unaligned load/store instructions");
           ImGui::EndTooltip();
         }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -23,6 +23,7 @@ $end_info$
 #include <mutex>
 
 #include <FEXCore/Core/SignalDelegator.h>
+#include <FEXCore/Utils/ArchHelpers/Arm64.h>
 #include <FEXCore/Utils/Telemetry.h>
 
 namespace FEXCore {
@@ -127,7 +128,9 @@ public:
 
   void SignalThread(FEXCore::Core::InternalThreadState* Thread, FEXCore::Core::SignalEvent Event) override;
 
-  FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
+  FEXCore::ArchHelpers::Arm64::UnalignedHandlerType GetUnalignedHandlerType() const {
+    return UnalignedHandlerType;
+  }
 
   void SaveTelemetry();
 private:
@@ -156,6 +159,10 @@ private:
   fextl::string const ApplicationName;
   FEXCORE_TELEMETRY_INIT(CrashMask, TYPE_CRASH_MASK);
   FEXCORE_TELEMETRY_INIT(UnhandledNonCanonical, TYPE_UNHANDLED_NONCANONICAL_ADDRESS);
+  FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
+  FEX_CONFIG_OPT(HalfBarrierTSOEnabled, HALFBARRIERTSOENABLED);
+
+  FEXCore::ArchHelpers::Arm64::UnalignedHandlerType UnalignedHandlerType {FEXCore::ArchHelpers::Arm64::UnalignedHandlerType::HalfBarrier};
 
   enum DefaultBehaviour {
     DEFAULT_TERM,


### PR DESCRIPTION
A feature of FEX's JIT is that when an unaligned atomic load/store operation occurs, the instructions will be backpatched in to a barrier plus a non-atomic memory instruction. This is the half-barrier technique that still ensures correct visibility of loadstores in an unaligned context.

The problem with this approach is that the dmb instructions are HEAVY, because they effectively stop the world until all memory operations in flight are visible. But it is a necessary evil since unaligned atomics aren't a thing on ARM processors. FEAT_LSE only gives you unaligned atomics inside of a 16-byte granularity, which doesn't match x86 behaviour of cacheline size (effectively always 64B).

This adds a new TSO option to disable the half-barrier on unaligned atomic and instead only convert it to a regular loadstore instruction, ommiting the half-barrier. This gives more insight in to how well a CPU's LRCPC implementation is by not stalling on DMB instructions when possible.

Originally implemented as a test to see if this makes Sonic Adventure 2 run full speed with TSO enabled (but all available TSO options disabled) on NVIDIA Orin. Unfortunately this basically makes the code no longer stall on dmb instructions and instead just showing how bad the LRCPC implementation is, since the stalls show up on `ldapur` instructions instead.

Tested Sonic Adventure 2 on X13s and it ran at 60FPS there without the hack anyway.
![Image_2024-04-24_12-56-25](https://github.com/FEX-Emu/FEX/assets/1018829/72a4bb3f-62d7-444d-981b-03b33378df76)
