### PR TITLE
FEXLogging: Changes representation of timestamp

### DIFF
--- a/Source/Common/FEXServerClient.h
+++ b/Source/Common/FEXServerClient.h
@@ -116,7 +116,7 @@ namespace Logging {
   };
 
   struct PacketHeader {
-    uint64_t Timestamp {};
+    struct timespec Timestamp {};
     PacketTypes PacketType {};
     int32_t PID {};
     int32_t TID {};
@@ -131,21 +131,17 @@ namespace Logging {
     uint32_t Pad {};
   };
 
-  static_assert(sizeof(PacketHeader) == 24, "Wrong size");
+  static_assert(sizeof(PacketHeader) == 32, "Wrong size");
 
   [[maybe_unused]]
   static PacketHeader FillHeader(Logging::PacketTypes Type) {
-    struct timespec Time {};
-    uint64_t Timestamp {};
-    clock_gettime(CLOCK_MONOTONIC, &Time);
-    Timestamp = Time.tv_sec * 1e9 + Time.tv_nsec;
 
     Logging::PacketHeader Msg {
-      .Timestamp = Timestamp,
       .PacketType = Type,
       .PID = ::getpid(),
       .TID = FHU::Syscalls::gettid(),
     };
+    clock_gettime(CLOCK_MONOTONIC, &Msg.Timestamp);
 
     return Msg;
   }

--- a/Source/Tools/FEXServer/Logger.cpp
+++ b/Source/Tools/FEXServer/Logger.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 namespace Logging {
-void ClientMsgHandler(int FD, uint64_t Timestamp, uint32_t PID, uint32_t TID, uint32_t Level, const char* Msg);
+void ClientMsgHandler(int FD, FEXServerClient::Logging::PacketMsg* const Msg, const char* MsgStr);
 }
 
 namespace Logger {
@@ -48,7 +48,7 @@ void HandleLogData(int Socket) {
     if (Header->PacketType == FEXServerClient::Logging::PacketTypes::TYPE_MSG) {
       FEXServerClient::Logging::PacketMsg* Msg = reinterpret_cast<FEXServerClient::Logging::PacketMsg*>(&Data[CurrentOffset]);
       const char* MsgText = reinterpret_cast<const char*>(&Data[CurrentOffset + sizeof(FEXServerClient::Logging::PacketMsg)]);
-      Logging::ClientMsgHandler(Socket, Msg->Header.Timestamp, Msg->Header.PID, Msg->Header.TID, Msg->Level, MsgText);
+      Logging::ClientMsgHandler(Socket, Msg, MsgText);
 
       CurrentOffset += sizeof(FEXServerClient::Logging::PacketMsg) + Msg->MessageLength;
     } else {

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -35,8 +35,9 @@ void AssertHandler(const char* Message) {
   write(STDOUT_FILENO, Output.c_str(), Output.size());
 }
 
-void ClientMsgHandler(int FD, uint64_t Timestamp, uint32_t PID, uint32_t TID, uint32_t Level, const char* Msg) {
-  const auto Output = fmt::format("[{}][{}][{}.{}] {}\n", LogMan::DebugLevelStr(Level), Timestamp, PID, TID, Msg);
+void ClientMsgHandler(int FD, FEXServerClient::Logging::PacketMsg* const Msg, const char* MsgStr) {
+  const auto Output = fmt::format("[{}][{}.{}][{}.{}] {}\n", LogMan::DebugLevelStr(Msg->Level), Msg->Header.Timestamp.tv_sec,
+                                  Msg->Header.Timestamp.tv_nsec, Msg->Header.PID, Msg->Header.TID, MsgStr);
   write(STDERR_FILENO, Output.c_str(), Output.size());
 }
 } // namespace Logging


### PR DESCRIPTION
This was a bit confusing to read and I had always expected to change this at some point.

Previous:
```
[INFO][1579518391560577][1601857.1601857] clone: Unsupported flags w/o CLONE_THREAD (Shared Resources), 4100
```

Now:
```
[INFO][1590468.992593376][1629501.1629501] clone: Unsupported flags w/o CLONE_THREAD (Shared Resources), 4100
```