### PR TITLE
FEXServer: Removes temporary variable allocation

### DIFF
--- a/Source/Tools/FEXServer/ProcessPipe.cpp
+++ b/Source/Tools/FEXServer/ProcessPipe.cpp
@@ -338,7 +338,7 @@ void HandleSocketData(int Socket) {
       break;
     }
     case FEXServerClient::PacketType::TYPE_GET_ROOTFS_PATH: {
-      fextl::string MountFolder = SquashFS::GetMountFolder();
+      const fextl::string& MountFolder = SquashFS::GetMountFolder();
 
       FEXServerClient::FEXServerResultPacket Res {
         .MountPath {
@@ -357,7 +357,7 @@ void HandleSocketData(int Socket) {
           .iov_len = sizeof(Res),
         },
         {
-          .iov_base = MountFolder.data(),
+          .iov_base = const_cast<char*>(MountFolder.data()),
           .iov_len = MountFolder.size(),
         },
         {

--- a/Source/Tools/FEXServer/SquashFS.cpp
+++ b/Source/Tools/FEXServer/SquashFS.cpp
@@ -265,7 +265,7 @@ bool InitializeSquashFS() {
   return true;
 }
 
-fextl::string GetMountFolder() {
+const fextl::string& GetMountFolder() {
   return MountFolder;
 }
 } // namespace SquashFS

--- a/Source/Tools/FEXServer/SquashFS.h
+++ b/Source/Tools/FEXServer/SquashFS.h
@@ -5,5 +5,5 @@
 namespace SquashFS {
 bool InitializeSquashFS();
 void UnmountRootFS();
-fextl::string GetMountFolder();
+const fextl::string& GetMountFolder();
 } // namespace SquashFS


### PR DESCRIPTION
Was causing unnecessary memory allocation churn when a FEXInterpreter was asking for the rootfs folder path.