### PR TITLE
fextl: Implements a custom unique_ptr

### DIFF
--- a/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/FEXCore/Source/Interface/IR/AOTIR.h
@@ -82,7 +82,7 @@ struct AOTIRCacheEntry {
   AOTIRInlineIndex* Array;
   void* FilePtr;
   size_t Size;
-  std::unique_ptr<FEXCore::HLE::SourcecodeMap> SourcecodeMap;
+  fextl::unique_ptr<FEXCore::HLE::SourcecodeMap> SourcecodeMap;
   fextl::string FileId;
   fextl::string Filename;
   bool ContainsCode;

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -42,7 +42,7 @@ namespace {
   constexpr uint32_t INVALID_REG = FEXCore::IR::InvalidReg;
   constexpr uint32_t INVALID_CLASS = FEXCore::IR::InvalidClass.Val;
 
-  constexpr uint32_t DEFAULT_INTERFERENCE_LIST_COUNT = 122;
+  constexpr uint32_t DEFAULT_INTERFERENCE_LIST_COUNT = 120;
   constexpr uint32_t DEFAULT_INTERFERENCE_SPAN_COUNT = 30;
   constexpr uint32_t DEFAULT_NODE_COUNT = 8192;
 

--- a/FEXCore/include/FEXCore/fextl/memory.h
+++ b/FEXCore/include/FEXCore/fextl/memory.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 #include <FEXCore/fextl/allocator.h>
+#include <FEXCore/Utils/LogManager.h>
 
 #include <memory>
 #include <new>
@@ -21,7 +22,137 @@ struct default_delete : public std::default_delete<T> {
 };
 
 template<class T, class Deleter = fextl::default_delete<T>>
-using unique_ptr = std::unique_ptr<T, Deleter>;
+class unique_ptr {
+  static_assert(!std::is_rvalue_reference_v<Deleter>, "Deleter must not be an r-value reference.");
+
+public:
+  using pointer = T*;
+  using element_type = T;
+  using deleter_type = Deleter;
+
+  // Constructors
+  constexpr unique_ptr() noexcept
+    : pair {} {}
+
+  constexpr unique_ptr(std::nullptr_t) noexcept
+    : pair {} {}
+
+  template<typename Del = Deleter>
+  constexpr explicit unique_ptr(pointer p) noexcept
+    : pair {} {
+    pair.first = p;
+  }
+
+  template<typename Del = Deleter>
+  requires (std::is_copy_constructible_v<Del>)
+  constexpr unique_ptr(pointer p, const Deleter& d)
+    : pair {p, d} {}
+
+  template<typename Del = Deleter>
+  requires (std::is_move_constructible_v<Del>)
+  constexpr unique_ptr(pointer p, Deleter&& d)
+    : pair {p, std::move(d)} {}
+
+  template<class U, class E>
+  requires (!std::is_array_v<U> && std::is_convertible_v<E, deleter_type> &&
+            (std::is_same_v<E, deleter_type> || !std::is_lvalue_reference_v<deleter_type>))
+  constexpr unique_ptr(unique_ptr<U, E>&& r) noexcept
+    : pair {r.release(), std::forward<E>(r.get_deleter())} {}
+
+  // TODO: Missing a bunch
+  unique_ptr(const unique_ptr&) = delete;
+
+  // Destructor
+  constexpr ~unique_ptr() {
+    reset();
+  }
+
+  // Assignments
+  constexpr unique_ptr& operator=(unique_ptr&& r) noexcept {
+    reset(r.release());
+    pair.second = std::move(r.get_deleter());
+    return *this;
+  }
+
+  template<class U, class E>
+  requires (!std::is_array_v<U> && std::is_convertible_v<E, deleter_type> &&
+            (std::is_same_v<E, deleter_type> || !std::is_lvalue_reference_v<deleter_type>))
+  constexpr unique_ptr& operator=(unique_ptr<U, E>&& r) noexcept {
+    reset(r.release());
+    pair.second = std::forward<E>(r.get_deleter());
+    return *this;
+  }
+
+  constexpr unique_ptr& operator=(std::nullptr_t) noexcept {
+    reset();
+    return *this;
+  }
+
+  unique_ptr& operator=(const unique_ptr&) = delete;
+
+  // Modifiers
+  constexpr pointer release() noexcept {
+    auto backup = pair.first;
+    pair.first = nullptr;
+    return backup;
+  }
+
+  void reset(pointer p = pointer()) noexcept {
+    if (pair.first) {
+      pair.second(pair.first);
+    }
+    pair.first = p;
+  }
+
+  void swap(unique_ptr& other) noexcept {
+    std::swap(pair, other.pair);
+  }
+
+  // Observers
+  pointer get() const noexcept {
+    return pair.first;
+  }
+
+  deleter_type& get_deleter() noexcept {
+    return pair.second;
+  }
+
+  const deleter_type& get_deleter() const noexcept {
+    return pair.second;
+  }
+
+  constexpr explicit operator bool() const noexcept {
+    return pair.first != nullptr;
+  }
+
+  // Dereferencing
+  constexpr typename std::add_lvalue_reference<T>::type operator*() const noexcept(noexcept(*std::declval<pointer>())) {
+    LogMan::Throw::AFmt(get() != pointer(), "operator* called without unique_ptr ownership!");
+    return *get();
+  }
+
+  constexpr pointer operator->() const noexcept {
+    LogMan::Throw::AFmt(get() != pointer(), "operator-> called without unique_ptr ownership!");
+    return get();
+  }
+
+private:
+  std::pair<pointer, deleter_type> pair {};
+};
+
+static_assert(std::is_standard_layout_v<unique_ptr<uint32_t>>, "Needs to be standard layout");
+
+// Non-member equality operators
+// TODO: Missing a bunch
+template< class T1, class D1, class T2, class D2 >
+constexpr bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y) {
+  return x.get() == y.get();
+}
+
+template< class T, class D >
+constexpr bool operator==(const unique_ptr<T, D>& x, std::nullptr_t) noexcept {
+  return !x;
+}
 
 template<class T, class... Args>
 requires (!std::is_array_v<T>)
@@ -30,4 +161,5 @@ fextl::unique_ptr<T> make_unique(Args&&... args) {
   auto Result = ::new (ptr) T(std::forward<Args>(args)...);
   return fextl::unique_ptr<T>(Result);
 }
+
 } // namespace fextl


### PR DESCRIPTION
Gets rid of the absolutely obnoxious warning messages due to using offsetof on non-standard-layout type.

```
/home/buildbot/actions-runner/_work/FEX/FEX/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp:732:77: warning: offset of on non-standard-layout type 'FEXCore::Core::InternalThreadState' [-Winvalid-offsetof]
         offsetof(FEXCore::Core::InternalThreadState, InterruptFaultPage) - offsetof(FEXCore::Core::InternalThreadState, BaseFrameState));
                                                                            ^                                            ~~~~~~~
/usr/lib/llvm-14/lib/clang/14.0.0/include/stddef.h:104:24: note: expanded from macro 'offsetof'
```

Number of times this message gets spammed in a clean build:
```bash
$ ninja | grep "invalid-offsetof" | wc -l
187
```
Also needed to patch two locations that we forgot to change
- AOTIR: Was accidentally converting fextl::unique_ptr to std::unique_ptr
   - benign but good to keep in in fextl
   - Only worked because fextl::unique_ptr was technically the same type under the hood
- RegisterAllocationPass
   - Taking advantage of a quirk that libstdc++ unique_ptr decomposes default deleters to the size of a pointer
   - new fextl::unique_ptr implementation can't do that, not even sure quite how to do so.

Just a bit of busy work while I'm sick.

