### PR TITLE
FEX: Consolidate JSON allocators and fix 3691

### DIFF
--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRCS
   Config.cpp
   ArgumentLoader.cpp
   EnvironmentLoader.cpp
+  JSONPool.cpp
   StringUtil.cpp)
 
 if (NOT MINGW_BUILD)

--- a/Source/Common/JSONPool.cpp
+++ b/Source/Common/JSONPool.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+#include "Common/JSONPool.h"
+
+namespace FEX::JSON {
+json_t* PoolInit(jsonPool_t* Pool);
+json_t* PoolAlloc(jsonPool_t* Pool);
+
+JsonAllocator::JsonAllocator()
+  : PoolObject {
+      .init = FEX::JSON::PoolInit,
+      .alloc = FEX::JSON::PoolAlloc,
+    } {}
+
+json_t* PoolInit(jsonPool_t* Pool) {
+  JsonAllocator* alloc = reinterpret_cast<JsonAllocator*>(Pool);
+  return &*alloc->json_objects.emplace(alloc->json_objects.end());
+}
+
+json_t* PoolAlloc(jsonPool_t* Pool) {
+  JsonAllocator* alloc = reinterpret_cast<JsonAllocator*>(Pool);
+  return &*alloc->json_objects.emplace(alloc->json_objects.end());
+}
+} // namespace FEX::JSON

--- a/Source/Common/JSONPool.h
+++ b/Source/Common/JSONPool.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+#include <FEXCore/fextl/memory.h>
+#include <FEXCore/fextl/list.h>
+
+#include <tiny-json.h>
+
+namespace FEX::JSON {
+struct JsonAllocator {
+  jsonPool_t PoolObject;
+  fextl::list<json_t> json_objects;
+
+  JsonAllocator();
+};
+static_assert(offsetof(JsonAllocator, PoolObject) == 0, "This needs to be at offset zero");
+
+template<typename T>
+const json_t* CreateJSON(T& Container, JsonAllocator& Allocator) {
+  if (Container.empty()) {
+    return nullptr;
+  }
+
+  return json_createWithPool(&Container.at(0), &Allocator.PoolObject);
+}
+} // namespace FEX::JSON


### PR DESCRIPTION
Fixes #3691

We weren't checking if the file was empty before using its `at` function member. This was causing an early crash if the config file existed but was empty.

Consolidates the three locations that copy and pasted the json allocator tools and adds an empty check for all of them.

Also adds two missing checks to the ThunksDB handler that could have resulted in the same crash if ThunksDB was an empty file.