### PR TITLE
FEXCore: Get rid of DeferredSignalFaultAddress and use the InterruptFaultPage

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -403,8 +403,6 @@ ContextImpl::CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::C
   InitializeCompiler(Thread);
 
   Thread->CurrentFrame->State.DeferredSignalRefCount.Store(0);
-  Thread->CurrentFrame->State.DeferredSignalFaultAddress =
-    reinterpret_cast<Core::NonAtomicRefCounter<uint64_t>*>(FEXCore::Allocator::VirtualAlloc(4096));
 
   if (Config.BlockJITNaming() || Config.GlobalJITNaming() || Config.LibraryJITNaming()) {
     // Allocate a JIT symbol buffer only if enabled.
@@ -421,7 +419,8 @@ void ContextImpl::DestroyThread(FEXCore::Core::InternalThreadState* Thread, bool
 #endif
   }
 
-  FEXCore::Allocator::VirtualFree(reinterpret_cast<void*>(Thread->CurrentFrame->State.DeferredSignalFaultAddress), 4096);
+  FEXCore::Allocator::VirtualProtect(&Thread->InterruptFaultPage, sizeof(Thread->InterruptFaultPage),
+                                     Allocator::ProtectOptions::Read | Allocator::ProtectOptions::Write);
   delete Thread;
 }
 

--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -267,8 +267,8 @@ void Dispatcher::EmitDispatcher() {
     str(TMP2, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
 
     // Trigger segfault if any deferred signals are pending
-    ldr(TMP2, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalFaultAddress));
-    str(ARMEmitter::XReg::zr, TMP2, 0);
+    strb(ARMEmitter::XReg::zr, STATE,
+         offsetof(FEXCore::Core::InternalThreadState, InterruptFaultPage) - offsetof(FEXCore::Core::InternalThreadState, BaseFrameState));
 
     br(TMP1);
   }
@@ -317,8 +317,8 @@ void Dispatcher::EmitDispatcher() {
     str(TMP1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
 
     // Trigger segfault if any deferred signals are pending
-    ldr(TMP1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalFaultAddress));
-    str(ARMEmitter::XReg::zr, TMP1, 0);
+    strb(ARMEmitter::XReg::zr, STATE,
+         offsetof(FEXCore::Core::InternalThreadState, InterruptFaultPage) - offsetof(FEXCore::Core::InternalThreadState, BaseFrameState));
 
     b(&LoopTop);
   }

--- a/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/DeadContextStoreElimination.cpp
@@ -357,17 +357,6 @@ static void ClassifyContextStruct(ContextInfo* ContextClassificationInfo, bool S
     FEXCore::IR::InvalidClass,
   });
 
-  // DeferredSignalFaultAddress
-  ContextClassification->emplace_back(ContextMemberInfo {
-    ContextMemberClassification {
-      offsetof(FEXCore::Core::CPUState, DeferredSignalFaultAddress),
-      sizeof(FEXCore::Core::CPUState::DeferredSignalFaultAddress),
-    },
-    LastAccessType::NONE,
-    FEXCore::IR::InvalidClass,
-  });
-
-
   [[maybe_unused]] size_t ClassifiedStructSize {};
   ContextClassificationInfo->Lookup.reserve(sizeof(FEXCore::Core::CPUState));
   for (auto& it : *ContextClassification) {
@@ -451,7 +440,6 @@ static void ResetClassificationAccesses(ContextInfo* ContextClassificationInfo, 
   SetAccess(Offset++, LastAccessType::NONE);
   SetAccess(Offset++, LastAccessType::NONE);
 
-  SetAccess(Offset++, LastAccessType::INVALID);
   SetAccess(Offset++, LastAccessType::INVALID);
   SetAccess(Offset++, LastAccessType::INVALID);
 }

--- a/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/FEXCore/include/FEXCore/Core/CoreState.h
@@ -117,8 +117,6 @@ struct CPUState {
   // Reference counter for FEX's per-thread deferred signals.
   // Counts the nesting depth of program sections that cause signals to be deferred.
   NonAtomicRefCounter<uint64_t> DeferredSignalRefCount;
-  // Since this memory region is thread local, we use NonAtomicRefCounter for fast atomic access.
-  NonAtomicRefCounter<uint64_t>* DeferredSignalFaultAddress;
 
   // PF/AF are statically mapped as-if they were r16/r17 (which do not exist in
   // x86 otherwise). This allows a straightforward mapping for SRA.

--- a/FEXCore/include/FEXCore/Utils/EnumOperators.h
+++ b/FEXCore/include/FEXCore/Utils/EnumOperators.h
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 #pragma once
+#include <type_traits>
 
 #define FEX_DEF_ENUM_CLASS_BIN_OP(Enum, Op) \
   [[maybe_unused]] static constexpr Enum operator Op(Enum lhs, Enum rhs) { \

--- a/FEXCore/include/FEXCore/Utils/SignalScopeGuards.h
+++ b/FEXCore/include/FEXCore/Utils/SignalScopeGuards.h
@@ -137,11 +137,13 @@ public:
       // X86-64 must do an additional check around the store.
       if ((Result - 1) == 0) {
         // Must happen after the refcount store
-        Thread->CurrentFrame->State.DeferredSignalFaultAddress->Store(0);
+        auto InterruptFaultPage = reinterpret_cast<Core::NonAtomicRefCounter<uint64_t>*>(&Thread->InterruptFaultPage);
+        InterruptFaultPage->Store(0);
       }
 #else
       Thread->CurrentFrame->State.DeferredSignalRefCount.Decrement(1);
-      Thread->CurrentFrame->State.DeferredSignalFaultAddress->Store(0);
+      auto InterruptFaultPage = reinterpret_cast<Core::NonAtomicRefCounter<uint64_t>*>(&Thread->InterruptFaultPage);
+      InterruptFaultPage->Store(0);
 #endif
     }
   }

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -85,7 +85,7 @@
         "str w0, [x28, #728]",
         "str x8, [x28, #40]",
         "mov w0, #0x100",
-        "str x0, [x28, #1056]",
+        "str x0, [x28, #1048]",
         "sub sp, sp, #0x10 (16)",
         "mov w8, #0xa8",
         "mov x0, sp",
@@ -96,7 +96,7 @@
         "ldr w8, [x28, #728]",
         "msr nzcv, x8",
         "ldr x8, [x28, #40]",
-        "str xzr, [x28, #1056]",
+        "str xzr, [x28, #1048]",
         "orr x5, x0, x1, lsl #12"
       ]
     }

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -927,7 +927,7 @@
         "str w0, [x28, #728]",
         "str x8, [x28, #40]",
         "mov w0, #0x100",
-        "str x0, [x28, #1056]",
+        "str x0, [x28, #1048]",
         "sub sp, sp, #0x10 (16)",
         "mov w8, #0xa8",
         "mov x0, sp",
@@ -938,7 +938,7 @@
         "ldr w8, [x28, #728]",
         "msr nzcv, x8",
         "ldr x8, [x28, #40]",
-        "str xzr, [x28, #1056]",
+        "str xzr, [x28, #1048]",
         "orr x20, x0, x1, lsl #12",
         "mov w4, w20"
       ]
@@ -951,7 +951,7 @@
         "str w0, [x28, #728]",
         "str x8, [x28, #40]",
         "mov w0, #0x100",
-        "str x0, [x28, #1056]",
+        "str x0, [x28, #1048]",
         "sub sp, sp, #0x10 (16)",
         "mov w8, #0xa8",
         "mov x0, sp",
@@ -962,7 +962,7 @@
         "ldr w8, [x28, #728]",
         "msr nzcv, x8",
         "ldr x8, [x28, #40]",
-        "str xzr, [x28, #1056]",
+        "str xzr, [x28, #1048]",
         "orr x20, x0, x1, lsl #12",
         "mov w4, w20"
       ]

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -85,7 +85,7 @@
         "str w0, [x28, #728]",
         "str x8, [x28, #40]",
         "mov w0, #0x100",
-        "str x0, [x28, #1056]",
+        "str x0, [x28, #1048]",
         "sub sp, sp, #0x10 (16)",
         "mov w8, #0xa8",
         "mov x0, sp",
@@ -96,7 +96,7 @@
         "ldr w8, [x28, #728]",
         "msr nzcv, x8",
         "ldr x8, [x28, #40]",
-        "str xzr, [x28, #1056]",
+        "str xzr, [x28, #1048]",
         "orr x5, x0, x1, lsl #12"
       ]
     },


### PR DESCRIPTION
Arm64ec introduced the InterruptFaultPage which is lower overhead since instead of ldr+str it just turns in to a single str. We were already allocating the space, FEXCore and the frontend signal delegator just needed to be updated to understand the new location.

We can additionally use this in the future if we want to make deferred async signals INSIDE the JIT only cost a single str as well.

Side-benefit: Shaving 1 page off each thread's state object allocation size. From 3 pages down to 2. Not much but eh, isn't the point of this PR.