### PR TITLE
CPUInfo: Optimize CalculateNumberOfCPUs

### DIFF
--- a/FEXCore/Source/Utils/CPUInfo.cpp
+++ b/FEXCore/Source/Utils/CPUInfo.cpp
@@ -3,6 +3,8 @@
 
 #include <fmt/format.h>
 
+#include <atomic>
+#include <charconv>
 #include <cstddef>
 #include <cstdint>
 #ifdef _WIN32
@@ -14,13 +16,24 @@
 namespace FEXCore::CPUInfo {
 #ifndef _WIN32
 uint32_t CalculateNumberOfCPUs() {
-  char Tmp[PATH_MAX];
+  static std::atomic<uint32_t> NumCPUs {};
+  if (NumCPUs.load(std::memory_order_relaxed)) {
+    return NumCPUs.load(std::memory_order_relaxed);
+  }
+
+  // Support up to 8 digits of CPU cores plus the null terminator.
+  constexpr std::string_view CPUString = "/sys/devices/system/cpu/cpu";
+  char Tmp[CPUString.size() + 1 + 8];
+  std::ranges::copy(CPUString, Tmp);
   size_t CPUs = 1;
 
   for (;; ++CPUs) {
-    auto Size = fmt::format_to_n(Tmp, sizeof(Tmp), "/sys/devices/system/cpu/cpu{}", CPUs);
-    Tmp[Size.size] = 0;
+    auto Res = std::to_chars(&Tmp[CPUString.size()], &Tmp[sizeof(Tmp)], CPUs);
+    // null terminate the string.
+    Res.ptr[0] = '\0';
+
     if (!FHU::Filesystem::Exists(Tmp)) {
+      NumCPUs.store(CPUs, std::memory_order_relaxed);
       break;
     }
   }


### PR DESCRIPTION
Caches the result for future requests since we call this multiple times.

Additionally instead of using fmt::format_to_n, it instead uses std::to_chars for just the index at the end of the filename.

This causes the function to go from around 146k ns to 55k ns, nearly 1/3rd the amount of time to execute.