### PR TITLE
unittests/bextr: add SrcSize tests

### DIFF
--- a/unittests/ASM/VEX/bextr.asm
+++ b/unittests/ASM/VEX/bextr.asm
@@ -4,6 +4,8 @@
       "RBX": "0",
       "RDX": "0xFF",
       "RSI": "0",
+      "R8" : "0xDEADBEEFDEADBEEF",
+      "R9" : "0xDEADBEEF",
       "R14": "0x7F",
       "R15": "0x838"
   },
@@ -21,6 +23,11 @@ mov rbx, -1
 mov rcx, 0
 bextr rbx, rbx, rcx
 
+; Extraction with 'SrcSize' bits should get the unchanged register
+mov r8, 0xDEADBEEFDEADBEEF
+mov r9, 16384              ; Start at 0 extract 64 bits
+bextr r8, r8, r9           ; r8 should stay the same
+
 ; Same tests as above but with 32-bit registers
 
 ; General extraction
@@ -32,5 +39,10 @@ bextr edx, edx, esi         ; This results in 0xFF being placed into EDX
 mov rsi, -1
 mov rdi, 0
 bextr esi, esi, edi
+
+; Extraction with 'SrcSize' bits should get the unchanged register
+mov r9, 0xDEADBEEFDEADBEEF
+mov r10, 8192               ; Start at 0 extract 32 bits
+bextr r9d, r9d, r10d        ; r9 should become 0xDEADBEEF (and r9d stays the same)
 
 hlt


### PR DESCRIPTION
dougallj mentioned that adding these tests might expose a bug in bextr. Since bextr implementation was changed apparently it now works correctly, that's good.