### PR TITLE
InstCountCI: add segment register cases

### DIFF
--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -1025,6 +1025,32 @@
       "ExpectedArm64ASM": [
         "ldr x7, [x4, x5, sxtx #3]"
       ]
+    },
+    "mov ebx, fs:0x14": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "ldr x20, [x28, #968]",
+        "ldr w7, [x20, #20]"
+      ]
+    },
+    "mov rbx, gs:0x14": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "ldr x20, [x28, #960]",
+        "ldur x7, [x20, #20]"
+      ]
+    },
+    "Multiple segment registers": {
+      "x86Insts": [
+        "mov rax, gs:0x100",
+        "mov rbx, gs:0x14"
+      ],
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "ldr x20, [x28, #960]",
+        "ldr x4, [x20, #256]",
+        "ldur x7, [x20, #20]"
+      ]
     }
   }
 }

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -303,6 +303,32 @@
       "ExpectedArm64ASM": [
         "ldr d16, [x5, #256]"
       ]
+    },
+    "mov ebx, fs:0x14": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #968]",
+        "ldr w7, [x20, #20]"
+      ]
+    },
+    "mov ebx, gs:0x14": {
+      "ExpectedInstructionCount": 2,
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #960]",
+        "ldr w7, [x20, #20]"
+      ]
+    },
+    "Multiple segment registers": {
+      "x86Insts": [
+        "mov eax, gs:0x100",
+        "mov ebx, gs:0x14"
+      ],
+      "ExpectedInstructionCount": 3,
+      "ExpectedArm64ASM": [
+        "ldr w20, [x28, #960]",
+        "ldr w4, [x20, #256]",
+        "ldr w7, [x20, #20]"
+      ]
     }
   }
 }


### PR DESCRIPTION
add a bit of coverage for this funny addressing corner. We do handle this optimally but I had to write this to check ;)