### PR TITLE
CMake: Remove obsolete Catch2 setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,8 +235,6 @@ add_definitions(-Wno-trigraphs)
 add_definitions(-DGLOBAL_DATA_DIRECTORY="${DATA_DIRECTORY}/")
 
 if (BUILD_TESTS)
-  option(CATCH_BUILD_STATIC_LIBRARY "" ON)
-  set(CATCH_BUILD_STATIC_LIBRARY ON)
   add_subdirectory(External/Catch2/)
 
   # Pull in catch_discover_tests definition


### PR DESCRIPTION
This setting was removed in Catch2 3.0 and has no effect anymore.