### PR TITLE
OpcodeDispatcher: Refactor address modes

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4394,7 +4394,7 @@ Ref OpDispatchBuilder::LoadSource_WithOpSize(RegisterClassType Class, const X86T
   if ((IsOperandMem(Operand, true) && LoadData) || ForceLoad) {
     A = AddSegmentToAddress(A, Flags);
 
-    return _LoadMemAutoTSO(Class, OpSize, A, Align == -1 ? OpSize : Align, A.NonTSO);
+    return _LoadMemAutoTSO(Class, OpSize, A, Align == -1 ? OpSize : Align);
   } else {
     return LoadEffectiveAddress(A, AllowUpperGarbage);
   }
@@ -4523,7 +4523,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
     auto Upper = _VExtractToGPR(16, 8, Src, 1);
     _StoreMem(GPRClass, 2, Upper, MemStoreDst, _Constant(8), std::min<uint8_t>(Align, 8), MEM_OFFSET_SXTX, 1);
   } else {
-    _StoreMemAutoTSO(Class, OpSize, A, Src, Align == -1 ? OpSize : Align, A.NonTSO);
+    _StoreMemAutoTSO(Class, OpSize, A, Src, Align == -1 ? OpSize : Align);
   }
 }
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -2126,8 +2126,8 @@ private:
     }
   }
 
-  Ref _LoadMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, AddressMode A, uint8_t Align = 1, bool ForceNonTSO = false) {
-    bool AtomicTSO = CTX->IsAtomicTSOEnabled() && !ForceNonTSO;
+  Ref _LoadMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, AddressMode A, uint8_t Align = 1) {
+    bool AtomicTSO = CTX->IsAtomicTSOEnabled() && !A.NonTSO;
     A = SelectAddressMode(A, AtomicTSO, Class != GPRClass, Size);
 
     if (AtomicTSO) {
@@ -2137,8 +2137,8 @@ private:
     }
   }
 
-  Ref _StoreMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, AddressMode A, Ref Value, uint8_t Align = 1, bool ForceNonTSO = false) {
-    bool AtomicTSO = CTX->IsAtomicTSOEnabled() && !ForceNonTSO;
+  Ref _StoreMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, AddressMode A, Ref Value, uint8_t Align = 1) {
+    bool AtomicTSO = CTX->IsAtomicTSOEnabled() && !A.NonTSO;
     A = SelectAddressMode(A, AtomicTSO, Class != GPRClass, Size);
 
     if (AtomicTSO) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1216,6 +1216,11 @@ private:
   Ref LoadEffectiveAddress(AddressMode A, bool AllowUpperGarbage = false);
   AddressMode SelectAddressMode(AddressMode A, bool AtomicTSO, bool Vector, unsigned AccessSize);
 
+  bool IsOperandMem(const X86Tables::DecodedOperand& Operand, bool Load) {
+    // Literals are immediates as sources but memory addresses as destinations.
+    return !(Load && Operand.IsLiteral()) && !Operand.IsGPR();
+  }
+
   Ref LoadSource(RegisterClassType Class, const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, uint32_t Flags,
                  const LoadSourceOptions& Options = {});
   Ref LoadSource_WithOpSize(RegisterClassType Class, const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand,

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -79,6 +79,7 @@ struct AddressMode {
 
   // Size in bytes for the address calculation. 8 for an arm64 hardware mode.
   uint8_t AddrSize;
+  bool NonTSO;
 };
 
 class OpDispatchBuilder final : public IREmitter {
@@ -1224,6 +1225,8 @@ private:
   bool IsNonTSOReg(MemoryAccessType Access, uint8_t Reg) {
     return Access == MemoryAccessType::DEFAULT && Reg == X86State::REG_RSP;
   }
+
+  AddressMode DecodeAddress(const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, MemoryAccessType AccessType, bool IsLoad);
 
   Ref LoadSource(RegisterClassType Class, const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, uint32_t Flags,
                  const LoadSourceOptions& Options = {});

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1221,6 +1221,10 @@ private:
     return !(Load && Operand.IsLiteral()) && !Operand.IsGPR();
   }
 
+  bool IsNonTSOReg(MemoryAccessType Access, uint8_t Reg) {
+    return Access == MemoryAccessType::DEFAULT && Reg == X86State::REG_RSP;
+  }
+
   Ref LoadSource(RegisterClassType Class, const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, uint32_t Flags,
                  const LoadSourceOptions& Options = {});
   Ref LoadSource_WithOpSize(RegisterClassType Class, const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand,


### PR DESCRIPTION
Extract some helpers to deduplicate the code to decode address modes, so when AVX128 adds its own load/store helpers we won't end up with 4 (!) copies of this logic.

[I'm now porting the AVX128 helpers to use this, don't worry about that]