### PR TITLE
FileManagement: Fix fstatat/statx with self and NOFOLLOW

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
@@ -79,6 +79,7 @@ public:
   uint64_t Statfs(const char* path, void* buf);
 
   std::optional<std::string_view> GetSelf(const char* Pathname);
+  bool IsSelfNoFollow(const char* Pathname, int flags) const;
 
   void UpdatePID(uint32_t PID) {
     CurrentPID = PID;

--- a/unittests/FEXLinuxTests/tests/fs/self_symlink.cpp
+++ b/unittests/FEXLinuxTests/tests/fs/self_symlink.cpp
@@ -1,0 +1,29 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+
+TEST_CASE("proc-self symlink") {
+  // Saw with the Darwinia Linux game port.
+  // It sanity checks that `/proc/self/exe` is a symlink and also that it points to a regular file.
+  // This uses newfsstatat or statx behind the scenes which FEX didn't handle this edge-case correctly.
+
+  // Create a path with /proc/self/exe
+  std::filesystem::path path {"/proc/self/exe"};
+
+  // Check the status of the file with status first.
+  std::error_code ec;
+  auto status = std::filesystem::status(path, ec);
+
+  // No error
+  REQUIRE(!ec);
+  CHECK(status.type() == std::filesystem::file_type::regular);
+
+  // Now check the status with symlink_status.
+  status = std::filesystem::symlink_status(path, ec);
+
+  // No error
+  REQUIRE(!ec);
+  CHECK(status.type() == std::filesystem::file_type::symlink);
+
+  // The game would then continue to read std::filesystem::read_symlink.
+}


### PR DESCRIPTION
When asked to not follow the symlink, FEX needs to return data about the symlink itself rather than following to the target executable. In that case we need to return symlink information otherwise games that sanity check can break.

This is what happened with Darwinia in #3662.

We return the FEXInterpreter symlink information in this case since it doesn't return any information that is relevent to leaking emulator state. Once the application asks to follow through to the symlink target is when we will replace.

Also adds a unit test to ensure we don't break it.