### PR TITLE
FEXCore: Fixes Call with 32-bit displacement and address size override

### DIFF
--- a/unittests/ASM/FEX_bugs/NegativeCallAddressSizeOverride.asm
+++ b/unittests/ASM/FEX_bugs/NegativeCallAddressSizeOverride.asm
@@ -1,0 +1,24 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "1"
+  }
+}
+%endif
+
+; FEX had a bug with relative call instructions.
+; It was incorrectly truncating the immediate displacement based on address size override AND operand size override.
+; Address size override doesn't actually change immediate representation on the call instruction.
+
+mov rsp, 0xe000_1000
+mov rax, 0
+
+jmp .after
+.test:
+mov rax, 1
+hlt
+
+.after:
+a32 call .test
+
+hlt


### PR DESCRIPTION
FEX had a bug with this instruction where it was incorrectly using both the address size override and operand size override to truncate the immediate offset. This isn't how the instruction should behave as it should actually ignore the address size override.

This now puts it correctly inline with how the jump instruction works and adds a unit test to ensure it doesn't break again.

This fixes a crash from the Arch rootfs from the glibc dynamic linker being compiling in a way where a call instruction was getting aligned using this prefix (Since the compiler knew it does nothing).

As a side-note, FEX doesn't handle 16-bit displacement at all in both the jump and call instructions. This is because the operand size qualifier controls both the immediate size and the RIP size. This is because the override will truncate the resulting rip to 16-bit, which falls in to the 16-bit guard pages at the start of the process. Theoretically an application can abuse this with fault behaviour but wiring up unittests for this would be a nightmare. I'm opting to continue not supporting this behaviour.