### PR TITLE
AVX128: Minor optimization to 256-bit vpshufb

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1469,7 +1469,8 @@ private:
 
   Ref PSADBWOpImpl(size_t Size, Ref Src1, Ref Src2);
 
-  Ref PSHUFBOpImpl(uint8_t SrcSize, Ref Src1, Ref Src2);
+  Ref GeneratePSHUFBMask(uint8_t SrcSize);
+  Ref PSHUFBOpImpl(uint8_t SrcSize, Ref Src1, Ref Src2, Ref MaskVector);
 
   Ref PSIGNImpl(OpcodeArgs, size_t ElementSize, Ref Src1, Ref Src2);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -2012,8 +2012,9 @@ void OpDispatchBuilder::AVX128_VHSUBP(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::AVX128_VPSHUFB(OpcodeArgs) {
+  auto MaskVector = GeneratePSHUFBMask(OpSize::i128Bit);
   AVX128_VectorBinaryImpl(Op, GetDstSize(Op), OpSize::i8Bit,
-                          [this](size_t, Ref Src1, Ref Src2) { return PSHUFBOpImpl(OpSize::i128Bit, Src1, Src2); });
+                          [this, MaskVector](size_t, Ref Src1, Ref Src2) { return PSHUFBOpImpl(OpSize::i128Bit, Src1, Src2, MaskVector); });
 }
 
 void OpDispatchBuilder::AVX128_VPSADBW(OpcodeArgs) {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -25,19 +25,18 @@
       ]
     },
     "vpshufb ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 2 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x28, #32]",
-        "ldr q3, [x28, #48]",
-        "movi v4.16b, #0x8f",
-        "and v4.16b, v18.16b, v4.16b",
-        "tbl v16.16b, {v17.16b}, v4.16b",
-        "movi v4.16b, #0x8f",
-        "and v3.16b, v3.16b, v4.16b",
-        "tbl v2.16b, {v2.16b}, v3.16b",
+        "movi v2.16b, #0x8f",
+        "ldr q3, [x28, #32]",
+        "ldr q4, [x28, #48]",
+        "and v5.16b, v18.16b, v2.16b",
+        "tbl v16.16b, {v17.16b}, v5.16b",
+        "and v2.16b, v4.16b, v2.16b",
+        "tbl v2.16b, {v3.16b}, v2.16b",
         "str q2, [x28, #16]"
       ]
     },


### PR DESCRIPTION
Generate the same mask register once and use it for both low and high 128-bits