### PR TITLE
AVX128: More instructions Part 3

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1137,6 +1137,9 @@ public:
 
   void AVX128_PHMINPOSUW(OpcodeArgs);
 
+  template<size_t ElementSize>
+  void AVX128_VectorRound(OpcodeArgs);
+
   // End of AVX 128-bit implementation
 
   void InvalidOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -583,6 +583,8 @@ public:
   template<size_t DstElementSize, size_t SrcElementSize>
   void AVXInsertScalar_CVT_Float_To_Float(OpcodeArgs);
 
+  RoundType TranslateRoundType(uint8_t Mode);
+
   template<size_t ElementSize>
   void InsertScalarRound(OpcodeArgs);
   template<size_t ElementSize>

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1139,6 +1139,8 @@ public:
 
   template<size_t ElementSize>
   void AVX128_VectorRound(OpcodeArgs);
+  template<size_t ElementSize>
+  void AVX128_InsertScalarRound(OpcodeArgs);
 
   // End of AVX 128-bit implementation
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1130,6 +1130,11 @@ public:
   void AVX128_VAESDecLast(OpcodeArgs);
   void AVX128_VAESKeyGenAssist(OpcodeArgs);
 
+  void AVX128_VPCMPESTRI(OpcodeArgs);
+  void AVX128_VPCMPESTRM(OpcodeArgs);
+  void AVX128_VPCMPISTRI(OpcodeArgs);
+  void AVX128_VPCMPISTRM(OpcodeArgs);
+
   // End of AVX 128-bit implementation
 
   void InvalidOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1317,7 +1317,7 @@ private:
 
   Ref InsertScalarFCMPOpImpl(OpSize Size, uint8_t OpDstSize, size_t ElementSize, Ref Src1, Ref Src2, uint8_t CompType, bool ZeroUpperBits);
 
-  Ref VectorRoundImpl(OpcodeArgs, size_t ElementSize, Ref Src, uint64_t Mode);
+  Ref VectorRoundImpl(OpSize Size, size_t ElementSize, Ref Src, uint64_t Mode);
 
   Ref Scalar_CVT_Float_To_FloatImpl(OpcodeArgs, size_t DstElementSize, size_t SrcElementSize, const X86Tables::DecodedOperand& Src1Op,
                                     const X86Tables::DecodedOperand& Src2Op);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1123,6 +1123,12 @@ public:
   void AVX128_Vector_CVT_Int_To_Float(OpcodeArgs);
 
   void AVX128_VEXTRACT128(OpcodeArgs);
+  void AVX128_VAESImc(OpcodeArgs);
+  void AVX128_VAESEnc(OpcodeArgs);
+  void AVX128_VAESEncLast(OpcodeArgs);
+  void AVX128_VAESDec(OpcodeArgs);
+  void AVX128_VAESDecLast(OpcodeArgs);
+  void AVX128_VAESKeyGenAssist(OpcodeArgs);
 
   // End of AVX 128-bit implementation
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1135,6 +1135,8 @@ public:
   void AVX128_VPCMPISTRI(OpcodeArgs);
   void AVX128_VPCMPISTRM(OpcodeArgs);
 
+  void AVX128_PHMINPOSUW(OpcodeArgs);
+
   // End of AVX 128-bit implementation
 
   void InvalidOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1004,6 +1004,8 @@ public:
   void AVX128_VectorBinaryImpl(OpcodeArgs, size_t SrcSize, size_t ElementSize, std::function<Ref(size_t ElementSize, Ref Src1, Ref Src2)> Helper);
   void AVX128_VectorShiftWideImpl(OpcodeArgs, size_t ElementSize, IROps IROp);
   void AVX128_VectorShiftImmImpl(OpcodeArgs, size_t ElementSize, IROps IROp);
+  void AVX128_VectorTrinaryImpl(OpcodeArgs, size_t SrcSize, size_t ElementSize, Ref Src3,
+                                std::function<Ref(size_t ElementSize, Ref Src1, Ref Src2, Ref Src3)> Helper);
 
   enum class ShiftDirection { RIGHT, LEFT };
   void AVX128_ShiftDoubleImm(OpcodeArgs, ShiftDirection Dir);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -372,10 +372,10 @@ void OpDispatchBuilder::InstallAVX128Handlers() {
     // TODO: {OPD(3, 0b01, 0x4B), 1, &OpDispatchBuilder::AVXVectorVariableBlend<8>},
     // TODO: {OPD(3, 0b01, 0x4C), 1, &OpDispatchBuilder::AVXVectorVariableBlend<1>},
 
-    // TODO: {OPD(3, 0b01, 0x60), 1, &OpDispatchBuilder::VPCMPESTRMOp},
-    // TODO: {OPD(3, 0b01, 0x61), 1, &OpDispatchBuilder::VPCMPESTRIOp},
-    // TODO: {OPD(3, 0b01, 0x62), 1, &OpDispatchBuilder::VPCMPISTRMOp},
-    // TODO: {OPD(3, 0b01, 0x63), 1, &OpDispatchBuilder::VPCMPISTRIOp},
+    {OPD(3, 0b01, 0x60), 1, &OpDispatchBuilder::AVX128_VPCMPESTRM},
+    {OPD(3, 0b01, 0x61), 1, &OpDispatchBuilder::AVX128_VPCMPESTRI},
+    {OPD(3, 0b01, 0x62), 1, &OpDispatchBuilder::AVX128_VPCMPISTRM},
+    {OPD(3, 0b01, 0x63), 1, &OpDispatchBuilder::AVX128_VPCMPISTRI},
 
     {OPD(3, 0b01, 0xDF), 1, &OpDispatchBuilder::AVX128_VAESKeyGenAssist},
   };
@@ -1652,6 +1652,34 @@ void OpDispatchBuilder::AVX128_VAESKeyGenAssist(OpcodeArgs) {
   AVX128_VectorUnaryImpl(Op, OpSize::i128Bit, OpSize::i128Bit, [this, ZeroRegister, KeyGenSwizzle, RCON](size_t, Ref Src) {
     return _VAESKeyGenAssist(Src, KeyGenSwizzle, ZeroRegister, RCON);
   });
+}
+
+void OpDispatchBuilder::AVX128_VPCMPESTRI(OpcodeArgs) {
+  PCMPXSTRXOpImpl(Op, true, false);
+
+  ///< Zero the upper 128-bits of hardcoded YMM0
+  AVX128_StoreXMMRegister(0, LoadZeroVector(OpSize::i128Bit), true);
+}
+
+void OpDispatchBuilder::AVX128_VPCMPESTRM(OpcodeArgs) {
+  PCMPXSTRXOpImpl(Op, true, true);
+
+  ///< Zero the upper 128-bits of hardcoded YMM0
+  AVX128_StoreXMMRegister(0, LoadZeroVector(OpSize::i128Bit), true);
+}
+
+void OpDispatchBuilder::AVX128_VPCMPISTRI(OpcodeArgs) {
+  PCMPXSTRXOpImpl(Op, false, false);
+
+  ///< Zero the upper 128-bits of hardcoded YMM0
+  AVX128_StoreXMMRegister(0, LoadZeroVector(OpSize::i128Bit), true);
+}
+
+void OpDispatchBuilder::AVX128_VPCMPISTRM(OpcodeArgs) {
+  PCMPXSTRXOpImpl(Op, false, true);
+
+  ///< Zero the upper 128-bits of hardcoded YMM0
+  AVX128_StoreXMMRegister(0, LoadZeroVector(OpSize::i128Bit), true);
 }
 
 } // namespace FEXCore::IR

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -339,8 +339,8 @@ void OpDispatchBuilder::InstallAVX128Handlers() {
     // TODO: {OPD(3, 0b01, 0x04), 1, &OpDispatchBuilder::VPERMILImmOp<4>},
     // TODO: {OPD(3, 0b01, 0x05), 1, &OpDispatchBuilder::VPERMILImmOp<8>},
     // TODO: {OPD(3, 0b01, 0x06), 1, &OpDispatchBuilder::VPERM2Op},
-    // TODO: {OPD(3, 0b01, 0x08), 1, &OpDispatchBuilder::AVXVectorRound<4>},
-    // TODO: {OPD(3, 0b01, 0x09), 1, &OpDispatchBuilder::AVXVectorRound<8>},
+    {OPD(3, 0b01, 0x08), 1, &OpDispatchBuilder::AVX128_VectorRound<4>},
+    {OPD(3, 0b01, 0x09), 1, &OpDispatchBuilder::AVX128_VectorRound<8>},
     // TODO: {OPD(3, 0b01, 0x0A), 1, &OpDispatchBuilder::AVXInsertScalarRound<4>},
     // TODO: {OPD(3, 0b01, 0x0B), 1, &OpDispatchBuilder::AVXInsertScalarRound<8>},
     // TODO: {OPD(3, 0b01, 0x0C), 1, &OpDispatchBuilder::VPBLENDDOp},
@@ -1685,6 +1685,15 @@ void OpDispatchBuilder::AVX128_VPCMPISTRM(OpcodeArgs) {
 void OpDispatchBuilder::AVX128_PHMINPOSUW(OpcodeArgs) {
   Ref Result = PHMINPOSUWOpImpl(Op);
   AVX128_StoreResult_WithOpSize(Op, Op->Dest, AVX128_Zext(Result));
+}
+
+template<size_t ElementSize>
+void OpDispatchBuilder::AVX128_VectorRound(OpcodeArgs) {
+  const auto Size = GetSrcSize(Op);
+  const auto Mode = Op->Src[1].Literal();
+
+  AVX128_VectorUnaryImpl(Op, Size, ElementSize,
+                         [this, Mode](size_t, Ref Src) { return VectorRoundImpl(OpSize::i128Bit, ElementSize, Src, Mode); });
 }
 
 } // namespace FEXCore::IR

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -312,7 +312,7 @@ void OpDispatchBuilder::InstallAVX128Handlers() {
     {OPD(2, 0b01, 0x3F), 1, &OpDispatchBuilder::AVX128_VectorALU<IR::OP_VUMAX, 4>},
 
     {OPD(2, 0b01, 0x40), 1, &OpDispatchBuilder::AVX128_VectorALU<IR::OP_VMUL, 4>},
-    // TODO: {OPD(2, 0b01, 0x41), 1, &OpDispatchBuilder::PHMINPOSUWOp},
+    {OPD(2, 0b01, 0x41), 1, &OpDispatchBuilder::AVX128_PHMINPOSUW},
     {OPD(2, 0b01, 0x45), 1, &OpDispatchBuilder::AVX128_VPSRLV},
     {OPD(2, 0b01, 0x46), 1, &OpDispatchBuilder::AVX128_VPSRAVD},
     {OPD(2, 0b01, 0x47), 1, &OpDispatchBuilder::AVX128_VPSLLV},
@@ -1680,6 +1680,11 @@ void OpDispatchBuilder::AVX128_VPCMPISTRM(OpcodeArgs) {
 
   ///< Zero the upper 128-bits of hardcoded YMM0
   AVX128_StoreXMMRegister(0, LoadZeroVector(OpSize::i128Bit), true);
+}
+
+void OpDispatchBuilder::AVX128_PHMINPOSUW(OpcodeArgs) {
+  Ref Result = PHMINPOSUWOpImpl(Op);
+  AVX128_StoreResult_WithOpSize(Op, Op->Dest, AVX128_Zext(Result));
 }
 
 } // namespace FEXCore::IR

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -327,11 +327,11 @@ void OpDispatchBuilder::InstallAVX128Handlers() {
     // TODO: {OPD(2, 0b01, 0x8C), 1, &OpDispatchBuilder::VPMASKMOVOp<false>},
     // TODO: {OPD(2, 0b01, 0x8E), 1, &OpDispatchBuilder::VPMASKMOVOp<true>},
 
-    // TODO: {OPD(2, 0b01, 0xDB), 1, &OpDispatchBuilder::AESImcOp},
-    // TODO: {OPD(2, 0b01, 0xDC), 1, &OpDispatchBuilder::VAESEncOp},
-    // TODO: {OPD(2, 0b01, 0xDD), 1, &OpDispatchBuilder::VAESEncLastOp},
-    // TODO: {OPD(2, 0b01, 0xDE), 1, &OpDispatchBuilder::VAESDecOp},
-    // TODO: {OPD(2, 0b01, 0xDF), 1, &OpDispatchBuilder::VAESDecLastOp},
+    {OPD(2, 0b01, 0xDB), 1, &OpDispatchBuilder::AVX128_VAESImc},
+    {OPD(2, 0b01, 0xDC), 1, &OpDispatchBuilder::AVX128_VAESEnc},
+    {OPD(2, 0b01, 0xDD), 1, &OpDispatchBuilder::AVX128_VAESEncLast},
+    {OPD(2, 0b01, 0xDE), 1, &OpDispatchBuilder::AVX128_VAESDec},
+    {OPD(2, 0b01, 0xDF), 1, &OpDispatchBuilder::AVX128_VAESDecLast},
 
     // TODO: {OPD(3, 0b01, 0x00), 1, &OpDispatchBuilder::VPERMQOp},
     // TODO: {OPD(3, 0b01, 0x01), 1, &OpDispatchBuilder::VPERMQOp},
@@ -377,7 +377,7 @@ void OpDispatchBuilder::InstallAVX128Handlers() {
     // TODO: {OPD(3, 0b01, 0x62), 1, &OpDispatchBuilder::VPCMPISTRMOp},
     // TODO: {OPD(3, 0b01, 0x63), 1, &OpDispatchBuilder::VPCMPISTRIOp},
 
-    // TODO: {OPD(3, 0b01, 0xDF), 1, &OpDispatchBuilder::AESKeyGenAssist},
+    {OPD(3, 0b01, 0xDF), 1, &OpDispatchBuilder::AVX128_VAESKeyGenAssist},
   };
 #undef OPD
 
@@ -1616,6 +1616,42 @@ void OpDispatchBuilder::AVX128_VEXTRACT128(OpcodeArgs) {
   }
 
   AVX128_StoreResult_WithOpSize(Op, Op->Dest, Result);
+}
+
+void OpDispatchBuilder::AVX128_VAESImc(OpcodeArgs) {
+  ///< 128-bit only.
+  AVX128_VectorUnaryImpl(Op, OpSize::i128Bit, OpSize::i128Bit, [this](size_t, Ref Src) { return _VAESImc(Src); });
+}
+
+void OpDispatchBuilder::AVX128_VAESEnc(OpcodeArgs) {
+  AVX128_VectorTrinaryImpl(Op, GetDstSize(Op), OpSize::i128Bit, LoadZeroVector(OpSize::i128Bit),
+                           [this](size_t, Ref Src1, Ref Src2, Ref Src3) { return _VAESEnc(OpSize::i128Bit, Src1, Src2, Src3); });
+}
+
+void OpDispatchBuilder::AVX128_VAESEncLast(OpcodeArgs) {
+  AVX128_VectorTrinaryImpl(Op, GetDstSize(Op), OpSize::i128Bit, LoadZeroVector(OpSize::i128Bit),
+                           [this](size_t, Ref Src1, Ref Src2, Ref Src3) { return _VAESEncLast(OpSize::i128Bit, Src1, Src2, Src3); });
+}
+
+void OpDispatchBuilder::AVX128_VAESDec(OpcodeArgs) {
+  AVX128_VectorTrinaryImpl(Op, GetDstSize(Op), OpSize::i128Bit, LoadZeroVector(OpSize::i128Bit),
+                           [this](size_t, Ref Src1, Ref Src2, Ref Src3) { return _VAESDec(OpSize::i128Bit, Src1, Src2, Src3); });
+}
+
+void OpDispatchBuilder::AVX128_VAESDecLast(OpcodeArgs) {
+  AVX128_VectorTrinaryImpl(Op, GetDstSize(Op), OpSize::i128Bit, LoadZeroVector(OpSize::i128Bit),
+                           [this](size_t, Ref Src1, Ref Src2, Ref Src3) { return _VAESDecLast(OpSize::i128Bit, Src1, Src2, Src3); });
+}
+
+void OpDispatchBuilder::AVX128_VAESKeyGenAssist(OpcodeArgs) {
+  ///< 128-bit only.
+  const uint64_t RCON = Op->Src[1].Literal();
+  auto ZeroRegister = LoadZeroVector(OpSize::i128Bit);
+  auto KeyGenSwizzle = LoadAndCacheNamedVectorConstant(OpSize::i128Bit, NAMED_VECTOR_AESKEYGENASSIST_SWIZZLE);
+
+  AVX128_VectorUnaryImpl(Op, OpSize::i128Bit, OpSize::i128Bit, [this, ZeroRegister, KeyGenSwizzle, RCON](size_t, Ref Src) {
+    return _VAESKeyGenAssist(Src, KeyGenSwizzle, ZeroRegister, RCON);
+  });
 }
 
 } // namespace FEXCore::IR

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3702,8 +3702,7 @@ template void OpDispatchBuilder::ExtendVectorElements<2, 4, true>(OpcodeArgs);
 template void OpDispatchBuilder::ExtendVectorElements<2, 8, true>(OpcodeArgs);
 template void OpDispatchBuilder::ExtendVectorElements<4, 8, true>(OpcodeArgs);
 
-Ref OpDispatchBuilder::VectorRoundImpl(OpcodeArgs, size_t ElementSize, Ref Src, uint64_t Mode) {
-  const auto Size = GetDstSize(Op);
+Ref OpDispatchBuilder::VectorRoundImpl(OpSize Size, size_t ElementSize, Ref Src, uint64_t Mode) {
   const uint64_t RoundControlSource = (Mode >> 2) & 1;
   uint64_t RoundControl = Mode & 0b11;
 
@@ -3728,7 +3727,7 @@ void OpDispatchBuilder::VectorRound(OpcodeArgs) {
   Ref Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
 
   const uint64_t Mode = Op->Src[1].Literal();
-  Src = VectorRoundImpl(Op, ElementSize, Src, Mode);
+  Src = VectorRoundImpl(OpSizeFromDst(Op), ElementSize, Src, Mode);
 
   StoreResult(FPRClass, Op, Src, -1);
 }
@@ -3745,7 +3744,7 @@ void OpDispatchBuilder::AVXVectorRound(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
 
   Ref Src = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], SrcSize, Op->Flags);
-  Ref Result = VectorRoundImpl(Op, ElementSize, Src, Mode);
+  Ref Result = VectorRoundImpl(OpSizeFromDst(Op), ElementSize, Src, Mode);
 
   StoreResult(FPRClass, Op, Result, -1);
 }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -594,16 +594,7 @@ void OpDispatchBuilder::AVXInsertScalar_CVT_Float_To_Float(OpcodeArgs) {
 template void OpDispatchBuilder::AVXInsertScalar_CVT_Float_To_Float<4, 8>(OpcodeArgs);
 template void OpDispatchBuilder::AVXInsertScalar_CVT_Float_To_Float<8, 4>(OpcodeArgs);
 
-Ref OpDispatchBuilder::InsertScalarRoundImpl(OpcodeArgs, size_t DstSize, size_t ElementSize, const X86Tables::DecodedOperand& Src1Op,
-                                             const X86Tables::DecodedOperand& Src2Op, uint64_t Mode, bool ZeroUpperBits) {
-  // We load the full vector width when dealing with a source vector,
-  // so that we don't do any unnecessary zero extension to the scalar
-  // element that we're going to operate on.
-  const auto SrcSize = GetSrcSize(Op);
-
-  Ref Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags);
-  Ref Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags, {.AllowUpperGarbage = true});
-
+RoundType OpDispatchBuilder::TranslateRoundType(uint8_t Mode) {
   const uint64_t RoundControlSource = (Mode >> 2) & 1;
   uint64_t RoundControl = Mode & 0b11;
 
@@ -614,8 +605,20 @@ Ref OpDispatchBuilder::InsertScalarRoundImpl(OpcodeArgs, size_t DstSize, size_t 
     FEXCore::IR::Round_Towards_Zero,
   };
 
-  const auto SourceMode = RoundControlSource ? Round_Host : SourceModes[RoundControl];
+  return RoundControlSource ? Round_Host : SourceModes[RoundControl];
+}
 
+Ref OpDispatchBuilder::InsertScalarRoundImpl(OpcodeArgs, size_t DstSize, size_t ElementSize, const X86Tables::DecodedOperand& Src1Op,
+                                             const X86Tables::DecodedOperand& Src2Op, uint64_t Mode, bool ZeroUpperBits) {
+  // We load the full vector width when dealing with a source vector,
+  // so that we don't do any unnecessary zero extension to the scalar
+  // element that we're going to operate on.
+  const auto SrcSize = GetSrcSize(Op);
+
+  Ref Src1 = LoadSource_WithOpSize(FPRClass, Op, Src1Op, DstSize, Op->Flags);
+  Ref Src2 = LoadSource_WithOpSize(FPRClass, Op, Src2Op, SrcSize, Op->Flags, {.AllowUpperGarbage = true});
+
+  const auto SourceMode = TranslateRoundType(Mode);
   auto ALUOp = _VFToIScalarInsert(IR::SizeToOpSize(DstSize), ElementSize, Src1, Src2, SourceMode, ZeroUpperBits);
 
   return ALUOp;
@@ -3703,20 +3706,7 @@ template void OpDispatchBuilder::ExtendVectorElements<2, 8, true>(OpcodeArgs);
 template void OpDispatchBuilder::ExtendVectorElements<4, 8, true>(OpcodeArgs);
 
 Ref OpDispatchBuilder::VectorRoundImpl(OpSize Size, size_t ElementSize, Ref Src, uint64_t Mode) {
-  const uint64_t RoundControlSource = (Mode >> 2) & 1;
-  uint64_t RoundControl = Mode & 0b11;
-
-  if (RoundControlSource) {
-    RoundControl = 0; // MXCSR
-  }
-
-  static constexpr std::array SourceModes = {
-    FEXCore::IR::Round_Nearest, FEXCore::IR::Round_Negative_Infinity, FEXCore::IR::Round_Positive_Infinity, FEXCore::IR::Round_Towards_Zero,
-    FEXCore::IR::Round_Host,
-  };
-
-  const auto SourceMode = SourceModes[(RoundControlSource << 2) | RoundControl];
-  return _Vector_FToI(Size, ElementSize, Src, SourceMode);
+  return _Vector_FToI(Size, ElementSize, Src, TranslateRoundType(Mode));
 }
 
 template<size_t ElementSize>


### PR DESCRIPTION
Based on top of #3746

Adds AES instructions, SSE4.2 string ops, silly minposuw, and rounds.