### PR TITLE
FEXCore ARM64EC CI support

### DIFF
--- a/.github/workflows/mingw_build.yml
+++ b/.github/workflows/mingw_build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.arch }}
     strategy:
       matrix:
-        arch: [[self-hosted, ARM64, mingw]]
+        arch: [[self-hosted, ARM64, mingw], [self-hosted, ARM64EC, mingw, ARM64]]
       fail-fast: false
 
     steps:
@@ -37,6 +37,11 @@ jobs:
       if: matrix.arch[1] == 'ARM64'
       run: |
         echo "MINGW_TRIPLE=aarch64-w64-mingw32" >> $GITHUB_ENV
+
+    - name: Set CC Arm64EC
+      if: matrix.arch[1] == 'ARM64EC'
+      run: |
+        echo "MINGW_TRIPLE=arm64ec-w64-mingw32" >> $GITHUB_ENV
 
     - name: Set rootfs paths
       run: |
@@ -73,7 +78,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/toolchain_mingw.cmake -DMINGW_TRIPLE=$MINGW_TRIPLE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DBUILD_TESTS=False -DENABLE_JEMALLOC=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/toolchain_mingw.cmake -DMINGW_TRIPLE=$MINGW_TRIPLE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DBUILD_TESTS=False -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ if (NOT CONTAINS_MINGW EQUAL -1)
   message (STATUS "Mingw build")
   set (MINGW_BUILD TRUE)
   set (ENABLE_JEMALLOC FALSE)
+  set (ENABLE_JEMALLOC_GLIBC_ALLOC FALSE)
 endif()
 
 if (NOT MINGW_BUILD)
@@ -195,7 +196,7 @@ if (ENABLE_JEMALLOC_GLIBC_ALLOC)
   # All host native libraries will use this allocator, while *most* other FEX internal allocations will use the other jemalloc allocator.
   add_definitions(-DENABLE_JEMALLOC_GLIBC=1)
   add_subdirectory(External/jemalloc_glibc/)
-else()
+elseif (NOT MINGW_BUILD)
   message (STATUS
     " jemalloc glibc allocator disabled!\n"
     " This is not a recommended configuration!\n"
@@ -208,7 +209,7 @@ if (ENABLE_JEMALLOC)
   add_definitions(-DENABLE_JEMALLOC=1)
   add_subdirectory(External/jemalloc/)
   include_directories(External/jemalloc/pregen/include/)
-else()
+elseif (NOT MINGW_BUILD)
   message (STATUS
     " jemalloc disabled!\n"
     " This is not a recommended configuration!\n"

--- a/Source/Windows/CMakeLists.txt
+++ b/Source/Windows/CMakeLists.txt
@@ -17,6 +17,6 @@ build_implib(wow64)
 
 add_subdirectory(Common)
 
-if (_M_ARM_64)
+if (_M_ARM_64 AND (NOT _M_ARM_64EC))
   add_subdirectory(WOW64)
 endif()


### PR DESCRIPTION
Dep on #3773, the toolchain artifact from https://github.com/bylaws/llvm-mingw/releases/download/20240628/llvm-mingw-20240627-ucrt-ubuntu-20.04-aarch64.tar.xz  will also need to be installed on the runner