### PR TITLE
JIT: fix neon vec4 faddv

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -1181,7 +1181,7 @@ DEF_OP(VFAddV) {
     // ASIMD doesn't support faddv, need to use multiple faddp to match behaviour.
     if (ElementSize == 4) {
       faddp(SubRegSize.Vector, Dst.Q(), Vector.Q(), Vector.Q());
-      faddp(SubRegSize.Scalar, Dst, Vector);
+      faddp(SubRegSize.Scalar, Dst, Dst);
     } else {
       faddp(SubRegSize.Scalar, Dst, Vector);
     }


### PR DESCRIPTION
We were previously genrating nonsense code if the destination != source:

         faddp v2.4s, v4.4s, v4.4s
         faddp s2, v4.2s

The result of the first faddp is ignored, so the second merely calculates the sum of the first 2 sources (not all 4 as needed).

The correct fix is to feed the first add into the second, regardless of the final destination:

         faddp v2.4s, v4.4s, v4.4s
         faddp s2, v2.2s

Hit in an ASM test with new RA.