### PR TITLE
unittests: Split up vtestps unittest to accumulate flags in independent registers.

### DIFF
--- a/unittests/ASM/VEX/vtestps.asm
+++ b/unittests/ASM/VEX/vtestps.asm
@@ -2,7 +2,8 @@
 {
   "HostFeatures": ["AVX"],
   "RegData": {
-    "R15":  "0x0000000EDDFFB77F",
+    "R15":  "0x000000000003B77F",
+    "R14":  "0x000000000003B77F",
     "XMM0": ["0x0000000000000000", "0x0000000000000000", "0x0000000000000000", "0x0000000000000000"],
     "XMM1": ["0xFFFFFFFFFFFFFFFF", "0xFFFFFFFFFFFFFFFF", "0xFFFFFFFFFFFFFFFF", "0xFFFFFFFFFFFFFFFF"],
     "XMM2": ["0x4142434445464748", "0x5152535455565758", "0x4142434445464748", "0x5152535455565758"]
@@ -10,9 +11,9 @@
 }
 %endif
 
-; Uses AX and BX and stores result in r15
+; Uses AX and BX and stores result in the passed in register
 ; CF:ZF
-%macro zfcfmerge 0
+%macro zfcfmerge 1
   lahf
 
   ; Shift CF to zero
@@ -22,10 +23,10 @@
   mov bx, ax
   and rbx, 1
 
-  shl r15, 1
-  or r15, rbx
+  shl %{1}, 1
+  or %{1}, rbx
 
-  shl r15, 1
+  shl %{1}, 1
 
   ; Move to a temp
   mov bx, ax
@@ -35,28 +36,28 @@
   and rbx, 1
 
   ; Insert ZF
-  or r15, rbx
+  or %{1}, rbx
 %endmacro
 
-%macro tests 1
+%macro tests 2
   vtestps %{1}0, [rdx + 32 * 3]
-  zfcfmerge
+  zfcfmerge %{2}
   vtestps %{1}1, [rdx + 32 * 4]
-  zfcfmerge
+  zfcfmerge %{2}
   vtestps %{1}2, [rdx + 32 * 5]
-  zfcfmerge
+  zfcfmerge %{2}
   vtestps %{1}0, [rdx + 32 * 6]
-  zfcfmerge
+  zfcfmerge %{2}
   vtestps %{1}1, [rdx + 32 * 7]
-  zfcfmerge
+  zfcfmerge %{2}
   vtestps %{1}2, [rdx + 32 * 8]
-  zfcfmerge
+  zfcfmerge %{2}
   vtestps %{1}0, [rdx + 32 * 9]
-  zfcfmerge
+  zfcfmerge %{2}
   vtestps %{1}1, [rdx + 32 * 10]
-  zfcfmerge
+  zfcfmerge %{2}
   vtestps %{1}2, [rdx + 32 * 11]
-  zfcfmerge
+  zfcfmerge %{2}
 %endmacro
 
 lea rdx, [rel .data]
@@ -64,13 +65,16 @@ lea rdx, [rel .data]
 mov rax, 0
 mov rbx, 0
 mov r15, 0
+mov r14, 0
 
 vmovaps ymm0, [rdx + 32 * 0]
 vmovaps ymm1, [rdx + 32 * 1]
 vmovaps ymm2, [rdx + 32 * 2]
 
-tests xmm
-tests ymm
+; Accumulate xmm results in r15
+tests xmm, r15
+; Accumulate ymm results in r14
+tests ymm, r14
 
 hlt
 


### PR DESCRIPTION
Makes it easier to see what is failing on the 128-bit side versus 256-bit side.