### PR TITLE
FEXCore: Implement AVX reconstruction helpers

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -104,6 +104,9 @@ public:
   uint32_t ReconstructCompactedEFLAGS(FEXCore::Core::InternalThreadState* Thread, bool WasInJIT, uint64_t* HostGPRs, uint64_t PSTATE) override;
   void SetFlagsFromCompactedEFLAGS(FEXCore::Core::InternalThreadState* Thread, uint32_t EFLAGS) override;
 
+  void ReconstructXMMRegisters(const FEXCore::Core::InternalThreadState* Thread, __uint128_t* XMM_Low, __uint128_t* YMM_High) override;
+  void SetXMMRegistersFromState(FEXCore::Core::InternalThreadState* Thread, const __uint128_t* XMM_Low, const __uint128_t* YMM_High) override;
+
   /**
    * @brief Used to create FEX thread objects in preparation for creating a true OS thread. Does set a TID or PID.
    *

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -194,6 +194,11 @@ public:
   ///< Sets FEX's internal EFLAGS representation to the passed in compacted form.
   FEX_DEFAULT_VISIBILITY virtual void SetFlagsFromCompactedEFLAGS(FEXCore::Core::InternalThreadState* Thread, uint32_t EFLAGS) = 0;
 
+  FEX_DEFAULT_VISIBILITY virtual void
+  ReconstructXMMRegisters(const FEXCore::Core::InternalThreadState* Thread, __uint128_t* XMM_Low, __uint128_t* YMM_High) = 0;
+  FEX_DEFAULT_VISIBILITY virtual void
+  SetXMMRegistersFromState(FEXCore::Core::InternalThreadState* Thread, const __uint128_t* XMM_Low, const __uint128_t* YMM_High) = 0;
+
   /**
    * @brief Create a new thread object that doesn't inherit any state.
    * Used to create FEX thread objects in preparation for creating a true OS thread.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -256,14 +256,14 @@ private:
                           GuestSigAction* GuestAction, stack_t* GuestStack, uint64_t NewGuestSP, const uint32_t eflags);
 
   ///< Setup the signal frame for a 32-bit signal without SA_SIGINFO.
-  uint64_t SetupFrame_ia32(ArchHelpers::Context::ContextBackup* ContextBackup, FEXCore::Core::CpuStateFrame* Frame, int Signal,
-                           siginfo_t* HostSigInfo, void* ucontext, GuestSigAction* GuestAction, stack_t* GuestStack, uint64_t NewGuestSP,
-                           const uint32_t eflags);
+  uint64_t SetupFrame_ia32(FEXCore::Core::InternalThreadState* Thread, ArchHelpers::Context::ContextBackup* ContextBackup,
+                           FEXCore::Core::CpuStateFrame* Frame, int Signal, siginfo_t* HostSigInfo, void* ucontext,
+                           GuestSigAction* GuestAction, stack_t* GuestStack, uint64_t NewGuestSP, const uint32_t eflags);
 
   ///< Setup the signal frame for a 32-bit signal with SA_SIGINFO.
-  uint64_t SetupRTFrame_ia32(ArchHelpers::Context::ContextBackup* ContextBackup, FEXCore::Core::CpuStateFrame* Frame, int Signal,
-                             siginfo_t* HostSigInfo, void* ucontext, GuestSigAction* GuestAction, stack_t* GuestStack, uint64_t NewGuestSP,
-                             const uint32_t eflags);
+  uint64_t SetupRTFrame_ia32(FEXCore::Core::InternalThreadState* Thread, ArchHelpers::Context::ContextBackup* ContextBackup,
+                             FEXCore::Core::CpuStateFrame* Frame, int Signal, siginfo_t* HostSigInfo, void* ucontext,
+                             GuestSigAction* GuestAction, stack_t* GuestStack, uint64_t NewGuestSP, const uint32_t eflags);
 
   enum class RestoreType {
     TYPE_REALTIME,    ///< Signal restore type is from a `realtime` signal.

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -323,6 +323,17 @@ int main(int argc, char** argv, char** const envp) {
     FEX::HLE::_SyscallHandler->TM.DestroyThread(ParentThread, true);
 
     SyscallHandler.reset();
+
+    if (SupportsAVX) {
+      ///< Reconstruct the XMM registers even if they are in split view, then remerge them.
+      __uint128_t XMM_Low[FEXCore::Core::CPUState::NUM_XMMS];
+      __uint128_t YMM_High[FEXCore::Core::CPUState::NUM_XMMS];
+      CTX->ReconstructXMMRegisters(ParentThread->Thread, XMM_Low, YMM_High);
+      for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_XMMS; ++i) {
+        memcpy(&State.xmm.avx.data[i][0], &XMM_Low[i], sizeof(__uint128_t));
+        memcpy(&State.xmm.avx.data[i][2], &YMM_High[i], sizeof(__uint128_t));
+      }
+    }
   }
 #ifndef _WIN32
   else {

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -159,7 +159,7 @@ void LoadStateFromWowContext(FEXCore::Core::InternalThreadState* Thread, uint64_
   // Floating-point register state
   const auto* XSave = reinterpret_cast<XSAVE_FORMAT*>(Context->ExtendedRegisters);
 
-  memcpy(State.xmm.sse.data, XSave->XmmRegisters, sizeof(State.xmm.sse.data));
+  CTX->SetXMMRegistersFromState(Thread, reinterpret_cast<const __uint128_t*>(XSave->XmmRegisters), nullptr);
   memcpy(State.mm, XSave->FloatRegisters, sizeof(State.mm));
 
   State.FCW = XSave->ControlWord;
@@ -199,7 +199,7 @@ void StoreWowContextFromState(FEXCore::Core::InternalThreadState* Thread, WOW64_
 
   auto* XSave = reinterpret_cast<XSAVE_FORMAT*>(Context->ExtendedRegisters);
 
-  memcpy(XSave->XmmRegisters, State.xmm.sse.data, sizeof(State.xmm.sse.data));
+  CTX->ReconstructXMMRegisters(Thread, reinterpret_cast<__uint128_t*>(XSave->XmmRegisters), nullptr);
   memcpy(XSave->FloatRegisters, State.mm, sizeof(State.mm));
 
   XSave->ControlWord = State.FCW;


### PR DESCRIPTION
Due to the distinct view of AVX registers changing depending on if the host supports SVE256 or not, introduce some helpers to reconverge the view in the ways that Linux and Wow64 wants.

The TestHarnessRunner has a bit of a kludge but rewriting it to not read the InternalThreadState object directly will take longer than currently desired. So fetch the register state, then reconverge the AVX register state. Once the InternalThreadState object changes its view to cut out those excess 256bytes then this will get refactored at that point.