### PR TITLE
Arm64: Fixes long signed divide 

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -47,8 +47,8 @@ static uint64_t LUDIV(uint64_t SrcHigh, uint64_t SrcLow, uint64_t Divisor) {
   return Res;
 }
 
-static int64_t LDIV(int64_t SrcHigh, int64_t SrcLow, int64_t Divisor) {
-  __int128_t Source = (static_cast<__int128_t>(SrcHigh) << 64) | SrcLow;
+static int64_t LDIV(uint64_t SrcHigh, uint64_t SrcLow, int64_t Divisor) {
+  __int128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
   __int128_t Res = Source / Divisor;
   return Res;
 }
@@ -59,8 +59,8 @@ static uint64_t LUREM(uint64_t SrcHigh, uint64_t SrcLow, uint64_t Divisor) {
   return Res;
 }
 
-static int64_t LREM(int64_t SrcHigh, int64_t SrcLow, int64_t Divisor) {
-  __int128_t Source = (static_cast<__int128_t>(SrcHigh) << 64) | SrcLow;
+static int64_t LREM(uint64_t SrcHigh, uint64_t SrcLow, int64_t Divisor) {
+  __int128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
   __int128_t Res = Source % Divisor;
   return Res;
 }

--- a/unittests/ASM/FEX_bugs/LongSignedDivide.asm
+++ b/unittests/ASM/FEX_bugs/LongSignedDivide.asm
@@ -1,0 +1,20 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xfa4fa4fa4fa50e8f",
+    "RDX": "0x000000000000001c"
+  }
+}
+%endif
+; FEX-Emu had a bug where a 128-bit divide with a large unsigned number with a negative number would result in incorrect data.
+; This only manifested itself when the sign bit differed between upper and lower halves of the dividend.
+
+mov rax, 0xfffffffffffc70f9
+mov rdx, 0x0000000000000000
+mov rbx, 0xffffffffffffffd3
+
+jmp .test
+.test:
+idiv rbx
+
+hlt


### PR DESCRIPTION
The two halves are provided as two uint64_t values that shouldn't be
sign extended between them. Treat them as uint64_t until combined in to
a single int128_t. Fixes long signed divide.