### PR TITLE
Arm64: Minor VBSL optimization with SVE128 

### DIFF
--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -1,0 +1,98 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "SVE128"
+    ],
+    "DisabledHostFeatures": [
+      "AFP",
+      "SVE256"
+    ]
+  },
+  "Instructions": {
+    "vblendvps xmm0, xmm1, xmm2, xmm3": {
+      "ExpectedInstructionCount": 3,
+      "Comment": [
+        "Map 3 0b01 0x4a 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "sshr v2.4s, v19.4s, #31",
+        "movprfx z16, z18",
+        "bsl z16.d, z16.d, z17.d, z2.d"
+      ]
+    },
+    "vblendvps ymm0, ymm1, ymm2, ymm3": {
+      "ExpectedInstructionCount": 9,
+      "Comment": [
+        "Map 3 0b01 0x4a 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #32]",
+        "ldr q3, [x28, #48]",
+        "ldr q4, [x28, #64]",
+        "sshr v5.4s, v19.4s, #31",
+        "movprfx z16, z18",
+        "bsl z16.d, z16.d, z17.d, z5.d",
+        "sshr v4.4s, v4.4s, #31",
+        "bit v2.16b, v3.16b, v4.16b",
+        "str q2, [x28, #16]"
+      ]
+    },
+    "vblendvpd xmm0, xmm1, xmm2, xmm3": {
+      "ExpectedInstructionCount": 3,
+      "Comment": [
+        "Map 3 0b01 0x4b 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "sshr v2.2d, v19.2d, #63",
+        "movprfx z16, z18",
+        "bsl z16.d, z16.d, z17.d, z2.d"
+      ]
+    },
+    "vblendvpd ymm0, ymm1, ymm2, ymm3": {
+      "ExpectedInstructionCount": 9,
+      "Comment": [
+        "Map 3 0b01 0x4b 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #32]",
+        "ldr q3, [x28, #48]",
+        "ldr q4, [x28, #64]",
+        "sshr v5.2d, v19.2d, #63",
+        "movprfx z16, z18",
+        "bsl z16.d, z16.d, z17.d, z5.d",
+        "sshr v4.2d, v4.2d, #63",
+        "bit v2.16b, v3.16b, v4.16b",
+        "str q2, [x28, #16]"
+      ]
+    },
+    "vpblendvb xmm0, xmm1, xmm2, xmm3": {
+      "ExpectedInstructionCount": 3,
+      "Comment": [
+        "Map 3 0b01 0x4c 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "sshr v2.16b, v19.16b, #7",
+        "movprfx z16, z18",
+        "bsl z16.d, z16.d, z17.d, z2.d"
+      ]
+    },
+    "vpblendvb ymm0, ymm1, ymm2, ymm3": {
+      "ExpectedInstructionCount": 9,
+      "Comment": [
+        "Map 3 0b01 0x4c 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #32]",
+        "ldr q3, [x28, #48]",
+        "ldr q4, [x28, #64]",
+        "sshr v5.16b, v19.16b, #7",
+        "movprfx z16, z18",
+        "bsl z16.d, z16.d, z17.d, z5.d",
+        "sshr v4.16b, v4.16b, #7",
+        "bit v2.16b, v3.16b, v4.16b",
+        "str q2, [x28, #16]"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is a very minor performance change. On Cortex CPUs that support
SVE, they do movprfx+<instruction> fusion to remove two cycles and a
dependency from the backend.

This is a minor win to convert from ASIMD mov+bsl to SVE movprfx+bsl
because of this, saving two cycles and a dependency on Cortex A710 and
A715. This is slightly less of a win on Cortex-A720/A725 because it supports
zero-cycle vector register renames, but it is still a win on Cortex-X925
because that is an older core design that doesn't support zero-cycle
vector register renames.

Very silly little thing.