### PR TITLE
OpcodeDispatcher: Optimize x86 canonical vector zero register 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5074,8 +5074,8 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
     {OPD(1, 0b00, 0x56), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VOR, 16>},
     {OPD(1, 0b01, 0x56), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VOR, 16>},
 
-    {OPD(1, 0b00, 0x57), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VXOR, 16>},
-    {OPD(1, 0b01, 0x57), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VXOR, 16>},
+    {OPD(1, 0b00, 0x57), 1, &OpDispatchBuilder::AVXVectorXOROp},
+    {OPD(1, 0b01, 0x57), 1, &OpDispatchBuilder::AVXVectorXOROp},
 
     {OPD(1, 0b00, 0x58), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VFADD, 4>},
     {OPD(1, 0b01, 0x58), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VFADD, 8>},
@@ -5207,7 +5207,7 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
     {OPD(1, 0b01, 0xEC), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VSQADD, 1>},
     {OPD(1, 0b01, 0xED), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VSQADD, 2>},
     {OPD(1, 0b01, 0xEE), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VSMAX, 2>},
-    {OPD(1, 0b01, 0xEF), 1, &OpDispatchBuilder::AVXVectorALUOp<IR::OP_VXOR, 16>},
+    {OPD(1, 0b01, 0xEF), 1, &OpDispatchBuilder::AVXVectorXOROp},
 
     {OPD(1, 0b11, 0xF0), 1, &OpDispatchBuilder::MOVVectorUnalignedOp},
     {OPD(1, 0b01, 0xF1), 1, &OpDispatchBuilder::VPSLLOp<2>},
@@ -5637,7 +5637,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0x54, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VAND, 16>},
     {0x55, 1, &OpDispatchBuilder::VectorALUROp<IR::OP_VANDN, 8>},
     {0x56, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VOR, 16>},
-    {0x57, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VXOR, 16>},
+    {0x57, 1, &OpDispatchBuilder::VectorXOROp},
     {0x58, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VFADD, 4>},
     {0x59, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VFMUL, 4>},
     {0x5A, 1, &OpDispatchBuilder::Vector_CVT_Float_To_Float<8, 4>},
@@ -5696,7 +5696,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0xEC, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VSQADD, 1>},
     {0xED, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VSQADD, 2>},
     {0xEE, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VSMAX, 2>},
-    {0xEF, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VXOR, 8>},
+    {0xEF, 1, &OpDispatchBuilder::VectorXOROp},
 
     {0xF1, 1, &OpDispatchBuilder::PSLL<2>},
     {0xF2, 1, &OpDispatchBuilder::PSLL<4>},
@@ -5926,7 +5926,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0x54, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VAND, 16>},
     {0x55, 1, &OpDispatchBuilder::VectorALUROp<IR::OP_VANDN, 8>},
     {0x56, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VOR, 16>},
-    {0x57, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VXOR, 16>},
+    {0x57, 1, &OpDispatchBuilder::VectorXOROp},
     {0x58, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VFADD, 8>},
     {0x59, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VFMUL, 8>},
     {0x5A, 1, &OpDispatchBuilder::Vector_CVT_Float_To_Float<4, 8>},
@@ -5997,7 +5997,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
     {0xEC, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VSQADD, 1>},
     {0xED, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VSQADD, 2>},
     {0xEE, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VSMAX, 2>},
-    {0xEF, 1, &OpDispatchBuilder::VectorALUOp<IR::OP_VXOR, 16>},
+    {0xEF, 1, &OpDispatchBuilder::VectorXOROp},
 
     {0xF1, 1, &OpDispatchBuilder::PSLL<2>},
     {0xF2, 1, &OpDispatchBuilder::PSLL<4>},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -454,6 +454,8 @@ public:
   void MOVSSOp(OpcodeArgs);
   template<FEXCore::IR::IROps IROp, size_t ElementSize>
   void VectorALUOp(OpcodeArgs);
+  void VectorXOROp(OpcodeArgs);
+
   template<FEXCore::IR::IROps IROp, size_t ElementSize>
   void VectorALUROp(OpcodeArgs);
   template<FEXCore::IR::IROps IROp, size_t ElementSize>
@@ -545,6 +547,7 @@ public:
   // AVX Ops
   template<IROps IROp, size_t ElementSize>
   void AVXVectorALUOp(OpcodeArgs);
+  void AVXVectorXOROp(OpcodeArgs);
   template<IROps IROp, size_t ElementSize>
   void AVXVectorUnaryOp(OpcodeArgs);
 
@@ -1053,6 +1056,7 @@ public:
 
   template<IROps IROp, size_t ElementSize>
   void AVX128_VectorALU(OpcodeArgs);
+  void AVX128_VectorXOR(OpcodeArgs);
   template<IROps IROp, size_t ElementSize>
   void AVX128_VectorUnary(OpcodeArgs);
 

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -914,6 +914,50 @@
         "str q2, [x28, #16]"
       ]
     },
+    "vxorps xmm0, xmm1, xmm1": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b00 0x57 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0",
+        "str q16, [x28, #16]"
+      ]
+    },
+    "vxorps ymm0, ymm1, ymm1": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b00 0x57 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0",
+        "str q16, [x28, #16]"
+      ]
+    },
+    "vxorpd xmm0, xmm1, xmm1": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b01 0x57 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0",
+        "str q16, [x28, #16]"
+      ]
+    },
+    "vxorpd ymm0, ymm1, ymm1": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b01 0x57 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0",
+        "str q16, [x28, #16]"
+      ]
+    },
     "vpunpcklbw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 3,
       "Comment": [
@@ -5136,6 +5180,28 @@
         "eor v16.16b, v17.16b, v18.16b",
         "eor v2.16b, v2.16b, v3.16b",
         "str q2, [x28, #16]"
+      ]
+    },
+    "vpxor xmm0, xmm1, xmm1": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b01 0xef 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0",
+        "str q16, [x28, #16]"
+      ]
+    },
+    "vpxor ymm0, ymm1, ymm1": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b01 0xef 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0",
+        "str q16, [x28, #16]"
       ]
     },
     "vlddqu xmm0, [rax]": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -719,6 +719,13 @@
         "eor v16.16b, v16.16b, v17.16b"
       ]
     },
+    "xorps xmm0, xmm0": {
+      "ExpectedInstructionCount": 1,
+      "Comment": "0x0f 0x57",
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
+      ]
+    },
     "addps xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
       "Comment": "0x0f 0x58",
@@ -3646,6 +3653,14 @@
         "ldr d2, [x28, #1056]",
         "ldr d3, [x28, #1040]",
         "eor v2.16b, v3.16b, v2.16b",
+        "str d2, [x28, #1040]"
+      ]
+    },
+    "pxor mm0, mm0": {
+      "ExpectedInstructionCount": 2,
+      "Comment": "0x0f 0xef",
+      "ExpectedArm64ASM": [
+        "movi v2.2d, #0x0",
         "str d2, [x28, #1040]"
       ]
     },

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -1261,6 +1261,13 @@
         "eor v16.16b, v16.16b, v17.16b"
       ]
     },
+    "pxor xmm0, xmm0": {
+      "ExpectedInstructionCount": 1,
+      "Comment": "0x66 0x0f 0xef",
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
+      ]
+    },
     "psllw xmm0, xmm1": {
       "ExpectedInstructionCount": 4,
       "Comment": "0x66 0x0f 0xf1",

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -835,6 +835,46 @@
         "eor z16.d, z16.d, z17.d"
       ]
     },
+    "vxorps xmm0, xmm1, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b00 0x57 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
+      ]
+    },
+    "vxorps ymm0, ymm1, ymm1": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b00 0x57 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
+      ]
+    },
+    "vxorpd xmm0, xmm1, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b01 0x57 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
+      ]
+    },
+    "vxorpd ymm0, ymm1, ymm1": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b01 0x57 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
+      ]
+    },
     "vpunpcklbw xmm0, xmm1, xmm2": {
       "ExpectedInstructionCount": 1,
       "Comment": [
@@ -5148,6 +5188,26 @@
       ],
       "ExpectedArm64ASM": [
         "eor z16.d, z17.d, z18.d"
+      ]
+    },
+    "vpxor xmm0, xmm1, xmm1": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b01 0xef 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
+      ]
+    },
+    "vpxor ymm0, ymm1, ymm1": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "xor with itself to get zero register",
+        "Map 1 0b01 0xef 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "movi v16.2d, #0x0"
       ]
     },
     "vlddqu xmm0, [rax]": {


### PR DESCRIPTION
The canonical way to generate a zero register vector in x86 is to xor
itself. Capture this can convert it to canonical zero register instead.

Can get zero-cycle renamed on latest CPUs.