### PR TITLE
Revert "OpcodeDispatcher: optimize logical flags"

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -511,13 +511,10 @@ void OpDispatchBuilder::CalculateFlags_Logical(uint8_t SrcSize, Ref Res, Ref Src
   // Undefined
   _InvalidateFlags(1 << X86State::RFLAG_AF_RAW_LOC);
 
-  if (SrcSize >= 4) {
-    HandleNZ00Write();
-    CalculatePF(_AndWithFlags(IR::SizeToOpSize(SrcSize), Res, Res));
-  } else {
-    SetNZ_ZeroCV(SrcSize, Res);
-    CalculatePF(Res);
-  }
+  CalculatePF(Res);
+
+  // SF/ZF/CF/OF
+  SetNZ_ZeroCV(SrcSize, Res);
 }
 
 void OpDispatchBuilder::CalculateFlags_ShiftLeftImmediate(uint8_t SrcSize, Ref UnmaskedRes, Ref Src1, uint64_t Shift) {

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -64,8 +64,8 @@
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "ldsetal w5, w20, [x4]",
-        "orr w20, w20, w5",
-        "ands w26, w20, w20"
+        "orr w26, w20, w5",
+        "tst w26, w26"
       ]
     },
     "lock adc byte [rax], cl": {
@@ -290,8 +290,8 @@
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "ldeoral w5, w20, [x4]",
-        "eor w20, w20, w5",
-        "ands w26, w20, w20"
+        "eor w26, w20, w5",
+        "tst w26, w26"
       ]
     },
     "lock add qword [rax], rcx": {
@@ -537,8 +537,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "ldsetal w20, w20, [x4]",
-        "orr w20, w20, #0x100",
-        "ands w26, w20, w20"
+        "orr w26, w20, #0x100",
+        "tst w26, w26"
       ]
     },
     "lock or dword [rax], 0xFFFFFFFF": {
@@ -547,8 +547,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "ldsetal w20, w21, [x4]",
-        "orr w20, w21, w20",
-        "ands w26, w20, w20"
+        "orr w26, w21, w20",
+        "tst w26, w26"
       ]
     },
     "lock or qword [rax], 0x100": {
@@ -557,8 +557,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "ldsetal x20, x20, [x4]",
-        "orr x20, x20, #0x100",
-        "ands x26, x20, x20"
+        "orr x26, x20, #0x100",
+        "tst x26, x26"
       ]
     },
     "lock or qword [rax], -2147483647": {
@@ -567,8 +567,8 @@
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
         "ldsetal x20, x20, [x4]",
-        "orr x20, x20, #0xffffffff80000001",
-        "ands x26, x20, x20"
+        "orr x26, x20, #0xffffffff80000001",
+        "tst x26, x26"
       ]
     },
     "lock or word [rax], 1": {
@@ -587,8 +587,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldsetal w20, w20, [x4]",
-        "orr w20, w20, #0x1",
-        "ands w26, w20, w20"
+        "orr w26, w20, #0x1",
+        "tst w26, w26"
       ]
     },
     "lock or qword [rax], 1": {
@@ -597,8 +597,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldsetal x20, x20, [x4]",
-        "orr x20, x20, #0x1",
-        "ands x26, x20, x20"
+        "orr x26, x20, #0x1",
+        "tst x26, x26"
       ]
     },
     "lock adc byte [rax], 1": {
@@ -1326,8 +1326,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "ldeoral w20, w20, [x4]",
-        "eor w20, w20, #0x100",
-        "ands w26, w20, w20"
+        "eor w26, w20, #0x100",
+        "tst w26, w26"
       ]
     },
     "lock xor dword [rax], 0xFFFFFFFF": {
@@ -1336,8 +1336,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "ldeoral w20, w21, [x4]",
-        "eor w20, w21, w20",
-        "ands w26, w20, w20"
+        "eor w26, w21, w20",
+        "tst w26, w26"
       ]
     },
     "lock xor qword [rax], 0x100": {
@@ -1346,8 +1346,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "ldeoral x20, x20, [x4]",
-        "eor x20, x20, #0x100",
-        "ands x26, x20, x20"
+        "eor x26, x20, #0x100",
+        "tst x26, x26"
       ]
     },
     "lock xor qword [rax], -2147483647": {
@@ -1356,8 +1356,8 @@
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
         "ldeoral x20, x20, [x4]",
-        "eor x20, x20, #0xffffffff80000001",
-        "ands x26, x20, x20"
+        "eor x26, x20, #0xffffffff80000001",
+        "tst x26, x26"
       ]
     },
     "lock xor word [rax], 1": {
@@ -1376,8 +1376,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldeoral w20, w20, [x4]",
-        "eor w20, w20, #0x1",
-        "ands w26, w20, w20"
+        "eor w26, w20, #0x1",
+        "tst w26, w26"
       ]
     },
     "lock xor qword [rax], 1": {
@@ -1386,8 +1386,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldeoral x20, x20, [x4]",
-        "eor x20, x20, #0x1",
-        "ands x26, x20, x20"
+        "eor x26, x20, #0x1",
+        "tst x26, x26"
       ]
     },
     "lock dec byte [rax]": {

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -65,8 +65,8 @@
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "ldsetal w5, w20, [x4]",
-        "orr w20, w20, w5",
-        "ands w26, w20, w20"
+        "orr w26, w20, w5",
+        "tst w26, w26"
       ]
     },
     "lock adc byte [rax], cl": {
@@ -269,8 +269,8 @@
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "ldeoral w5, w20, [x4]",
-        "eor w20, w20, w5",
-        "ands w26, w20, w20"
+        "eor w26, w20, w5",
+        "tst w26, w26"
       ]
     },
     "lock add qword [rax], rcx": {
@@ -486,8 +486,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "ldsetal w20, w20, [x4]",
-        "orr w20, w20, #0x100",
-        "ands w26, w20, w20"
+        "orr w26, w20, #0x100",
+        "tst w26, w26"
       ]
     },
     "lock or dword [rax], 0xFFFFFFFF": {
@@ -496,8 +496,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "ldsetal w20, w21, [x4]",
-        "orr w20, w21, w20",
-        "ands w26, w20, w20"
+        "orr w26, w21, w20",
+        "tst w26, w26"
       ]
     },
     "lock or qword [rax], 0x100": {
@@ -506,8 +506,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "ldsetal x20, x20, [x4]",
-        "orr x20, x20, #0x100",
-        "ands x26, x20, x20"
+        "orr x26, x20, #0x100",
+        "tst x26, x26"
       ]
     },
     "lock or qword [rax], -2147483647": {
@@ -516,8 +516,8 @@
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
         "ldsetal x20, x20, [x4]",
-        "orr x20, x20, #0xffffffff80000001",
-        "ands x26, x20, x20"
+        "orr x26, x20, #0xffffffff80000001",
+        "tst x26, x26"
       ]
     },
     "lock or word [rax], 1": {
@@ -536,8 +536,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldsetal w20, w20, [x4]",
-        "orr w20, w20, #0x1",
-        "ands w26, w20, w20"
+        "orr w26, w20, #0x1",
+        "tst w26, w26"
       ]
     },
     "lock or qword [rax], 1": {
@@ -546,8 +546,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldsetal x20, x20, [x4]",
-        "orr x20, x20, #0x1",
-        "ands x26, x20, x20"
+        "orr x26, x20, #0x1",
+        "tst x26, x26"
       ]
     },
     "lock adc byte [rax], 1": {
@@ -1199,8 +1199,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "ldeoral w20, w20, [x4]",
-        "eor w20, w20, #0x100",
-        "ands w26, w20, w20"
+        "eor w26, w20, #0x100",
+        "tst w26, w26"
       ]
     },
     "lock xor dword [rax], 0xFFFFFFFF": {
@@ -1209,8 +1209,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "ldeoral w20, w21, [x4]",
-        "eor w20, w21, w20",
-        "ands w26, w20, w20"
+        "eor w26, w21, w20",
+        "tst w26, w26"
       ]
     },
     "lock xor qword [rax], 0x100": {
@@ -1219,8 +1219,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x100",
         "ldeoral x20, x20, [x4]",
-        "eor x20, x20, #0x100",
-        "ands x26, x20, x20"
+        "eor x26, x20, #0x100",
+        "tst x26, x26"
       ]
     },
     "lock xor qword [rax], -2147483647": {
@@ -1229,8 +1229,8 @@
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffff80000001",
         "ldeoral x20, x20, [x4]",
-        "eor x20, x20, #0xffffffff80000001",
-        "ands x26, x20, x20"
+        "eor x26, x20, #0xffffffff80000001",
+        "tst x26, x26"
       ]
     },
     "lock xor word [rax], 1": {
@@ -1249,8 +1249,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldeoral w20, w20, [x4]",
-        "eor w20, w20, #0x1",
-        "ands w26, w20, w20"
+        "eor w26, w20, #0x1",
+        "tst w26, w26"
       ]
     },
     "lock xor qword [rax], 1": {
@@ -1259,8 +1259,8 @@
       "ExpectedArm64ASM": [
         "mov w20, #0x1",
         "ldeoral x20, x20, [x4]",
-        "eor x20, x20, #0x1",
-        "ands x26, x20, x20"
+        "eor x26, x20, #0x1",
+        "tst x26, x26"
       ]
     },
     "lock dec byte [rax]": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -217,19 +217,21 @@
       ]
     },
     "or ebx, ecx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "orr w7, w7, w5",
-        "ands w26, w7, w7"
+        "mov x26, x7",
+        "tst w7, w7"
       ]
     },
     "or rbx, rcx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "orr x7, x7, x5",
-        "ands x26, x7, x7"
+        "mov x26, x7",
+        "tst x7, x7"
       ]
     },
     "db 0x0A, 0xcb": {
@@ -257,25 +259,27 @@
       ]
     },
     "db 0x0B, 0xcb": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "0x0B",
         "or ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
         "orr w5, w5, w7",
-        "ands w26, w5, w5"
+        "mov x26, x5",
+        "tst w5, w5"
       ]
     },
     "db 0x48, 0x0B, 0xcb": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "0x0B",
         "or rbx, rcx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
         "orr x5, x5, x7",
-        "ands x26, x5, x5"
+        "mov x26, x5",
+        "tst x5, x5"
       ]
     },
     "or al, 1": {
@@ -297,19 +301,21 @@
       ]
     },
     "or eax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x1",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x1",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "or al, -1": {
@@ -331,21 +337,23 @@
       ]
     },
     "or eax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "orr w4, w4, w20",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
         "orr x4, x4, x20",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "adc bl, cl": {
@@ -1223,19 +1231,21 @@
       ]
     },
     "xor ebx, ecx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "eor w7, w7, w5",
-        "ands w26, w7, w7"
+        "mov x26, x7",
+        "tst w7, w7"
       ]
     },
     "xor rbx, rcx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "eor x7, x7, x5",
-        "ands x26, x7, x7"
+        "mov x26, x7",
+        "tst x7, x7"
       ]
     },
     "db 0x32, 0xcb": {
@@ -1263,25 +1273,27 @@
       ]
     },
     "db 0x33, 0xcb": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "0x33",
         "xor ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
         "eor w5, w5, w7",
-        "ands w26, w5, w5"
+        "mov x26, x5",
+        "tst w5, w5"
       ]
     },
     "db 0x48, 0x33, 0xcb": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "0x33",
         "xor rbx, rcx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
         "eor x5, x5, x7",
-        "ands x26, x5, x5"
+        "mov x26, x5",
+        "tst x5, x5"
       ]
     },
     "xor al, 1": {
@@ -1303,19 +1315,21 @@
       ]
     },
     "xor eax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x1",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x1",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp bl, cl": {
@@ -1348,21 +1362,23 @@
       ]
     },
     "xor eax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "eor w4, w4, w20",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
         "eor x4, x4, x20",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp bx, cx": {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -248,19 +248,21 @@
       ]
     },
     "or eax, 256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x100",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, 256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x100",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "adc eax, 256": {
@@ -344,19 +346,21 @@
       ]
     },
     "xor eax, 256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x100",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, 256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x100",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp eax, 256": {
@@ -409,19 +413,21 @@
       ]
     },
     "or eax, -256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0xffffff00",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, -256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0xffffffffffffff00",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "adc eax, -256": {
@@ -506,19 +512,21 @@
       ]
     },
     "xor eax, -256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0xffffff00",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, -256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0xffffffffffffff00",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp eax, -256": {
@@ -571,19 +579,21 @@
       ]
     },
     "or eax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x1",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x1",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "adc eax, 1": {
@@ -667,19 +677,21 @@
       ]
     },
     "xor eax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x1",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x1",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp eax, 1": {
@@ -732,21 +744,23 @@
       ]
     },
     "or eax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "GROUP1 0x83 /-1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "orr w4, w4, w20",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "GROUP1 0x83 /-1",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
         "orr x4, x4, x20",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "adc eax, -1": {
@@ -833,21 +847,23 @@
       ]
     },
     "xor eax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "eor w4, w4, w20",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
         "eor x4, x4, x20",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp eax, -1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -344,23 +344,25 @@
       ]
     },
     "andn eax, ebx, ecx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b00 0xf2 32-bit"
       ],
       "ExpectedArm64ASM": [
         "bic w4, w5, w7",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "andn rax, rbx, rcx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b00 0xf2 64-bit"
       ],
       "ExpectedArm64ASM": [
         "bic x4, x5, x7",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "bzhi eax, ebx, ecx": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -216,19 +216,21 @@
       ]
     },
     "or ebx, ecx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "orr w7, w7, w5",
-        "ands w26, w7, w7"
+        "mov x26, x7",
+        "tst w7, w7"
       ]
     },
     "or rbx, rcx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x09",
       "ExpectedArm64ASM": [
         "orr x7, x7, x5",
-        "ands x26, x7, x7"
+        "mov x26, x7",
+        "tst x7, x7"
       ]
     },
     "db 0x0A, 0xcb": {
@@ -256,25 +258,27 @@
       ]
     },
     "db 0x0B, 0xcb": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "0x0B",
         "or ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
         "orr w5, w5, w7",
-        "ands w26, w5, w5"
+        "mov x26, x5",
+        "tst w5, w5"
       ]
     },
     "db 0x48, 0x0B, 0xcb": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "0x0B",
         "or rbx, rcx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
         "orr x5, x5, x7",
-        "ands x26, x5, x5"
+        "mov x26, x5",
+        "tst x5, x5"
       ]
     },
     "or al, 1": {
@@ -296,19 +300,21 @@
       ]
     },
     "or eax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x1",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x1",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "or al, -1": {
@@ -330,21 +336,23 @@
       ]
     },
     "or eax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "orr w4, w4, w20",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "0x0D",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
         "orr x4, x4, x20",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "adc bl, cl": {
@@ -1334,19 +1342,21 @@
       ]
     },
     "xor ebx, ecx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "eor w7, w7, w5",
-        "ands w26, w7, w7"
+        "mov x26, x7",
+        "tst w7, w7"
       ]
     },
     "xor rbx, rcx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x31",
       "ExpectedArm64ASM": [
         "eor x7, x7, x5",
-        "ands x26, x7, x7"
+        "mov x26, x7",
+        "tst x7, x7"
       ]
     },
     "db 0x32, 0xcb": {
@@ -1374,25 +1384,27 @@
       ]
     },
     "db 0x33, 0xcb": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "0x33",
         "xor ebx, ecx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
         "eor w5, w5, w7",
-        "ands w26, w5, w5"
+        "mov x26, x5",
+        "tst w5, w5"
       ]
     },
     "db 0x48, 0x33, 0xcb": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "0x33",
         "xor rbx, rcx but modrm.rm as source"
       ],
       "ExpectedArm64ASM": [
         "eor x5, x5, x7",
-        "ands x26, x5, x5"
+        "mov x26, x5",
+        "tst x5, x5"
       ]
     },
     "xor al, 1": {
@@ -1414,19 +1426,21 @@
       ]
     },
     "xor eax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x1",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x1",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp bl, cl": {
@@ -1461,21 +1475,23 @@
       ]
     },
     "xor eax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "eor w4, w4, w20",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "0x35",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
         "eor x4, x4, x20",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp bx, cx": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -271,19 +271,21 @@
       ]
     },
     "or eax, 256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x100",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, 256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x100",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "adc eax, 256": {
@@ -379,19 +381,21 @@
       ]
     },
     "xor eax, 256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x100",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, 256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x100",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp eax, 256": {
@@ -448,19 +452,21 @@
       ]
     },
     "or eax, -256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0xffffff00",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, -256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0xffffffffffffff00",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "adc eax, -256": {
@@ -557,19 +563,21 @@
       ]
     },
     "xor eax, -256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0xffffff00",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, -256": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x81 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0xffffffffffffff00",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp eax, -256": {
@@ -626,19 +634,21 @@
       ]
     },
     "or eax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "orr w4, w4, #0x1",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x83 /1",
       "ExpectedArm64ASM": [
         "orr x4, x4, #0x1",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "adc eax, 1": {
@@ -734,19 +744,21 @@
       ]
     },
     "xor eax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "eor w4, w4, #0x1",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, 1": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "eor x4, x4, #0x1",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp eax, 1": {
@@ -803,21 +815,23 @@
       ]
     },
     "or eax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "GROUP1 0x83 /-1",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "orr w4, w4, w20",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "or rax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "GROUP1 0x83 /-1",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
         "orr x4, x4, x20",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "adc eax, -1": {
@@ -916,21 +930,23 @@
       ]
     },
     "xor eax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov w20, #0xffffffff",
         "eor w4, w4, w20",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "xor rax, -1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 4,
       "Comment": "GROUP1 0x83 /6",
       "ExpectedArm64ASM": [
         "mov x20, #0xffffffffffffffff",
         "eor x4, x4, x20",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "cmp eax, -1": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -3167,23 +3167,25 @@
       ]
     },
     "andn eax, ebx, ecx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b00 0xf2 32-bit"
       ],
       "ExpectedArm64ASM": [
         "bic w4, w5, w7",
-        "ands w26, w4, w4"
+        "mov x26, x4",
+        "tst w4, w4"
       ]
     },
     "andn rax, rbx, rcx": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b00 0xf2 64-bit"
       ],
       "ExpectedArm64ASM": [
         "bic x4, x5, x7",
-        "ands x26, x4, x4"
+        "mov x26, x4",
+        "tst x4, x4"
       ]
     },
     "bzhi eax, ebx, ecx": {


### PR DESCRIPTION
This reverts commit bb8336fcad9cf5619215e5a9f765ca48c7d48970.

Fixes #3686

Tried creating some unit tests to figure out why this is broken, but it is likely an interaction between multiple instructions.
Revert for now to fix the compatibility issue, which will be a minor performance hit.