### PR TITLE
FEXCore: Disentangle the SVE256 feature from AVX

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -521,8 +521,8 @@ void Arm64JITCore::Op_NoOp(const IR::IROp_Header* IROp, IR::NodeID Node) {}
 Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl* ctx, FEXCore::Core::InternalThreadState* Thread)
   : CPUBackend(Thread, INITIAL_CODE_SIZE, MAX_CODE_SIZE)
   , Arm64Emitter(ctx)
-  , HostSupportsSVE128 {ctx->HostFeatures.SupportsSVE}
-  , HostSupportsSVE256 {ctx->HostFeatures.SupportsAVX}
+  , HostSupportsSVE128 {ctx->HostFeatures.SupportsSVE128}
+  , HostSupportsSVE256 {ctx->HostFeatures.SupportsSVE256}
   , HostSupportsRPRES {ctx->HostFeatures.SupportsRPRES}
   , HostSupportsAFP {ctx->HostFeatures.SupportsAFP}
   , CTX {ctx} {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4436,7 +4436,7 @@ Ref OpDispatchBuilder::LoadGPRRegister(uint32_t GPR, int8_t Size, uint8_t Offset
 }
 
 Ref OpDispatchBuilder::LoadXMMRegister(uint32_t XMM) {
-  const auto VectorSize = CTX->HostFeatures.SupportsAVX ? 32 : 16;
+  const auto VectorSize = CTX->HostFeatures.SupportsSVE256 ? 32 : 16;
   return _LoadRegister(XMM, FPRClass, VectorSize);
 }
 
@@ -4457,7 +4457,7 @@ void OpDispatchBuilder::StoreGPRRegister(uint32_t GPR, const Ref Src, int8_t Siz
 }
 
 void OpDispatchBuilder::StoreXMMRegister(uint32_t XMM, const Ref Src) {
-  const auto VectorSize = CTX->HostFeatures.SupportsAVX ? 32 : 16;
+  const auto VectorSize = CTX->HostFeatures.SupportsSVE256 ? 32 : 16;
   _StoreRegister(Src, XMM, FPRClass, VectorSize);
 }
 
@@ -4491,7 +4491,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
       _StoreContext(OpSize, Class, Src, offsetof(FEXCore::Core::CPUState, mm[gpr - FEXCore::X86State::REG_MM_0]));
     } else if (gpr >= FEXCore::X86State::REG_XMM_0) {
       const auto gprIndex = gpr - X86State::REG_XMM_0;
-      const auto VectorSize = CTX->HostFeatures.SupportsAVX ? 32 : 16;
+      const auto VectorSize = CTX->HostFeatures.SupportsSVE256 ? 32 : 16;
 
       auto Result = Src;
       if (OpSize != VectorSize) {
@@ -5476,7 +5476,7 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
     InstallToTable(FEXCore::X86Tables::SecondInstGroupOps, SecondaryExtensionOp_RDRAND);
   }
 
-  if (CTX->HostFeatures.SupportsAVX) {
+  if (CTX->HostFeatures.SupportsSVE256) {
     InstallToTable(FEXCore::X86Tables::VEXTableOps, AVXTable);
     InstallToTable(FEXCore::X86Tables::VEXTableGroupOps, VEXTableGroupOps);
   }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1246,7 +1246,7 @@ private:
   }
 
   constexpr OpSize GetGuestVectorLength() const {
-    return CTX->HostFeatures.SupportsAVX ? OpSize::i256Bit : OpSize::i128Bit;
+    return CTX->HostFeatures.SupportsSVE256 ? OpSize::i256Bit : OpSize::i128Bit;
   }
 
   [[nodiscard]]

--- a/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -70,7 +70,7 @@ void PassManager::AddDefaultPasses(FEXCore::Context::ContextImpl* ctx) {
   FEX_CONFIG_OPT(DisablePasses, O0);
 
   if (!DisablePasses()) {
-    InsertPass(CreateContextLoadStoreElimination(ctx->HostFeatures.SupportsAVX));
+    InsertPass(CreateContextLoadStoreElimination(ctx->HostFeatures.SupportsSVE256));
     InsertPass(CreateDeadStoreElimination());
     InsertPass(CreateConstProp(ctx->HostFeatures.SupportsTSOImm9, &ctx->CPUID));
     InsertPass(CreateDeadFlagCalculationEliminination());

--- a/FEXCore/Source/Interface/IR/Passes.h
+++ b/FEXCore/Source/Interface/IR/Passes.h
@@ -17,7 +17,7 @@ class RegisterAllocationPass;
 class RegisterAllocationData;
 
 fextl::unique_ptr<FEXCore::IR::Pass> CreateConstProp(bool SupportsTSOImm9, const FEXCore::CPUIDEmu* CPUID);
-fextl::unique_ptr<FEXCore::IR::Pass> CreateContextLoadStoreElimination(bool SupportsAVX);
+fextl::unique_ptr<FEXCore::IR::Pass> CreateContextLoadStoreElimination(bool SupportsSVE256);
 fextl::unique_ptr<FEXCore::IR::Pass> CreateDeadFlagCalculationEliminination();
 fextl::unique_ptr<FEXCore::IR::Pass> CreateDeadStoreElimination();
 fextl::unique_ptr<FEXCore::IR::RegisterAllocationPass> CreateRegisterAllocationPass();

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -26,7 +26,8 @@ public:
   bool SupportsSSE4A {};
   bool SupportsAVX {};
   bool SupportsAVX2 {};
-  bool SupportsSVE {};
+  bool SupportsSVE128 {};
+  bool SupportsSVE256 {};
   bool SupportsSHA {};
   bool SupportsBMI1 {};
   bool SupportsBMI2 {};


### PR DESCRIPTION
In quite a few locations we are mixing the case that SVE256 == AVX or that AVX means the guest register size is 256-bit.

While this is true today, this is entanglement is going to change very quickly and cause confusion in follow-up PRs.

Now we have SVE128, SVE256, and SVE2 HostFeatures to disambiguate the different features which mean different things.

This PR keeps the alias that `SupportsAVX` = `SupportsSVE256 && SupportsSVE2` but that alias is going to very quickly change its definition.