### PR TITLE
Fix segfault when starting TestHarnessRunner with missing arguments

### DIFF
--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -198,13 +198,14 @@ int main(int argc, char** argv, char** const envp) {
   FEXCore::Config::Load();
 
   auto Args = FEX::ArgLoader::Get();
-  auto Filename = Args[0];
-  auto ConfigFile = Args[1];
 
   if (Args.size() < 2) {
     LogMan::Msg::EFmt("Not enough arguments");
     return -1;
   }
+
+  auto Filename = Args[0];
+  auto ConfigFile = Args[1];
 
   if (!FHU::Filesystem::Exists(Filename)) {
     LogMan::Msg::EFmt("File {} does not exist", Filename);


### PR DESCRIPTION
Found while trying to discover FEX codebase a bit.

Since https://github.com/FEX-Emu/FEX/pull/3390, launching `TestHarnessRunner` with missing arguments would cause a crash.
