### PR TITLE
Pass compulsory `mode` argument to `open` when `O_CREAT` is used

### DIFF
--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -329,7 +329,8 @@ int main(int argc, char** argv, char** const envp) {
         LogMan::Msg::InstallHandler(FEXServerLogging::MsgHandler);
       }
     } else if (!LogFile.empty()) {
-      OutputFD = open(LogFile.c_str(), O_CREAT | O_CLOEXEC | O_WRONLY);
+      constexpr int USER_PERMS = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+      OutputFD = open(LogFile.c_str(), O_CREAT | O_CLOEXEC | O_WRONLY, USER_PERMS);
     }
   }
 


### PR DESCRIPTION
From `man 2 open`:

> The mode argument must be supplied if O_CREAT or O_TMPFILE is
> specified in flags; if it is not supplied, some arbitrary bytes
> from the stack will be applied as the file mode.

(Fix broken build on Fedora Rawhide: https://download.copr.fedorainfracloud.org/results/teohhanhui/fex-emu/fedora-rawhide-aarch64/07399392-fex-emu/builder-live.log.gz)