### PR TITLE
Track tied sources in the IR

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1748,12 +1748,6 @@ void OpDispatchBuilder::RotateOp(OpcodeArgs) {
     auto Res = _Ror(OpSize, Dest, Left ? _Neg(OpSize, Src) : Src);
     StoreResult(GPRClass, Op, Res, -1);
 
-    // Ends up faster overall if we don't have FlagM, slower if we do...
-    // If Shift != 1, OF is undefined so we choose to zero here.
-    if (!CTX->HostFeatures.SupportsFlagM) {
-      ZeroCV();
-    }
-
     // Extract the last bit shifted in to CF
     SetRFLAG<FEXCore::X86State::RFLAG_CF_RAW_LOC>(Res, Left ? 0 : Size - 1, true);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1322,16 +1322,6 @@ private:
     NZCVDirty = true;
   }
 
-  void ZeroCV() {
-    // Get old NZCV before we mess with PossiblySetNZCVBits
-    auto OldNZCV = GetNZCV();
-
-    // Mask out the NZ bits, clearing CV. Even if the code sets CV after, this can end up faster
-    // moves by allowing orlshl to be used instead of bfi.
-    PossiblySetNZCVBits = (1u << IndexNZCV(FEXCore::X86State::RFLAG_SF_RAW_LOC)) | (1u << IndexNZCV(FEXCore::X86State::RFLAG_ZF_RAW_LOC));
-    SetNZCV(_And(OpSize::i32Bit, OldNZCV, _Constant(PossiblySetNZCVBits)));
-  }
-
   void SetNZ_ZeroCV(unsigned SrcSize, OrderedNode* Res) {
     HandleNZ00Write();
     _TestNZ(IR::SizeToOpSize(SrcSize), Res, Res);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -549,6 +549,7 @@
         "Desc": ["Does a memory load to a single element of a vector.",
                  "Leaves the rest of the vector's data intact.",
                  "Matches arm64 ld1 semantics"],
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
@@ -570,6 +571,7 @@
           "The address is decremented by the value size while.",
           "The return value size is the size of the current operating mode"
         ],
+        "TiedSource": 1,
         "HasSideEffects": true,
         "DestSize": "Size"
       },
@@ -1195,6 +1197,7 @@
         "Desc": ["Integer binary and"
                 ],
         "DestSize": "Size",
+        "TiedSource": 0,
         "HasSideEffects": true
       },
       "GPR = Andn OpSize:#Size, GPR:$Src1, GPR:$Src2": {
@@ -1335,6 +1338,7 @@
                  "The bitfield is copied in to Dest[(Width + lsb):lsb]"
                 ],
         "DestSize": "Size",
+        "TiedSource": 0,
         "EmitValidation": [
           "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
@@ -1346,6 +1350,7 @@
                  "The bitfield is copied in to Dest[Width:0]"
                 ],
         "DestSize": "Size",
+        "TiedSource": 0,
         "EmitValidation": [
           "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
@@ -1776,29 +1781,35 @@
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VShlI u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, u8:$BitShift": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VUShrI u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, u8:$BitShift": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VUShraI u8:#RegisterSize, u8:#ElementSize, FPR:$DestVector, FPR:$Vector, u8:$BitShift": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VSShrI u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, u8:$BitShift": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
 
       "FPR = VUShrNI u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, u8:$BitShift": {
+        "TiedSource": 0,
         "Desc": "Unsigned shifts right each element and then narrows to the next lower element size",
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / (ElementSize >> 1)"
       },
 
       "FPR = VUShrNI2 u8:#RegisterSize, u8:#ElementSize, FPR:$VectorLower, FPR:$VectorUpper, u8:$BitShift": {
+        "TiedSource": 0,
         "Desc": ["Unsigned shifts right each element and then narrows to the next lower element size",
                  "Inserts results in to the high elements of the first argument"
                 ],
@@ -1830,10 +1841,12 @@
         "NumElements": "RegisterSize / (ElementSize << 1)"
       },
       "FPR = VSQXTN u8:#RegisterSize, u8:#ElementSize, FPR:$Vector": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / (ElementSize >> 1)"
       },
       "FPR = VSQXTN2 u8:#RegisterSize, u8:#ElementSize, FPR:$VectorLower, FPR:$VectorUpper": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / (ElementSize >> 1)"
       },
@@ -1861,6 +1874,7 @@
         "Desc": ["Signed rounding shift right by immediate",
                  "Exactly matching Arm64 srshr semantics"
                 ],
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
@@ -1868,6 +1882,7 @@
         "Desc": ["Signed satuating shift left by immediate",
                  "Exactly matching Arm64 sqshl semantics"
                 ],
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
@@ -2076,42 +2091,52 @@
         "NumElements": "RegisterSize / (ElementSize << 1)"
       },
       "FPR = VUShl u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, FPR:$ShiftVector, i1:$RangeCheck": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VUShr u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, FPR:$ShiftVector, i1:$RangeCheck": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VSShr u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, FPR:$ShiftVector, i1:$RangeCheck": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VUShlS u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, FPR:$ShiftScalar": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VUShrS u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, FPR:$ShiftScalar": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VSShrS u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, FPR:$ShiftScalar": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VUShrSWide u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, FPR:$ShiftScalar": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VSShrSWide u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, FPR:$ShiftScalar": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VUShlSWide u8:#RegisterSize, u8:#ElementSize, FPR:$Vector, FPR:$ShiftScalar": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
       "FPR = VInsElement u8:#RegisterSize, u8:#ElementSize, u8:$DestIdx, u8:$SrcIdx, FPR:$DestVector, FPR:$SrcVector": {
+        "TiedSource": 0,
         "DestSize": "RegisterSize",
         "NumElements": "RegisterSize / ElementSize"
       },
@@ -2198,6 +2223,7 @@
                  "Table is always treated as a 128bit register",
                  "Indices matches destination size. Either 64bit or 128bit"
                 ],
+        "TiedSource": 0,
         "DestSize": "RegisterSize"
       },
       "FPR = VBSL u8:#RegisterSize, FPR:$VectorMask, FPR:$VectorTrue, FPR:$VectorFalse": {

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -388,6 +388,18 @@ private:
       }
     }
 
+    // Try to handle tied registers. This can fail, the JIT will insert moves.
+    if (int TiedIdx = IR::TiedSource(IROp->Op); TiedIdx >= 0) {
+      PhysicalRegister Reg = SSAToReg[IROp->Args[TiedIdx].ID().Value];
+      RegisterClass* Class = GetClass(Reg);
+      uint32_t RegBits = GetRegBits(Reg);
+
+      if (Reg.Class != GPRFixedClass && Reg.Class != FPRFixedClass && (Class->Available & RegBits) == RegBits) {
+        SetReg(CodeNode, Reg);
+        return;
+      }
+    }
+
     RegisterClassType OrigClassType = GetRegClassFromNode(IR, IROp);
     bool Pair = OrigClassType == GPRPairClass;
     RegisterClassType ClassType = Pair ? GPRClass : OrigClassType;

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -1517,7 +1517,7 @@
       ]
     },
     "lock dec dword [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
@@ -1525,14 +1525,12 @@
         "cset w20, hs",
         "subs w26, w27, #0x1 (1)",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "lock dec qword [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
@@ -1540,10 +1538,8 @@
         "cset w20, hs",
         "subs x26, x27, #0x1 (1)",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "lock inc byte [rax]": {
@@ -1577,7 +1573,7 @@
       ]
     },
     "lock inc dword [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1585,14 +1581,12 @@
         "cset w20, hs",
         "adds w26, w27, #0x1 (1)",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "lock inc qword [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
@@ -1600,10 +1594,8 @@
         "cset w20, hs",
         "adds x26, x27, #0x1 (1)",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     }
   }

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -909,7 +909,7 @@
       ]
     },
     "rcl al, 2": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 18,
       "Comment": "GROUP2 0xC0 /2",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -925,30 +925,26 @@
         "bfi x21, x22, #36, #1",
         "bfi x21, x20, #19, #8",
         "bfi x21, x22, #27, #1",
-        "mov x0, x21",
-        "bfxil x0, x20, #0, #8",
-        "mov x20, x0",
-        "ror x21, x20, #62",
-        "bfxil x4, x21, #0, #8",
-        "ror x20, x20, #61",
+        "bfxil x21, x20, #0, #8",
+        "ror x20, x21, #62",
+        "bfxil x4, x20, #0, #8",
+        "ror x20, x21, #61",
         "rmif x20, #63, #nzCv"
       ]
     },
     "rcr al, 2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP2 0xC0 /3",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "uxtb w21, w4",
-        "mov x0, x21",
-        "bfi x0, x20, #8, #1",
-        "mov x20, x0",
-        "bfi x20, x20, #9, #9",
-        "bfi x20, x20, #18, #18",
-        "bfi x20, x20, #36, #9",
-        "lsr w21, w20, #2",
-        "bfxil x4, x21, #0, #8",
-        "rmif x20, #0, #nzCv"
+        "bfi x21, x20, #8, #1",
+        "bfi x21, x21, #9, #9",
+        "bfi x21, x21, #18, #18",
+        "bfi x21, x21, #36, #9",
+        "lsr w20, w21, #2",
+        "bfxil x4, x20, #0, #8",
+        "rmif x21, #0, #nzCv"
       ]
     },
     "shl al, 2": {
@@ -1038,7 +1034,7 @@
       ]
     },
     "rcl ax, 2": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 14,
       "Comment": "GROUP2 0xC1 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1050,12 +1046,10 @@
         "bfi x21, x22, #46, #1",
         "bfi x21, x20, #13, #16",
         "bfi x21, x22, #29, #1",
-        "mov x0, x21",
-        "bfxil x0, x20, #0, #16",
-        "mov x20, x0",
-        "ror x21, x20, #62",
-        "bfxil x4, x21, #0, #16",
-        "ror x20, x20, #61",
+        "bfxil x21, x20, #0, #16",
+        "ror x20, x21, #62",
+        "bfxil x4, x20, #0, #16",
+        "ror x20, x21, #61",
         "rmif x20, #63, #nzCv"
       ]
     },
@@ -1082,19 +1076,17 @@
       ]
     },
     "rcr ax, 2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP2 0xC1 /3",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "uxth w21, w4",
-        "mov x0, x21",
-        "bfi x0, x20, #16, #1",
-        "mov x20, x0",
-        "bfi x20, x20, #17, #17",
-        "bfi x20, x20, #34, #17",
-        "lsr w21, w20, #2",
-        "bfxil x4, x21, #0, #16",
-        "rmif x20, #0, #nzCv"
+        "bfi x21, x20, #16, #1",
+        "bfi x21, x21, #17, #17",
+        "bfi x21, x21, #34, #17",
+        "lsr w20, w21, #2",
+        "bfxil x4, x20, #0, #16",
+        "rmif x21, #0, #nzCv"
       ]
     },
     "rcr eax, 2": {
@@ -1573,11 +1565,11 @@
       ]
     },
     "rcl al, cl": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 26,
       "Comment": "GROUP2 0xd2 /2",
       "ExpectedArm64ASM": [
         "and w20, w5, #0x1f",
-        "cbz x20, #+0x6c",
+        "cbz x20, #+0x64",
         "and w20, w5, #0x1f",
         "uxtb w21, w4",
         "mov w22, #0x0",
@@ -1592,40 +1584,36 @@
         "bfi x22, x23, #36, #1",
         "bfi x22, x21, #19, #8",
         "bfi x22, x23, #27, #1",
-        "mov x0, x22",
-        "bfxil x0, x21, #0, #8",
-        "mov x21, x0",
-        "neg w22, w20",
-        "ror x22, x21, x22",
-        "bfxil x4, x22, #0, #8",
+        "bfxil x22, x21, #0, #8",
+        "neg w21, w20",
+        "ror x21, x22, x21",
+        "bfxil x4, x21, #0, #8",
         "mov w23, #0x3f",
         "sub x20, x23, x20",
-        "ror x20, x21, x20",
+        "ror x20, x22, x20",
         "rmif x20, #63, #nzCv",
-        "eor x20, x20, x22, lsr #7",
+        "eor x20, x20, x21, lsr #7",
         "rmif x20, #0, #nzcV"
       ]
     },
     "rcr al, cl": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 15,
       "Comment": "GROUP2 0xd2 /3",
       "ExpectedArm64ASM": [
         "and w20, w5, #0x1f",
-        "cbz x20, #+0x40",
+        "cbz x20, #+0x38",
         "cset w20, hs",
         "uxtb w21, w4",
-        "mov x0, x21",
-        "bfi x0, x20, #8, #1",
-        "mov x20, x0",
-        "bfi x20, x20, #9, #9",
-        "bfi x20, x20, #18, #18",
-        "bfi x20, x20, #36, #9",
-        "lsr w21, w20, w5",
-        "bfxil x4, x21, #0, #8",
+        "bfi x21, x20, #8, #1",
+        "bfi x21, x21, #9, #9",
+        "bfi x21, x21, #18, #18",
+        "bfi x21, x21, #36, #9",
+        "lsr w20, w21, w5",
+        "bfxil x4, x20, #0, #8",
         "sub w22, w5, #0x1 (1)",
-        "lsr w20, w20, w22",
-        "rmif x20, #63, #nzCv",
-        "eor w20, w21, w21, lsr #1",
+        "lsr w21, w21, w22",
+        "rmif x21, #63, #nzCv",
+        "eor w20, w20, w20, lsr #1",
         "rmif x20, #6, #nzcV"
       ]
     },
@@ -1760,11 +1748,11 @@
       ]
     },
     "rcl ax, cl": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 22,
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
         "and w20, w5, #0x1f",
-        "cbz x20, #+0x5c",
+        "cbz x20, #+0x54",
         "and w20, w5, #0x1f",
         "uxth w21, w4",
         "mov w22, #0x0",
@@ -1775,17 +1763,15 @@
         "bfi x22, x23, #46, #1",
         "bfi x22, x21, #13, #16",
         "bfi x22, x23, #29, #1",
-        "mov x0, x22",
-        "bfxil x0, x21, #0, #16",
-        "mov x21, x0",
-        "neg w22, w20",
-        "ror x22, x21, x22",
-        "bfxil x4, x22, #0, #16",
+        "bfxil x22, x21, #0, #16",
+        "neg w21, w20",
+        "ror x21, x22, x21",
+        "bfxil x4, x21, #0, #16",
         "mov w23, #0x3f",
         "sub x20, x23, x20",
-        "ror x20, x21, x20",
+        "ror x20, x22, x20",
         "rmif x20, #63, #nzCv",
-        "eor x20, x20, x22, lsr #15",
+        "eor x20, x20, x21, lsr #15",
         "rmif x20, #0, #nzcV"
       ]
     },
@@ -1830,24 +1816,22 @@
       ]
     },
     "rcr ax, cl": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 14,
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
         "and w20, w5, #0x1f",
-        "cbz x20, #+0x3c",
+        "cbz x20, #+0x34",
         "cset w20, hs",
         "uxth w21, w4",
-        "mov x0, x21",
-        "bfi x0, x20, #16, #1",
-        "mov x20, x0",
-        "bfi x20, x20, #17, #17",
-        "bfi x20, x20, #34, #17",
-        "lsr w21, w20, w5",
-        "bfxil x4, x21, #0, #16",
+        "bfi x21, x20, #16, #1",
+        "bfi x21, x21, #17, #17",
+        "bfi x21, x21, #34, #17",
+        "lsr w20, w21, w5",
+        "bfxil x4, x20, #0, #16",
         "sub w22, w5, #0x1 (1)",
-        "lsr w20, w20, w22",
-        "rmif x20, #63, #nzCv",
-        "eor w20, w21, w21, lsr #1",
+        "lsr w21, w21, w22",
+        "rmif x21, #63, #nzCv",
+        "eor w20, w20, w20, lsr #1",
         "rmif x20, #14, #nzcV"
       ]
     },
@@ -2080,7 +2064,7 @@
       ]
     },
     "div bl": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP2 0xf6 /6",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2092,14 +2076,12 @@
         "uxth w1, w20",
         "udiv w2, w0, w1",
         "msub w20, w2, w1, w0",
-        "mov x0, x22",
-        "bfi x0, x20, #8, #8",
-        "mov x20, x0",
-        "bfxil x4, x20, #0, #16"
+        "bfi x22, x20, #8, #8",
+        "bfxil x4, x22, #0, #16"
       ]
     },
     "idiv bl": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP2 0xf6 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2109,10 +2091,8 @@
         "sdiv x22, x21, x20",
         "sdiv x0, x21, x20",
         "msub x20, x0, x20, x21",
-        "mov x0, x22",
-        "bfi x0, x20, #8, #8",
-        "mov x20, x0",
-        "bfxil x4, x20, #0, #16"
+        "bfi x22, x20, #8, #8",
+        "bfxil x4, x22, #0, #16"
       ]
     },
     "test bx, 1": {

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -656,7 +656,7 @@
       ]
     },
     "sha1msg2 xmm0, xmm1": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 11,
       "Comment": [
         "0x66 0x0f 0x38 0xca"
       ],
@@ -665,17 +665,13 @@
         "ext v2.16b, v2.16b, v17.16b, #12",
         "eor v2.16b, v16.16b, v2.16b",
         "shl v3.4s, v2.4s, #1",
-        "mov v0.16b, v3.16b",
-        "usra v0.4s, v2.4s, #31",
-        "mov v2.16b, v0.16b",
-        "dup v3.4s, v2.s[3]",
-        "eor v3.16b, v16.16b, v3.16b",
-        "shl v4.4s, v3.4s, #1",
-        "mov v0.16b, v4.16b",
-        "usra v0.4s, v3.4s, #31",
-        "mov v3.16b, v0.16b",
-        "mov v16.16b, v2.16b",
-        "mov v16.s[0], v3.s[0]"
+        "usra v3.4s, v2.4s, #31",
+        "dup v2.4s, v3.s[3]",
+        "eor v2.16b, v16.16b, v2.16b",
+        "shl v4.4s, v2.4s, #1",
+        "usra v4.4s, v2.4s, #31",
+        "mov v16.16b, v3.16b",
+        "mov v16.s[0], v4.s[0]"
       ]
     },
     "sha256rnds2 xmm0, xmm1": {
@@ -861,7 +857,7 @@
       ]
     },
     "adcx eax, ebx": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 14,
       "Comment": [
         "0x66 0x0f 0x38 0xf6"
       ],
@@ -878,14 +874,12 @@
         "cset x21, ls",
         "cmp x20, #0x1 (1)",
         "csel x20, x21, x23, eq",
-        "mov w0, w22",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w22, w20, #29, #1",
+        "msr nzcv, x22"
       ]
     },
     "adcx rax, rbx": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0x66 REX.W 0x0f 0x38 0xf6"
       ],
@@ -900,14 +894,12 @@
         "cset x23, ls",
         "cmp x20, #0x1 (1)",
         "csel x20, x23, x22, eq",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "adox eax, ebx": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 14,
       "Comment": [
         "0xf3 0x0f 0x38 0xf6"
       ],
@@ -924,14 +916,12 @@
         "cset x21, ls",
         "cmp x20, #0x1 (1)",
         "csel x20, x21, x23, eq",
-        "mov w0, w22",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "adox rax, rbx": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xf3 REX.W 0x0f 0x38 0xf6"
       ],
@@ -946,10 +936,8 @@
         "cset x23, ls",
         "cmp x20, #0x1 (1)",
         "csel x20, x23, x22, eq",
-        "mov w0, w21",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w21, w20, #28, #1",
+        "msr nzcv, x21"
       ]
     }
   }

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -2652,7 +2652,7 @@
       ]
     },
     "sahf": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 14,
       "Comment": "0x9e",
       "ExpectedArm64ASM": [
         "ubfx w20, w4, #8, #8",
@@ -2661,16 +2661,14 @@
         "orr x27, x20, #0x2",
         "ubfx x20, x27, #0, #1",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "ubfx w21, w27, #2, #1",
-        "eor w26, w21, #0x1",
-        "ubfx x21, x27, #6, #1",
-        "bfi w20, w21, #30, #1",
-        "ubfx x21, x27, #7, #1",
-        "bfi w20, w21, #31, #1",
-        "msr nzcv, x20"
+        "bfi w21, w20, #29, #1",
+        "ubfx w20, w27, #2, #1",
+        "eor w26, w20, #0x1",
+        "ubfx x20, x27, #6, #1",
+        "bfi w21, w20, #30, #1",
+        "ubfx x20, x27, #7, #1",
+        "bfi w21, w20, #31, #1",
+        "msr nzcv, x21"
       ]
     },
     "lahf": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -973,7 +973,7 @@
       ]
     },
     "rol al, 2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP2 0xC0 /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -981,30 +981,28 @@
         "bfi w20, w20, #16, #16",
         "ror w20, w20, #30",
         "bfxil x4, x20, #0, #8",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
         "ubfx x20, x20, #0, #1",
-        "orr w20, w21, w20, lsl #29",
-        "msr nzcv, x20"
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "ror al, 2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP2 0xC0 /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
         "bfi w20, w4, #8, #8",
         "ror w20, w20, #2",
         "bfxil x4, x20, #0, #8",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
         "ubfx x20, x20, #7, #1",
-        "orr w20, w21, w20, lsl #29",
-        "msr nzcv, x20"
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "rcl al, 2": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 21,
       "Comment": "GROUP2 0xC0 /2",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1020,40 +1018,32 @@
         "bfi x21, x22, #36, #1",
         "bfi x21, x20, #19, #8",
         "bfi x21, x22, #27, #1",
-        "mov x0, x21",
-        "bfxil x0, x20, #0, #8",
-        "mov x20, x0",
-        "ror x21, x20, #62",
-        "bfxil x4, x21, #0, #8",
-        "ror x20, x20, #61",
+        "bfxil x21, x20, #0, #8",
+        "ror x20, x21, #62",
+        "bfxil x4, x20, #0, #8",
+        "ror x20, x21, #61",
         "ubfx x20, x20, #0, #1",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "rcr al, 2": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 12,
       "Comment": "GROUP2 0xC0 /3",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "uxtb w21, w4",
-        "mov x0, x21",
-        "bfi x0, x20, #8, #1",
-        "mov x20, x0",
-        "bfi x20, x20, #9, #9",
-        "bfi x20, x20, #18, #18",
-        "bfi x20, x20, #36, #9",
-        "lsr w21, w20, #2",
-        "bfxil x4, x21, #0, #8",
-        "ubfx x20, x20, #1, #1",
+        "bfi x21, x20, #8, #1",
+        "bfi x21, x21, #9, #9",
+        "bfi x21, x21, #18, #18",
+        "bfi x21, x21, #36, #9",
+        "lsr w20, w21, #2",
+        "bfxil x4, x20, #0, #8",
+        "ubfx x20, x21, #1, #1",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "shl al, 2": {
@@ -1098,85 +1088,79 @@
       ]
     },
     "rol ax, 2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP2 0xC1 /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
         "bfi w20, w4, #16, #16",
         "ror w20, w20, #30",
         "bfxil x4, x20, #0, #16",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
         "ubfx x20, x20, #0, #1",
-        "orr w20, w21, w20, lsl #29",
-        "msr nzcv, x20"
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "rol eax, 2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP2 0xC1 /0",
       "ExpectedArm64ASM": [
         "ror w4, w4, #30",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "ubfx x21, x4, #0, #1",
-        "orr w20, w20, w21, lsl #29",
-        "msr nzcv, x20"
+        "ubfx x20, x4, #0, #1",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "rol rax, 2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP2 0xC1 /0",
       "ExpectedArm64ASM": [
         "ror x4, x4, #62",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "ubfx x21, x4, #0, #1",
-        "orr w20, w20, w21, lsl #29",
-        "msr nzcv, x20"
+        "ubfx x20, x4, #0, #1",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "ror ax, 2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP2 0xC1 /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
         "bfi w20, w4, #16, #16",
         "ror w20, w20, #2",
         "bfxil x4, x20, #0, #16",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
         "ubfx x20, x20, #15, #1",
-        "orr w20, w21, w20, lsl #29",
-        "msr nzcv, x20"
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "ror eax, 2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP2 0xC1 /1",
       "ExpectedArm64ASM": [
         "ror w4, w4, #2",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "ubfx x21, x4, #31, #1",
-        "orr w20, w20, w21, lsl #29",
-        "msr nzcv, x20"
+        "ubfx x20, x4, #31, #1",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "ror rax, 2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": "GROUP2 0xC1 /1",
       "ExpectedArm64ASM": [
         "ror x4, x4, #2",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "lsr x21, x4, #63",
-        "orr w20, w20, w21, lsl #29",
-        "msr nzcv, x20"
+        "lsr x20, x4, #63",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "rcl ax, 2": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 17,
       "Comment": "GROUP2 0xC1 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1188,18 +1172,14 @@
         "bfi x21, x22, #46, #1",
         "bfi x21, x20, #13, #16",
         "bfi x21, x22, #29, #1",
-        "mov x0, x21",
-        "bfxil x0, x20, #0, #16",
-        "mov x20, x0",
-        "ror x21, x20, #62",
-        "bfxil x4, x21, #0, #16",
-        "ror x20, x20, #61",
+        "bfxil x21, x20, #0, #16",
+        "ror x20, x21, #62",
+        "bfxil x4, x20, #0, #16",
+        "ror x20, x21, #61",
         "ubfx x20, x20, #0, #1",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "rcl eax, 2": {
@@ -1229,24 +1209,20 @@
       ]
     },
     "rcr ax, 2": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP2 0xC1 /3",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "uxth w21, w4",
-        "mov x0, x21",
-        "bfi x0, x20, #16, #1",
-        "mov x20, x0",
-        "bfi x20, x20, #17, #17",
-        "bfi x20, x20, #34, #17",
-        "lsr w21, w20, #2",
-        "bfxil x4, x21, #0, #16",
-        "ubfx x20, x20, #1, #1",
+        "bfi x21, x20, #16, #1",
+        "bfi x21, x21, #17, #17",
+        "bfi x21, x21, #34, #17",
+        "lsr w20, w21, #2",
+        "bfxil x4, x20, #0, #16",
+        "ubfx x20, x21, #1, #1",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w21, w20, #29, #1",
+        "msr nzcv, x21"
       ]
     },
     "rcr eax, 2": {
@@ -1395,7 +1371,7 @@
       ]
     },
     "rol al, 1": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Comment": "GROUP2 0xd0 /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1403,36 +1379,34 @@
         "bfi w20, w20, #16, #16",
         "ror w20, w20, #31",
         "bfxil x4, x20, #0, #8",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
-        "ubfx x22, x20, #0, #1",
-        "orr w21, w21, w22, lsl #29",
+        "ubfx x21, x20, #0, #1",
+        "mrs x22, nzcv",
+        "bfi w22, w21, #29, #1",
         "eor w20, w20, w20, lsr #7",
         "ubfx x20, x20, #0, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "ror al, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP2 0xd0 /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
         "bfi w20, w4, #8, #8",
         "ror w20, w20, #1",
         "bfxil x4, x20, #0, #8",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
-        "ubfx x22, x20, #7, #1",
-        "orr w21, w21, w22, lsl #29",
+        "ubfx x21, x20, #7, #1",
+        "mrs x22, nzcv",
+        "bfi w22, w21, #29, #1",
         "eor w20, w20, w20, lsr #1",
         "ubfx x20, x20, #6, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "rcl al, 1": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP2 0xd0 /2",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
@@ -1440,38 +1414,30 @@
         "orr w21, w21, w20, lsl #1",
         "ubfx x22, x20, #7, #1",
         "mrs x23, nzcv",
-        "mov w0, w23",
-        "bfi w0, w22, #29, #1",
-        "mov w22, w0",
+        "bfi w23, w22, #29, #1",
         "eor w20, w21, w20",
         "ubfx x20, x20, #7, #1",
-        "mov w0, w22",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
+        "bfi w23, w20, #28, #1",
         "bfxil x4, x21, #0, #8",
-        "msr nzcv, x20"
+        "msr nzcv, x23"
       ]
     },
     "rcr al, 1": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 12,
       "Comment": "GROUP2 0xd0 /3",
       "ExpectedArm64ASM": [
         "uxtb w20, w4",
         "cset w21, hs",
         "ubfx x22, x20, #0, #1",
         "mrs x23, nzcv",
-        "mov w0, w23",
-        "bfi w0, w22, #29, #1",
-        "mov w22, w0",
+        "bfi w23, w22, #29, #1",
         "ubfx w20, w20, #1, #7",
         "bfi w20, w21, #7, #1",
         "bfxil x4, x20, #0, #8",
         "eor w20, w20, w20, lsr #1",
         "ubfx x20, x20, #6, #1",
-        "mov w0, w22",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w23, w20, #28, #1",
+        "msr nzcv, x23"
       ]
     },
     "shl al, 1": {
@@ -1521,103 +1487,97 @@
       ]
     },
     "rol ax, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP2 0xd1 /0",
       "ExpectedArm64ASM": [
         "mov w20, w4",
         "bfi w20, w4, #16, #16",
         "ror w20, w20, #31",
         "bfxil x4, x20, #0, #16",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
-        "ubfx x22, x20, #0, #1",
-        "orr w21, w21, w22, lsl #29",
+        "ubfx x21, x20, #0, #1",
+        "mrs x22, nzcv",
+        "bfi w22, w21, #29, #1",
         "eor w20, w20, w20, lsr #15",
         "ubfx x20, x20, #0, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "rol eax, 1": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP2 0xd1 /0",
       "ExpectedArm64ASM": [
         "ror w4, w4, #31",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "ubfx x21, x4, #0, #1",
-        "orr w20, w20, w21, lsl #29",
-        "eor w21, w4, w4, lsr #31",
-        "ubfx x21, x21, #0, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "ubfx x20, x4, #0, #1",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "eor w20, w4, w4, lsr #31",
+        "ubfx x20, x20, #0, #1",
+        "bfi w21, w20, #28, #1",
+        "msr nzcv, x21"
       ]
     },
     "rol rax, 1": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP2 0xd1 /0",
       "ExpectedArm64ASM": [
         "ror x4, x4, #63",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "ubfx x21, x4, #0, #1",
-        "orr w20, w20, w21, lsl #29",
-        "eor x21, x4, x4, lsr #63",
-        "ubfx x21, x21, #0, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "ubfx x20, x4, #0, #1",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "eor x20, x4, x4, lsr #63",
+        "ubfx x20, x20, #0, #1",
+        "bfi w21, w20, #28, #1",
+        "msr nzcv, x21"
       ]
     },
     "ror ax, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP2 0xd1 /1",
       "ExpectedArm64ASM": [
         "mov w20, w4",
         "bfi w20, w4, #16, #16",
         "ror w20, w20, #1",
         "bfxil x4, x20, #0, #16",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
-        "ubfx x22, x20, #15, #1",
-        "orr w21, w21, w22, lsl #29",
+        "ubfx x21, x20, #15, #1",
+        "mrs x22, nzcv",
+        "bfi w22, w21, #29, #1",
         "eor w20, w20, w20, lsr #1",
         "ubfx x20, x20, #14, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "ror eax, 1": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP2 0xd1 /1",
       "ExpectedArm64ASM": [
         "ror w4, w4, #1",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "ubfx x21, x4, #31, #1",
-        "orr w20, w20, w21, lsl #29",
-        "eor w21, w4, w4, lsr #1",
-        "ubfx x21, x21, #30, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "ubfx x20, x4, #31, #1",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "eor w20, w4, w4, lsr #1",
+        "ubfx x20, x20, #30, #1",
+        "bfi w21, w20, #28, #1",
+        "msr nzcv, x21"
       ]
     },
     "ror rax, 1": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": "GROUP2 0xd1 /1",
       "ExpectedArm64ASM": [
         "ror x4, x4, #1",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "lsr x21, x4, #63",
-        "orr w20, w20, w21, lsl #29",
-        "eor x21, x4, x4, lsr #1",
-        "ubfx x21, x21, #62, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsr x20, x4, #63",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "eor x20, x4, x4, lsr #1",
+        "ubfx x20, x20, #62, #1",
+        "bfi w21, w20, #28, #1",
+        "msr nzcv, x21"
       ]
     },
     "rcl ax, 1": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
         "uxth w20, w4",
@@ -1625,20 +1585,16 @@
         "orr w21, w21, w20, lsl #1",
         "ubfx x22, x20, #15, #1",
         "mrs x23, nzcv",
-        "mov w0, w23",
-        "bfi w0, w22, #29, #1",
-        "mov w22, w0",
+        "bfi w23, w22, #29, #1",
         "eor w20, w21, w20",
         "ubfx x20, x20, #15, #1",
-        "mov w0, w22",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
+        "bfi w23, w20, #28, #1",
         "bfxil x4, x21, #0, #16",
-        "msr nzcv, x20"
+        "msr nzcv, x23"
       ]
     },
     "rcl eax, 1": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
         "mov w20, w4",
@@ -1646,92 +1602,74 @@
         "orr w4, w21, w20, lsl #1",
         "ubfx x21, x20, #31, #1",
         "mrs x22, nzcv",
-        "mov w0, w22",
-        "bfi w0, w21, #29, #1",
-        "mov w21, w0",
+        "bfi w22, w21, #29, #1",
         "eor w20, w4, w20",
         "ubfx x20, x20, #31, #1",
-        "mov w0, w21",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "rcl rax, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 10,
       "Comment": "GROUP2 0xd1 /2",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "orr x20, x20, x4, lsl #1",
         "lsr x21, x4, #63",
         "mrs x22, nzcv",
-        "mov w0, w22",
-        "bfi w0, w21, #29, #1",
-        "mov w21, w0",
-        "eor x22, x20, x4",
-        "lsr x22, x22, #63",
-        "bfi w21, w22, #28, #1",
+        "bfi w22, w21, #29, #1",
+        "eor x21, x20, x4",
+        "lsr x21, x21, #63",
+        "bfi w22, w21, #28, #1",
         "mov x4, x20",
-        "msr nzcv, x21"
+        "msr nzcv, x22"
       ]
     },
     "rcr ax, 1": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP2 0xd1 /3",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "ubfx x21, x4, #0, #1",
         "mrs x22, nzcv",
-        "mov w0, w22",
-        "bfi w0, w21, #29, #1",
-        "mov w21, w0",
-        "ubfx w22, w4, #1, #15",
-        "orr w20, w22, w20, lsl #15",
+        "bfi w22, w21, #29, #1",
+        "ubfx w21, w4, #1, #15",
+        "orr w20, w21, w20, lsl #15",
         "bfxil x4, x20, #0, #16",
         "eor x20, x20, x20, lsr #1",
         "ubfx x20, x20, #14, #1",
-        "mov w0, w21",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "rcr eax, 1": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP2 0xd1 /3",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "ubfx x21, x4, #0, #1",
         "mrs x22, nzcv",
-        "mov w0, w22",
-        "bfi w0, w21, #29, #1",
-        "mov w21, w0",
+        "bfi w22, w21, #29, #1",
         "extr w4, w20, w4, #1",
         "eor x20, x4, x4, lsr #1",
         "ubfx x20, x20, #30, #1",
-        "mov w0, w21",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "rcr rax, 1": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP2 0xd1 /3",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "ubfx x21, x4, #0, #1",
         "mrs x22, nzcv",
-        "mov w0, w22",
-        "bfi w0, w21, #29, #1",
-        "mov w21, w0",
+        "bfi w22, w21, #29, #1",
         "extr x4, x20, x4, #1",
         "eor x20, x4, x4, lsr #1",
         "ubfx x20, x20, #62, #1",
-        "mov w0, w21",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "shl ax, 1": {
@@ -1869,54 +1807,52 @@
       ]
     },
     "rol al, cl": {
-      "ExpectedInstructionCount": 16,
-      "Comment": "GROUP2 0xd2 /0",
-      "ExpectedArm64ASM": [
-        "and x20, x5, #0x1f",
-        "cbz x20, #+0x3c",
-        "mov w20, w4",
-        "bfi w20, w4, #8, #8",
-        "bfi w20, w20, #16, #16",
-        "neg w21, w5",
-        "ror w20, w20, w21",
-        "bfxil x4, x20, #0, #8",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
-        "ubfx x22, x20, #0, #1",
-        "orr w21, w21, w22, lsl #29",
-        "eor w20, w20, w20, lsr #7",
-        "ubfx x20, x20, #0, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
-      ]
-    },
-    "ror al, cl": {
       "ExpectedInstructionCount": 15,
-      "Comment": "GROUP2 0xd2 /1",
+      "Comment": "GROUP2 0xd2 /0",
       "ExpectedArm64ASM": [
         "and x20, x5, #0x1f",
         "cbz x20, #+0x38",
         "mov w20, w4",
         "bfi w20, w4, #8, #8",
         "bfi w20, w20, #16, #16",
+        "neg w21, w5",
+        "ror w20, w20, w21",
+        "bfxil x4, x20, #0, #8",
+        "ubfx x21, x20, #0, #1",
+        "mrs x22, nzcv",
+        "bfi w22, w21, #29, #1",
+        "eor w20, w20, w20, lsr #7",
+        "ubfx x20, x20, #0, #1",
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
+      ]
+    },
+    "ror al, cl": {
+      "ExpectedInstructionCount": 14,
+      "Comment": "GROUP2 0xd2 /1",
+      "ExpectedArm64ASM": [
+        "and x20, x5, #0x1f",
+        "cbz x20, #+0x34",
+        "mov w20, w4",
+        "bfi w20, w4, #8, #8",
+        "bfi w20, w20, #16, #16",
         "ror w20, w20, w5",
         "bfxil x4, x20, #0, #8",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
-        "ubfx x22, x20, #7, #1",
-        "orr w21, w21, w22, lsl #29",
+        "ubfx x21, x20, #7, #1",
+        "mrs x22, nzcv",
+        "bfi w22, w21, #29, #1",
         "eor w20, w20, w20, lsr #1",
         "ubfx x20, x20, #6, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "rcl al, cl": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 30,
       "Comment": "GROUP2 0xd2 /2",
       "ExpectedArm64ASM": [
         "and w20, w5, #0x1f",
-        "cbz x20, #+0x8c",
+        "cbz x20, #+0x74",
         "and w20, w5, #0x1f",
         "uxtb w21, w4",
         "mov w22, #0x0",
@@ -1931,55 +1867,45 @@
         "bfi x22, x23, #36, #1",
         "bfi x22, x21, #19, #8",
         "bfi x22, x23, #27, #1",
-        "mov x0, x22",
-        "bfxil x0, x21, #0, #8",
-        "mov x21, x0",
-        "neg w22, w20",
-        "ror x22, x21, x22",
-        "bfxil x4, x22, #0, #8",
+        "bfxil x22, x21, #0, #8",
+        "neg w21, w20",
+        "ror x21, x22, x21",
+        "bfxil x4, x21, #0, #8",
         "mov w23, #0x3f",
         "sub x20, x23, x20",
-        "ror x20, x21, x20",
-        "ubfx x21, x20, #0, #1",
+        "ror x20, x22, x20",
+        "ubfx x22, x20, #0, #1",
         "mrs x23, nzcv",
-        "mov w0, w23",
-        "bfi w0, w21, #29, #1",
-        "mov w21, w0",
-        "eor x20, x20, x22, lsr #7",
+        "bfi w23, w22, #29, #1",
+        "eor x20, x20, x21, lsr #7",
         "ubfx x20, x20, #0, #1",
-        "mov w0, w21",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w23, w20, #28, #1",
+        "msr nzcv, x23"
       ]
     },
     "rcr al, cl": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 19,
       "Comment": "GROUP2 0xd2 /3",
       "ExpectedArm64ASM": [
         "and w20, w5, #0x1f",
-        "cbz x20, #+0x58",
+        "cbz x20, #+0x48",
         "cset w20, hs",
         "uxtb w21, w4",
-        "mov x0, x21",
-        "bfi x0, x20, #8, #1",
-        "mov x20, x0",
-        "bfi x20, x20, #9, #9",
-        "bfi x20, x20, #18, #18",
-        "bfi x20, x20, #36, #9",
-        "lsr w21, w20, w5",
-        "bfxil x4, x21, #0, #8",
+        "bfi x21, x20, #8, #1",
+        "bfi x21, x21, #9, #9",
+        "bfi x21, x21, #18, #18",
+        "bfi x21, x21, #36, #9",
+        "lsr w20, w21, w5",
+        "bfxil x4, x20, #0, #8",
         "sub w22, w5, #0x1 (1)",
-        "lsr w20, w20, w22",
-        "ubfx x20, x20, #0, #1",
+        "lsr w21, w21, w22",
+        "ubfx x21, x21, #0, #1",
         "mrs x22, nzcv",
-        "mov w0, w22",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "eor w21, w21, w21, lsr #1",
-        "ubfx x21, x21, #6, #1",
-        "bfi w20, w21, #28, #1",
-        "msr nzcv, x20"
+        "bfi w22, w21, #29, #1",
+        "eor w20, w20, w20, lsr #1",
+        "ubfx x20, x20, #6, #1",
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "shl al, cl": {
@@ -2040,122 +1966,116 @@
       ]
     },
     "rol ax, cl": {
-      "ExpectedInstructionCount": 15,
-      "Comment": "GROUP2 0xd3 /0",
-      "ExpectedArm64ASM": [
-        "and x20, x5, #0x1f",
-        "cbz x20, #+0x38",
-        "mov w20, w4",
-        "bfi w20, w4, #16, #16",
-        "neg w21, w5",
-        "ror w20, w20, w21",
-        "bfxil x4, x20, #0, #16",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
-        "ubfx x22, x20, #0, #1",
-        "orr w21, w21, w22, lsl #29",
-        "eor w20, w20, w20, lsr #15",
-        "ubfx x20, x20, #0, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
-      ]
-    },
-    "rol eax, cl": {
-      "ExpectedInstructionCount": 12,
-      "Comment": "GROUP2 0xd3 /0",
-      "ExpectedArm64ASM": [
-        "and x20, x5, #0x1f",
-        "cbz x20, #+0x2c",
-        "neg w20, w5",
-        "ror w4, w4, w20",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "ubfx x21, x4, #0, #1",
-        "orr w20, w20, w21, lsl #29",
-        "eor w21, w4, w4, lsr #31",
-        "ubfx x21, x21, #0, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
-      ]
-    },
-    "rol rax, cl": {
-      "ExpectedInstructionCount": 12,
-      "Comment": "GROUP2 0xd3 /0",
-      "ExpectedArm64ASM": [
-        "and x20, x5, #0x3f",
-        "cbz x20, #+0x2c",
-        "neg x20, x5",
-        "ror x4, x4, x20",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "ubfx x21, x4, #0, #1",
-        "orr w20, w20, w21, lsl #29",
-        "eor x21, x4, x4, lsr #63",
-        "ubfx x21, x21, #0, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
-      ]
-    },
-    "ror ax, cl": {
       "ExpectedInstructionCount": 14,
-      "Comment": "GROUP2 0xd3 /1",
+      "Comment": "GROUP2 0xd3 /0",
       "ExpectedArm64ASM": [
         "and x20, x5, #0x1f",
         "cbz x20, #+0x34",
         "mov w20, w4",
         "bfi w20, w4, #16, #16",
-        "ror w20, w20, w5",
+        "neg w21, w5",
+        "ror w20, w20, w21",
         "bfxil x4, x20, #0, #16",
-        "mrs x21, nzcv",
-        "and w21, w21, #0xc0000000",
-        "ubfx x22, x20, #15, #1",
-        "orr w21, w21, w22, lsl #29",
-        "eor w20, w20, w20, lsr #1",
-        "ubfx x20, x20, #14, #1",
-        "orr w20, w21, w20, lsl #28",
-        "msr nzcv, x20"
+        "ubfx x21, x20, #0, #1",
+        "mrs x22, nzcv",
+        "bfi w22, w21, #29, #1",
+        "eor w20, w20, w20, lsr #15",
+        "ubfx x20, x20, #0, #1",
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
-    "ror eax, cl": {
+    "rol eax, cl": {
       "ExpectedInstructionCount": 11,
-      "Comment": "GROUP2 0xd3 /1",
+      "Comment": "GROUP2 0xd3 /0",
       "ExpectedArm64ASM": [
         "and x20, x5, #0x1f",
         "cbz x20, #+0x28",
-        "ror w4, w4, w5",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "ubfx x21, x4, #31, #1",
-        "orr w20, w20, w21, lsl #29",
-        "eor w21, w4, w4, lsr #1",
-        "ubfx x21, x21, #30, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "neg w20, w5",
+        "ror w4, w4, w20",
+        "ubfx x20, x4, #0, #1",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "eor w20, w4, w4, lsr #31",
+        "ubfx x20, x20, #0, #1",
+        "bfi w21, w20, #28, #1",
+        "msr nzcv, x21"
       ]
     },
-    "ror rax, cl": {
+    "rol rax, cl": {
       "ExpectedInstructionCount": 11,
-      "Comment": "GROUP2 0xd3 /1",
+      "Comment": "GROUP2 0xd3 /0",
       "ExpectedArm64ASM": [
         "and x20, x5, #0x3f",
         "cbz x20, #+0x28",
+        "neg x20, x5",
+        "ror x4, x4, x20",
+        "ubfx x20, x4, #0, #1",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "eor x20, x4, x4, lsr #63",
+        "ubfx x20, x20, #0, #1",
+        "bfi w21, w20, #28, #1",
+        "msr nzcv, x21"
+      ]
+    },
+    "ror ax, cl": {
+      "ExpectedInstructionCount": 13,
+      "Comment": "GROUP2 0xd3 /1",
+      "ExpectedArm64ASM": [
+        "and x20, x5, #0x1f",
+        "cbz x20, #+0x30",
+        "mov w20, w4",
+        "bfi w20, w4, #16, #16",
+        "ror w20, w20, w5",
+        "bfxil x4, x20, #0, #16",
+        "ubfx x21, x20, #15, #1",
+        "mrs x22, nzcv",
+        "bfi w22, w21, #29, #1",
+        "eor w20, w20, w20, lsr #1",
+        "ubfx x20, x20, #14, #1",
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
+      ]
+    },
+    "ror eax, cl": {
+      "ExpectedInstructionCount": 10,
+      "Comment": "GROUP2 0xd3 /1",
+      "ExpectedArm64ASM": [
+        "and x20, x5, #0x1f",
+        "cbz x20, #+0x24",
+        "ror w4, w4, w5",
+        "ubfx x20, x4, #31, #1",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "eor w20, w4, w4, lsr #1",
+        "ubfx x20, x20, #30, #1",
+        "bfi w21, w20, #28, #1",
+        "msr nzcv, x21"
+      ]
+    },
+    "ror rax, cl": {
+      "ExpectedInstructionCount": 10,
+      "Comment": "GROUP2 0xd3 /1",
+      "ExpectedArm64ASM": [
+        "and x20, x5, #0x3f",
+        "cbz x20, #+0x24",
         "ror x4, x4, x5",
-        "mrs x20, nzcv",
-        "and w20, w20, #0xc0000000",
-        "lsr x21, x4, #63",
-        "orr w20, w20, w21, lsl #29",
-        "eor x21, x4, x4, lsr #1",
-        "ubfx x21, x21, #62, #1",
-        "orr w20, w20, w21, lsl #28",
-        "msr nzcv, x20"
+        "lsr x20, x4, #63",
+        "mrs x21, nzcv",
+        "bfi w21, w20, #29, #1",
+        "eor x20, x4, x4, lsr #1",
+        "ubfx x20, x20, #62, #1",
+        "bfi w21, w20, #28, #1",
+        "msr nzcv, x21"
       ]
     },
     "rcl ax, cl": {
-      "ExpectedInstructionCount": 32,
+      "ExpectedInstructionCount": 26,
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
         "and w20, w5, #0x1f",
-        "cbz x20, #+0x7c",
+        "cbz x20, #+0x64",
         "and w20, w5, #0x1f",
         "uxth w21, w4",
         "mov w22, #0x0",
@@ -2166,34 +2086,28 @@
         "bfi x22, x23, #46, #1",
         "bfi x22, x21, #13, #16",
         "bfi x22, x23, #29, #1",
-        "mov x0, x22",
-        "bfxil x0, x21, #0, #16",
-        "mov x21, x0",
-        "neg w22, w20",
-        "ror x22, x21, x22",
-        "bfxil x4, x22, #0, #16",
+        "bfxil x22, x21, #0, #16",
+        "neg w21, w20",
+        "ror x21, x22, x21",
+        "bfxil x4, x21, #0, #16",
         "mov w23, #0x3f",
         "sub x20, x23, x20",
-        "ror x20, x21, x20",
-        "ubfx x21, x20, #0, #1",
+        "ror x20, x22, x20",
+        "ubfx x22, x20, #0, #1",
         "mrs x23, nzcv",
-        "mov w0, w23",
-        "bfi w0, w21, #29, #1",
-        "mov w21, w0",
-        "eor x20, x20, x22, lsr #15",
+        "bfi w23, w22, #29, #1",
+        "eor x20, x20, x21, lsr #15",
         "ubfx x20, x20, #0, #1",
-        "mov w0, w21",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w23, w20, #28, #1",
+        "msr nzcv, x23"
       ]
     },
     "rcl eax, cl": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 18,
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
         "and w20, w5, #0x1f",
-        "cbz x20, #+0x54",
+        "cbz x20, #+0x44",
         "lsl w20, w4, w5",
         "cset w21, hs",
         "neg w22, w5",
@@ -2202,26 +2116,22 @@
         "lsr w22, w4, w22",
         "ubfx x23, x22, #0, #1",
         "mrs x24, nzcv",
-        "mov w0, w24",
-        "bfi w0, w23, #29, #1",
-        "mov w23, w0",
-        "sub w24, w5, #0x1 (1)",
-        "lsl w21, w21, w24",
+        "bfi w24, w23, #29, #1",
+        "sub w23, w5, #0x1 (1)",
+        "lsl w21, w21, w23",
         "orr w4, w20, w21",
         "eor w20, w4, w22, lsl #31",
         "ubfx x20, x20, #31, #1",
-        "mov w0, w23",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w24, w20, #28, #1",
+        "msr nzcv, x24"
       ]
     },
     "rcl rax, cl": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 18,
       "Comment": "GROUP2 0xd3 /2",
       "ExpectedArm64ASM": [
         "and x20, x5, #0x3f",
-        "cbz x20, #+0x54",
+        "cbz x20, #+0x44",
         "lsl x20, x4, x5",
         "cset w21, hs",
         "neg x22, x5",
@@ -2230,54 +2140,46 @@
         "lsr x22, x4, x22",
         "ubfx x23, x22, #0, #1",
         "mrs x24, nzcv",
-        "mov w0, w24",
-        "bfi w0, w23, #29, #1",
-        "mov w23, w0",
-        "sub x24, x5, #0x1 (1)",
-        "lsl x21, x21, x24",
+        "bfi w24, w23, #29, #1",
+        "sub x23, x5, #0x1 (1)",
+        "lsl x21, x21, x23",
         "orr x4, x20, x21",
         "eor x20, x4, x22, lsl #63",
         "lsr x20, x20, #63",
-        "mov w0, w23",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w24, w20, #28, #1",
+        "msr nzcv, x24"
       ]
     },
     "rcr ax, cl": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 18,
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
         "and w20, w5, #0x1f",
-        "cbz x20, #+0x54",
+        "cbz x20, #+0x44",
         "cset w20, hs",
         "uxth w21, w4",
-        "mov x0, x21",
-        "bfi x0, x20, #16, #1",
-        "mov x20, x0",
-        "bfi x20, x20, #17, #17",
-        "bfi x20, x20, #34, #17",
-        "lsr w21, w20, w5",
-        "bfxil x4, x21, #0, #16",
+        "bfi x21, x20, #16, #1",
+        "bfi x21, x21, #17, #17",
+        "bfi x21, x21, #34, #17",
+        "lsr w20, w21, w5",
+        "bfxil x4, x20, #0, #16",
         "sub w22, w5, #0x1 (1)",
-        "lsr w20, w20, w22",
-        "ubfx x20, x20, #0, #1",
+        "lsr w21, w21, w22",
+        "ubfx x21, x21, #0, #1",
         "mrs x22, nzcv",
-        "mov w0, w22",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
-        "eor w21, w21, w21, lsr #1",
-        "ubfx x21, x21, #14, #1",
-        "bfi w20, w21, #28, #1",
-        "msr nzcv, x20"
+        "bfi w22, w21, #29, #1",
+        "eor w20, w20, w20, lsr #1",
+        "ubfx x20, x20, #14, #1",
+        "bfi w22, w20, #28, #1",
+        "msr nzcv, x22"
       ]
     },
     "rcr eax, cl": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 18,
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
         "and w20, w5, #0x1f",
-        "cbz x20, #+0x54",
+        "cbz x20, #+0x44",
         "lsr w20, w4, w5",
         "cset w21, hs",
         "neg w22, w5",
@@ -2287,25 +2189,21 @@
         "lsr w23, w4, w23",
         "ubfx x23, x23, #0, #1",
         "mrs x24, nzcv",
-        "mov w0, w24",
-        "bfi w0, w23, #29, #1",
-        "mov w23, w0",
+        "bfi w24, w23, #29, #1",
         "lsl w21, w21, w22",
         "orr w4, w20, w21",
         "eor w20, w4, w4, lsr #1",
         "ubfx x20, x20, #30, #1",
-        "mov w0, w23",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w24, w20, #28, #1",
+        "msr nzcv, x24"
       ]
     },
     "rcr rax, cl": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 18,
       "Comment": "GROUP2 0xd3 /3",
       "ExpectedArm64ASM": [
         "and x20, x5, #0x3f",
-        "cbz x20, #+0x54",
+        "cbz x20, #+0x44",
         "lsr x20, x4, x5",
         "cset w21, hs",
         "neg x22, x5",
@@ -2315,17 +2213,13 @@
         "lsr x23, x4, x23",
         "ubfx x23, x23, #0, #1",
         "mrs x24, nzcv",
-        "mov w0, w24",
-        "bfi w0, w23, #29, #1",
-        "mov w23, w0",
+        "bfi w24, w23, #29, #1",
         "lsl x21, x21, x22",
         "orr x4, x20, x21",
         "eor x20, x4, x4, lsr #1",
         "ubfx x20, x20, #62, #1",
-        "mov w0, w23",
-        "bfi w0, w20, #28, #1",
-        "mov w20, w0",
-        "msr nzcv, x20"
+        "bfi w24, w20, #28, #1",
+        "msr nzcv, x24"
       ]
     },
     "shl ax, cl": {
@@ -2550,7 +2444,7 @@
       ]
     },
     "div bl": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP2 0xf6 /6",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2562,14 +2456,12 @@
         "uxth w1, w20",
         "udiv w2, w0, w1",
         "msub w20, w2, w1, w0",
-        "mov x0, x22",
-        "bfi x0, x20, #8, #8",
-        "mov x20, x0",
-        "bfxil x4, x20, #0, #16"
+        "bfi x22, x20, #8, #8",
+        "bfxil x4, x22, #0, #16"
       ]
     },
     "idiv bl": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 9,
       "Comment": "GROUP2 0xf6 /7",
       "ExpectedArm64ASM": [
         "uxtb w20, w7",
@@ -2579,10 +2471,8 @@
         "sdiv x22, x21, x20",
         "sdiv x0, x21, x20",
         "msub x20, x0, x20, x21",
-        "mov x0, x22",
-        "bfi x0, x20, #8, #8",
-        "mov x20, x0",
-        "bfxil x4, x20, #0, #16"
+        "bfi x22, x20, #8, #8",
+        "bfxil x4, x22, #0, #16"
       ]
     },
     "test bx, 1": {
@@ -2956,33 +2846,29 @@
       ]
     },
     "inc eax": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "mov x27, x4",
         "adds w26, w4, #0x1 (1)",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
+        "bfi w21, w20, #29, #1",
         "mov x4, x26",
-        "msr nzcv, x20"
+        "msr nzcv, x21"
       ]
     },
     "inc rax": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP4 0xfe /0",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "mov x27, x4",
         "adds x26, x4, #0x1 (1)",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
+        "bfi w21, w20, #29, #1",
         "mov x4, x26",
-        "msr nzcv, x20"
+        "msr nzcv, x21"
       ]
     },
     "dec ax": {
@@ -3002,33 +2888,29 @@
       ]
     },
     "dec eax": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "mov x27, x4",
         "subs w26, w4, #0x1 (1)",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
+        "bfi w21, w20, #29, #1",
         "mov x4, x26",
-        "msr nzcv, x20"
+        "msr nzcv, x21"
       ]
     },
     "dec rax": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "GROUP4 0xfe /1",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "mov x27, x4",
         "subs x26, x4, #0x1 (1)",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
+        "bfi w21, w20, #29, #1",
         "mov x4, x26",
-        "msr nzcv, x20"
+        "msr nzcv, x21"
       ]
     },
     "push ax": {

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -199,18 +199,16 @@
       ]
     },
     "inc eax": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x40",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "mov x27, x4",
         "adds w26, w4, #0x1 (1)",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
+        "bfi w21, w20, #29, #1",
         "mov x4, x26",
-        "msr nzcv, x20"
+        "msr nzcv, x21"
       ]
     },
     "dec ax": {
@@ -244,18 +242,16 @@
       ]
     },
     "dec eax": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 7,
       "Comment": "0x48",
       "ExpectedArm64ASM": [
         "cset w20, hs",
         "mov x27, x4",
         "subs w26, w4, #0x1 (1)",
         "mrs x21, nzcv",
-        "mov w0, w21",
-        "bfi w0, w20, #29, #1",
-        "mov w20, w0",
+        "bfi w21, w20, #29, #1",
         "mov x4, x26",
-        "msr nzcv, x20"
+        "msr nzcv, x21"
       ]
     },
     "pusha": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -5305,7 +5305,7 @@
       ]
     },
     "vpsadbw ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 36,
       "Comment": [
         "Map 1 0b01 0xf6 256-bit"
       ],
@@ -5330,18 +5330,17 @@
         "mov z2.d, p0/m, z1.d",
         "msr nzcv, x0",
         "mov z1.q, q2",
-        "mov z2.d, z4.d",
         "not p0.b, p7/z, p6.b",
-        "mov z2.b, p0/m, z1.b",
-        "mov z1.d, z2.d[1]",
-        "mov z3.d, z2.d",
+        "mov z4.b, p0/m, z1.b",
+        "mov z1.d, z4.d[1]",
+        "mov z2.d, z4.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z3.d, p0/m, z1.d",
+        "mov z2.d, p0/m, z1.d",
         "msr nzcv, x0",
-        "mov z1.d, z2.d[2]",
-        "mov z16.d, z3.d",
+        "mov z1.d, z4.d[2]",
+        "mov z16.d, z2.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",


### PR DESCRIPTION
Many FEX IR ops want their dests assigned to the same register as a particular source. Denote this in the IR.

Then, add a very simple heuristic in the RA to take advantage of this in typical cases. The "proper" RA handling will hopefully come soon(tm) in a follow up PR, that will guarantee coalescing in all cases to let us delete a chunk of JIT code. But this is a step towards that anyhow.