### PR TITLE
JIT/VectorOps: deduplicate common implementations

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -101,39 +101,13 @@ DEF_OP(Jump) {
   PendingTargetLabel = &JumpTargets.try_emplace(Target).first->second;
 }
 
-static ARMEmitter::Condition MapBranchCC(IR::CondClassType Cond) {
-  switch (Cond.Val) {
-  case FEXCore::IR::COND_EQ: return ARMEmitter::Condition::CC_EQ;
-  case FEXCore::IR::COND_NEQ: return ARMEmitter::Condition::CC_NE;
-  case FEXCore::IR::COND_SGE: return ARMEmitter::Condition::CC_GE;
-  case FEXCore::IR::COND_SLT: return ARMEmitter::Condition::CC_LT;
-  case FEXCore::IR::COND_SGT: return ARMEmitter::Condition::CC_GT;
-  case FEXCore::IR::COND_SLE: return ARMEmitter::Condition::CC_LE;
-  case FEXCore::IR::COND_UGE: return ARMEmitter::Condition::CC_CS;
-  case FEXCore::IR::COND_ULT: return ARMEmitter::Condition::CC_CC;
-  case FEXCore::IR::COND_UGT: return ARMEmitter::Condition::CC_HI;
-  case FEXCore::IR::COND_ULE: return ARMEmitter::Condition::CC_LS;
-  case FEXCore::IR::COND_FLU: return ARMEmitter::Condition::CC_LT;
-  case FEXCore::IR::COND_FGE: return ARMEmitter::Condition::CC_GE;
-  case FEXCore::IR::COND_FLEU: return ARMEmitter::Condition::CC_LE;
-  case FEXCore::IR::COND_FGT: return ARMEmitter::Condition::CC_GT;
-  case FEXCore::IR::COND_FU: return ARMEmitter::Condition::CC_VS;
-  case FEXCore::IR::COND_FNU: return ARMEmitter::Condition::CC_VC;
-  case FEXCore::IR::COND_VS:
-  case FEXCore::IR::COND_VC:
-  case FEXCore::IR::COND_MI: return ARMEmitter::Condition::CC_MI;
-  case FEXCore::IR::COND_PL: return ARMEmitter::Condition::CC_PL;
-  default: LOGMAN_MSG_A_FMT("Unsupported compare type"); return ARMEmitter::Condition::CC_NV;
-  }
-}
-
 DEF_OP(CondJump) {
   auto Op = IROp->C<IR::IROp_CondJump>();
 
   auto TrueTargetLabel = &JumpTargets.try_emplace(Op->TrueBlock.ID()).first->second;
 
   if (Op->FromNZCV) {
-    b(MapBranchCC(Op->Cond), TrueTargetLabel);
+    b(MapCC(Op->Cond), TrueTargetLabel);
   } else {
     [[maybe_unused]] uint64_t Const;
     [[maybe_unused]] const bool isConst = IsInlineConstant(Op->Cmp2, &Const);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -222,6 +222,33 @@ private:
   }
 
   [[nodiscard]]
+  ARMEmitter::Condition MapCC(IR::CondClassType Cond) {
+    switch (Cond.Val) {
+    case FEXCore::IR::COND_EQ: return ARMEmitter::Condition::CC_EQ;
+    case FEXCore::IR::COND_NEQ: return ARMEmitter::Condition::CC_NE;
+    case FEXCore::IR::COND_SGE: return ARMEmitter::Condition::CC_GE;
+    case FEXCore::IR::COND_SLT: return ARMEmitter::Condition::CC_LT;
+    case FEXCore::IR::COND_SGT: return ARMEmitter::Condition::CC_GT;
+    case FEXCore::IR::COND_SLE: return ARMEmitter::Condition::CC_LE;
+    case FEXCore::IR::COND_UGE: return ARMEmitter::Condition::CC_CS;
+    case FEXCore::IR::COND_ULT: return ARMEmitter::Condition::CC_CC;
+    case FEXCore::IR::COND_UGT: return ARMEmitter::Condition::CC_HI;
+    case FEXCore::IR::COND_ULE: return ARMEmitter::Condition::CC_LS;
+    case FEXCore::IR::COND_FLU: return ARMEmitter::Condition::CC_LT;
+    case FEXCore::IR::COND_FGE: return ARMEmitter::Condition::CC_GE;
+    case FEXCore::IR::COND_FLEU: return ARMEmitter::Condition::CC_LE;
+    case FEXCore::IR::COND_FGT: return ARMEmitter::Condition::CC_GT;
+    case FEXCore::IR::COND_FU: return ARMEmitter::Condition::CC_VS;
+    case FEXCore::IR::COND_FNU: return ARMEmitter::Condition::CC_VC;
+    case FEXCore::IR::COND_VS:
+    case FEXCore::IR::COND_VC:
+    case FEXCore::IR::COND_MI: return ARMEmitter::Condition::CC_MI;
+    case FEXCore::IR::COND_PL: return ARMEmitter::Condition::CC_PL;
+    default: LOGMAN_MSG_A_FMT("Unsupported compare type"); return ARMEmitter::Condition::CC_NV;
+    }
+  }
+
+  [[nodiscard]]
   bool IsFPR(IR::NodeID Node) const;
   [[nodiscard]]
   bool IsGPR(IR::NodeID Node) const;


### PR DESCRIPTION
Part of my project to clean up FEXCore in prep. for IR go-fast