### PR TITLE
 Library Forwarding: Add support for 32-bit OpenGL

### DIFF
--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -144,7 +144,7 @@ void GenerateThunkLibsAction::EmitLayoutWrappers(clang::ASTContext& context, std
     auto struct_name = get_type_name(context, type);
 
     // Opaque types don't need layout definitions
-    if (type_repack_info.assumed_compatible && type_repack_info.pointers_only) {
+    if (type_repack_info.assumed_compatible && type_repack_info.pointers_only && struct_name != "void") {
       if (guest_abi.pointer_size != 4) {
         fmt::print(file, "template<> inline constexpr bool has_compatible_data_layout<{}*> = true;\n", struct_name);
       }

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -175,18 +175,6 @@ if (BITNESS EQUAL 64)
   generate(libasound ${CMAKE_CURRENT_SOURCE_DIR}/../libasound/libasound_interface.cpp)
   add_guest_lib(asound "libasound.so.2")
 
-  generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp)
-  add_guest_lib(EGL "libEGL.so.1")
-
-  generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp)
-  add_guest_lib(GL "libGL.so.1")
-
-  # libGL must pull in libX11.so, so generate a placeholder libX11.so to link against
-  add_library(PlaceholderX11 SHARED ../libX11/libX11_NativeGuest.cpp)
-  target_link_options(PlaceholderX11 PRIVATE "LINKER:-soname,libX11.so.6")
-  set_target_properties(PlaceholderX11 PROPERTIES NO_SONAME ON)
-  target_link_libraries(GL-guest PRIVATE PlaceholderX11)
-
   # disabled for now, headers are platform specific
   # find_package(SDL2 REQUIRED)
   # generate(libSDL2)
@@ -240,3 +228,16 @@ if (BUILD_FEX_LINUX_TESTS)
   generate(libfex_thunk_test ${CMAKE_CURRENT_SOURCE_DIR}/../libfex_thunk_test/libfex_thunk_test_interface.cpp)
   add_guest_lib(fex_thunk_test "libfex_thunk_test.so")
 endif()
+
+generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp)
+add_guest_lib(GL "libGL.so.1")
+
+generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp)
+add_guest_lib(EGL "libEGL.so.1")
+target_link_libraries(EGL-guest PRIVATE GL-guest)
+
+# libGL must pull in libX11.so, so generate a placeholder libX11.so to link against
+add_library(PlaceholderX11 SHARED ../libX11/libX11_NativeGuest.cpp)
+target_link_options(PlaceholderX11 PRIVATE "LINKER:-soname,libX11.so.6")
+set_target_properties(PlaceholderX11 PROPERTIES NO_SONAME ON)
+target_link_libraries(GL-guest PRIVATE PlaceholderX11)

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -109,15 +109,6 @@ foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
   generate(libasound ${CMAKE_CURRENT_SOURCE_DIR}/../libasound/libasound_interface.cpp ${GUEST_BITNESS})
   add_host_lib(asound ${GUEST_BITNESS})
 
-  generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp ${GUEST_BITNESS})
-  add_host_lib(EGL ${GUEST_BITNESS})
-
-  generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp ${GUEST_BITNESS})
-  add_host_lib(GL ${GUEST_BITNESS})
-
-  find_package(OpenGL REQUIRED)
-  target_link_libraries(GL-host-${GUEST_BITNESS} PRIVATE OpenGL::GL)
-
   # disabled for now, headers are platform specific
   # find_package(SDL2 REQUIRED)
   # generate(libSDL2)
@@ -141,6 +132,15 @@ foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
 
   generate(libwayland-client ${CMAKE_CURRENT_SOURCE_DIR}/../libwayland-client/libwayland-client_interface.cpp ${GUEST_BITNESS})
   add_host_lib(wayland-client ${GUEST_BITNESS})
+
+  generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp ${GUEST_BITNESS})
+  add_host_lib(EGL ${GUEST_BITNESS})
+
+  generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp ${GUEST_BITNESS})
+  add_host_lib(GL ${GUEST_BITNESS})
+
+  find_package(OpenGL REQUIRED)
+  target_link_libraries(GL-host-${GUEST_BITNESS} PRIVATE OpenGL::GL)
 endforeach()
 
 add_library(fex_thunk_test SHARED ../libfex_thunk_test/lib.cpp)

--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -405,6 +405,12 @@ struct host_to_guest_convertible {
   {
     return {static_cast<uint32_t>(from.data)};
   }
+
+  // libGL also needs to allow long->int conversions for return values...
+  operator guest_layout<int32_t>() const requires (std::is_same_v<T, long>)
+  {
+    return {static_cast<int32_t>(from.data)};
+  }
 #endif
 
   // Make guest_layout of "long long" and "long" interoperable, since they are

--- a/ThunkLibs/include/common/Host.h
+++ b/ThunkLibs/include/common/Host.h
@@ -536,8 +536,8 @@ struct CallbackUnpack<Result(Args...)> {
   }
 };
 
-template<bool Cond, typename T>
-using as_guest_layout_if = std::conditional_t<Cond, guest_layout<T>, T>;
+template<bool Cond, typename T, typename GuestT>
+using as_guest_layout_if = std::conditional_t<Cond, guest_layout<GuestT>, T>;
 
 template<typename, typename...>
 struct GuestWrapperForHostFunction;
@@ -552,7 +552,7 @@ struct GuestWrapperForHostFunction<Result(Args...), GuestArgs...> {
     static_assert(sizeof...(GuestArgs) == sizeof...(Args));
 
     auto args =
-      reinterpret_cast<PackedArguments<as_guest_layout_if<!std::is_void_v<Result>, Result>, guest_layout<GuestArgs>..., uintptr_t>*>(argsv);
+      reinterpret_cast<PackedArguments<as_guest_layout_if<!std::is_void_v<Result>, Result, Result>, guest_layout<GuestArgs>..., uintptr_t>*>(argsv);
     constexpr auto CBIndex = sizeof...(GuestArgs);
     uintptr_t cb;
     static_assert(CBIndex <= 18 || CBIndex == 23);
@@ -600,9 +600,8 @@ struct GuestWrapperForHostFunction<Result(Args...), GuestArgs...> {
 
     // This is almost the same type as "Result func(Args..., uintptr_t)", but
     // individual types annotated as passthrough are wrapped in guest_layout<>
-    auto callback =
-      reinterpret_cast<as_guest_layout_if<RetAnnotations.is_passthrough, Result> (*)(as_guest_layout_if<Annotations.is_passthrough, Args>..., uintptr_t)>(
-        cb);
+    auto callback = reinterpret_cast<as_guest_layout_if<RetAnnotations.is_passthrough, Result, Result> (*)(
+      as_guest_layout_if<Annotations.is_passthrough, Args, GuestArgs>..., uintptr_t)>(cb);
 
     auto f = [&callback](guest_layout<GuestArgs>... args, uintptr_t target) {
       // Fold over each of Annotations, Args, and args. This will match up the elements in triplets.

--- a/ThunkLibs/libGL/libGL_Guest.cpp
+++ b/ThunkLibs/libGL/libGL_Guest.cpp
@@ -16,9 +16,10 @@ $end_info$
 #undef GL_ARB_viewport_array
 #include "glcorearb.h"
 
-#include <stdio.h>
-#include <cstdlib>
 #include <dlfcn.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <functional>
 #include <string_view>
 #include <unordered_map>

--- a/ThunkLibs/libGL/libGL_Host.cpp
+++ b/ThunkLibs/libGL/libGL_Host.cpp
@@ -68,7 +68,53 @@ static void fexfn_impl_libGL_SetGuestXDisplayString(uintptr_t GuestTarget, uintp
 auto fexfn_impl_libGL_glXGetProcAddress(const GLubyte* name) -> void (*)() {
   using VoidFn = void (*)();
   std::string_view name_sv {reinterpret_cast<const char*>(name)};
-  if (name_sv == "glXChooseFBConfig") {
+  if (name_sv == "glCompileShaderIncludeARB") {
+    return (VoidFn)fexfn_impl_libGL_glCompileShaderIncludeARB;
+  } else if (name_sv == "glCreateShaderProgramv") {
+    return (VoidFn)fexfn_impl_libGL_glCreateShaderProgramv;
+  } else if (name_sv == "glGetBufferPointerv") {
+    return (VoidFn)fexfn_impl_libGL_glGetBufferPointerv;
+  } else if (name_sv == "glGetBufferPointervARB") {
+    return (VoidFn)fexfn_impl_libGL_glGetBufferPointervARB;
+  } else if (name_sv == "glGetNamedBufferPointerv") {
+    return (VoidFn)fexfn_impl_libGL_glGetNamedBufferPointerv;
+  } else if (name_sv == "glGetNamedBufferPointervEXT") {
+    return (VoidFn)fexfn_impl_libGL_glGetNamedBufferPointervEXT;
+  } else if (name_sv == "glGetPointerv") {
+    return (VoidFn)fexfn_impl_libGL_glGetPointerv;
+  } else if (name_sv == "glGetPointervEXT") {
+    return (VoidFn)fexfn_impl_libGL_glGetPointervEXT;
+  } else if (name_sv == "glGetPointeri_vEXT") {
+    return (VoidFn)fexfn_impl_libGL_glGetPointeri_vEXT;
+  } else if (name_sv == "glGetPointerIndexedvEXT") {
+    return (VoidFn)fexfn_impl_libGL_glGetPointerIndexedvEXT;
+  } else if (name_sv == "glGetVariantPointervEXT") {
+    return (VoidFn)fexfn_impl_libGL_glGetVariantPointervEXT;
+  } else if (name_sv == "glGetVertexAttribPointervARB") {
+    return (VoidFn)fexfn_impl_libGL_glGetVertexAttribPointervARB;
+  } else if (name_sv == "glGetVertexAttribPointerv") {
+    return (VoidFn)fexfn_impl_libGL_glGetVertexAttribPointerv;
+  } else if (name_sv == "glGetVertexAttribPointervNV") {
+    return (VoidFn)fexfn_impl_libGL_glGetVertexAttribPointervNV;
+  } else if (name_sv == "glGetVertexArrayPointeri_vEXT") {
+    return (VoidFn)fexfn_impl_libGL_glGetVertexArrayPointeri_vEXT;
+  } else if (name_sv == "glGetVertexArrayPointervEXT") {
+    return (VoidFn)fexfn_impl_libGL_glGetVertexArrayPointervEXT;
+  } else if (name_sv == "glShaderSource") {
+    return (VoidFn)fexfn_impl_libGL_glShaderSource;
+  } else if (name_sv == "glShaderSourceARB") {
+    return (VoidFn)fexfn_impl_libGL_glShaderSourceARB;
+#ifdef IS_32BIT_THUNK
+  } else if (name_sv == "glBindBuffersRange") {
+    return (VoidFn)fexfn_impl_libGL_glBindBuffersRange;
+  } else if (name_sv == "glBindVertexBuffers") {
+    return (VoidFn)fexfn_impl_libGL_glBindVertexBuffers;
+  } else if (name_sv == "glGetUniformIndices") {
+    return (VoidFn)fexfn_impl_libGL_glGetUniformIndices;
+  } else if (name_sv == "glVertexArrayVertexBuffers") {
+    return (VoidFn)fexfn_impl_libGL_glVertexArrayVertexBuffers;
+#endif
+  } else if (name_sv == "glXChooseFBConfig") {
     return (VoidFn)fexfn_impl_libGL_glXChooseFBConfig;
   } else if (name_sv == "glXChooseFBConfigSGIX") {
     return (VoidFn)fexfn_impl_libGL_glXChooseFBConfigSGIX;
@@ -92,6 +138,124 @@ auto fexfn_impl_libGL_glXGetProcAddress(const GLubyte* name) -> void (*)() {
     return (VoidFn)fexfn_impl_libGL_glXGetVisualFromFBConfig;
   }
   return (VoidFn)glXGetProcAddress((const GLubyte*)name);
+}
+
+void fexfn_impl_libGL_glCompileShaderIncludeARB(GLuint a_0, GLsizei Count, guest_layout<const GLchar* const*> a_2, const GLint* a_3) {
+  // TODO: Only on 32-bit
+  auto sources = (const char**)alloca(Count * sizeof(const char*));
+  for (GLsizei i = 0; i < Count; ++i) {
+    sources[i] = host_layout<const char* const> {a_2.get_pointer()[i]}.data;
+  }
+  return fexldr_ptr_libGL_glCompileShaderIncludeARB(a_0, Count, sources, a_3);
+}
+
+GLuint fexfn_impl_libGL_glCreateShaderProgramv(GLuint a_0, GLsizei count, guest_layout<const GLchar* const*> a_2) {
+  // TODO: Only on 32-bit
+  auto sources = (const char**)alloca(count * sizeof(const char*));
+  for (GLsizei i = 0; i < count; ++i) {
+    sources[i] = host_layout<const char* const> {a_2.get_pointer()[i]}.data;
+  }
+  return fexldr_ptr_libGL_glCreateShaderProgramv(a_0, count, sources);
+}
+
+void fexfn_impl_libGL_glGetBufferPointerv(GLenum a_0, GLenum a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetBufferPointerv(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetBufferPointervARB(GLenum a_0, GLenum a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetBufferPointervARB(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetNamedBufferPointerv(GLuint a_0, GLenum a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetNamedBufferPointerv(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetNamedBufferPointervEXT(GLuint a_0, GLenum a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetNamedBufferPointervEXT(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetPointerv(GLenum a_0, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetPointerv(a_0, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetPointervEXT(GLenum a_0, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetPointervEXT(a_0, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetPointeri_vEXT(GLenum a_0, GLuint a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetPointeri_vEXT(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetPointerIndexedvEXT(GLenum a_0, GLuint a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetPointerIndexedvEXT(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetVariantPointervEXT(GLuint a_0, GLenum a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetVariantPointervEXT(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetVertexAttribPointervARB(GLuint a_0, GLenum a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetVertexAttribPointervARB(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetVertexAttribPointerv(GLuint a_0, GLenum a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetVertexAttribPointerv(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetVertexAttribPointervNV(GLuint a_0, GLenum a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetVertexAttribPointervNV(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetVertexArrayPointeri_vEXT(GLuint a_0, GLuint a_1, GLenum a_2, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetVertexArrayPointeri_vEXT(a_0, a_1, a_2, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glGetVertexArrayPointervEXT(GLuint a_0, GLenum a_1, guest_layout<void**> GuestOut) {
+  void* HostOut;
+  fexldr_ptr_libGL_glGetVertexArrayPointervEXT(a_0, a_1, &HostOut);
+  *GuestOut.get_pointer() = to_guest(to_host_layout(HostOut));
+}
+
+void fexfn_impl_libGL_glShaderSource(GLuint a_0, GLsizei count, guest_layout<const GLchar* const*> a_2, const GLint* a_3) {
+  auto sources = (const char**)alloca(count * sizeof(const char*));
+  for (GLsizei i = 0; i < count; ++i) {
+    sources[i] = host_layout<const char* const> {a_2.get_pointer()[i]}.data;
+  }
+  return fexldr_ptr_libGL_glShaderSource(a_0, count, sources, a_3);
+}
+
+void fexfn_impl_libGL_glShaderSourceARB(GLuint a_0, GLsizei count, guest_layout<const GLcharARB**> a_2, const GLint* a_3) {
+  auto sources = (const char**)alloca(count * sizeof(const char*));
+  for (GLsizei i = 0; i < count; ++i) {
+    sources[i] = a_2.get_pointer()[i].force_get_host_pointer();
+  }
+  return fexldr_ptr_libGL_glShaderSourceARB(a_0, count, sources, a_3);
 }
 
 // Relocate data to guest heap so it can be called with XFree.
@@ -208,5 +372,43 @@ int fexfn_impl_libGL_glXGetConfig(Display* Display, guest_layout<XVisualInfo*> I
 guest_layout<XVisualInfo*> fexfn_impl_libGL_glXGetVisualFromFBConfig(Display* Display, GLXFBConfig Config) {
   return MapToGuestVisualInfo(Display, fexldr_ptr_libGL_glXGetVisualFromFBConfig(Display, Config));
 }
+
+#ifdef IS_32BIT_THUNK
+void fexfn_impl_libGL_glBindBuffersRange(GLenum a_0, GLuint a_1, GLsizei Count, const GLuint* a_3, guest_layout<const int*> Offsets,
+                                         guest_layout<const int*> Sizes) {
+  auto HostOffsets = (GLintptr*)alloca(Count * sizeof(GLintptr));
+  auto HostSizes = (GLsizeiptr*)alloca(Count * sizeof(GLsizeiptr));
+  for (int i = 0; i < Count; ++i) {
+    HostOffsets[i] = Offsets.get_pointer()[i].data;
+    HostSizes[i] = Sizes.get_pointer()[i].data;
+  }
+  return fexldr_ptr_libGL_glBindBuffersRange(a_0, a_1, Count, a_3, HostOffsets, HostSizes);
+}
+
+void fexfn_impl_libGL_glBindVertexBuffers(GLuint a_0, GLsizei count, const GLuint* a_2, guest_layout<const int*> Offsets, const GLsizei* a_4) {
+  auto HostOffsets = (GLintptr*)alloca(count * sizeof(GLintptr));
+  for (int i = 0; i < count; ++i) {
+    HostOffsets[i] = Offsets.get_pointer()[i].data;
+  }
+  fexldr_ptr_libGL_glBindVertexBuffers(a_0, count, a_2, HostOffsets, a_4);
+}
+
+void fexfn_impl_libGL_glGetUniformIndices(GLuint a_0, GLsizei Count, guest_layout<const GLchar* const*> Names, GLuint* a_3) {
+  auto HostNames = (const GLchar**)alloca(Count * sizeof(GLintptr));
+  for (int i = 0; i < Count; ++i) {
+    HostNames[i] = host_layout<const char* const> {Names.get_pointer()[i]}.data;
+  }
+  fexldr_ptr_libGL_glGetUniformIndices(a_0, Count, HostNames, a_3);
+}
+
+void fexfn_impl_libGL_glVertexArrayVertexBuffers(GLuint a_0, GLuint a_1, GLsizei count, const GLuint* a_3, guest_layout<const int*> Offsets,
+                                                 const GLsizei* a_5) {
+  auto HostOffsets = (GLintptr*)alloca(count * sizeof(GLintptr));
+  for (int i = 0; i < count; ++i) {
+    HostOffsets[i] = Offsets.get_pointer()[i].data;
+  }
+  fexldr_ptr_libGL_glVertexArrayVertexBuffers(a_0, a_1, count, a_3, HostOffsets, a_5);
+}
+#endif
 
 EXPORTS(libGL)

--- a/ThunkLibs/libGL/libGL_Host.cpp
+++ b/ThunkLibs/libGL/libGL_Host.cpp
@@ -157,20 +157,26 @@ auto fexfn_impl_libGL_glXGetProcAddress(const GLubyte* name) -> void (*)() {
 
 
 void fexfn_impl_libGL_glCompileShaderIncludeARB(GLuint a_0, GLsizei Count, guest_layout<const GLchar* const*> a_2, const GLint* a_3) {
-  // TODO: Only on 32-bit
+#ifndef IS_32BIT_THUNK
+  auto sources = a_2.force_get_host_pointer();
+#else
   auto sources = (const char**)alloca(Count * sizeof(const char*));
   for (GLsizei i = 0; i < Count; ++i) {
     sources[i] = host_layout<const char* const> {a_2.get_pointer()[i]}.data;
   }
+#endif
   return fexldr_ptr_libGL_glCompileShaderIncludeARB(a_0, Count, sources, a_3);
 }
 
 GLuint fexfn_impl_libGL_glCreateShaderProgramv(GLuint a_0, GLsizei count, guest_layout<const GLchar* const*> a_2) {
-  // TODO: Only on 32-bit
+#ifndef IS_32BIT_THUNK
+  auto sources = a_2.force_get_host_pointer();
+#else
   auto sources = (const char**)alloca(count * sizeof(const char*));
   for (GLsizei i = 0; i < count; ++i) {
     sources[i] = host_layout<const char* const> {a_2.get_pointer()[i]}.data;
   }
+#endif
   return fexldr_ptr_libGL_glCreateShaderProgramv(a_0, count, sources);
 }
 
@@ -259,18 +265,26 @@ void fexfn_impl_libGL_glGetVertexArrayPointervEXT(GLuint a_0, GLenum a_1, guest_
 }
 
 void fexfn_impl_libGL_glShaderSource(GLuint a_0, GLsizei count, guest_layout<const GLchar* const*> a_2, const GLint* a_3) {
+#ifndef IS_32BIT_THUNK
+  auto sources = a_2.force_get_host_pointer();
+#else
   auto sources = (const char**)alloca(count * sizeof(const char*));
   for (GLsizei i = 0; i < count; ++i) {
     sources[i] = host_layout<const char* const> {a_2.get_pointer()[i]}.data;
   }
+#endif
   return fexldr_ptr_libGL_glShaderSource(a_0, count, sources, a_3);
 }
 
 void fexfn_impl_libGL_glShaderSourceARB(GLuint a_0, GLsizei count, guest_layout<const GLcharARB**> a_2, const GLint* a_3) {
+#ifndef IS_32BIT_THUNK
+  auto sources = a_2.force_get_host_pointer();
+#else
   auto sources = (const char**)alloca(count * sizeof(const char*));
   for (GLsizei i = 0; i < count; ++i) {
     sources[i] = a_2.get_pointer()[i].force_get_host_pointer();
   }
+#endif
   return fexldr_ptr_libGL_glShaderSourceARB(a_0, count, sources, a_3);
 }
 

--- a/ThunkLibs/libGL/libGL_Host.cpp
+++ b/ThunkLibs/libGL/libGL_Host.cpp
@@ -291,9 +291,9 @@ void fexfn_impl_libGL_glShaderSourceARB(GLuint a_0, GLsizei count, guest_layout<
 // Relocate data to guest heap so it can be called with XFree.
 // The memory at the given host location will be de-allocated.
 template<typename T>
-T* RelocateArrayToGuestHeap(T* Data, int NumItems) {
+guest_layout<T*> RelocateArrayToGuestHeap(T* Data, int NumItems) {
   if (!Data) {
-    return nullptr;
+    return guest_layout<T*> {.data = 0};
   }
 
   guest_layout<T*> GuestData;
@@ -302,7 +302,7 @@ T* RelocateArrayToGuestHeap(T* Data, int NumItems) {
     GuestData.get_pointer()[Index] = to_guest(to_host_layout(Data[Index]));
   }
   x11_manager.HostXFree(Data);
-  return GuestData.force_get_host_pointer();
+  return GuestData;
 }
 
 // Maps to a host-side XVisualInfo, which must be XFree'ed by the caller.
@@ -350,12 +350,12 @@ static guest_layout<XVisualInfo*> MapToGuestVisualInfo(Display* HostDisplay, XVi
   return GuestRet;
 }
 
-GLXFBConfig* fexfn_impl_libGL_glXChooseFBConfig(Display* Display, int Screen, const int* Attributes, int* NumItems) {
+guest_layout<GLXFBConfig*> fexfn_impl_libGL_glXChooseFBConfig(Display* Display, int Screen, const int* Attributes, int* NumItems) {
   auto ret = fexldr_ptr_libGL_glXChooseFBConfig(Display, Screen, Attributes, NumItems);
   return RelocateArrayToGuestHeap(ret, *NumItems);
 }
 
-GLXFBConfigSGIX* fexfn_impl_libGL_glXChooseFBConfigSGIX(Display* Display, int Screen, int* Attributes, int* NumItems) {
+guest_layout<GLXFBConfigSGIX*> fexfn_impl_libGL_glXChooseFBConfigSGIX(Display* Display, int Screen, int* Attributes, int* NumItems) {
   auto ret = fexldr_ptr_libGL_glXChooseFBConfigSGIX(Display, Screen, Attributes, NumItems);
   return RelocateArrayToGuestHeap(ret, *NumItems);
 }
@@ -370,7 +370,7 @@ guest_layout<_XDisplay*> fexfn_impl_libGL_glXGetCurrentDisplayEXT() {
   return x11_manager.HostToGuestDisplay(ret);
 }
 
-GLXFBConfig* fexfn_impl_libGL_glXGetFBConfigs(Display* Display, int Screen, int* NumItems) {
+guest_layout<GLXFBConfig*> fexfn_impl_libGL_glXGetFBConfigs(Display* Display, int Screen, int* NumItems) {
   auto ret = fexldr_ptr_libGL_glXGetFBConfigs(Display, Screen, NumItems);
   return RelocateArrayToGuestHeap(ret, *NumItems);
 }

--- a/ThunkLibs/libGL/libGL_interface.cpp
+++ b/ThunkLibs/libGL/libGL_interface.cpp
@@ -74,7 +74,6 @@ struct fex_gen_config : fexgen::generate_guest_symtable, fexgen::indirect_guest_
 template<auto, int, typename = void>
 struct fex_gen_param {};
 
-#ifndef IS_32BIT_THUNK
 template<>
 struct fex_gen_config<glXQueryCurrentRendererStringMESA> {};
 template<>
@@ -135,8 +134,16 @@ template<>
 struct fex_gen_config<glXDestroyGLXPbufferSGIX> {};
 template<>
 struct fex_gen_config<glXFreeContextEXT> {};
+#ifndef IS_32BIT_THUNK
 template<>
 struct fex_gen_config<glXGetSelectedEventSGIX> {};
+#else
+template<>
+struct fex_gen_config<glXGetSelectedEventSGIX> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glXGetSelectedEventSGIX, 2, unsigned long*> : fexgen::ptr_passthrough {};
+#endif
+
 template<>
 struct fex_gen_config<glXQueryGLXPbufferSGIX> {};
 template<>
@@ -215,8 +222,15 @@ template<>
 struct fex_gen_config<glXDestroyWindow> {};
 template<>
 struct fex_gen_config<glXFreeMemoryNV> {};
+#ifndef IS_32BIT_THUNK
 template<>
 struct fex_gen_config<glXGetSelectedEvent> {};
+#else
+template<>
+struct fex_gen_config<glXGetSelectedEvent> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glXGetSelectedEvent, 2, unsigned long*> : fexgen::ptr_passthrough {};
+#endif
 template<>
 struct fex_gen_config<glXQueryDrawable> {};
 template<>
@@ -241,7 +255,6 @@ template<>
 struct fex_gen_config<glXCreateContextAttribsARB> {};
 template<>
 struct fex_gen_config<glXSwapIntervalEXT> {};
-#endif
 
 template<>
 struct fex_gen_config<glColorP3ui> {};
@@ -6352,7 +6365,6 @@ struct fex_gen_config<glGetPathTexGenfvNV> {};
 template<>
 struct fex_gen_config<glBlendEquationSeparateATI> {};
 
-#ifndef IS_32BIT_THUNK
 // glx.h
 template<>
 struct fex_gen_config<glXWaitX> {};
@@ -6428,8 +6440,11 @@ template<>
 struct fex_gen_config<glXResetFrameCountNV> {};
 template<>
 struct fex_gen_config<glXBindVideoCaptureDeviceNV> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glXEnumerateVideoCaptureDevicesNV> {};
+#endif
 template<>
 struct fex_gen_config<glXLockVideoCaptureDeviceNV> {};
 template<>
@@ -6444,10 +6459,13 @@ template<>
 struct fex_gen_config<glXBindVideoImageNV> {};
 template<>
 struct fex_gen_config<glXReleaseVideoImageNV> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glXSendPbufferToVideoNV> {};
 template<>
 struct fex_gen_config<glXGetVideoInfoNV> {};
+#endif
 template<>
 struct fex_gen_config<glXQueryHyperpipeNetworkSGIX> {};
 template<>
@@ -6482,6 +6500,8 @@ template<>
 struct fex_gen_config<glXChannelRectSyncSGIX> {};
 template<>
 struct fex_gen_config<glXCushionSGI> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glXGetTransparentIndexSUN> {};
 #endif

--- a/ThunkLibs/libGL/libGL_interface.cpp
+++ b/ThunkLibs/libGL/libGL_interface.cpp
@@ -70,9 +70,11 @@ namespace internal {
 template<auto>
 struct fex_gen_config : fexgen::generate_guest_symtable, fexgen::indirect_guest_calls {};
 
+// Function, parameter index, parameter type [optional]
 template<auto, int, typename = void>
 struct fex_gen_param {};
 
+#ifndef IS_32BIT_THUNK
 template<>
 struct fex_gen_config<glXQueryCurrentRendererStringMESA> {};
 template<>
@@ -239,6 +241,7 @@ template<>
 struct fex_gen_config<glXCreateContextAttribsARB> {};
 template<>
 struct fex_gen_config<glXSwapIntervalEXT> {};
+#endif
 
 template<>
 struct fex_gen_config<glColorP3ui> {};
@@ -667,7 +670,9 @@ struct fex_gen_config<glCreateShader> {};
 template<>
 struct fex_gen_config<glCreateShaderProgramEXT> {};
 template<>
-struct fex_gen_config<glCreateShaderProgramv> {};
+struct fex_gen_config<glCreateShaderProgramv> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glCreateShaderProgramv, 2, const GLchar* const*> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glGenAsyncMarkersSGIX> {};
 template<>
@@ -806,8 +811,17 @@ template<>
 struct fex_gen_config<glBindBufferRangeNV> {};
 template<>
 struct fex_gen_config<glBindBuffersBase> {};
+#ifndef IS_32BIT_THUNK
 template<>
 struct fex_gen_config<glBindBuffersRange> {};
+#else
+template<>
+struct fex_gen_config<glBindBuffersRange> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glBindBuffersRange, 4, const GLintptr*> : fexgen::ptr_passthrough {};
+template<>
+struct fex_gen_param<glBindBuffersRange, 5, const GLsizeiptr*> : fexgen::ptr_passthrough {};
+#endif
 template<>
 struct fex_gen_config<glBindFragDataLocationEXT> {};
 template<>
@@ -862,8 +876,15 @@ template<>
 struct fex_gen_config<glBindVertexArray> {};
 template<>
 struct fex_gen_config<glBindVertexBuffer> {};
+#ifndef IS_32BIT_THUNK
 template<>
 struct fex_gen_config<glBindVertexBuffers> {};
+#else
+template<>
+struct fex_gen_config<glBindVertexBuffers> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glBindVertexBuffers, 3, const GLintptr*> : fexgen::ptr_passthrough {};
+#endif
 template<>
 struct fex_gen_config<glBindVertexShaderEXT> {};
 template<>
@@ -1180,10 +1201,17 @@ template<>
 struct fex_gen_config<glColorPointerEXT> {};
 template<>
 struct fex_gen_config<glColorPointer> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glColorPointerListIBM> {};
 template<>
+struct fex_gen_param<glColorPointerListIBM, 3, const void**> : fexgen::assume_compatible_data_layout {};
+template<>
 struct fex_gen_config<glColorPointervINTEL> {};
+template<>
+struct fex_gen_param<glColorPointervINTEL, 2, const void**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glColorSubTableEXT> {};
 template<>
@@ -1225,7 +1253,9 @@ struct fex_gen_config<glCompileShaderARB> {};
 template<>
 struct fex_gen_config<glCompileShader> {};
 template<>
-struct fex_gen_config<glCompileShaderIncludeARB> {};
+struct fex_gen_config<glCompileShaderIncludeARB> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glCompileShaderIncludeARB, 2, const GLchar* const*> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glCompressedMultiTexImage1DEXT> {};
 template<>
@@ -1622,12 +1652,18 @@ template<>
 struct fex_gen_config<glDrawBuffers> {};
 template<>
 struct fex_gen_config<glDrawCommandsAddressNV> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glDrawCommandsNV> {};
+#endif
 template<>
 struct fex_gen_config<glDrawCommandsStatesAddressNV> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glDrawCommandsStatesNV> {};
+#endif
 template<>
 struct fex_gen_config<glDrawElementArrayAPPLE> {};
 template<>
@@ -1690,8 +1726,13 @@ template<>
 struct fex_gen_config<glEdgeFlagPointerEXT> {};
 template<>
 struct fex_gen_config<glEdgeFlagPointer> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glEdgeFlagPointerListIBM> {};
+template<>
+struct fex_gen_param<glEdgeFlagPointerListIBM, 1, const GLboolean**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glEdgeFlagv> {};
 template<>
@@ -1858,8 +1899,13 @@ template<>
 struct fex_gen_config<glFogCoordhvNV> {};
 template<>
 struct fex_gen_config<glFogCoordPointerEXT> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glFogCoordPointerListIBM> {};
+template<>
+struct fex_gen_param<glFogCoordPointerListIBM, 2, const void**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glFogf> {};
 template<>
@@ -2077,9 +2123,13 @@ struct fex_gen_config<glGetBufferParameteriv> {};
 template<>
 struct fex_gen_config<glGetBufferParameterui64vNV> {};
 template<>
-struct fex_gen_config<glGetBufferPointervARB> {};
+struct fex_gen_config<glGetBufferPointerv> : fexgen::custom_host_impl {};
 template<>
-struct fex_gen_config<glGetBufferPointerv> {};
+struct fex_gen_param<glGetBufferPointerv, 2, void**> : fexgen::ptr_passthrough {};
+template<>
+struct fex_gen_config<glGetBufferPointervARB> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glGetBufferPointervARB, 2, void**> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glGetBufferSubDataARB> {};
 template<>
@@ -2335,9 +2385,13 @@ struct fex_gen_config<glGetNamedBufferParameteriv> {};
 template<>
 struct fex_gen_config<glGetNamedBufferParameterui64vNV> {};
 template<>
-struct fex_gen_config<glGetNamedBufferPointervEXT> {};
+struct fex_gen_config<glGetNamedBufferPointerv> : fexgen::custom_host_impl {};
 template<>
-struct fex_gen_config<glGetNamedBufferPointerv> {};
+struct fex_gen_param<glGetNamedBufferPointerv, 2, void**> : fexgen::ptr_passthrough {};
+template<>
+struct fex_gen_config<glGetNamedBufferPointervEXT> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glGetNamedBufferPointervEXT, 2, void**> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glGetNamedBufferSubDataEXT> {};
 template<>
@@ -2452,8 +2506,11 @@ template<>
 struct fex_gen_config<glGetPerfMonitorGroupsAMD> {};
 template<>
 struct fex_gen_config<glGetPerfMonitorGroupStringAMD> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glGetPerfQueryDataINTEL> {};
+#endif
 template<>
 struct fex_gen_config<glGetPerfQueryIdByNameINTEL> {};
 template<>
@@ -2475,13 +2532,21 @@ struct fex_gen_config<glGetPixelTransformParameterfvEXT> {};
 template<>
 struct fex_gen_config<glGetPixelTransformParameterivEXT> {};
 template<>
-struct fex_gen_config<glGetPointerIndexedvEXT> {};
+struct fex_gen_config<glGetPointerv> : fexgen::custom_host_impl {};
 template<>
-struct fex_gen_config<glGetPointeri_vEXT> {};
+struct fex_gen_param<glGetPointerv, 1, void**> : fexgen::ptr_passthrough {};
 template<>
-struct fex_gen_config<glGetPointervEXT> {};
+struct fex_gen_config<glGetPointervEXT> : fexgen::custom_host_impl {};
 template<>
-struct fex_gen_config<glGetPointerv> {};
+struct fex_gen_param<glGetPointervEXT, 1, void**> : fexgen::ptr_passthrough {};
+template<>
+struct fex_gen_config<glGetPointeri_vEXT> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glGetPointeri_vEXT, 2, void**> : fexgen::ptr_passthrough {};
+template<>
+struct fex_gen_config<glGetPointerIndexedvEXT> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glGetPointerIndexedvEXT, 2, void**> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glGetPolygonStipple> {};
 template<>
@@ -2644,8 +2709,13 @@ template<>
 struct fex_gen_config<glGetTexParameterIuiv> {};
 template<>
 struct fex_gen_config<glGetTexParameteriv> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glGetTexParameterPointervAPPLE> {};
+template<>
+struct fex_gen_param<glGetTexParameterPointervAPPLE, 2, void**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glGetTexParameterxvOES> {};
 template<>
@@ -2702,8 +2772,17 @@ template<>
 struct fex_gen_config<glGetUniformi64vARB> {};
 template<>
 struct fex_gen_config<glGetUniformi64vNV> {};
+#ifndef IS_32BIT_THUNK
 template<>
 struct fex_gen_config<glGetUniformIndices> {};
+template<>
+struct fex_gen_param<glGetUniformIndices, 2, const char* const*> : fexgen::assume_compatible_data_layout {};
+#else
+template<>
+struct fex_gen_config<glGetUniformIndices> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glGetUniformIndices, 2, const char* const*> : fexgen::ptr_passthrough {};
+#endif
 template<>
 struct fex_gen_config<glGetUniformivARB> {};
 template<>
@@ -2733,7 +2812,9 @@ struct fex_gen_config<glGetVariantFloatvEXT> {};
 template<>
 struct fex_gen_config<glGetVariantIntegervEXT> {};
 template<>
-struct fex_gen_config<glGetVariantPointervEXT> {};
+struct fex_gen_config<glGetVariantPointervEXT> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glGetVariantPointervEXT, 2, void**> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glGetVertexArrayIndexed64iv> {};
 template<>
@@ -2745,9 +2826,13 @@ struct fex_gen_config<glGetVertexArrayIntegervEXT> {};
 template<>
 struct fex_gen_config<glGetVertexArrayiv> {};
 template<>
-struct fex_gen_config<glGetVertexArrayPointeri_vEXT> {};
+struct fex_gen_config<glGetVertexArrayPointeri_vEXT> : fexgen::custom_host_impl {};
 template<>
-struct fex_gen_config<glGetVertexArrayPointervEXT> {};
+struct fex_gen_param<glGetVertexArrayPointeri_vEXT, 3, void**> : fexgen::ptr_passthrough {};
+template<>
+struct fex_gen_config<glGetVertexArrayPointervEXT> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glGetVertexArrayPointervEXT, 2, void**> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glGetVertexAttribArrayObjectfvATI> {};
 template<>
@@ -2789,11 +2874,17 @@ struct fex_gen_config<glGetVertexAttribLui64vARB> {};
 template<>
 struct fex_gen_config<glGetVertexAttribLui64vNV> {};
 template<>
-struct fex_gen_config<glGetVertexAttribPointervARB> {};
+struct fex_gen_config<glGetVertexAttribPointervARB> : fexgen::custom_host_impl {};
 template<>
-struct fex_gen_config<glGetVertexAttribPointerv> {};
+struct fex_gen_param<glGetVertexAttribPointervARB, 2, void**> : fexgen::ptr_passthrough {};
 template<>
-struct fex_gen_config<glGetVertexAttribPointervNV> {};
+struct fex_gen_config<glGetVertexAttribPointerv> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glGetVertexAttribPointerv, 2, void**> : fexgen::ptr_passthrough {};
+template<>
+struct fex_gen_config<glGetVertexAttribPointervNV> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glGetVertexAttribPointervNV, 2, void**> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glGetVideoCaptureivNV> {};
 template<>
@@ -2880,8 +2971,13 @@ template<>
 struct fex_gen_config<glIndexPointerEXT> {};
 template<>
 struct fex_gen_config<glIndexPointer> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glIndexPointerListIBM> {};
+template<>
+struct fex_gen_param<glIndexPointerListIBM, 2, const void**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glIndexs> {};
 template<>
@@ -2968,8 +3064,13 @@ template<>
 struct fex_gen_config<glLinkProgram> {};
 template<>
 struct fex_gen_config<glListBase> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glListDrawCommandsStatesClientNV> {};
+template<>
+struct fex_gen_param<glListDrawCommandsStatesClientNV, 2, const void**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glListParameterfSGIX> {};
 template<>
@@ -3224,12 +3325,22 @@ template<>
 struct fex_gen_config<glMultiDrawArraysIndirect> {};
 template<>
 struct fex_gen_config<glMultiDrawElementArrayAPPLE> {};
+#ifndef IS_32BIT_THUNK
+// Needs manual handling: The type of this is actually int8_t**, int16_t**, or int32_t**, depending on the "type" argument
+// TODO: Do these values get copied or do they have to stay valid past the call?
 template<>
 struct fex_gen_config<glMultiDrawElementsBaseVertex> {};
 template<>
+struct fex_gen_param<glMultiDrawElementsBaseVertex, 3, const void* const*> : fexgen::assume_compatible_data_layout {};
+template<>
 struct fex_gen_config<glMultiDrawElementsEXT> {};
 template<>
+struct fex_gen_param<glMultiDrawElementsEXT, 3, const void* const*> : fexgen::assume_compatible_data_layout {};
+template<>
 struct fex_gen_config<glMultiDrawElements> {};
+template<>
+struct fex_gen_param<glMultiDrawElements, 3, const void* const*> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glMultiDrawElementsIndirectAMD> {};
 template<>
@@ -3250,8 +3361,13 @@ template<>
 struct fex_gen_config<glMultiDrawRangeElementArrayAPPLE> {};
 template<>
 struct fex_gen_config<glMultiModeDrawArraysIBM> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glMultiModeDrawElementsIBM> {};
+template<>
+struct fex_gen_param<glMultiModeDrawElementsIBM, 3, const void* const*> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glMultiTexBufferEXT> {};
 template<>
@@ -3632,10 +3748,17 @@ template<>
 struct fex_gen_config<glNormalPointerEXT> {};
 template<>
 struct fex_gen_config<glNormalPointer> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glNormalPointerListIBM> {};
 template<>
+struct fex_gen_param<glNormalPointerListIBM, 2, const void**> : fexgen::assume_compatible_data_layout {};
+template<>
 struct fex_gen_config<glNormalPointervINTEL> {};
+template<>
+struct fex_gen_param<glNormalPointervINTEL, 1, const void**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glNormalStream3bATI> {};
 template<>
@@ -4328,8 +4451,13 @@ template<>
 struct fex_gen_config<glRenderbufferStorageMultisample> {};
 template<>
 struct fex_gen_config<glRenderGpuMaskNV> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glReplacementCodePointerSUN> {};
+template<>
+struct fex_gen_param<glReplacementCodePointerSUN, 2, const void**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glReplacementCodeubSUN> {};
 template<>
@@ -4488,8 +4616,13 @@ template<>
 struct fex_gen_config<glSecondaryColorFormatNV> {};
 template<>
 struct fex_gen_config<glSecondaryColorPointerEXT> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glSecondaryColorPointerListIBM> {};
+template<>
+struct fex_gen_param<glSecondaryColorPointerListIBM, 3, const void**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glSelectBuffer> {};
 template<>
@@ -4523,9 +4656,13 @@ struct fex_gen_config<glShaderOp2EXT> {};
 template<>
 struct fex_gen_config<glShaderOp3EXT> {};
 template<>
-struct fex_gen_config<glShaderSourceARB> {};
+struct fex_gen_config<glShaderSource> : fexgen::custom_host_impl {};
 template<>
-struct fex_gen_config<glShaderSource> {};
+struct fex_gen_param<glShaderSource, 2, const GLchar* const*> : fexgen::ptr_passthrough {};
+template<>
+struct fex_gen_config<glShaderSourceARB> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glShaderSourceARB, 2, const GLcharARB**> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glShaderStorageBlockBinding> {};
 template<>
@@ -4798,10 +4935,17 @@ template<>
 struct fex_gen_config<glTexCoordPointerEXT> {};
 template<>
 struct fex_gen_config<glTexCoordPointer> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glTexCoordPointerListIBM> {};
 template<>
+struct fex_gen_param<glTexCoordPointerListIBM, 3, const void**> : fexgen::assume_compatible_data_layout {};
+template<>
 struct fex_gen_config<glTexCoordPointervINTEL> {};
+template<>
+struct fex_gen_param<glTexCoordPointervINTEL, 2, const void**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glTexEnvf> {};
 template<>
@@ -4972,8 +5116,11 @@ template<>
 struct fex_gen_config<glTextureParameterivEXT> {};
 template<>
 struct fex_gen_config<glTextureParameteriv> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glTextureRangeAPPLE> {};
+#endif
 template<>
 struct fex_gen_config<glTextureRenderbufferEXT> {};
 template<>
@@ -5032,10 +5179,17 @@ template<>
 struct fex_gen_config<glTransformFeedbackBufferRange> {};
 template<>
 struct fex_gen_config<glTransformFeedbackStreamAttribsNV> {};
+#ifndef IS_32BIT_THUNK
+// TODO
 template<>
 struct fex_gen_config<glTransformFeedbackVaryingsEXT> {};
 template<>
+struct fex_gen_param<glTransformFeedbackVaryingsEXT, 2, const char* const*> : fexgen::assume_compatible_data_layout {};
+template<>
 struct fex_gen_config<glTransformFeedbackVaryings> {};
+template<>
+struct fex_gen_param<glTransformFeedbackVaryings, 2, const char* const*> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glTransformFeedbackVaryingsNV> {};
 template<>
@@ -5288,8 +5442,11 @@ template<>
 struct fex_gen_config<glUnmapObjectBufferATI> {};
 template<>
 struct fex_gen_config<glUnmapTexture2DINTEL> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glUpdateObjectBufferATI> {};
+#endif
 template<>
 struct fex_gen_config<glUploadGpuMaskNVX> {};
 template<>
@@ -5332,12 +5489,18 @@ template<>
 struct fex_gen_config<glVDPAUGetSurfaceivNV> {};
 template<>
 struct fex_gen_config<glVDPAUInitNV> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glVDPAUMapSurfacesNV> {};
+#endif
 template<>
 struct fex_gen_config<glVDPAUSurfaceAccessNV> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glVDPAUUnmapSurfacesNV> {};
+#endif
 template<>
 struct fex_gen_config<glVDPAUUnregisterSurfaceNV> {};
 template<>
@@ -5454,8 +5617,11 @@ template<>
 struct fex_gen_config<glVertexArrayParameteriAPPLE> {};
 template<>
 struct fex_gen_config<glVertexArrayRangeAPPLE> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glVertexArrayRangeNV> {};
+#endif
 template<>
 struct fex_gen_config<glVertexArraySecondaryColorOffsetEXT> {};
 template<>
@@ -5480,8 +5646,15 @@ template<>
 struct fex_gen_config<glVertexArrayVertexBindingDivisorEXT> {};
 template<>
 struct fex_gen_config<glVertexArrayVertexBuffer> {};
+#ifndef IS_32BIT_THUNK
 template<>
 struct fex_gen_config<glVertexArrayVertexBuffers> {};
+#else
+template<>
+struct fex_gen_config<glVertexArrayVertexBuffers> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glVertexArrayVertexBuffers, 4, const GLintptr*> : fexgen::ptr_passthrough {};
+#endif
 template<>
 struct fex_gen_config<glVertexArrayVertexOffsetEXT> {};
 template<>
@@ -5944,10 +6117,17 @@ template<>
 struct fex_gen_config<glVertexPointerEXT> {};
 template<>
 struct fex_gen_config<glVertexPointer> {};
+#ifndef IS_32BIT_THUNK
+// TODO: 32-bit support
 template<>
 struct fex_gen_config<glVertexPointerListIBM> {};
 template<>
+struct fex_gen_param<glVertexPointerListIBM, 3, const void**> : fexgen::assume_compatible_data_layout {};
+template<>
 struct fex_gen_config<glVertexPointervINTEL> {};
+template<>
+struct fex_gen_param<glVertexPointervINTEL, 2, const void**> : fexgen::assume_compatible_data_layout {};
+#endif
 template<>
 struct fex_gen_config<glVertexStream1dATI> {};
 template<>
@@ -6172,6 +6352,7 @@ struct fex_gen_config<glGetPathTexGenfvNV> {};
 template<>
 struct fex_gen_config<glBlendEquationSeparateATI> {};
 
+#ifndef IS_32BIT_THUNK
 // glx.h
 template<>
 struct fex_gen_config<glXWaitX> {};
@@ -6303,4 +6484,5 @@ template<>
 struct fex_gen_config<glXCushionSGI> {};
 template<>
 struct fex_gen_config<glXGetTransparentIndexSUN> {};
+#endif
 } // namespace internal

--- a/ThunkLibs/libGL/libGL_interface.cpp
+++ b/ThunkLibs/libGL/libGL_interface.cpp
@@ -38,6 +38,11 @@ struct fex_gen_config<SetGuestXDisplayString> : fexgen::custom_guest_entrypoint,
 template<typename>
 struct fex_gen_type {};
 
+// Assume void* always points to data with consistent layout.
+// It's used in too many functions to annotate them all.
+template<>
+struct fex_gen_type<void> : fexgen::opaque_type {};
+
 template<>
 struct fex_gen_type<std::remove_pointer_t<GLXContext>> : fexgen::opaque_type {};
 template<>

--- a/ThunkLibs/libGL/libGL_interface.cpp
+++ b/ThunkLibs/libGL/libGL_interface.cpp
@@ -45,6 +45,10 @@ struct fex_gen_type<void> : fexgen::opaque_type {};
 
 template<>
 struct fex_gen_type<std::remove_pointer_t<GLXContext>> : fexgen::opaque_type {};
+// NOTE: The data layout of this is almost the same between 64-bit and 32-bit,
+//       but the total struct size is 4 bytes larger on 64-bit due to stricter
+//       alignment requirements (8 vs 4 bytes). Since it's always allocated on
+//       the host *and* never directly used in arrays, this is not a problem.
 template<>
 struct fex_gen_type<std::remove_pointer_t<GLXFBConfig>> : fexgen::opaque_type {};
 template<>
@@ -88,6 +92,8 @@ template<>
 struct fex_gen_config<glXGetCurrentReadDrawableSGI> {};
 template<>
 struct fex_gen_config<glXChooseFBConfigSGIX> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glXChooseFBConfigSGIX, -1, GLXFBConfigSGIX*> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glXGetFBConfigFromVisualSGIX> : fexgen::custom_host_impl {};
 template<>
@@ -179,7 +185,11 @@ struct fex_gen_config<glXGetCurrentReadDrawable> {};
 template<>
 struct fex_gen_config<glXChooseFBConfig> : fexgen::custom_host_impl {};
 template<>
+struct fex_gen_param<glXChooseFBConfig, -1, GLXFBConfig*> : fexgen::ptr_passthrough {};
+template<>
 struct fex_gen_config<glXGetFBConfigs> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glXGetFBConfigs, -1, GLXFBConfig*> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glXCreatePbuffer> {};
 template<>

--- a/ThunkLibs/libGL/libGL_interface.cpp
+++ b/ThunkLibs/libGL/libGL_interface.cpp
@@ -161,7 +161,9 @@ struct fex_gen_config<glXQueryExtensionsString> {};
 template<>
 struct fex_gen_config<glXQueryServerString> {};
 template<>
-struct fex_gen_config<glXGetCurrentDisplay> {};
+struct fex_gen_config<glXGetCurrentDisplay> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glXGetCurrentDisplay, -1, _XDisplay*> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glXCreateContext> : fexgen::custom_host_impl {};
 template<>
@@ -6403,7 +6405,9 @@ struct fex_gen_config<glXGetCurrentAssociatedContextAMD> {};
 template<>
 struct fex_gen_config<glXBlitContextFramebufferAMD> {};
 template<>
-struct fex_gen_config<glXGetCurrentDisplayEXT> {};
+struct fex_gen_config<glXGetCurrentDisplayEXT> : fexgen::custom_host_impl {};
+template<>
+struct fex_gen_param<glXGetCurrentDisplayEXT, -1, _XDisplay*> : fexgen::ptr_passthrough {};
 template<>
 struct fex_gen_config<glXGetAGPOffsetMESA> {};
 template<>


### PR DESCRIPTION
## Overview

This PR adds support for forwarding the overwhelming majority of the OpenGL API to the host driver for 32-bit applications. Previously, this was exclusively possible for 64-bit titles.

This work is enabled by #3584, thanks to which forwarding OpenGL calls to the host does not require forwarding libX11 calls anymore. We can now tick off the last critical box in the [Library Forwarding Roadmap](https://gist.github.com/neobrain/3812c111a2da57bfd8376dd21d61a886):
|                          | X11 (64-bit) | Wayland (64-bit) | Wayland (32-bit) | X11 (32-bit) |
| ------------------------ | ------------ | ---------------- | ---------------- |------------- |
| no forwarding            | ☑️ 2022      | ☑️ 2022         | ☑️ 2022          | ☑️ 2022      |
| only Wayland forwarding  | N/A          | ☑️ Phase 1      | ☑️ Phase 3          | N/A           |
| Vulkan               | ☑️ 2022      | ☑️ Phase 1      | ☑️ Phase 4          | Phase 7       |
| zink on Vulkan       | ☑️ Phase 2   | ☑️ Phase 2      | Phase 4          | Phase 7       |
| OpenGL               | ☑️ 2022      | Phase 5         | Phase 6          | ✅ Phase 7       |

That leaves only 32-bit Vulkan applications and OpenGL-on-Wayland unsupported. The former is barely used in the wild, and the latter is also still uncommon in practice. (Note that due to putting #3487 on hold, the phase numbering is off)

## Implementation

`thunkgen` has caught all APIs that are problematic with regards to 32-bit support:
* Pointers to `size_t`/`intptr_t` (only in-parameters)
* `char**` (only in-parameters)
* `void**` (only out-parameters)

The first two cases are handled by relocating the data element-by-element (onto the stack). The last case only occurs in APIs that write a single pointer to a user-provided destination and is easily handled without overhead.

Other errors raised by `thunkgen` refer to unannotated `void*` pointers. Since these are very common in the OpenGL API but always refer to data of consistent layout, an escape hatch is added to ignore errors from `void*` specifically.

## Limitations

A small number of vendor-specific functions is currently not implemented on 32-bit, simply because exhaustively doing so is tedious busy-work that I couldn't verify the results of for lack of corresponding hardware. If individual functions are considered critical, adding support for them should be easy though.

## Testing

I only have few 32-bit OpenGL applications in my library, so further testing will be needed in addition to these 

* ✅ 7 Billion Humans
* ✅ Dandara: Trials of Fear Edition
* ✅ Enter the Gungeon
* ✅ FTL
* ✅ Super Meat Boy
* ✅ World of Goo
* ✅ Xonotic (both GLX/SDL builds)

Testing round 2:
* ✅ Portal (native)
* ✅ Half Life 2 (native)

Testing round 3:
* ✅ FEZ (wined3d)
* ✅ Floating Point (wined3d)
* ✅ Magicka 2 (wined3d)
* ✅ Mirror's Edge (wined3d)
* ✅ Portal (native, wined3d)
* ✅ Portal 2 (native, wined3d)
* ✅ Psychonauts (native)

## TODO

* [x] Drop void* pointer automation (or make it specific to libGL)
* [x] Relocate double-pointers only for 32-bit applications
* [x] Reconsider whether `alloca` is suitable in all instances (should be fine, since the `count` parameters should never be huge)
* [x] Testing
* [x] Tidy up commit history

