### PR TITLE
Optimize large sign-extended constants

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -454,6 +454,17 @@ void Arm64Emitter::LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, ui
     }
   }
 
+  // If we can't handle negatives with the orr, try with movn+movk
+  if (Is64Bit && ((~Constant) >> 32) == 0) {
+    movn(s, Reg, (~Constant) & 0xFFFF);
+    movk(s, Reg, (Constant >> 16) & 0xFFFF, 16);
+    if (NOPPad) {
+      nop();
+      nop();
+    }
+    return;
+  }
+
   // ADRP+ADD is specifically optimized in hardware
   // Check if we can use this
   auto PC = GetCursorAddress<uint64_t>();

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -1008,6 +1008,21 @@
         "ccmn xzr, #0, #nzCV, eq"
       ]
     },
+    "imul rsi, rax, 0xffffffff8646c299": {
+      "ExpectedInstructionCount": 9,
+      "Comment": "0x0f 0xaf",
+      "ExpectedArm64ASM": [
+        "mov x20, #0xc299",
+        "movk x20, #0x8646, lsl #16",
+        "movk x20, #0xffff, lsl #32",
+        "movk x20, #0xffff, lsl #48",
+        "smulh x21, x4, x20",
+        "mul x10, x4, x20",
+        "asr x20, x10, #63",
+        "cmp x21, x20",
+        "ccmn xzr, #0, #nzCV, eq"
+      ]
+    },
     "cmpxchg cl, bl": {
       "ExpectedInstructionCount": 11,
       "ExpectedArm64ASM": [

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -1009,13 +1009,11 @@
       ]
     },
     "imul rsi, rax, 0xffffffff8646c299": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x0f 0xaf",
       "ExpectedArm64ASM": [
-        "mov x20, #0xc299",
+        "mov x20, #0xffffffffffffc299",
         "movk x20, #0x8646, lsl #16",
-        "movk x20, #0xffff, lsl #32",
-        "movk x20, #0xffff, lsl #48",
         "smulh x21, x4, x20",
         "mul x10, x4, x20",
         "asr x20, x10, #63",


### PR DESCRIPTION
from looking idly at bytemark asm