### PR TITLE
FEXLoader: Cleanup FD extraction from environment variables

### DIFF
--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -38,8 +38,8 @@ struct ApplicationNames {
  *
  * @return The application name and path structure
  */
-ApplicationNames LoadConfig(bool NoFEXArguments, bool LoadProgramConfig, int argc, char** argv, char** const envp, bool ExecFDInterp,
-                            const std::string_view ProgramFDFromEnv);
+ApplicationNames
+LoadConfig(bool NoFEXArguments, bool LoadProgramConfig, int argc, char** argv, char** const envp, bool ExecFDInterp, int ProgramFDFromEnv);
 
 const char* GetHomeDirectory();
 

--- a/Source/Tools/FEXLoader/ELFCodeLoader.h
+++ b/Source/Tools/FEXLoader/ELFCodeLoader.h
@@ -231,7 +231,7 @@ public:
 
   fextl::vector<LoadedSection> Sections;
 
-  ELFCodeLoader(const fextl::string& Filename, const std::string_view FEXFDString, const fextl::string& RootFS,
+  ELFCodeLoader(const fextl::string& Filename, int ProgramFDFromEnv, const fextl::string& RootFS,
                 [[maybe_unused]] const fextl::vector<fextl::string>& args, const fextl::vector<fextl::string>& ParsedArgs,
                 char** const envp = nullptr, FEXCore::Config::Value<fextl::string>* AdditionalEnvp = nullptr)
     : Args {args} {
@@ -239,16 +239,9 @@ public:
     bool LoadedWithFD = false;
     int FD = getauxval(AT_EXECFD);
 
-    if (!FEXFDString.empty()) {
+    if (ProgramFDFromEnv != -1) {
       // If we passed the execve FD to us then use that.
-      const char* StartPtr = FEXFDString.data();
-      char* EndPtr {};
-      FD = ::strtol(StartPtr, &EndPtr, 10);
-      if (EndPtr == StartPtr) {
-        LogMan::Msg::AFmt("FEXInterpreter passed invalid FD to exececute: {}", FEXFDString);
-        return;
-      }
-      unsetenv("FEX_EXECVEFD");
+      FD = ProgramFDFromEnv;
     }
 
     // If we are provided an EXECFD then attempt to execute that first


### PR DESCRIPTION
In preparation for seccomp execve inheritance where we need to extract another FD from a different environment variable.

- Small function to extract the FD and also unset the environment variable in the same place.
   - Keeping the fetch and unset together instead of spreading to another location in the source.
- Extract the FD upfront instead of passing the string_view around, since we are unsetting the environment variable at the same place.

Future seccomp inheritance will get the FD just after the FEXFD
   - `int FEXSeccompFD {GetFEXFDFromEnv("FEX_SECCOMPFD")};`