### PR TITLE
Github: Support a timeout on checkout

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Checkout through merge base
         uses: rmacklin/fetch-through-merge-base@v0
+        timeout-minutes: 3
         with:
           base_ref: ${{ github.event.pull_request.base.ref }}
           head_ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Sometimes github or the CI runner times out trying to checkout the source and stays timing out forever.

Give it a three minute timeout otherwise the CI runner will stall forever.


This seems to occur if you push a change to a branch and then force push a new commit before the original code format step has run. It forever walks backwards trying to find a commit and it can't ever find one.