### PR TITLE
AOTIR: Refactor interfaces to clarify ownership flow

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -57,6 +57,7 @@ namespace HLE {
 
 namespace FEXCore::IR {
 class RegisterAllocationData;
+struct IRListCopy;
 class IRListView;
 namespace Validation {
   class IRValidation;
@@ -290,8 +291,7 @@ public:
   void RemoveCustomIREntrypoint(uintptr_t Entrypoint);
 
   struct GenerateIRResult {
-    FEXCore::IR::IRListView* IRList;
-    FEXCore::IR::RegisterAllocationData::UniquePtr RAData;
+    fextl::unique_ptr<FEXCore::IR::IRStorageBase> IR;
     uint64_t TotalInstructions;
     uint64_t TotalInstructionsLength;
     uint64_t StartAddr;
@@ -302,9 +302,8 @@ public:
 
   struct CompileCodeResult {
     void* CompiledCode;
-    FEXCore::IR::IRListView* IRData;
+    fextl::unique_ptr<FEXCore::IR::IRStorageBase> IR;
     FEXCore::Core::DebugData* DebugData;
-    FEXCore::IR::RegisterAllocationData::UniquePtr RAData;
     bool GeneratedIR;
     uint64_t StartAddr;
     uint64_t Length;

--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -140,7 +140,7 @@ namespace CPU {
      */
     [[nodiscard]]
     virtual CompiledCode CompileCode(uint64_t Entry, const FEXCore::IR::IRListView* IR, FEXCore::Core::DebugData* DebugData,
-                                     FEXCore::IR::RegisterAllocationData* RAData) = 0;
+                                     const FEXCore::IR::RegisterAllocationData* RAData) = 0;
 
     /**
      * @brief Relocates a block of code from the JIT code object cache

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -650,7 +650,6 @@ ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalT
   FEXCore::IR::IRListView* IRList {};
   FEXCore::Core::DebugData* DebugData {};
   FEXCore::IR::RegisterAllocationData::UniquePtr RAData {};
-  bool GeneratedIR {};
   uint64_t StartAddr {};
   uint64_t Length {};
 
@@ -690,7 +689,6 @@ ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalT
       DebugData = IRFromAOT->DebugData;
       StartAddr = IRFromAOT->StartAddr;
       Length = IRFromAOT->Length;
-      GeneratedIR = true;
     }
   }
 
@@ -705,9 +703,6 @@ ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalT
     DebugData = new FEXCore::Core::DebugData();
     StartAddr = _StartAddr;
     Length = _Length;
-
-    // These blocks aren't already in the cache
-    GeneratedIR = true;
   }
 
   if (IRList == nullptr) {
@@ -722,7 +717,7 @@ ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalT
     .IRData = IRList,
     .DebugData = DebugData,
     .RAData = std::move(RAData),
-    .GeneratedIR = GeneratedIR,
+    .GeneratedIR = true,
     .StartAddr = StartAddr,
     .Length = Length,
   };

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -682,15 +682,15 @@ ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalT
 
   // AOT IR bookkeeping and cache
   {
-    auto [IRCopy, RACopy, DebugDataCopy, _StartAddr, _Length, _GeneratedIR] = IRCaptureCache.PreGenerateIRFetch(Thread, GuestRIP, IRList);
-    if (_GeneratedIR) {
+    auto IRFromAOT = IRCaptureCache.PreGenerateIRFetch(Thread, GuestRIP, IRList);
+    if (IRFromAOT) {
       // Setup pointers to internal structures
-      IRList = IRCopy;
-      RAData = std::move(RACopy);
-      DebugData = DebugDataCopy;
-      StartAddr = _StartAddr;
-      Length = _Length;
-      GeneratedIR = _GeneratedIR;
+      IRList = IRFromAOT->IRList;
+      RAData = std::move(IRFromAOT->RAData);
+      DebugData = IRFromAOT->DebugData;
+      StartAddr = IRFromAOT->StartAddr;
+      Length = IRFromAOT->Length;
+      GeneratedIR = true;
     }
   }
 

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -468,6 +468,40 @@ static void IRDumper(FEXCore::Core::InternalThreadState* Thread, IR::IREmitter* 
   fextl::fmt::print(FD, "IR-ShouldDump-{} 0x{:x}:\n{}\n@@@@@\n", RA ? "post" : "pre", GuestRIP, out.str());
 };
 
+// IRStorageBase with fully owned memory
+struct IRListCopy : public IR::IRStorageBase {
+  std::span<std::byte> IRData;
+  std::span<std::byte> ListData;
+
+  // TODO: Consider defaulting to empty RAData instead?
+  IR::RegisterAllocationData::UniquePtr RADataInternal;
+
+  IRListCopy(const IR::IRListView& view, IR::RegisterAllocationData::UniquePtr RAData)
+    : RADataInternal(std::move(RAData)) {
+    std::byte* Storage = reinterpret_cast<std::byte*>(FEXCore::Allocator::malloc(view.GetDataSize() + view.GetListSize()));
+
+    IRData = {Storage, Storage + view.GetDataSize()};
+    ListData = {Storage + view.GetDataSize(), Storage + view.GetDataSize() + view.GetListSize()};
+    memcpy(IRData.data(), (char*)view.GetData(), IRData.size());
+    memcpy(ListData.data(), (char*)view.GetListData(), ListData.size());
+  }
+
+  IRListCopy(const IRListCopy& other) = delete;
+  IRListCopy(IRListCopy&& other) = delete;
+
+  ~IRListCopy() {
+    FEXCore::Allocator::free(IRData.data());
+  }
+
+  const IR::RegisterAllocationData* RAData() override {
+    return RADataInternal.get();
+  }
+  IR::IRListView GetIRView() override {
+    return IR::IRListView {IRData.data(), ListData.data(), IRData.size(), ListData.size()};
+  }
+};
+
+
 ContextImpl::GenerateIRResult
 ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, bool ExtendedDebugInfo, uint64_t MaxInst) {
   FEXCORE_PROFILE_SCOPED("GenerateIR");
@@ -590,7 +624,7 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
         if (HadDispatchError && TotalInstructions == 0) {
           // Couldn't handle any instruction in op dispatcher
           Thread->OpDispatcher->ResetWorkingList();
-          return {nullptr, nullptr, 0, 0, 0, 0};
+          return {nullptr, 0, 0, 0, 0};
         }
 
         if (NeedsBlockEnd) {
@@ -632,13 +666,12 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
   }
 
   auto RAData = Thread->PassManager->HasPass("RA") ? Thread->PassManager->GetPass<IR::RegisterAllocationPass>("RA")->PullAllocationData() : nullptr;
-  auto IRList = IREmitter->CreateIRCopy();
+  auto IRList = fextl::make_unique<IRListCopy>(IREmitter->ViewIR(), std::move(RAData));
 
   IREmitter->DelayedDisownBuffer();
 
   return {
-    .IRList = IRList,
-    .RAData = std::move(RAData),
+    .IR = std::move(IRList),
     .TotalInstructions = TotalInstructions,
     .TotalInstructionsLength = TotalInstructionsLength,
     .StartAddr = Thread->FrontendDecoder->DecodedMinAddress,
@@ -647,12 +680,6 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
 }
 
 ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, uint64_t MaxInst) {
-  FEXCore::IR::IRListView* IRList {};
-  FEXCore::Core::DebugData* DebugData {};
-  FEXCore::IR::RegisterAllocationData::UniquePtr RAData {};
-  uint64_t StartAddr {};
-  uint64_t Length {};
-
   // JIT Code object cache lookup
   if (CodeObjectCacheService) {
     auto CodeCacheEntry = CodeObjectCacheService->FetchCodeObjectFromCache(GuestRIP);
@@ -661,9 +688,8 @@ ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalT
       if (CompiledCode) {
         return {
           .CompiledCode = CompiledCode,
-          .IRData = nullptr,    // No IR data generated
+          .IR = nullptr,        // No IR/RA data generated
           .DebugData = nullptr, // nullptr here ensures that code serialization doesn't occur on from cache read
-          .RAData = nullptr,    // No RA data generated
           .GeneratedIR = false, // nullptr here ensures IR cache mechanisms won't run
           .StartAddr = 0,       // Unused
           .Length = 0,          // Unused
@@ -679,44 +705,46 @@ ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalT
     }
   }
 
+  fextl::unique_ptr<FEXCore::IR::IRStorageBase> IR;
+  FEXCore::Core::DebugData* DebugData {};
+  uint64_t StartAddr {};
+  uint64_t Length {};
+
   // AOT IR bookkeeping and cache
   {
     auto IRFromAOT = IRCaptureCache.PreGenerateIRFetch(Thread, GuestRIP);
     if (IRFromAOT) {
       // Setup pointers to internal structures
-      IRList = IRFromAOT->IRList;
-      RAData = std::move(IRFromAOT->RAData);
+      IR = std::move(IRFromAOT->IR);
       DebugData = IRFromAOT->DebugData;
       StartAddr = IRFromAOT->StartAddr;
       Length = IRFromAOT->Length;
     }
   }
 
-  if (IRList == nullptr) {
+  if (!IR) {
     // Generate IR + Meta Info
-    auto [IRCopy, RACopy, TotalInstructions, TotalInstructionsLength, _StartAddr, _Length] =
-      GenerateIR(Thread, GuestRIP, Config.GDBSymbols(), MaxInst);
+    auto [IRCopy, TotalInstructions, TotalInstructionsLength, _StartAddr, _Length] = GenerateIR(Thread, GuestRIP, Config.GDBSymbols(), MaxInst);
 
     // Setup pointers to internal structures
-    IRList = IRCopy;
-    RAData = std::move(RACopy);
+    IR = std::move(IRCopy);
     DebugData = new FEXCore::Core::DebugData();
     StartAddr = _StartAddr;
     Length = _Length;
   }
 
-  if (IRList == nullptr) {
+  if (!IR) {
     return {};
   }
   // Attempt to get the CPU backend to compile this code
+  auto IRView = IR->GetIRView();
   return {
     // FEX currently throws away the CPUBackend::CompiledCode object other than the entrypoint
     // In the future with code caching getting wired up, we will pass the rest of the data forward.
     // TODO: Pass the data forward when code caching is wired up to this.
-    .CompiledCode = Thread->CPUBackend->CompileCode(GuestRIP, IRList, DebugData, RAData.get()).BlockEntry,
-    .IRData = IRList,
+    .CompiledCode = Thread->CPUBackend->CompileCode(GuestRIP, &IRView, DebugData, IR->RAData()).BlockEntry,
+    .IR = std::move(IR),
     .DebugData = DebugData,
-    .RAData = std::move(RAData),
     .GeneratedIR = true,
     .StartAddr = StartAddr,
     .Length = Length,
@@ -744,7 +772,7 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
     return HostCode;
   }
 
-  auto [CodePtr, IRList, DebugData, RAData, GeneratedIR, StartAddr, Length] = CompileCode(Thread, GuestRIP, MaxInst);
+  auto [CodePtr, IR, DebugData, GeneratedIR, StartAddr, Length] = CompileCode(Thread, GuestRIP, MaxInst);
   if (CodePtr == nullptr) {
     return 0;
   }
@@ -795,7 +823,7 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
   // Clear any relocations that might have been generated
   Thread->CPUBackend->ClearRelocations();
 
-  if (IRCaptureCache.PostCompileCode(Thread, CodePtr, GuestRIP, StartAddr, Length, std::move(RAData), IRList, DebugData, GeneratedIR)) {
+  if (IRCaptureCache.PostCompileCode(Thread, CodePtr, GuestRIP, StartAddr, Length, std::move(IR), DebugData, GeneratedIR)) {
     // Early exit
     return (uintptr_t)CodePtr;
   }

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -682,7 +682,7 @@ ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalT
 
   // AOT IR bookkeeping and cache
   {
-    auto IRFromAOT = IRCaptureCache.PreGenerateIRFetch(Thread, GuestRIP, IRList);
+    auto IRFromAOT = IRCaptureCache.PreGenerateIRFetch(Thread, GuestRIP);
     if (IRFromAOT) {
       // Setup pointers to internal structures
       IRList = IRFromAOT->IRList;

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -744,21 +744,7 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
     return HostCode;
   }
 
-  void* CodePtr {};
-  FEXCore::IR::IRListView* IRList {};
-  FEXCore::Core::DebugData* DebugData {};
-
-  bool GeneratedIR {};
-  uint64_t StartAddr {}, Length {};
-
-  auto [Code, IR, Data, RAData, Generated, _StartAddr, _Length] = CompileCode(Thread, GuestRIP, MaxInst);
-  CodePtr = Code;
-  IRList = IR;
-  DebugData = Data;
-  GeneratedIR = Generated;
-  StartAddr = _StartAddr;
-  Length = _Length;
-
+  auto [CodePtr, IRList, DebugData, RAData, GeneratedIR, StartAddr, Length] = CompileCode(Thread, GuestRIP, MaxInst);
   if (CodePtr == nullptr) {
     return 0;
   }

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -668,7 +668,7 @@ bool Arm64JITCore::IsGPRPair(IR::NodeID Node) const {
 }
 
 CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, const FEXCore::IR::IRListView* IR, FEXCore::Core::DebugData* DebugData,
-                                                   FEXCore::IR::RegisterAllocationData* RAData) {
+                                                   const FEXCore::IR::RegisterAllocationData* RAData) {
   FEXCORE_PROFILE_SCOPED("Arm64::CompileCode");
 
   JumpTargets.clear();

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -47,7 +47,7 @@ public:
 
   [[nodiscard]]
   CPUBackend::CompiledCode CompileCode(uint64_t Entry, const FEXCore::IR::IRListView* IR, FEXCore::Core::DebugData* DebugData,
-                                       FEXCore::IR::RegisterAllocationData* RAData) override;
+                                       const FEXCore::IR::RegisterAllocationData* RAData) override;
 
   [[nodiscard]]
   void* MapRegion(void* HostPtr, uint64_t, uint64_t) override {
@@ -281,7 +281,7 @@ private:
   // This is purely a debugging aid for developers to see if they are in JIT code space when inspecting raw memory
   void EmitDetectionString();
   IR::RegisterAllocationPass* RAPass;
-  IR::RegisterAllocationData* RAData;
+  const IR::RegisterAllocationData* RAData;
   FEXCore::Core::DebugData* DebugData;
 
   void ResetStack();

--- a/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -259,7 +259,7 @@ void AOTIRCaptureCache::WriteFilesWithCode(const Context::AOTIRCodeFileWriterFn&
   }
 }
 
-AOTIRCaptureCache::PreGenerateIRFetchResult
+std::optional<AOTIRCaptureCache::PreGenerateIRFetchResult>
 AOTIRCaptureCache::PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, FEXCore::IR::IRListView* IRList) {
   auto AOTIRCacheEntry = CTX->SyscallHandler->LookupAOTIRCacheEntry(Thread, GuestRIP);
 
@@ -286,7 +286,7 @@ AOTIRCaptureCache::PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread
             Result.DebugData = new FEXCore::Core::DebugData();
             Result.StartAddr = MappedStart;
             Result.Length = AOTEntry->GuestLength;
-            Result.GeneratedIR = true;
+            return Result;
           } else {
             LogMan::Msg::IFmt("AOTIR: hash check failed {:x}\n", MappedStart);
           }
@@ -297,7 +297,7 @@ AOTIRCaptureCache::PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread
     }
   }
 
-  return Result;
+  return std::nullopt;
 }
 
 bool AOTIRCaptureCache::PostCompileCode(FEXCore::Core::InternalThreadState* Thread, void* CodePtr, uint64_t GuestRIP, uint64_t StartAddr,

--- a/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -260,7 +260,7 @@ void AOTIRCaptureCache::WriteFilesWithCode(const Context::AOTIRCodeFileWriterFn&
 }
 
 std::optional<AOTIRCaptureCache::PreGenerateIRFetchResult>
-AOTIRCaptureCache::PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, FEXCore::IR::IRListView* IRList) {
+AOTIRCaptureCache::PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP) {
   auto AOTIRCacheEntry = CTX->SyscallHandler->LookupAOTIRCacheEntry(Thread, GuestRIP);
 
   PreGenerateIRFetchResult Result {};
@@ -268,7 +268,7 @@ AOTIRCaptureCache::PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread
   if (AOTIRCacheEntry.Entry) {
     AOTIRCacheEntry.Entry->ContainsCode = true;
 
-    if (IRList == nullptr && CTX->Config.AOTIRLoad()) {
+    if (CTX->Config.AOTIRLoad()) {
       auto Mod = AOTIRCacheEntry.Entry->Array;
 
       if (Mod != nullptr) {

--- a/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/FEXCore/Source/Interface/IR/AOTIR.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "Interface/IR/RegisterAllocationData.h"
+#include "Interface/IR/IntrusiveIRList.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/fextl/map.h>
@@ -74,8 +75,8 @@ struct AOTIRCaptureCacheEntry {
   fextl::unique_ptr<FEXCore::Context::AOTIRWriter> Stream;
   fextl::map<uint64_t, uint64_t> Index;
 
-  void AppendAOTIRCaptureCache(uint64_t GuestRIP, uint64_t Start, uint64_t Length, uint64_t Hash, FEXCore::IR::IRListView* IRList,
-                               FEXCore::IR::RegisterAllocationData* RAData);
+  void AppendAOTIRCaptureCache(uint64_t GuestRIP, uint64_t Start, uint64_t Length, uint64_t Hash, const FEXCore::IR::IRListView& IRList,
+                               const FEXCore::IR::RegisterAllocationData* RAData);
 };
 
 struct AOTIRCacheEntry {
@@ -103,8 +104,7 @@ public:
   void WriteFilesWithCode(const Context::AOTIRCodeFileWriterFn& Writer);
 
   struct PreGenerateIRFetchResult {
-    FEXCore::IR::IRListView* IRList {};
-    FEXCore::IR::RegisterAllocationData::UniquePtr RAData {};
+    fextl::unique_ptr<IRStorageBase> IR;
     FEXCore::Core::DebugData* DebugData {};
     uint64_t StartAddr {};
     uint64_t Length {};
@@ -113,8 +113,7 @@ public:
   std::optional<PreGenerateIRFetchResult> PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP);
 
   bool PostCompileCode(FEXCore::Core::InternalThreadState* Thread, void* CodePtr, uint64_t GuestRIP, uint64_t StartAddr, uint64_t Length,
-                       FEXCore::IR::RegisterAllocationData::UniquePtr RAData, FEXCore::IR::IRListView* IRList,
-                       FEXCore::Core::DebugData* DebugData, bool GeneratedIR);
+                       fextl::unique_ptr<FEXCore::IR::IRStorageBase> IR, FEXCore::Core::DebugData* DebugData, bool GeneratedIR);
 
   AOTIRCacheEntry* LoadAOTIRCacheEntry(const fextl::string& filename);
   void UnloadAOTIRCacheEntry(AOTIRCacheEntry* Entry);

--- a/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/FEXCore/Source/Interface/IR/AOTIR.h
@@ -108,10 +108,10 @@ public:
     FEXCore::Core::DebugData* DebugData {};
     uint64_t StartAddr {};
     uint64_t Length {};
-    bool GeneratedIR {};
   };
   [[nodiscard]]
-  PreGenerateIRFetchResult PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, FEXCore::IR::IRListView* IRList);
+  std::optional<PreGenerateIRFetchResult>
+  PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, FEXCore::IR::IRListView* IRList);
 
   bool PostCompileCode(FEXCore::Core::InternalThreadState* Thread, void* CodePtr, uint64_t GuestRIP, uint64_t StartAddr, uint64_t Length,
                        FEXCore::IR::RegisterAllocationData::UniquePtr RAData, FEXCore::IR::IRListView* IRList,

--- a/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/FEXCore/Source/Interface/IR/AOTIR.h
@@ -110,8 +110,7 @@ public:
     uint64_t Length {};
   };
   [[nodiscard]]
-  std::optional<PreGenerateIRFetchResult>
-  PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, FEXCore::IR::IRListView* IRList);
+  std::optional<PreGenerateIRFetchResult> PreGenerateIRFetch(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP);
 
   bool PostCompileCode(FEXCore::Core::InternalThreadState* Thread, void* CodePtr, uint64_t GuestRIP, uint64_t StartAddr, uint64_t Length,
                        FEXCore::IR::RegisterAllocationData::UniquePtr RAData, FEXCore::IR::IRListView* IRList,

--- a/FEXCore/Source/Interface/IR/IREmitter.h
+++ b/FEXCore/Source/Interface/IR/IREmitter.h
@@ -41,10 +41,7 @@ public:
   }
 
   IRListView ViewIR() {
-    return IRListView(&DualListData, false);
-  }
-  IRListView* CreateIRCopy() {
-    return new IRListView(&DualListData, true);
+    return IRListView(&DualListData);
   }
   void ResetWorkingList();
 

--- a/FEXCore/Source/Interface/IR/IntrusiveIRList.h
+++ b/FEXCore/Source/Interface/IR/IntrusiveIRList.h
@@ -171,9 +171,6 @@ public:
     stream.Write((const char*)&DataSize, sizeof(DataSize));
     // size_t ListSize;
     stream.Write((const char*)&ListSize, sizeof(ListSize));
-    // uint64_t Flags;
-    uint64_t WrittenFlags = 0;
-    stream.Write((const char*)&WrittenFlags, sizeof(WrittenFlags));
 
     // inline data
     stream.Write((const char*)GetData(), DataSize);
@@ -194,10 +191,6 @@ public:
     // size_t ListSize;
     memcpy(ptr, &ListSize, sizeof(ListSize));
     ptr += sizeof(ListSize);
-    // uint64_t Flags;
-    uint64_t WrittenFlags = 0;
-    memcpy(ptr, &WrittenFlags, sizeof(WrittenFlags));
-    ptr += sizeof(WrittenFlags);
 
     // inline data
     memcpy(ptr, (const void*)GetData(), DataSize);
@@ -208,7 +201,7 @@ public:
 
   [[nodiscard]]
   size_t GetInlineSize() const {
-    static_assert(sizeof(*this) == 40);
+    static_assert(sizeof(*this) == 32);
     return sizeof(*this) + DataSize + ListSize;
   }
 
@@ -410,7 +403,6 @@ private:
   void* ListDataInternal;
   size_t DataSize;
   size_t ListSize;
-  [[maybe_unused]] uint64_t Flags {0}; // TODO: Drop. Used for backwards-compatibility
   uint8_t InlineData[0];
 };
 

--- a/FEXCore/Source/Interface/IR/RegisterAllocationData.h
+++ b/FEXCore/Source/Interface/IR/RegisterAllocationData.h
@@ -43,7 +43,6 @@ class FEX_PACKED RegisterAllocationData {
 public:
   uint32_t SpillSlotCount {};
   uint32_t MapCount {};
-  [[maybe_unused]] uint8_t IsShared_deprecated {};
   PhysicalRegister Map[0];
 
   PhysicalRegister GetNodeRegister(NodeID Node) const {
@@ -67,9 +66,6 @@ public:
     stream.Write((const char*)&SpillSlotCount, sizeof(SpillSlotCount));
     stream.Write((const char*)&MapCount, sizeof(MapCount));
     // RAData (inline)
-    // NOTE: IsShared isn't used anymore, but is written for backwards-compatibility
-    uint8_t _IsShared = 1;
-    stream.Write((const char*)&_IsShared, sizeof(_IsShared));
     stream.Write((const char*)&Map[0], sizeof(Map[0]) * MapCount);
   }
 };

--- a/FEXCore/Source/Interface/IR/RegisterAllocationData.h
+++ b/FEXCore/Source/Interface/IR/RegisterAllocationData.h
@@ -43,7 +43,7 @@ class FEX_PACKED RegisterAllocationData {
 public:
   uint32_t SpillSlotCount {};
   uint32_t MapCount {};
-  bool IsShared {false};
+  [[maybe_unused]] uint8_t IsShared_deprecated {};
   PhysicalRegister Map[0];
 
   PhysicalRegister GetNodeRegister(NodeID Node) const {
@@ -67,18 +67,16 @@ public:
     stream.Write((const char*)&SpillSlotCount, sizeof(SpillSlotCount));
     stream.Write((const char*)&MapCount, sizeof(MapCount));
     // RAData (inline)
-    // In file, IsShared is always set
-    bool _IsShared = true;
-    stream.Write((const char*)&_IsShared, sizeof(IsShared));
+    // NOTE: IsShared isn't used anymore, but is written for backwards-compatibility
+    uint8_t _IsShared = 1;
+    stream.Write((const char*)&_IsShared, sizeof(_IsShared));
     stream.Write((const char*)&Map[0], sizeof(Map[0]) * MapCount);
   }
 };
 
 struct RegisterAllocationDataDeleter {
   void operator()(RegisterAllocationData* r) const {
-    if (!r->IsShared) {
-      FEXCore::Allocator::free(r);
-    }
+    FEXCore::Allocator::free(r);
   }
 };
 
@@ -87,7 +85,6 @@ inline auto RegisterAllocationData::Create(uint32_t NodeCount) -> UniquePtr {
   memset(&Ret->Map[0], PhysicalRegister::Invalid().Raw, NodeCount);
   Ret->SpillSlotCount = 0;
   Ret->MapCount = NodeCount;
-  Ret->IsShared = false;
   return UniquePtr {Ret};
 }
 
@@ -96,7 +93,6 @@ inline auto RegisterAllocationData::CreateCopy() const -> UniquePtr {
   memcpy((void*)&copy->Map[0], (void*)&Map[0], MapCount * sizeof(Map[0]));
   copy->SpillSlotCount = SpillSlotCount;
   copy->MapCount = MapCount;
-  copy->IsShared = IsShared;
   return UniquePtr {copy};
 }
 


### PR DESCRIPTION
## Background

FEX normally stores IR/RA data on the heap, but it can also read them as an overlay from a memory-mapped file if IR caching is used. This requires a careful dance around ownership issues, which is an easy source for memory leaks or double-frees that are difficult to audit for.

## Overview

This PR identifies two core issues and fixes them:
1. Raw pointers are passed across multiple layers and modules without indication of memory ownership
2. The `IRListView` type can either act as a proper, non-owning view, or it can act as an owning container. In practice it's often impossible to tell if code referencing an `IRListView` owns the underlying memory or not.

The solution to (2) is to split `IRListView` into two types: One for the purely non-owning view, and one for memory storage (which in turn can be either the heap or a memory-mapped IR cache). This split then allows to address (1) by converting all raw pointers to `unique_ptr<>`.

A side benefit: The code is more optimal thanks to not needing to copy around *RA data*, and copies of *IR data* are now explicit instead of hiding behind an innocent-looking IRListView constructor.

Some additional, minor changes are included to clean up related interfaces. Some unused code was removed too, since it's easier to re-add later than to eternally carry it around without a clear purpose.
