### PR TITLE
Config: Change default TSO options

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -401,14 +401,14 @@
       },
       "VectorTSOEnabled": {
         "Type": "bool",
-        "Default": "true",
+        "Default": "false",
         "Desc": [
           "When TSO emulation is enabled, controls if vector loadstores should also be atomic."
         ]
       },
       "MemcpySetTSOEnabled": {
         "Type": "bool",
-        "Default": "true",
+        "Default": "false",
         "Desc": [
           "When TSO emulation is enabled, controls if memcpy and memset should also be atomic.",
           "Only affects REP MOVS and REP STOS instructions"


### PR DESCRIPTION
After two months of testing I finally have enough confidence that these default options getting changed is safe enough that most games won't notice the difference. But the performance differences can be wild.

Might want to come back and reenable this on platforms that support hardware TSO and LRCPC3 (for the vector feature), but we can care once those platforms come up to speed.

![Image_2024-05-21_18-08-30](https://github.com/FEX-Emu/FEX/assets/1018829/e9238b76-7a17-456c-9b13-b57c341e6954)
