### PR TITLE
Frontend: Expose AVX W flag

### DIFF
--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -659,6 +659,9 @@ bool Decoder::NormalOpHeader(const FEXCore::X86Tables::X86InstInfo* Info, uint16
       if (CTX->Config.Is64BitMode && (Byte1 & 0b00100000) == 0) {
         DecodeInst->Flags |= DecodeFlags::FLAG_REX_XGPR_B;
       }
+      if (options.w) {
+        DecodeInst->Flags |= DecodeFlags::FLAG_OPTION_AVX_W;
+      }
       if (!(map_select >= 1 && map_select <= 3)) {
         LogMan::Msg::EFmt("We don't understand a map_select of: {}", map_select);
         return false;

--- a/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -27,7 +27,7 @@ constexpr uint32_t FLAG_LOCK          = (1 << 2);
 constexpr uint32_t FLAG_LEGACY_PREFIX = (1 << 3);
 constexpr uint32_t FLAG_REX_PREFIX    = (1 << 4);
 constexpr uint32_t FLAG_VSIB_BYTE     = (1 << 5);
-// Hole where 1 << 6 is
+constexpr uint32_t FLAG_OPTION_AVX_W  = (1 << 6);
 constexpr uint32_t FLAG_REX_WIDENING  = (1 << 7);
 constexpr uint32_t FLAG_REX_XGPR_B    = (1 << 8);
 constexpr uint32_t FLAG_REX_XGPR_X    = (1 << 9);


### PR DESCRIPTION
Previously we could always tell the size of the operation depending on how this effects the operating size of the instruction. Converting 64-bit down to 32-bit as an example.

AVX gather instructions are the first instruction class that can't infer this information. The element load size is determined by the W flag but the operating size of 128-bit or 256-bit is determined by other means.

Expose this flag so we can determine this difference. The FMA instructions are going to need this flag as well.