### PR TITLE
OpcodeDispatcher: Implement support for non-temporal vector stores 

### DIFF
--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -3321,7 +3321,18 @@ public:
 
   // SVE Memory - Contiguous Store with Immediate Offset
   // SVE contiguous non-temporal store (scalar plus immediate)
-  // XXX:
+  void stnt1b(ZRegister zt, PRegister pg, Register rn, int32_t Imm = 0) {
+    SVEContiguousNontemporalStore(0b00, zt, pg, rn, Imm);
+  }
+  void stnt1h(ZRegister zt, PRegister pg, Register rn, int32_t Imm = 0) {
+    SVEContiguousNontemporalStore(0b01, zt, pg, rn, Imm);
+  }
+  void stnt1w(ZRegister zt, PRegister pg, Register rn, int32_t Imm = 0) {
+    SVEContiguousNontemporalStore(0b10, zt, pg, rn, Imm);
+  }
+  void stnt1d(ZRegister zt, PRegister pg, Register rn, int32_t Imm = 0) {
+    SVEContiguousNontemporalStore(0b11, zt, pg, rn, Imm);
+  }
 
   // SVE store multiple structures (scalar plus immediate)
   void st2b(ZRegister zt1, ZRegister zt2, PRegister pg, Register rn, int32_t Imm = 0) {
@@ -4478,6 +4489,22 @@ private:
     if (is_store) {
       Instr |= 0x40100000U;
     }
+    dc32(Instr);
+  }
+
+  // SVE contiguous non-temporal store (scalar plus immediate)
+  void SVEContiguousNontemporalStore(uint32_t msz, ZRegister zt, PRegister pg, Register rn, int32_t imm) {
+    LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
+    LOGMAN_THROW_AA_FMT(imm >= -8 && imm <= 7,
+                        "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
+
+    const auto imm4 = static_cast<uint32_t>(imm) & 0xF;
+    uint32_t Instr = 0b1110'0100'0001'0000'1110'0000'0000'0000;
+    Instr |= msz << 23;
+    Instr |= imm4 << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= zt.Idx();
     dc32(Instr);
   }
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -805,12 +805,25 @@ void OpDispatchBuilder::AVX128_MOVVectorNT(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
   const auto Is128Bit = SrcSize == Core::CPUState::XMM_SSE_REG_SIZE;
 
-  auto Src = AVX128_LoadSource_WithOpSize(Op, Op->Src[0], Op->Flags, !Is128Bit, MemoryAccessType::STREAM);
+  if (Op->Dest.IsGPR()) {
+    ///< MOVNTDQA load non-temporal comes from SSE4.1 and is extended by AVX/AVX2.
+    auto Src = AVX128_LoadSource_WithOpSize(Op, Op->Src[0], Op->Flags, !Is128Bit, MemoryAccessType::STREAM);
+    if (Is128Bit) {
+      Src.High = LoadZeroVector(OpSize::i128Bit);
+    }
+    AVX128_StoreResult_WithOpSize(Op, Op->Dest, Src);
+  } else {
+    auto Src = AVX128_LoadSource_WithOpSize(Op, Op->Src[0], Op->Flags, !Is128Bit, MemoryAccessType::STREAM);
+    Ref Dest = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.LoadData = false});
 
-  if (Op->Dest.IsGPR() && Is128Bit) {
-    Src.High = LoadZeroVector(OpSize::i128Bit);
+    if (Is128Bit) {
+      // Single store non-temporal for 128-bit operations.
+      _VStoreNonTemporal(OpSize::i128Bit, Src.Low, Dest, 0);
+    } else {
+      // For a 256-bit store, use a non-temporal store pair
+      _VStoreNonTemporalPair(OpSize::i128Bit, Src.Low, Src.High, Dest, 0);
+    }
   }
-  AVX128_StoreResult_WithOpSize(Op, Op->Dest, Src);
 }
 
 void OpDispatchBuilder::AVX128_MOVQ(OpcodeArgs) {

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -653,6 +653,30 @@
         ],
         "HasSideEffects": true,
         "DestSize": "8"
+      },
+      "VStoreNonTemporal u8:#RegisterSize, FPR:$Value, GPR:$Addr, i8:$Offset": {
+        "Desc": ["Does a non-temporal memory store of a vector.",
+                 "Matches arm64 SVE stnt1b semantics.",
+                 "Specifically weak-memory model ordered to match x86 non-temporal stores."
+        ],
+        "HasSideEffects": true,
+        "DestSize": "RegisterSize",
+        "EmitValidation": [
+          "_Offset % RegisterSize == 0",
+          "RegisterSize == FEXCore::IR::OpSize::i128Bit || RegisterSize == FEXCore::IR::OpSize::i256Bit"
+        ]
+      },
+      "VStoreNonTemporalPair u8:#RegisterSize, FPR:$ValueLow, FPR:$ValueHigh, GPR:$Addr, i8:$Offset": {
+        "Desc": ["Does a non-temporal memory store of two vector registers.",
+                 "Matches arm64 stnp semantics.",
+                 "Specifically weak-memory model ordered to match x86 non-temporal stores."
+        ],
+        "HasSideEffects": true,
+        "DestSize": "RegisterSize",
+        "EmitValidation": [
+          "_Offset % RegisterSize == 0",
+          "RegisterSize == FEXCore::IR::OpSize::i128Bit"
+        ]
       }
     },
     "Atomic": {

--- a/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -4539,6 +4539,24 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE store multiple structures 
                                                                                               "[x29, x30, lsl #3]");
 }
 
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE contiguous non-temporal store (scalar plus immediate)") {
+  TEST_SINGLE(stnt1b(ZReg::z31, PReg::p6, Reg::r29, 0), "stnt1b {z31.b}, p6, [x29]");
+  TEST_SINGLE(stnt1b(ZReg::z31, PReg::p6, Reg::r29, -8), "stnt1b {z31.b}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(stnt1b(ZReg::z31, PReg::p6, Reg::r29, 7), "stnt1b {z31.b}, p6, [x29, #7, mul vl]");
+
+  TEST_SINGLE(stnt1h(ZReg::z31, PReg::p6, Reg::r29, 0), "stnt1h {z31.h}, p6, [x29]");
+  TEST_SINGLE(stnt1h(ZReg::z31, PReg::p6, Reg::r29, -8), "stnt1h {z31.h}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(stnt1h(ZReg::z31, PReg::p6, Reg::r29, 7), "stnt1h {z31.h}, p6, [x29, #7, mul vl]");
+
+  TEST_SINGLE(stnt1w(ZReg::z31, PReg::p6, Reg::r29, 0), "stnt1w {z31.s}, p6, [x29]");
+  TEST_SINGLE(stnt1w(ZReg::z31, PReg::p6, Reg::r29, -8), "stnt1w {z31.s}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(stnt1w(ZReg::z31, PReg::p6, Reg::r29, 7), "stnt1w {z31.s}, p6, [x29, #7, mul vl]");
+
+  TEST_SINGLE(stnt1d(ZReg::z31, PReg::p6, Reg::r29, 0), "stnt1d {z31.d}, p6, [x29]");
+  TEST_SINGLE(stnt1d(ZReg::z31, PReg::p6, Reg::r29, -8), "stnt1d {z31.d}, p6, [x29, #-8, mul vl]");
+  TEST_SINGLE(stnt1d(ZReg::z31, PReg::p6, Reg::r29, 7), "stnt1d {z31.d}, p6, [x29, #7, mul vl]");
+}
+
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE store multiple structures (scalar plus immediate)") {
   TEST_SINGLE(st2b(ZReg::z31, ZReg::z0, PReg::p6, Reg::r29, 0), "st2b {z31.b, z0.b}, p6, [x29]");
   TEST_SINGLE(st2b(ZReg::z26, ZReg::z27, PReg::p6, Reg::r29, 0), "st2b {z26.b, z27.b}, p6, [x29]");

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -2804,14 +2804,13 @@
       ]
     },
     "vmovntps [rax], ymm0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x2B 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #16]",
-        "str q16, [x4]",
-        "str q2, [x4, #16]"
+        "stnp q16, q2, [x4]"
       ]
     },
     "vmovntpd [rax], xmm0": {
@@ -2824,14 +2823,13 @@
       ]
     },
     "vmovntpd [rax], ymm0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x2B 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #16]",
-        "str q16, [x4]",
-        "str q2, [x4, #16]"
+        "stnp q16, q2, [x4]"
       ]
     },
     "vcvttss2si eax, xmm0": {
@@ -4880,14 +4878,13 @@
       ]
     },
     "vmovntdq [rax], ymm0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xe7 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #16]",
-        "str q16, [x4]",
-        "str q2, [x4, #16]"
+        "stnp q16, q2, [x4]"
       ]
     },
     "vpsubsb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
@@ -1,0 +1,73 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "SVE128"
+    ],
+    "DisabledHostFeatures": [
+      "AFP",
+      "FLAGM",
+      "FLAGM2",
+      "SVE256"
+    ]
+  },
+  "Instructions": {
+    "vmovntps [rax], xmm0": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "Map 1 0b00 0x2B 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "stnt1b {z16.b}, p6, [x4]"
+      ]
+    },
+    "vmovntps [rax], ymm0": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "Map 1 0b00 0x2B 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #16]",
+        "stnp q16, q2, [x4]"
+      ]
+    },
+    "vmovntpd [rax], xmm0": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "Map 1 0b01 0x2B 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "stnt1b {z16.b}, p6, [x4]"
+      ]
+    },
+    "vmovntpd [rax], ymm0": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "Map 1 0b01 0x2B 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #16]",
+        "stnp q16, q2, [x4]"
+      ]
+    },
+    "vmovntdq [rax], xmm0": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "Map 1 0b01 0xe7 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "stnt1b {z16.b}, p6, [x4]"
+      ]
+    },
+    "vmovntdq [rax], ymm0": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "Map 1 0b01 0xe7 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #16]",
+        "stnp q16, q2, [x4]"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -3194,7 +3194,7 @@
         "Map 1 0b00 0x2B 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "str q16, [x4]"
+        "stnt1b {z16.b}, p6, [x4]"
       ]
     },
     "vmovntps [rax], ymm0": {
@@ -3203,7 +3203,7 @@
         "Map 1 0b00 0x2B 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "st1b {z16.b}, p7, [x4]"
+        "stnt1b {z16.b}, p7, [x4]"
       ]
     },
     "vmovntpd [rax], xmm0": {
@@ -3212,7 +3212,7 @@
         "Map 1 0b01 0x2B 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "str q16, [x4]"
+        "stnt1b {z16.b}, p6, [x4]"
       ]
     },
     "vmovntpd [rax], ymm0": {
@@ -3221,7 +3221,7 @@
         "Map 1 0b01 0x2B 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "st1b {z16.b}, p7, [x4]"
+        "stnt1b {z16.b}, p7, [x4]"
       ]
     },
     "vcvttss2si eax, xmm0": {
@@ -4952,7 +4952,7 @@
         "Map 1 0b01 0xe7 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "str q16, [x4]"
+        "stnt1b {z16.b}, p6, [x4]"
       ]
     },
     "vmovntdq [rax], ymm0": {
@@ -4961,7 +4961,7 @@
         "Map 1 0b01 0xe7 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "st1b {z16.b}, p7, [x4]"
+        "stnt1b {z16.b}, p7, [x4]"
       ]
     },
     "vpsubsb xmm0, xmm1, xmm2": {


### PR DESCRIPTION
x86 doesn't have a lot of non-temporal vector stores but we do have a
few of them.

- MMX: MOVNTQ
- SSE2: MOVNTDQ, MOVNTPS, MOVNTPD
- AVX: VMOVNTDQ (128-bit & 256-bit), VMOVNTPD

Additionally SSE4a adds 32-bit and 64-bit scalar vector non-temporal
stores, which we keep as regular stores. Since ARM doesn't have matching
semantics for those. MMX non-temporal store is also untouched since no matching semantics.

Additionally SSE4.1 adds non-temporal vector LOADS which this doesn't
touch.
- SSE4.1: MOVNTDQA
- AVX: VMOVNTDQA (128-bit)
- AVX2: VMOVNTDQA (256-bit)

Fixes https://github.com/FEX-Emu/FEX/issues/3364