### PR TITLE
LinuxEmulation: Add a helper for getting the ThreadStateObject from CPU frame

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -463,7 +463,7 @@ static void PrintFlags(uint64_t Flags) {
 
 static uint64_t Clone2Handler(FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args* args) {
   StackFrameData* Data = (StackFrameData*)FEXCore::Allocator::malloc(sizeof(StackFrameData));
-  Data->Thread = static_cast<FEX::HLE::ThreadStateObject*>(Frame->Thread->FrontendPtr);
+  Data->Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
   Data->CTX = Frame->Thread->CTX;
   Data->GuestArgs = *args;
 
@@ -489,7 +489,7 @@ static uint64_t Clone3Handler(FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clo
   constexpr size_t Offset = sizeof(StackFramePlusRet);
   StackFramePlusRet* Data = (StackFramePlusRet*)(reinterpret_cast<uint64_t>(args->NewStack) + args->StackSize - Offset);
   Data->Ret = (uint64_t)Clone3HandlerRet;
-  Data->Data.Thread = static_cast<FEX::HLE::ThreadStateObject*>(Frame->Thread->FrontendPtr);
+  Data->Data.Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
   Data->Data.CTX = Frame->Thread->CTX;
   Data->Data.GuestArgs = *args;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -385,7 +385,7 @@ void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
                                 // TLS/DTV teardown is something FEX can't control. Disable glibc checking when we leave a pthread.
                                 // Since this thread is hard stopping, we can't track the TLS/DTV teardown in FEX's thread handling.
                                 FEXCore::Allocator::YesIKnowImNotSupposedToUseTheGlibcAllocator::HardDisable();
-                                auto ThreadObject = static_cast<FEX::HLE::ThreadStateObject*>(Thread->FrontendPtr);
+                                auto ThreadObject = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
 
                                 if (Thread->ThreadManager.clear_child_tid) {
                                   std::atomic<uint32_t>* Addr = reinterpret_cast<std::atomic<uint32_t>*>(Thread->ThreadManager.clear_child_tid);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -217,8 +217,8 @@ void ThreadManager::UnlockAfterFork(FEXCore::Core::InternalThreadState* LiveThre
   // Remove all threads but the live thread from Threads
   Threads.clear();
 
-  auto LiveThreadData = static_cast<FEX::HLE::ThreadStateObject*>(LiveThread->FrontendPtr);
-  Threads.push_back(LiveThreadData);
+  auto ThreadObject = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(LiveThread->CurrentFrame);
+  Threads.push_back(ThreadObject);
 
   // Clean up dead stacks
   FEXCore::Threads::Thread::CleanupAfterFork();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -30,6 +30,11 @@ public:
 
   ~ThreadManager();
 
+  ///< Returns the ThreadStateObject from a CpuStateFrame object.
+  static inline FEX::HLE::ThreadStateObject* GetStateObjectFromCPUState(FEXCore::Core::CpuStateFrame* Frame) {
+    return static_cast<FEX::HLE::ThreadStateObject*>(Frame->Thread->FrontendPtr);
+  }
+
   FEX::HLE::ThreadStateObject*
   CreateThread(uint64_t InitialRIP, uint64_t StackPointer, FEXCore::Core::CPUState* NewThreadState = nullptr, uint64_t ParentTID = 0);
   void TrackThread(FEX::HLE::ThreadStateObject* Thread) {


### PR DESCRIPTION
Pulled from the seccomp WIP PR where it pulls this object more frequently. Since it is an opaque frontend pointer it needs to be cast and we already have a few locations that use it.

No functional change.