### PR TITLE
AVX128: Fixes vmovlhps

### DIFF
--- a/unittests/ASM/VEX/vmovlhps.asm
+++ b/unittests/ASM/VEX/vmovlhps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x43cc1ad6970b4549", "0xc4be43cc1ad6970b", "0", "0"],
+    "XMM1": ["0x43cc1ad6970b4549", "0xbd7eb46a1278f793", "0xef673dac6e4cbb7b", "0x5b3d85d342718be9"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+lea rdx, [rel .data]
+
+vmovapd ymm0, [rdx]
+vmovapd ymm1, [rdx + 32]
+vmovapd ymm2, [rdx + 64]
+
+vmovlhps xmm0, xmm1, xmm2
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -455,6 +455,17 @@
         "str q2, [x28, #16]"
       ]
     },
+    "vmovlhps xmm0, xmm1, xmm1": {
+      "ExpectedInstructionCount": 3,
+      "Comment": [
+        "Map 1 0b01 0x16 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "zip1 v16.2d, v17.2d, v17.2d",
+        "movi v2.2d, #0x0",
+        "str q2, [x28, #16]"
+      ]
+    },
     "vmovshdup xmm0, [rax]": {
       "ExpectedInstructionCount": 4,
       "Comment": [

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -420,6 +420,18 @@
         "mov v16.d[1], v3.d[0]"
       ]
     },
+    "vmovlhps xmm0, xmm1, xmm1": {
+      "ExpectedInstructionCount": 4,
+      "Comment": [
+        "Map 1 0b01 0x16 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov v2.8b, v17.8b",
+        "mov v3.8b, v17.8b",
+        "mov v16.16b, v2.16b",
+        "mov v16.d[1], v3.d[0]"
+      ]
+    },
     "vmovshdup xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
       "Comment": [


### PR DESCRIPTION
We didn't have a unit test for this and we weren't implementing it at all.
We treated it as vmovhps/vmovhpd accidentally. Once again caught by the libaom Intrinsics unit tests.