### PR TITLE
unittests: add XeSS test

### DIFF
--- a/unittests/ASM/Disabled_Tests
+++ b/unittests/ASM/Disabled_Tests
@@ -22,3 +22,6 @@ Test_X87/D9_F2.asm
 
 # Relies on rounding correctness
 Test_X87/D9_F8.asm
+
+# This is basically a benchmark.
+FEX_bugs/XeSS_quadratic.asm

--- a/unittests/ASM/FEX_bugs/XeSS_quadratic.asm
+++ b/unittests/ASM/FEX_bugs/XeSS_quadratic.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "MemoryRegions": {
+    "0x200000000": "0x20000"
+  }
+}
+%endif
+
+; FEX has had various bugs throughout the years leading to accidental
+; superlinear time, for example with constant pooling and register allocation.
+; This test mimics the massive block found in XeSS. If this test has
+; excessive runtime, something in broken in FEXCore.
+
+mov rsp, 0x200000000
+%assign i 0
+%rep 0x10000
+mov byte [rsp + (0x10000 + i)], (0x01 + (i << 2)) & 0xFF
+%assign i i+1
+%endrep
+
+hlt


### PR DESCRIPTION
Useful smoke test for the asymptoptic behaviour of our constant pooling code. Not useful for correctness testing, so skip in CI.