### PR TITLE
ConstProp fixes for Darwinia

### DIFF
--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1001,7 +1001,8 @@
       },
       "GPR = AddShift OpSize:#Size, GPR:$Src1, GPR:$Src2, ShiftType:$Shift{ShiftType::LSL}, u8:$ShiftAmount{0}": {
         "Desc": [ "Integer Add with shifted register",
-                  "Will truncate to 64 or 32bits"
+                  "Will truncate to 64 or 32bits",
+                  "Dest = Src1 + (Src2 << ShiftAmount)"
                 ],
         "DestSize": "Size",
         "EmitValidation": [

--- a/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -105,9 +105,9 @@ static std::optional<MemExtendedAddrResult> MemExtendedAddressing(IREmitter* IRE
       auto Scale = 1U << AddShift->ShiftAmount;
       if (IsMemoryScale(Scale, AccessSize)) {
         // remove shift as it can be folded to the mem op
-        return MemExtendedAddrResult {MEM_OFFSET_SXTX, (uint8_t)Scale, IREmit->UnwrapNode(AddShift->Src2), IREmit->UnwrapNode(AddShift->Src1)};
+        return MemExtendedAddrResult {MEM_OFFSET_SXTX, (uint8_t)Scale, IREmit->UnwrapNode(AddShift->Src1), IREmit->UnwrapNode(AddShift->Src2)};
       } else if (Scale == 1) {
-        return MemExtendedAddrResult {MEM_OFFSET_SXTX, 1, IREmit->UnwrapNode(AddShift->Src2), IREmit->UnwrapNode(AddShift->Src1)};
+        return MemExtendedAddrResult {MEM_OFFSET_SXTX, 1, IREmit->UnwrapNode(AddShift->Src1), IREmit->UnwrapNode(AddShift->Src2)};
       }
     }
 

--- a/unittests/ASM/FEX_bugs/SIBScaleTranspose.asm
+++ b/unittests/ASM/FEX_bugs/SIBScaleTranspose.asm
@@ -1,0 +1,95 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x5152535455565758",
+    "RBX": "0x5152535455565758",
+    "RCX": "0x5152535455565758",
+    "RDX": "0x5152535455565758",
+    "RDI": "0x5152535455565758",
+
+    "XMM0": ["0x5152535455565758", "0x0"],
+    "XMM1": ["0x5152535455565758", "0x0"],
+    "XMM2": ["0x5152535455565758", "0x0"],
+    "XMM3": ["0x5152535455565758", "0x0"],
+    "XMM4": ["0x5152535455565758", "0x0"],
+
+    "MM0": "0x5152535455565758",
+    "MM1": "0x5152535455565758",
+    "MM2": "0x5152535455565758",
+    "MM3": "0x5152535455565758",
+    "MM4": "0x5152535455565758"
+  },
+  "MemoryRegions": {
+    "0x00000000a0000000": "4096",
+    "0x0000000110000000": "4096"
+  },
+  "MemoryData": {
+    "0x00000000a0000000": "0x4142434445464748",
+    "0x0000000110000000": "0x5152535455565758"
+  }
+}
+%endif
+
+; FEX had a bug in its const-prop pass where x86 SIB scale would accidentally transpose the register that was scaling with the base.
+; This test explicitly tests SIB in a way that a transpose would load data from the wrong address.
+; Basic layout is [r14 + (r15 * 8)]
+
+; r14 will be the base
+mov r14, 0x1000_0000
+; r15 will be the index
+mov r15, 0x2000_0000
+
+; Correct transpose will be at 0x0000000110000000
+; Incorrect transpose will be at 0x00000000a0000000
+
+; Break the block
+jmp .test
+.test:
+
+; Basic GPR SIB test
+mov rax, [r14 + (r15 * 8)]
+
+; Basic Vector SIB test
+movq xmm0, [r14 + (r15 * 8)]
+
+; Basic MMX SIB test
+movq mm0, [r14 + (r15 * 8)]
+
+; Break the block now
+jmp .test2
+.test2:
+
+; FEX GPR/XMM LoadMem const prop might only happen with disjoint add + mul so check this
+; Need to be able to const-prop the multiply
+imul r13, r15, 8
+
+; Test base + offset transposed both ways, for all three types
+mov rbx, [r14 + r13]
+mov rcx, [r13 + r14]
+
+movq xmm1, [r14 + r13]
+movq xmm2, [r13 + r14]
+
+movq mm1, [r14 + r13]
+movq mm2, [r13 + r14]
+
+; Break the block now
+jmp .test3
+.test3:
+
+; FEX GPR/XMM LoadMem const prop might only happen with disjoint add + lshl so check this
+; Need to be able to const-prop the lshl
+mov r13, r15
+shl r13, 3
+
+; Test base + offset transposed both ways, for all three types
+mov rdx, [r14 + r13]
+mov rdi, [r13 + r14]
+
+movq xmm3, [r14 + r13]
+movq xmm4, [r13 + r14]
+
+movq mm3, [r14 + r13]
+movq mm4, [r13 + r14]
+
+hlt

--- a/unittests/ASM/FEX_bugs/VectorLoadCrash.asm
+++ b/unittests/ASM/FEX_bugs/VectorLoadCrash.asm
@@ -1,0 +1,26 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM5":  ["0x0000000000000048", "0x0000000000000047"]
+  }
+}
+%endif
+
+
+; FEX-Emu had a bug where a vector load that was using SIB addressing would overflow to larger than what ARM could encode.
+; Test that here.
+; Original bug came from the Darwinia Linux binary from function `HUF_readDTableX1_wksp`
+
+mov rbx, 0
+lea r15, [rel .data - 0x3d4]
+
+; Break the block
+jmp .test
+.test:
+
+pmovzxbq xmm5, word [rbx+r15+0x3d4]
+
+hlt
+
+.data:
+dq 0x4142434445464748, 0x5152535455565758

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -918,7 +918,7 @@
     "prefetch [rax + rcx*8]": {
       "ExpectedInstructionCount": 1,
       "ExpectedArm64ASM": [
-        "prfm pldl1keep, [x5, x4, sxtx #3]"
+        "prfm pldl1keep, [x4, x5, sxtx #3]"
       ]
     },
     "movzx ebx, byte [rax + rcx*1]": {

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -920,6 +920,114 @@
       "ExpectedArm64ASM": [
         "prfm pldl1keep, [x5, x4, sxtx #3]"
       ]
+    },
+    "movzx ebx, byte [rax + rcx*1]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldrb w7, [x4, x5, sxtx]"
+      ]
+    },
+    "movzx ebx, byte [rax + rcx*2]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #1",
+        "ldrb w7, [x20]"
+      ]
+    },
+    "movzx ebx, byte [rax + rcx*4]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #2",
+        "ldrb w7, [x20]"
+      ]
+    },
+    "movzx ebx, byte [rax + rcx*8]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #3",
+        "ldrb w7, [x20]"
+      ]
+    },
+    "movzx ebx, word [rax + rcx*1]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldrh w7, [x4, x5, sxtx]"
+      ]
+    },
+    "movzx ebx, word [rax + rcx*2]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #1",
+        "ldrh w7, [x20]"
+      ]
+    },
+    "movzx ebx, word [rax + rcx*4]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #2",
+        "ldrh w7, [x20]"
+      ]
+    },
+    "movzx ebx, word [rax + rcx*8]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #3",
+        "ldrh w7, [x20]"
+      ]
+    },
+    "mov ebx, [rax + rcx*1]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr w7, [x4, x5, sxtx]"
+      ]
+    },
+    "mov ebx, [rax + rcx*2]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #1",
+        "ldr w7, [x20]"
+      ]
+    },
+    "mov ebx, [rax + rcx*4]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #2",
+        "ldr w7, [x20]"
+      ]
+    },
+    "mov ebx, [rax + rcx*8]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #3",
+        "ldr w7, [x20]"
+      ]
+    },
+    "mov rbx, [rax + rcx*1]": {
+      "ExpectedInstructionCount": 1,
+      "ExpectedArm64ASM": [
+        "ldr x7, [x4, x5, sxtx]"
+      ]
+    },
+    "mov rbx, [rax + rcx*2]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #1",
+        "ldr x7, [x20]"
+      ]
+    },
+    "mov rbx, [rax + rcx*4]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #2",
+        "ldr x7, [x20]"
+      ]
+    },
+    "mov rbx, [rax + rcx*8]": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "add x20, x4, x5, lsl #3",
+        "ldr x7, [x20]"
+      ]
     }
   }
 }


### PR DESCRIPTION
Alongside #3666 This will fix Darwinia's Linux executable.

Two bugs here.
ConstProp with AddShift was transposing Base and Offset registers, which means we were scaling the Base and not scaling Offset.

Additionally we were accidentally allowing GPR loadstore limits on Vector loadstores which is invalid.

Both of these combined were causing fault behaviour in Darwinia after #3666 was fixed.

