### PR TITLE
AVX128: F16C support

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ConversionOps.cpp
@@ -355,21 +355,36 @@ DEF_OP(Vector_FToF) {
   }
 }
 
-DEF_OP(Vector_FToF2) {
-  const auto Op = IROp->C<IR::IROp_Vector_FToF2>();
+DEF_OP(VFCVTL2) {
+  const auto Op = IROp->C<IR::IROp_VFCVTL2>();
 
-  const auto ElementSize = Op->Header.ElementSize;
   const auto SubEmitSize = ConvertSubRegSize248(IROp);
 
   const auto Dst = GetVReg(Node);
   const auto Vector = GetVReg(Op->Vector.ID());
 
-  if (ElementSize > Op->SrcElementSize) {
-    LOGMAN_THROW_AA_FMT(Op->SrcElementSize == (ElementSize >> 1), "IR invariant");
-    fcvtl2(SubEmitSize, Dst.D(), Vector.D());
-  } else {
-    LOGMAN_THROW_AA_FMT(Op->SrcElementSize == (ElementSize << 1), "IR invariant");
-    fcvtn2(SubEmitSize, Dst.D(), Vector.D());
+  fcvtl2(SubEmitSize, Dst.D(), Vector.D());
+}
+
+DEF_OP(VFCVTN2) {
+  const auto Op = IROp->C<IR::IROp_VFCVTN2>();
+
+  const auto SubEmitSize = ConvertSubRegSize248(IROp);
+
+  const auto Dst = GetVReg(Node);
+  const auto VectorLower = GetVReg(Op->VectorLower.ID());
+  const auto VectorUpper = GetVReg(Op->VectorUpper.ID());
+
+  auto Lower = VectorLower;
+  if (Dst != VectorLower) {
+    mov(VTMP1.Q(), VectorLower.Q());
+    Lower = VTMP1;
+  }
+
+  fcvtn2(SubEmitSize, Lower.Q(), VectorUpper.Q());
+
+  if (Dst != VectorLower) {
+    mov(Dst.Q(), Lower.Q());
   }
 }
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1265,6 +1265,9 @@ public:
   template<size_t AddrElementSize>
   void AVX128_VPGATHER(OpcodeArgs);
 
+  void AVX128_VCVTPH2PS(OpcodeArgs);
+  void AVX128_VCVTPS2PH(OpcodeArgs);
+
   // End of AVX 128-bit implementation
   void InvalidOp(OpcodeArgs);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -1574,7 +1574,7 @@ void OpDispatchBuilder::AVX128_Vector_CVT_Float_To_Float(OpcodeArgs) {
   };
 
   auto TransformHigh = [this](Ref Src) -> Ref {
-    return _Vector_FToF2(OpSize::i128Bit, DstElementSize, Src, SrcElementSize);
+    return _VFCVTL2(OpSize::i128Bit, SrcElementSize, Src);
   };
 
   Result.Low = TransformLow(Src.Low);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -2375,13 +2375,27 @@
         "NumElements": "RegisterSize / DestElementSize"
       },
 
-      "FPR = Vector_FToF2 u8:#RegisterSize, u8:#DestElementSize, FPR:$Vector, u8:$SrcElementSize": {
+      "FPR = VFCVTL2 u8:#RegisterSize, u8:#ElementSize, FPR:$Vector": {
         "Desc": [
-          "Vector op: Converts float from source element size to destination size (fp32<->fp64)",
+          "Vector op: Converts float from source element size to destination size (fp32->fp64)",
           "Selecting from the high half of the register."
         ],
         "DestSize": "RegisterSize",
-        "NumElements": "RegisterSize / DestElementSize",
+        "NumElements": "RegisterSize / (ElementSize << 1)",
+        "EmitValidation": [
+          "RegisterSize != FEXCore::IR::OpSize::i256Bit && \"What does 256-bit mean in this context?\""
+        ]
+      },
+      "FPR = VFCVTN2 u8:#RegisterSize, u8:#ElementSize, FPR:$VectorLower, FPR:$VectorUpper": {
+        "TiedSource": 0,
+        "Desc": [
+          "Vector op: Converts float from source element size and inserting in to the high bits.",
+          "Bottom half is untouched",
+          "Narrowing to the element size below what is passed in.",
+          "F64->F32, F32->F16"
+        ],
+        "DestSize": "RegisterSize",
+        "NumElements": "RegisterSize / (ElementSize >> 1)",
         "EmitValidation": [
           "RegisterSize != FEXCore::IR::OpSize::i256Bit && \"What does 256-bit mean in this context?\""
         ]

--- a/unittests/ASM/Disabled_Tests_Simulator
+++ b/unittests/ASM/Disabled_Tests_Simulator
@@ -92,6 +92,10 @@ Test_VEX/vcvtps2ph_rtne.asm
 Test_VEX/vcvtps2ph_rd.asm
 Test_VEX/vcvtps2ph_ru.asm
 Test_VEX/vcvtps2ph_trunc.asm
+Test_VEX/vcvtps2ph_rtne_mxcsr.asm
+Test_VEX/vcvtps2ph_rd_mxcsr.asm
+Test_VEX/vcvtps2ph_ru_mxcsr.asm
+Test_VEX/vcvtps2ph_trunc_mxcsr.asm
 
 # Simulator doesn't support cycle counter reading
 Test_TwoByte/0F_31.asm

--- a/unittests/ASM/VEX/vcvtps2ph_rd_mxcsr.asm
+++ b/unittests/ASM/VEX/vcvtps2ph_rd_mxcsr.asm
@@ -1,0 +1,61 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x008000003F800000", "0x7FC000007F7FFFFF", "0", "0"],
+    "XMM1": ["0x7F80000040600000", "0x00000001FF800000", "0", "0"],
+    "XMM2": ["0x7E007BFF00003C00", "0x0000000000000000", "0", "0"],
+    "XMM3": ["0x0000FC007C004300", "0x0000000000000000", "0", "0"],
+    "XMM4": ["0x7E007BFF00003C00", "0x0000FC007C004300", "0", "0"],
+    "XMM5": ["0x008000003F800000", "0x7FC000007F7FFFFF", "0x7F80000040600000", "0x00000001FF800000"],
+    "XMM6": ["0x7E007BFF00003C00", "0x0000FC007C004300", "0", "0"],
+    "XMM7": ["0x7E007BFF00003C00", "0x0000FC007C004300", "0", "0"]
+  }
+}
+%endif
+
+; Set up MXCSR to Round Down
+vldmxcsr [rel .mxcsr]
+
+lea rdx, [rel .data]
+
+; 128-bit
+
+vmovapd xmm0, [rdx]
+vmovapd xmm1, [rdx + 16]
+
+; 128-bit register
+
+vcvtps2ph xmm2, xmm0, 100b
+vcvtps2ph xmm3, xmm1, 100b
+
+; 128-bit memory
+vcvtps2ph [rel .memarea + 0], xmm0, 100b
+vcvtps2ph [rel .memarea + 8], xmm1, 100b
+vmovapd xmm4, [rel .memarea]
+
+; 256-bit
+
+vmovapd ymm5, [rdx]
+
+; 256-bit register
+
+vcvtps2ph xmm6, ymm5, 100b
+
+; 256-bit memory
+
+vcvtps2ph [rel .memarea + 16], ymm5, 100b
+vmovapd xmm7, [rel .memarea + 16]
+
+hlt
+
+align 32
+.data:
+dd 0x3F800000, 0x00800000, 0x7F7FFFFF, 0x7FC00000 ; 1.0, FLT_MIN, FLT_MAX, QNaN
+dd 0x40600000, 0x7F800000, 0xFF800000, 0x00000001 ; 3.5, +inf, -inf, FLT_TRUE_MIN
+
+; A quaint little area for testing the store variant of VCVTPS2PH
+.memarea: times 16 dq 0
+
+.mxcsr:
+dq 0x0000000000003F80

--- a/unittests/ASM/VEX/vcvtps2ph_rtne_mxcsr.asm
+++ b/unittests/ASM/VEX/vcvtps2ph_rtne_mxcsr.asm
@@ -1,0 +1,61 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x008000003F800000", "0x7FC000007F7FFFFF", "0", "0"],
+    "XMM1": ["0x7F80000040600000", "0x00000001FF800000", "0", "0"],
+    "XMM2": ["0x7E007C0000003C00", "0x0000000000000000", "0", "0"],
+    "XMM3": ["0x0000FC007C004300", "0x0000000000000000", "0", "0"],
+    "XMM4": ["0x7E007C0000003C00", "0x0000FC007C004300", "0", "0"],
+    "XMM5": ["0x008000003F800000", "0x7FC000007F7FFFFF", "0x7F80000040600000", "0x00000001FF800000"],
+    "XMM6": ["0x7E007C0000003C00", "0x0000FC007C004300", "0", "0"],
+    "XMM7": ["0x7E007C0000003C00", "0x0000FC007C004300", "0", "0"]
+  }
+}
+%endif
+
+; Set up MXCSR to Round to Nearest Even
+vldmxcsr [rel .mxcsr]
+
+lea rdx, [rel .data]
+
+; 128-bit
+
+vmovapd xmm0, [rdx]
+vmovapd xmm1, [rdx + 16]
+
+; 128-bit register
+
+vcvtps2ph xmm2, xmm0, 100b
+vcvtps2ph xmm3, xmm1, 100b
+
+; 128-bit memory
+vcvtps2ph [rel .memarea + 0], xmm0, 100b
+vcvtps2ph [rel .memarea + 8], xmm1, 100b
+vmovapd xmm4, [rel .memarea]
+
+; 256-bit
+
+vmovapd ymm5, [rdx]
+
+; 256-bit register
+
+vcvtps2ph xmm6, ymm5, 100b
+
+; 256-bit memory
+
+vcvtps2ph [rel .memarea + 16], ymm5, 100b
+vmovapd xmm7, [rel .memarea + 16]
+
+hlt
+
+align 32
+.data:
+dd 0x3F800000, 0x00800000, 0x7F7FFFFF, 0x7FC00000 ; 1.0, FLT_MIN, FLT_MAX, QNaN
+dd 0x40600000, 0x7F800000, 0xFF800000, 0x00000001 ; 3.5, +inf, -inf, FLT_TRUE_MIN
+
+; A quaint little area for testing the store variant of VCVTPS2PH
+.memarea: times 16 dq 0
+
+.mxcsr:
+dq 0x0000000000001F80

--- a/unittests/ASM/VEX/vcvtps2ph_ru_mxcsr.asm
+++ b/unittests/ASM/VEX/vcvtps2ph_ru_mxcsr.asm
@@ -1,0 +1,61 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x008000003F800000", "0x7FC000007F7FFFFF", "0", "0"],
+    "XMM1": ["0x7F80000040600000", "0x00000001FF800000", "0", "0"],
+    "XMM2": ["0x7E007C0000013C00", "0x0000000000000000", "0", "0"],
+    "XMM3": ["0x0001FC007C004300", "0x0000000000000000", "0", "0"],
+    "XMM4": ["0x7E007C0000013C00", "0x0001FC007C004300", "0", "0"],
+    "XMM5": ["0x008000003F800000", "0x7FC000007F7FFFFF", "0x7F80000040600000", "0x00000001FF800000"],
+    "XMM6": ["0x7E007C0000013C00", "0x0001FC007C004300", "0", "0"],
+    "XMM7": ["0x7E007C0000013C00", "0x0001FC007C004300", "0", "0"]
+  }
+}
+%endif
+
+; Set up MXCSR to Round Up
+vldmxcsr [rel .mxcsr]
+
+lea rdx, [rel .data]
+
+; 128-bit
+
+vmovapd xmm0, [rdx]
+vmovapd xmm1, [rdx + 16]
+
+; 128-bit register
+
+vcvtps2ph xmm2, xmm0, 100b
+vcvtps2ph xmm3, xmm1, 100b
+
+; 128-bit memory
+vcvtps2ph [rel .memarea + 0], xmm0, 100b
+vcvtps2ph [rel .memarea + 8], xmm1, 100b
+vmovapd xmm4, [rel .memarea]
+
+; 256-bit
+
+vmovapd ymm5, [rdx]
+
+; 256-bit register
+
+vcvtps2ph xmm6, ymm5, 100b
+
+; 256-bit memory
+
+vcvtps2ph [rel .memarea + 16], ymm5, 100b
+vmovapd xmm7, [rel .memarea + 16]
+
+hlt
+
+align 32
+.data:
+dd 0x3F800000, 0x00800000, 0x7F7FFFFF, 0x7FC00000 ; 1.0, FLT_MIN, FLT_MAX, QNaN
+dd 0x40600000, 0x7F800000, 0xFF800000, 0x00000001 ; 3.5, +inf, -inf, FLT_TRUE_MIN
+
+; A quaint little area for testing the store variant of VCVTPS2PH
+.memarea: times 16 dq 0
+
+.mxcsr:
+dq 0x0000000000005F80

--- a/unittests/ASM/VEX/vcvtps2ph_trunc_mxcsr.asm
+++ b/unittests/ASM/VEX/vcvtps2ph_trunc_mxcsr.asm
@@ -1,0 +1,61 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x008000003F800000", "0x7FC000007F7FFFFF", "0", "0"],
+    "XMM1": ["0x7F80000040600000", "0x00000001FF800000", "0", "0"],
+    "XMM2": ["0x7E007BFF00003C00", "0x0000000000000000", "0", "0"],
+    "XMM3": ["0x0000FC007C004300", "0x0000000000000000", "0", "0"],
+    "XMM4": ["0x7E007BFF00003C00", "0x0000FC007C004300", "0", "0"],
+    "XMM5": ["0x008000003F800000", "0x7FC000007F7FFFFF", "0x7F80000040600000", "0x00000001FF800000"],
+    "XMM6": ["0x7E007BFF00003C00", "0x0000FC007C004300", "0", "0"],
+    "XMM7": ["0x7E007BFF00003C00", "0x0000FC007C004300", "0", "0"]
+  }
+}
+%endif
+
+; Set up MXCSR to truncate
+vldmxcsr [rel .mxcsr]
+
+lea rdx, [rel .data]
+
+; 128-bit
+
+vmovapd xmm0, [rdx]
+vmovapd xmm1, [rdx + 16]
+
+; 128-bit register
+
+vcvtps2ph xmm2, xmm0, 100b
+vcvtps2ph xmm3, xmm1, 100b
+
+; 128-bit memory
+vcvtps2ph [rel .memarea + 0], xmm0, 100b
+vcvtps2ph [rel .memarea + 8], xmm1, 100b
+vmovapd xmm4, [rel .memarea]
+
+; 256-bit
+
+vmovapd ymm5, [rdx]
+
+; 256-bit register
+
+vcvtps2ph xmm6, ymm5, 100b
+
+; 256-bit memory
+
+vcvtps2ph [rel .memarea + 16], ymm5, 100b
+vmovapd xmm7, [rel .memarea + 16]
+
+hlt
+
+align 32
+.data:
+dd 0x3F800000, 0x00800000, 0x7F7FFFFF, 0x7FC00000 ; 1.0, FLT_MIN, FLT_MAX, QNaN
+dd 0x40600000, 0x7F800000, 0xFF800000, 0x00000001 ; 3.5, +inf, -inf, FLT_TRUE_MIN
+
+; A quaint little area for testing the store variant of VCVTPS2PH
+.memarea: times 16 dq 0
+
+.mxcsr:
+dq 0x0000000000007F80


### PR DESCRIPTION
Adds a couple unit tests to ensure MXCSR is adhered to as well