### PR TITLE
json_ir_generator: don't print unrecoverable temps

### DIFF
--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -556,15 +556,16 @@ def print_ir_arg_printer():
             for i in range(0, len(op.Arguments)):
                 arg = op.Arguments[i]
 
+                # No point printing temporaries that we can't recover
+                if arg.Temporary:
+                    continue
+
                 if FirstArg:
                     FirstArg = False
                 else:
-                    output_file.write("\t*out << \", \";\n")
+                    output_file.write('\t*out << ", ";\n')
 
-                if arg.Temporary:
-                    # Temporary that we can't recover
-                    output_file.write("\t*out << \"{}:Tmp:{}\";\n".format(arg.Type, arg.Name))
-                elif arg.IsSSA:
+                if arg.IsSSA:
                     # SSA value
                     output_file.write("\tPrintArg(out, IR, Op->Header.Args[{}], RAData);\n".format(SSAArgNum))
                     SSAArgNum = SSAArgNum + 1

--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -552,9 +552,14 @@ def print_ir_arg_printer():
             output_file.write("\t*out << \" \";\n")
 
             SSAArgNum = 0
+            FirstArg = True
             for i in range(0, len(op.Arguments)):
                 arg = op.Arguments[i]
-                LastArg = len(op.Arguments) - i - 1 == 0
+
+                if FirstArg:
+                    FirstArg = False
+                else:
+                    output_file.write("\t*out << \", \";\n")
 
                 if arg.Temporary:
                     # Temporary that we can't recover
@@ -566,9 +571,6 @@ def print_ir_arg_printer():
                 else:
                     # User defined op that is stored
                     output_file.write("\tPrintArg(out, IR, Op->{});\n".format(arg.Name))
-
-                if not LastArg:
-                    output_file.write("\t*out << \", \";\n")
 
         output_file.write("break;\n")
         output_file.write("}\n")


### PR DESCRIPTION
    this makes the print more noisy for no benefit, don't do it.
    
    before:
    
        %9(GPRFixed16) i32 = Add OpSize:Tmp:Size, %6(GPRFixed0) i64, %17(Invalid)
        %10(GPR0) i64 = Bfi OpSize:Tmp:Size, #0x10, #0x0, %6(GPRFixed0) i64, %9(GPRFixed16) i32
        (%11 i64) StoreRegister %6(GPRFixed0) i64, #0x11, GPR, u8:Tmp:Size
        (%12 i64) StoreRegister %9(GPRFixed16) i32, #0x10, GPR, u8:Tmp:Size
        (%13 i64) StoreRegister %10(GPR0) i64, #0x0, GPR, u8:Tmp:Size
    
    after:
    
        %9(GPRFixed16) i32 = Add %6(GPRFixed0) i64, %17(Invalid)
        %10(GPR0) i64 = Bfi #0x10, #0x0, %6(GPRFixed0) i64, %9(GPRFixed16) i32
        (%11 i64) StoreRegister %6(GPRFixed0) i64, #0x11, GPR
        (%12 i64) StoreRegister %9(GPRFixed16) i32, #0x10, GPR
        (%13 i64) StoreRegister %10(GPR0) i64, #0x0, GPR