### PR TITLE
FEXLoader: Changes frontend thread management to wrap FEXCore thread objects

### DIFF
--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -544,7 +544,7 @@ int main(int argc, char** argv, char** const envp) {
       FEX::AOT::AOTGenSection(CTX.get(), Section);
     }
   } else {
-    CTX->RunUntilExit(ParentThread);
+    CTX->RunUntilExit(ParentThread->Thread);
   }
 
   if (AOTEnabled) {
@@ -565,10 +565,10 @@ int main(int argc, char** argv, char** const envp) {
     }
   }
 
-  auto ProgramStatus = ParentThread->StatusCode;
+  auto ProgramStatus = ParentThread->Thread->StatusCode;
 
   SignalDelegation->UninstallTLSState(ParentThread);
-  CTX->DestroyThread(ParentThread);
+  SyscallHandler->TM.DestroyThread(ParentThread);
 
   DebugServer.reset();
   SyscallHandler.reset();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -56,8 +56,8 @@ public:
   // Called from the signal trampoline function.
   void HandleSignal(int Signal, void* Info, void* UContext);
 
-  void RegisterTLSState(FEXCore::Core::InternalThreadState* Thread);
-  void UninstallTLSState(FEXCore::Core::InternalThreadState* Thread);
+  void RegisterTLSState(FEX::HLE::ThreadStateObject* Thread);
+  void UninstallTLSState(FEX::HLE::ThreadStateObject* Thread);
 
   /**
    * @brief Registers a signal handler for the host to handle a signal
@@ -134,7 +134,7 @@ public:
 
   void SaveTelemetry();
 private:
-  FEXCore::Core::InternalThreadState* GetTLSThread();
+  FEX::HLE::ThreadStateObject* GetTLSThread();
 
   // Called from the thunk handler to handle the signal
   void HandleGuestSignal(FEXCore::Core::InternalThreadState* Thread, int Signal, void* Info, void* UContext);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -363,7 +363,7 @@ static bool AllFlagsSet(uint64_t Flags, uint64_t Mask) {
 }
 
 struct StackFrameData {
-  FEXCore::Core::InternalThreadState* Thread {};
+  FEX::HLE::ThreadStateObject* Thread {};
   FEXCore::Context::Context* CTX {};
   FEXCore::Core::CpuStateFrame NewFrame {};
   FEX::HLE::clone3_args GuestArgs {};
@@ -443,7 +443,7 @@ static void PrintFlags(uint64_t Flags) {
 
 static uint64_t Clone2Handler(FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args* args) {
   StackFrameData* Data = (StackFrameData*)FEXCore::Allocator::malloc(sizeof(StackFrameData));
-  Data->Thread = Frame->Thread;
+  Data->Thread = static_cast<FEX::HLE::ThreadStateObject*>(Frame->Thread->FrontendPtr);
   Data->CTX = Frame->Thread->CTX;
   Data->GuestArgs = *args;
 
@@ -469,7 +469,7 @@ static uint64_t Clone3Handler(FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clo
   constexpr size_t Offset = sizeof(StackFramePlusRet);
   StackFramePlusRet* Data = (StackFramePlusRet*)(reinterpret_cast<uint64_t>(args->NewStack) + args->StackSize - Offset);
   Data->Ret = (uint64_t)Clone3HandlerRet;
-  Data->Data.Thread = Frame->Thread;
+  Data->Data.Thread = static_cast<FEX::HLE::ThreadStateObject*>(Frame->Thread->FrontendPtr);
   Data->Data.CTX = Frame->Thread->CTX;
   Data->Data.GuestArgs = *args;
 
@@ -609,17 +609,17 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args
     auto NewThread = FEX::HLE::CreateNewThread(Thread->CTX, Frame, args);
 
     // Return the new threads TID
-    uint64_t Result = NewThread->ThreadManager.GetTID();
+    uint64_t Result = NewThread->Thread->ThreadManager.GetTID();
 
     // Actually start the thread
     FEX::HLE::_SyscallHandler->TM.RunThread(NewThread);
 
     if (flags & CLONE_VFORK) {
       // If VFORK is set then the calling process is suspended until the thread exits with execve or exit
-      NewThread->ExecutionThread->join(nullptr);
+      NewThread->Thread->ExecutionThread->join(nullptr);
 
       // Normally a thread cleans itself up on exit. But because we need to join, we are now responsible
-      Thread->CTX->DestroyThread(NewThread);
+      FEX::HLE::_SyscallHandler->TM.DestroyThread(NewThread);
     }
 
     SYSCALL_ERRNO();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -10,6 +10,7 @@ $end_info$
 
 #include "LinuxSyscalls/FileManagement.h"
 #include "LinuxSyscalls/LinuxAllocator.h"
+#include "LinuxSyscalls/ThreadManager.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/HLE/SyscallHandler.h>
@@ -91,90 +92,6 @@ struct ExecveAtArgs {
 };
 
 uint64_t ExecveHandler(const char* pathname, char* const* argv, char* const* envp, ExecveAtArgs Args);
-
-class ThreadManager final {
-public:
-  ThreadManager(FEXCore::Context::Context* CTX, FEX::HLE::SignalDelegator* SignalDelegation)
-    : CTX {CTX}
-    , SignalDelegation {SignalDelegation} {}
-
-  ~ThreadManager();
-
-  FEXCore::Core::InternalThreadState*
-  CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::Core::CPUState* NewThreadState = nullptr, uint64_t ParentTID = 0);
-  void TrackThread(FEXCore::Core::InternalThreadState* Thread) {
-    std::lock_guard lk(ThreadCreationMutex);
-    Threads.emplace_back(Thread);
-  }
-
-  void DestroyThread(FEXCore::Core::InternalThreadState* Thread);
-  void StopThread(FEXCore::Core::InternalThreadState* Thread);
-  void RunThread(FEXCore::Core::InternalThreadState* Thread);
-
-  void Pause();
-  void Run();
-  void Step();
-  void Stop(bool IgnoreCurrentThread = false);
-
-  void WaitForIdle();
-  void WaitForIdleWithTimeout();
-  void WaitForThreadsToRun();
-
-  void SleepThread(FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame);
-
-  void UnlockAfterFork(FEXCore::Core::InternalThreadState* Thread, bool Child);
-
-  void IncrementIdleRefCount() {
-    ++IdleWaitRefCount;
-  }
-
-  void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* CallingThread, uint64_t Start, uint64_t Length) {
-    std::lock_guard lk(ThreadCreationMutex);
-
-    // Potential deferred since Thread might not be valid.
-    // Thread object isn't valid very early in frontend's initialization.
-    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
-    auto CodeInvalidationlk = GuardSignalDeferringSectionWithFallback(CTX->GetCodeInvalidationMutex(), CallingThread);
-
-    for (auto& Thread : Threads) {
-      CTX->InvalidateGuestCodeRange(Thread, Start, Length);
-    }
-  }
-
-  void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* CallingThread, uint64_t Start, uint64_t Length,
-                                FEXCore::Context::CodeRangeInvalidationFn callback) {
-    std::lock_guard lk(ThreadCreationMutex);
-
-    // Potential deferred since Thread might not be valid.
-    // Thread object isn't valid very early in frontend's initialization.
-    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
-    auto CodeInvalidationlk = GuardSignalDeferringSectionWithFallback(CTX->GetCodeInvalidationMutex(), CallingThread);
-
-    for (auto& Thread : Threads) {
-      CTX->InvalidateGuestCodeRange(Thread, Start, Length, callback);
-    }
-  }
-
-  const fextl::vector<FEXCore::Core::InternalThreadState*>* GetThreads() const {
-    return &Threads;
-  }
-
-private:
-  FEXCore::Context::Context* CTX;
-  FEX::HLE::SignalDelegator* SignalDelegation;
-
-  FEXCore::ForkableUniqueMutex ThreadCreationMutex;
-  fextl::vector<FEXCore::Core::InternalThreadState*> Threads;
-
-  // Thread idling support.
-  bool Running {};
-  std::mutex IdleWaitMutex;
-  std::condition_variable IdleWaitCV;
-  std::atomic<uint32_t> IdleWaitRefCount {};
-
-  void HandleThreadDeletion(FEXCore::Core::InternalThreadState* Thread);
-  void NotifyPause();
-};
 
 class SyscallHandler : public FEXCore::HLE::SyscallHandler, FEXCore::HLE::SourcecodeResolver, public FEXCore::Allocator::FEXAllocOperators {
 public:

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.h
@@ -15,9 +15,10 @@ struct CPUState;
 } // namespace FEXCore::Core
 
 namespace FEX::HLE {
-FEXCore::Core::InternalThreadState*
-CreateNewThread(FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args* args);
-uint64_t HandleNewClone(FEXCore::Core::InternalThreadState* Thread, FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame,
+struct ThreadStateObject;
+
+FEX::HLE::ThreadStateObject* CreateNewThread(FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args* args);
+uint64_t HandleNewClone(FEX::HLE::ThreadStateObject* Thread, FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame,
                         FEX::HLE::clone3_args* GuestArgs);
 uint64_t ForkGuest(FEXCore::Core::InternalThreadState* Thread, FEXCore::Core::CpuStateFrame* Frame, uint32_t flags, void* stack,
                    size_t StackSize, pid_t* parent_tid, pid_t* child_tid, void* tls);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+/*
+$info$
+tags: LinuxSyscalls|ThreadManager
+desc: Frontend thread management
+$end_info$
+*/
+
+#pragma once
+
+#include <FEXCore/Core/Context.h>
+#include <FEXCore/fextl/vector.h>
+#include <FEXCore/Utils/SignalScopeGuards.h>
+
+#include <cstdint>
+
+namespace FEX::HLE {
+class SyscallHandler;
+class SignalDelegator;
+
+
+class ThreadManager final {
+public:
+  ThreadManager(FEXCore::Context::Context* CTX, FEX::HLE::SignalDelegator* SignalDelegation)
+    : CTX {CTX}
+    , SignalDelegation {SignalDelegation} {}
+
+  ~ThreadManager();
+
+  FEXCore::Core::InternalThreadState*
+  CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::Core::CPUState* NewThreadState = nullptr, uint64_t ParentTID = 0);
+  void TrackThread(FEXCore::Core::InternalThreadState* Thread) {
+    std::lock_guard lk(ThreadCreationMutex);
+    Threads.emplace_back(Thread);
+  }
+
+  void DestroyThread(FEXCore::Core::InternalThreadState* Thread);
+  void StopThread(FEXCore::Core::InternalThreadState* Thread);
+  void RunThread(FEXCore::Core::InternalThreadState* Thread);
+
+  void Pause();
+  void Run();
+  void Step();
+  void Stop(bool IgnoreCurrentThread = false);
+
+  void WaitForIdle();
+  void WaitForIdleWithTimeout();
+  void WaitForThreadsToRun();
+
+  void SleepThread(FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame);
+
+  void UnlockAfterFork(FEXCore::Core::InternalThreadState* Thread, bool Child);
+
+  void IncrementIdleRefCount() {
+    ++IdleWaitRefCount;
+  }
+
+  void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* CallingThread, uint64_t Start, uint64_t Length) {
+    std::lock_guard lk(ThreadCreationMutex);
+
+    // Potential deferred since Thread might not be valid.
+    // Thread object isn't valid very early in frontend's initialization.
+    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
+    auto CodeInvalidationlk = GuardSignalDeferringSectionWithFallback(CTX->GetCodeInvalidationMutex(), CallingThread);
+
+    for (auto& Thread : Threads) {
+      CTX->InvalidateGuestCodeRange(Thread, Start, Length);
+    }
+  }
+
+  void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* CallingThread, uint64_t Start, uint64_t Length,
+                                FEXCore::Context::CodeRangeInvalidationFn callback) {
+    std::lock_guard lk(ThreadCreationMutex);
+
+    // Potential deferred since Thread might not be valid.
+    // Thread object isn't valid very early in frontend's initialization.
+    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
+    auto CodeInvalidationlk = GuardSignalDeferringSectionWithFallback(CTX->GetCodeInvalidationMutex(), CallingThread);
+
+    for (auto& Thread : Threads) {
+      CTX->InvalidateGuestCodeRange(Thread, Start, Length, callback);
+    }
+  }
+
+  const fextl::vector<FEXCore::Core::InternalThreadState*>* GetThreads() const {
+    return &Threads;
+  }
+
+private:
+  FEXCore::Context::Context* CTX;
+  FEX::HLE::SignalDelegator* SignalDelegation;
+
+  FEXCore::ForkableUniqueMutex ThreadCreationMutex;
+  fextl::vector<FEXCore::Core::InternalThreadState*> Threads;
+
+  // Thread idling support.
+  bool Running {};
+  std::mutex IdleWaitMutex;
+  std::condition_variable IdleWaitCV;
+  std::atomic<uint32_t> IdleWaitRefCount {};
+
+  void HandleThreadDeletion(FEXCore::Core::InternalThreadState* Thread);
+  void NotifyPause();
+};
+
+} // namespace FEX::HLE


### PR DESCRIPTION
A bit of refactoring necessary before we can move the remaining Linux specific code to the frontend.

Most of this taken from #3535 but attempting to be NFC as much as possible.