### PR TITLE
AVX128: Fixes SSE4.2 string compare instructions

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -1657,8 +1657,7 @@ void OpDispatchBuilder::AVX128_VAESKeyGenAssist(OpcodeArgs) {
 void OpDispatchBuilder::AVX128_VPCMPESTRI(OpcodeArgs) {
   PCMPXSTRXOpImpl(Op, true, false);
 
-  ///< Zero the upper 128-bits of hardcoded YMM0
-  AVX128_StoreXMMRegister(0, LoadZeroVector(OpSize::i128Bit), true);
+  ///< Does not zero anything.
 }
 
 void OpDispatchBuilder::AVX128_VPCMPESTRM(OpcodeArgs) {
@@ -1671,8 +1670,7 @@ void OpDispatchBuilder::AVX128_VPCMPESTRM(OpcodeArgs) {
 void OpDispatchBuilder::AVX128_VPCMPISTRI(OpcodeArgs) {
   PCMPXSTRXOpImpl(Op, false, false);
 
-  ///< Zero the upper 128-bits of hardcoded YMM0
-  AVX128_StoreXMMRegister(0, LoadZeroVector(OpSize::i128Bit), true);
+  ///< Does not zero anything.
 }
 
 void OpDispatchBuilder::AVX128_VPCMPISTRM(OpcodeArgs) {


### PR DESCRIPTION
Oops, this was just completely wrong.