### PR TITLE
Scripts/InstallFEX: update PPA URL

### DIFF
--- a/Scripts/InstallFEX.py
+++ b/Scripts/InstallFEX.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import re
 
 _Arch = None
 def GetArch():
@@ -131,7 +132,7 @@ def GetCPUFeaturesVersion():
     return _ArchVersion
 
 _PPAInstalled = None
-FEXPPA = "http://ppa.launchpad.net/fex-emu/fex/ubuntu"
+FEXPPA_REGEX = r".*\/fex-emu\/fex\/ubuntu$"
 
 def GetPPAStatus():
     global _PPAInstalled
@@ -147,7 +148,7 @@ def GetPPAStatus():
                 LineSplit = Line.split(" ")
 
                 # 'status' 'URL' 'series' 'arch' 'type'
-                if LineSplit[1] == FEXPPA:
+                if re.match(FEXPPA_REGEX, LineSplit[1]):
                     _PPAInstalled = True
                     break
 


### PR DESCRIPTION
After running the script my Ubuntu 24.04 lists https://ppa.launchpadcontent.net/fex-emu/fex/ubuntu in the output of `apt-cache policy` (which means GetPPAStatus would always fail).

Now, maybe older Ubuntus use http://ppa.launchpad.net/fex-emu/fex/ubuntu? If not then I guess the fix is just this commit, otherwise some sort of `or` with strings would be in order.