### PR TITLE
Add debug logging to server connections and config loads

### DIFF
--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -168,6 +168,7 @@ MainLoader::MainLoader(FEXCore::Config::LayerType Type, const char* ConfigFile)
   , Config {ConfigFile} {}
 
 void MainLoader::Load() {
+  LogMan::Msg::DFmt("[MainLoader] Loading config file: {}", Config.c_str());
   JSON::LoadJSonConfig(Config, [this](const char* Name, const char* ConfigString) { MapNameToOption(Name, ConfigString); });
 }
 
@@ -181,6 +182,7 @@ AppLoader::AppLoader(const fextl::string& Filename, FEXCore::Config::LayerType T
 }
 
 void AppLoader::Load() {
+  LogMan::Msg::DFmt("[AppLoader] Loading config file: {}", Config.c_str());
   JSON::LoadJSonConfig(Config, [this](const char* Name, const char* ConfigString) { MapNameToOption(Name, ConfigString); });
 }
 

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -182,7 +182,7 @@ AppLoader::AppLoader(const fextl::string& Filename, FEXCore::Config::LayerType T
 }
 
 void AppLoader::Load() {
-  LogMan::Msg::DFmt("[AppLoader] Loading config file: {}", Config.c_str());
+  LogMan::Msg::DFmt("[AppLoader] Loading config file: {}", Config);
   JSON::LoadJSonConfig(Config, [this](const char* Name, const char* ConfigString) { MapNameToOption(Name, ConfigString); });
 }
 

--- a/Source/Tools/FEXServer/ProcessPipe.cpp
+++ b/Source/Tools/FEXServer/ProcessPipe.cpp
@@ -449,6 +449,7 @@ void WaitForRequests() {
               int NewFD = accept(ServerSocketFD, reinterpret_cast<struct sockaddr*>(&Addr), &AddrSize);
 
               // Add the new client to the temporary array
+              LogMan::Msg::DFmt("[FEXServer] New connection accepted");
               NewPollFDs.emplace_back(pollfd {
                 .fd = NewFD,
                 .events = POLLIN | POLLPRI | POLLRDHUP,


### PR DESCRIPTION
I have found these messages to be useful to understand what's happening when debugging FEX, both to understand if a connection actually happened and to understand which config files are being used. Is it ok to merge it?