### PR TITLE
Arm64: Remove one move if possible in FMA operations 

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/VectorOps.cpp
@@ -4005,12 +4005,16 @@ DEF_OP(VFMLA) {
     const auto Mask = PRED_TMP_32B.Merging();
     ARMEmitter::VRegister DestTmp = Dst;
     if (Dst != VectorAddend) {
-      DestTmp = VTMP1;
+      if (Dst != Vector1 && Dst != Vector2) {
+        DestTmp = Dst;
+      } else {
+        DestTmp = VTMP1;
+      }
       mov(DestTmp.Z(), VectorAddend.Z());
     }
 
     fmla(SubRegSize, DestTmp.Z(), Mask, Vector1.Z(), Vector2.Z());
-    if (Dst != VectorAddend) {
+    if (Dst != DestTmp) {
       mov(Dst.Z(), DestTmp.Z());
     }
   } else {
@@ -4026,7 +4030,11 @@ DEF_OP(VFMLA) {
     }
     ARMEmitter::VRegister DestTmp = Dst;
     if (Dst != VectorAddend) {
-      DestTmp = VTMP1;
+      if (Dst != Vector1 && Dst != Vector2) {
+        DestTmp = Dst;
+      } else {
+        DestTmp = VTMP1;
+      }
       mov(DestTmp.Q(), VectorAddend.Q());
     }
     if (OpSize == 16) {
@@ -4035,7 +4043,7 @@ DEF_OP(VFMLA) {
       fmla(SubRegSize, DestTmp.D(), Vector1.D(), Vector2.D());
     }
 
-    if (Dst != VectorAddend) {
+    if (Dst != DestTmp) {
       mov(Dst.Q(), DestTmp.Q());
     }
   }
@@ -4063,24 +4071,32 @@ DEF_OP(VFMLS) {
     const auto Mask = PRED_TMP_32B.Merging();
     ARMEmitter::VRegister DestTmp = Dst;
     if (Dst != VectorAddend) {
-      DestTmp = VTMP1;
+      if (Dst != Vector1 && Dst != Vector2) {
+        DestTmp = Dst;
+      } else {
+        DestTmp = VTMP1;
+      }
       mov(DestTmp.Z(), VectorAddend.Z());
     }
 
     fnmls(SubRegSize, DestTmp.Z(), Mask, Vector1.Z(), Vector2.Z());
-    if (Dst != VectorAddend) {
+    if (Dst != DestTmp) {
       mov(Dst.Z(), DestTmp.Z());
     }
   } else if (HostSupportsSVE128 && Is128Bit) {
     const auto Mask = PRED_TMP_16B.Merging();
     ARMEmitter::VRegister DestTmp = Dst;
     if (Dst != VectorAddend) {
-      DestTmp = VTMP1;
+      if (Dst != Vector1 && Dst != Vector2) {
+        DestTmp = Dst;
+      } else {
+        DestTmp = VTMP1;
+      }
       mov(DestTmp.Z(), VectorAddend.Z());
     }
 
     fnmls(SubRegSize, DestTmp.Z(), Mask, Vector1.Z(), Vector2.Z());
-    if (Dst != VectorAddend) {
+    if (Dst != DestTmp) {
       mov(Dst.Z(), DestTmp.Z());
     }
   } else {
@@ -4096,15 +4112,29 @@ DEF_OP(VFMLS) {
     }
 
     // Addend needs to get negated to match correct behaviour here.
-    ARMEmitter::VRegister DestTmp = VTMP1;
+    ARMEmitter::VRegister DestTmp = Dst;
+    if (Dst == Vector1 || Dst == Vector2) {
+      DestTmp = VTMP1;
+    }
+
     if (Is128Bit) {
       fneg(SubRegSize, DestTmp.Q(), VectorAddend.Q());
-      fmla(SubRegSize, DestTmp.Q(), Vector1.Q(), Vector2.Q());
-      mov(Dst.Q(), DestTmp.Q());
     } else {
       fneg(SubRegSize, DestTmp.D(), VectorAddend.D());
+    }
+
+    if (Is128Bit) {
+      fmla(SubRegSize, DestTmp.Q(), Vector1.Q(), Vector2.Q());
+    } else {
       fmla(SubRegSize, DestTmp.D(), Vector1.D(), Vector2.D());
-      mov(Dst.D(), DestTmp.D());
+    }
+
+    if (DestTmp != Dst) {
+      if (Is128Bit) {
+        mov(Dst.Q(), DestTmp.Q());
+      } else {
+        mov(Dst.D(), DestTmp.D());
+      }
     }
   }
 }
@@ -4130,12 +4160,16 @@ DEF_OP(VFNMLA) {
     const auto Mask = PRED_TMP_32B.Merging();
     ARMEmitter::VRegister DestTmp = Dst;
     if (Dst != VectorAddend) {
-      DestTmp = VTMP1;
+      if (Dst != Vector1 && Dst != Vector2) {
+        DestTmp = Dst;
+      } else {
+        DestTmp = VTMP1;
+      }
       mov(DestTmp.Z(), VectorAddend.Z());
     }
 
     fmls(SubRegSize, DestTmp.Z(), Mask, Vector1.Z(), Vector2.Z());
-    if (Dst != VectorAddend) {
+    if (Dst != DestTmp) {
       mov(Dst.Z(), DestTmp.Z());
     }
   } else {
@@ -4152,7 +4186,11 @@ DEF_OP(VFNMLA) {
 
     ARMEmitter::VRegister DestTmp = Dst;
     if (Dst != VectorAddend) {
-      DestTmp = VTMP1;
+      if (Dst != Vector1 && Dst != Vector2) {
+        DestTmp = Dst;
+      } else {
+        DestTmp = VTMP1;
+      }
       mov(DestTmp.Q(), VectorAddend.Q());
     }
     if (OpSize == 16) {
@@ -4161,7 +4199,7 @@ DEF_OP(VFNMLA) {
       fmls(SubRegSize, DestTmp.D(), Vector1.D(), Vector2.D());
     }
 
-    if (Dst != VectorAddend) {
+    if (Dst != DestTmp) {
       mov(Dst.Q(), DestTmp.Q());
     }
   }
@@ -4190,24 +4228,32 @@ DEF_OP(VFNMLS) {
     const auto Mask = PRED_TMP_32B.Merging();
     ARMEmitter::VRegister DestTmp = Dst;
     if (Dst != VectorAddend) {
-      DestTmp = VTMP1;
+      if (Dst != Vector1 && Dst != Vector2) {
+        DestTmp = Dst;
+      } else {
+        DestTmp = VTMP1;
+      }
       mov(DestTmp.Z(), VectorAddend.Z());
     }
 
     fnmla(SubRegSize, DestTmp.Z(), Mask, Vector1.Z(), Vector2.Z());
-    if (Dst != VectorAddend) {
+    if (Dst != DestTmp) {
       mov(Dst.Z(), DestTmp.Z());
     }
   } else if (HostSupportsSVE128 && Is128Bit) {
     const auto Mask = PRED_TMP_16B.Merging();
     ARMEmitter::VRegister DestTmp = Dst;
     if (Dst != VectorAddend) {
-      DestTmp = VTMP1;
+      if (Dst != Vector1 && Dst != Vector2) {
+        DestTmp = Dst;
+      } else {
+        DestTmp = VTMP1;
+      }
       mov(DestTmp.Z(), VectorAddend.Z());
     }
 
     fnmla(SubRegSize, DestTmp.Z(), Mask, Vector1.Z(), Vector2.Z());
-    if (Dst != VectorAddend) {
+    if (Dst != DestTmp) {
       mov(Dst.Z(), DestTmp.Z());
     }
   } else {
@@ -4223,15 +4269,29 @@ DEF_OP(VFNMLS) {
     }
 
     // Addend needs to get negated to match correct behaviour here.
-    ARMEmitter::VRegister DestTmp = VTMP1;
+    ARMEmitter::VRegister DestTmp = Dst;
+    if (Dst == Vector1 || Dst == Vector2) {
+      DestTmp = VTMP1;
+    }
+
     if (Is128Bit) {
       fneg(SubRegSize, DestTmp.Q(), VectorAddend.Q());
-      fmls(SubRegSize, DestTmp.Q(), Vector1.Q(), Vector2.Q());
-      mov(Dst.Q(), DestTmp.Q());
     } else {
       fneg(SubRegSize, DestTmp.D(), VectorAddend.D());
+    }
+
+    if (Is128Bit) {
+      fmls(SubRegSize, DestTmp.Q(), Vector1.Q(), Vector2.Q());
+    } else {
       fmls(SubRegSize, DestTmp.D(), Vector1.D(), Vector2.D());
-      mov(Dst.D(), DestTmp.D());
+    }
+
+    if (DestTmp != Dst) {
+      if (Is128Bit) {
+        mov(Dst.Q(), DestTmp.Q());
+      } else {
+        mov(Dst.D(), DestTmp.D());
+      }
     }
   }
 }

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -4767,7 +4767,7 @@
       ]
     },
     "vfmsub132ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Map 2 0b01 0x9a 256-bit"
       ],
@@ -4778,9 +4778,8 @@
         "fneg v0.4s, v17.4s",
         "fmla v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "fneg v0.4s, v3.4s",
-        "fmla v0.4s, v2.4s, v4.4s",
-        "mov v3.16b, v0.16b",
+        "fneg v3.4s, v3.4s",
+        "fmla v3.4s, v2.4s, v4.4s",
         "str q3, [x28, #16]"
       ]
     },
@@ -4798,7 +4797,7 @@
       ]
     },
     "vfmsub132pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Map 2 0b01 0x9a 256-bit"
       ],
@@ -4809,9 +4808,8 @@
         "fneg v0.2d, v17.2d",
         "fmla v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "fneg v0.2d, v3.2d",
-        "fmla v0.2d, v2.2d, v4.2d",
-        "mov v3.16b, v0.16b",
+        "fneg v3.2d, v3.2d",
+        "fmla v3.2d, v2.2d, v4.2d",
         "str q3, [x28, #16]"
       ]
     },
@@ -4935,7 +4933,7 @@
       ]
     },
     "vfnmsub132ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Map 2 0b01 0x9e 256-bit"
       ],
@@ -4946,9 +4944,8 @@
         "fneg v0.4s, v17.4s",
         "fmls v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "fneg v0.4s, v3.4s",
-        "fmls v0.4s, v2.4s, v4.4s",
-        "mov v3.16b, v0.16b",
+        "fneg v3.4s, v3.4s",
+        "fmls v3.4s, v2.4s, v4.4s",
         "str q3, [x28, #16]"
       ]
     },
@@ -4966,7 +4963,7 @@
       ]
     },
     "vfnmsub132pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Map 2 0b01 0x9e 256-bit"
       ],
@@ -4977,9 +4974,8 @@
         "fneg v0.2d, v17.2d",
         "fmls v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "fneg v0.2d, v3.2d",
-        "fmls v0.2d, v2.2d, v4.2d",
-        "mov v3.16b, v0.16b",
+        "fneg v3.2d, v3.2d",
+        "fmls v3.2d, v2.2d, v4.2d",
         "str q3, [x28, #16]"
       ]
     },
@@ -5103,7 +5099,7 @@
       ]
     },
     "vfmsub213ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Map 2 0b01 0xaa 256-bit"
       ],
@@ -5114,9 +5110,8 @@
         "fneg v0.4s, v18.4s",
         "fmla v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "fneg v0.4s, v4.4s",
-        "fmla v0.4s, v3.4s, v2.4s",
-        "mov v4.16b, v0.16b",
+        "fneg v4.4s, v4.4s",
+        "fmla v4.4s, v3.4s, v2.4s",
         "str q4, [x28, #16]"
       ]
     },
@@ -5134,7 +5129,7 @@
       ]
     },
     "vfmsub213pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Map 2 0b01 0xaa 256-bit"
       ],
@@ -5145,9 +5140,8 @@
         "fneg v0.2d, v18.2d",
         "fmla v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "fneg v0.2d, v4.2d",
-        "fmla v0.2d, v3.2d, v2.2d",
-        "mov v4.16b, v0.16b",
+        "fneg v4.2d, v4.2d",
+        "fmla v4.2d, v3.2d, v2.2d",
         "str q4, [x28, #16]"
       ]
     },
@@ -5271,7 +5265,7 @@
       ]
     },
     "vfnmsub213ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Map 2 0b01 0xae 256-bit"
       ],
@@ -5282,9 +5276,8 @@
         "fneg v0.4s, v18.4s",
         "fmls v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "fneg v0.4s, v4.4s",
-        "fmls v0.4s, v3.4s, v2.4s",
-        "mov v4.16b, v0.16b",
+        "fneg v4.4s, v4.4s",
+        "fmls v4.4s, v3.4s, v2.4s",
         "str q4, [x28, #16]"
       ]
     },
@@ -5302,7 +5295,7 @@
       ]
     },
     "vfnmsub213pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Map 2 0b01 0xae 256-bit"
       ],
@@ -5313,9 +5306,8 @@
         "fneg v0.2d, v18.2d",
         "fmls v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "fneg v0.2d, v4.2d",
-        "fmls v0.2d, v3.2d, v2.2d",
-        "mov v4.16b, v0.16b",
+        "fneg v4.2d, v4.2d",
+        "fmls v4.2d, v3.2d, v2.2d",
         "str q4, [x28, #16]"
       ]
     },
@@ -5418,20 +5410,19 @@
       ]
     },
     "vfmsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xba 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fneg v0.4s, v16.4s",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
+        "fneg v16.4s, v16.4s",
+        "fmla v16.4s, v17.4s, v18.4s",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsub231ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 2 0b01 0xba 256-bit"
       ],
@@ -5439,30 +5430,27 @@
         "ldr q2, [x28, #16]",
         "ldr q3, [x28, #32]",
         "ldr q4, [x28, #48]",
-        "fneg v0.4s, v16.4s",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
-        "fneg v0.4s, v2.4s",
-        "fmla v0.4s, v3.4s, v4.4s",
-        "mov v2.16b, v0.16b",
+        "fneg v16.4s, v16.4s",
+        "fmla v16.4s, v17.4s, v18.4s",
+        "fneg v2.4s, v2.4s",
+        "fmla v2.4s, v3.4s, v4.4s",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xba 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fneg v0.2d, v16.2d",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
+        "fneg v16.2d, v16.2d",
+        "fmla v16.2d, v17.2d, v18.2d",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsub231pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 2 0b01 0xba 256-bit"
       ],
@@ -5470,12 +5458,10 @@
         "ldr q2, [x28, #16]",
         "ldr q3, [x28, #32]",
         "ldr q4, [x28, #48]",
-        "fneg v0.2d, v16.2d",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
-        "fneg v0.2d, v2.2d",
-        "fmla v0.2d, v3.2d, v4.2d",
-        "mov v2.16b, v0.16b",
+        "fneg v16.2d, v16.2d",
+        "fmla v16.2d, v17.2d, v18.2d",
+        "fneg v2.2d, v2.2d",
+        "fmla v2.2d, v3.2d, v4.2d",
         "str q2, [x28, #16]"
       ]
     },
@@ -5578,20 +5564,19 @@
       ]
     },
     "vfnmsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xbe 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fneg v0.4s, v16.4s",
-        "fmls v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
+        "fneg v16.4s, v16.4s",
+        "fmls v16.4s, v17.4s, v18.4s",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfnmsub231ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 2 0b01 0xbe 256-bit"
       ],
@@ -5599,30 +5584,27 @@
         "ldr q2, [x28, #16]",
         "ldr q3, [x28, #32]",
         "ldr q4, [x28, #48]",
-        "fneg v0.4s, v16.4s",
-        "fmls v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
-        "fneg v0.4s, v2.4s",
-        "fmls v0.4s, v3.4s, v4.4s",
-        "mov v2.16b, v0.16b",
+        "fneg v16.4s, v16.4s",
+        "fmls v16.4s, v17.4s, v18.4s",
+        "fneg v2.4s, v2.4s",
+        "fmls v2.4s, v3.4s, v4.4s",
         "str q2, [x28, #16]"
       ]
     },
     "vfnmsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xbe 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fneg v0.2d, v16.2d",
-        "fmls v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
+        "fneg v16.2d, v16.2d",
+        "fmls v16.2d, v17.2d, v18.2d",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfnmsub231pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 2 0b01 0xbe 256-bit"
       ],
@@ -5630,12 +5612,10 @@
         "ldr q2, [x28, #16]",
         "ldr q3, [x28, #32]",
         "ldr q4, [x28, #48]",
-        "fneg v0.2d, v16.2d",
-        "fmls v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
-        "fneg v0.2d, v2.2d",
-        "fmls v0.2d, v3.2d, v4.2d",
-        "mov v2.16b, v0.16b",
+        "fneg v16.2d, v16.2d",
+        "fmls v16.2d, v17.2d, v18.2d",
+        "fneg v2.2d, v2.2d",
+        "fmls v2.2d, v3.2d, v4.2d",
         "str q2, [x28, #16]"
       ]
     },
@@ -5800,22 +5780,21 @@
       ]
     },
     "vfmaddsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xb6 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2384]",
         "eor v2.16b, v16.16b, v2.16b",
-        "mov v0.16b, v2.16b",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v2.16b",
+        "fmla v16.4s, v17.4s, v18.4s",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfmaddsub231ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0xb6 256-bit"
       ],
@@ -5825,31 +5804,29 @@
         "ldr q4, [x28, #48]",
         "ldr q5, [x28, #2384]",
         "eor v6.16b, v16.16b, v5.16b",
-        "mov v0.16b, v6.16b",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v6.16b",
+        "fmla v16.4s, v17.4s, v18.4s",
         "eor v2.16b, v2.16b, v5.16b",
         "fmla v2.4s, v3.4s, v4.4s",
         "str q2, [x28, #16]"
       ]
     },
     "vfmaddsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xb6 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2416]",
         "eor v2.16b, v16.16b, v2.16b",
-        "mov v0.16b, v2.16b",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v2.16b",
+        "fmla v16.2d, v17.2d, v18.2d",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfmaddsub231pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0xb6 256-bit"
       ],
@@ -5859,31 +5836,29 @@
         "ldr q4, [x28, #48]",
         "ldr q5, [x28, #2416]",
         "eor v6.16b, v16.16b, v5.16b",
-        "mov v0.16b, v6.16b",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v6.16b",
+        "fmla v16.2d, v17.2d, v18.2d",
         "eor v2.16b, v2.16b, v5.16b",
         "fmla v2.2d, v3.2d, v4.2d",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsubadd231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xb7 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2448]",
         "eor v2.16b, v16.16b, v2.16b",
-        "mov v0.16b, v2.16b",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v2.16b",
+        "fmla v16.4s, v17.4s, v18.4s",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsubadd231ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0xb7 256-bit"
       ],
@@ -5893,31 +5868,29 @@
         "ldr q4, [x28, #48]",
         "ldr q5, [x28, #2448]",
         "eor v6.16b, v16.16b, v5.16b",
-        "mov v0.16b, v6.16b",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v6.16b",
+        "fmla v16.4s, v17.4s, v18.4s",
         "eor v2.16b, v2.16b, v5.16b",
         "fmla v2.4s, v3.4s, v4.4s",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsubadd231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xb7 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2480]",
         "eor v2.16b, v16.16b, v2.16b",
-        "mov v0.16b, v2.16b",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v2.16b",
+        "fmla v16.2d, v17.2d, v18.2d",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsubadd231pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0xb7 256-bit"
       ],
@@ -5927,9 +5900,8 @@
         "ldr q4, [x28, #48]",
         "ldr q5, [x28, #2480]",
         "eor v6.16b, v16.16b, v5.16b",
-        "mov v0.16b, v6.16b",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v6.16b",
+        "fmla v16.2d, v17.2d, v18.2d",
         "eor v2.16b, v2.16b, v5.16b",
         "fmla v2.2d, v3.2d, v4.2d",
         "str q2, [x28, #16]"

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -4905,22 +4905,21 @@
       ]
     },
     "vfmaddsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xb6 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2384]",
         "eor v2.16b, v16.16b, v2.16b",
-        "mov v0.16b, v2.16b",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v2.16b",
+        "fmla v16.4s, v17.4s, v18.4s",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfmaddsub231ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0xb6 256-bit"
       ],
@@ -4930,31 +4929,29 @@
         "ldr q4, [x28, #48]",
         "ldr q5, [x28, #2384]",
         "eor v6.16b, v16.16b, v5.16b",
-        "mov v0.16b, v6.16b",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v6.16b",
+        "fmla v16.4s, v17.4s, v18.4s",
         "eor v2.16b, v2.16b, v5.16b",
         "fmla v2.4s, v3.4s, v4.4s",
         "str q2, [x28, #16]"
       ]
     },
     "vfmaddsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xb6 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2416]",
         "eor v2.16b, v16.16b, v2.16b",
-        "mov v0.16b, v2.16b",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v2.16b",
+        "fmla v16.2d, v17.2d, v18.2d",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfmaddsub231pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0xb6 256-bit"
       ],
@@ -4964,31 +4961,29 @@
         "ldr q4, [x28, #48]",
         "ldr q5, [x28, #2416]",
         "eor v6.16b, v16.16b, v5.16b",
-        "mov v0.16b, v6.16b",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v6.16b",
+        "fmla v16.2d, v17.2d, v18.2d",
         "eor v2.16b, v2.16b, v5.16b",
         "fmla v2.2d, v3.2d, v4.2d",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsubadd231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xb7 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2448]",
         "eor v2.16b, v16.16b, v2.16b",
-        "mov v0.16b, v2.16b",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v2.16b",
+        "fmla v16.4s, v17.4s, v18.4s",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsubadd231ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0xb7 256-bit"
       ],
@@ -4998,31 +4993,29 @@
         "ldr q4, [x28, #48]",
         "ldr q5, [x28, #2448]",
         "eor v6.16b, v16.16b, v5.16b",
-        "mov v0.16b, v6.16b",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v6.16b",
+        "fmla v16.4s, v17.4s, v18.4s",
         "eor v2.16b, v2.16b, v5.16b",
         "fmla v2.4s, v3.4s, v4.4s",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsubadd231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xb7 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2480]",
         "eor v2.16b, v16.16b, v2.16b",
-        "mov v0.16b, v2.16b",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v2.16b",
+        "fmla v16.2d, v17.2d, v18.2d",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vfmsubadd231pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0xb7 256-bit"
       ],
@@ -5032,9 +5025,8 @@
         "ldr q4, [x28, #48]",
         "ldr q5, [x28, #2480]",
         "eor v6.16b, v16.16b, v5.16b",
-        "mov v0.16b, v6.16b",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v16.16b, v0.16b",
+        "mov v16.16b, v6.16b",
+        "fmla v16.2d, v17.2d, v18.2d",
         "eor v2.16b, v2.16b, v5.16b",
         "fmla v2.2d, v3.2d, v4.2d",
         "str q2, [x28, #16]"

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -4003,14 +4003,13 @@
       ]
     },
     "vfmadd132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x98 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v17.16b",
-        "fmla v0.4s, v16.4s, v18.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v17.16b",
+        "fmla v2.4s, v16.4s, v18.4s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4026,14 +4025,13 @@
       ]
     },
     "vfmadd132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x98 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v17.16b",
-        "fmla v0.2d, v16.2d, v18.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v17.16b",
+        "fmla v2.2d, v16.2d, v18.2d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4049,14 +4047,13 @@
       ]
     },
     "vfmadd132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x99 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v17.16b",
-        "fmla v0.4s, v16.4s, v18.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v17.16b",
+        "fmla v2.4s, v16.4s, v18.4s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4064,14 +4061,13 @@
       ]
     },
     "vfmadd132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x99 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v17.16b",
-        "fmla v0.2d, v16.2d, v18.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v17.16b",
+        "fmla v2.2d, v16.2d, v18.2d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4079,14 +4075,13 @@
       ]
     },
     "vfmsub132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z17.d",
-        "fnmls z0.s, p6/m, z16.s, z18.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z17.d",
+        "fnmls z2.s, p6/m, z16.s, z18.s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4102,14 +4097,13 @@
       ]
     },
     "vfmsub132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z17.d",
-        "fnmls z0.d, p6/m, z16.d, z18.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z17.d",
+        "fnmls z2.d, p6/m, z16.d, z18.d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4125,14 +4119,13 @@
       ]
     },
     "vfmsub132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x9b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z17.d",
-        "fnmls z0.s, p6/m, z16.s, z18.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z17.d",
+        "fnmls z2.s, p6/m, z16.s, z18.s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4140,14 +4133,13 @@
       ]
     },
     "vfmsub132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x9b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z17.d",
-        "fnmls z0.d, p6/m, z16.d, z18.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z17.d",
+        "fnmls z2.d, p6/m, z16.d, z18.d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4155,14 +4147,13 @@
       ]
     },
     "vfnmadd132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v17.16b",
-        "fmls v0.4s, v16.4s, v18.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v17.16b",
+        "fmls v2.4s, v16.4s, v18.4s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4178,14 +4169,13 @@
       ]
     },
     "vfnmadd132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v17.16b",
-        "fmls v0.2d, v16.2d, v18.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v17.16b",
+        "fmls v2.2d, v16.2d, v18.2d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4201,14 +4191,13 @@
       ]
     },
     "vfnmadd132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x9d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v17.16b",
-        "fmls v0.4s, v16.4s, v18.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v17.16b",
+        "fmls v2.4s, v16.4s, v18.4s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4216,14 +4205,13 @@
       ]
     },
     "vfnmadd132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x9d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v17.16b",
-        "fmls v0.2d, v16.2d, v18.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v17.16b",
+        "fmls v2.2d, v16.2d, v18.2d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4231,14 +4219,13 @@
       ]
     },
     "vfnmsub132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z17.d",
-        "fnmla z0.s, p6/m, z16.s, z18.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z17.d",
+        "fnmla z2.s, p6/m, z16.s, z18.s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4254,14 +4241,13 @@
       ]
     },
     "vfnmsub132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z17.d",
-        "fnmla z0.d, p6/m, z16.d, z18.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z17.d",
+        "fnmla z2.d, p6/m, z16.d, z18.d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4277,14 +4263,13 @@
       ]
     },
     "vfnmsub132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x9f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z17.d",
-        "fnmla z0.s, p6/m, z16.s, z18.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z17.d",
+        "fnmla z2.s, p6/m, z16.s, z18.s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4292,14 +4277,13 @@
       ]
     },
     "vfnmsub132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x9f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z17.d",
-        "fnmla z0.d, p6/m, z16.d, z18.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z17.d",
+        "fnmla z2.d, p6/m, z16.d, z18.d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4307,14 +4291,13 @@
       ]
     },
     "vfmadd213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xa8 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v18.16b",
-        "fmla v0.4s, v17.4s, v16.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v18.16b",
+        "fmla v2.4s, v17.4s, v16.4s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4330,14 +4313,13 @@
       ]
     },
     "vfmadd213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xa8 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v18.16b",
-        "fmla v0.2d, v17.2d, v16.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v18.16b",
+        "fmla v2.2d, v17.2d, v16.2d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4353,14 +4335,13 @@
       ]
     },
     "vfmadd213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xa9 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v18.16b",
-        "fmla v0.4s, v17.4s, v16.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v18.16b",
+        "fmla v2.4s, v17.4s, v16.4s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4368,14 +4349,13 @@
       ]
     },
     "vfmadd213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xa9 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v18.16b",
-        "fmla v0.2d, v17.2d, v16.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v18.16b",
+        "fmla v2.2d, v17.2d, v16.2d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4383,14 +4363,13 @@
       ]
     },
     "vfmsub213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xaa 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z18.d",
-        "fnmls z0.s, p6/m, z17.s, z16.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z18.d",
+        "fnmls z2.s, p6/m, z17.s, z16.s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4406,14 +4385,13 @@
       ]
     },
     "vfmsub213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xaa 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z18.d",
-        "fnmls z0.d, p6/m, z17.d, z16.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z18.d",
+        "fnmls z2.d, p6/m, z17.d, z16.d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4429,14 +4407,13 @@
       ]
     },
     "vfmsub213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xab 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z18.d",
-        "fnmls z0.s, p6/m, z17.s, z16.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z18.d",
+        "fnmls z2.s, p6/m, z17.s, z16.s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4444,14 +4421,13 @@
       ]
     },
     "vfmsub213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xab 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z18.d",
-        "fnmls z0.d, p6/m, z17.d, z16.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z18.d",
+        "fnmls z2.d, p6/m, z17.d, z16.d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4459,14 +4435,13 @@
       ]
     },
     "vfnmadd213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xac 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v18.16b",
-        "fmls v0.4s, v17.4s, v16.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v18.16b",
+        "fmls v2.4s, v17.4s, v16.4s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4482,14 +4457,13 @@
       ]
     },
     "vfnmadd213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xac 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v18.16b",
-        "fmls v0.2d, v17.2d, v16.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v18.16b",
+        "fmls v2.2d, v17.2d, v16.2d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4505,14 +4479,13 @@
       ]
     },
     "vfnmadd213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xad 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v18.16b",
-        "fmls v0.4s, v17.4s, v16.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v18.16b",
+        "fmls v2.4s, v17.4s, v16.4s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4520,14 +4493,13 @@
       ]
     },
     "vfnmadd213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xad 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v18.16b",
-        "fmls v0.2d, v17.2d, v16.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v18.16b",
+        "fmls v2.2d, v17.2d, v16.2d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4535,14 +4507,13 @@
       ]
     },
     "vfnmsub213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xae 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z18.d",
-        "fnmla z0.s, p6/m, z17.s, z16.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z18.d",
+        "fnmla z2.s, p6/m, z17.s, z16.s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4558,14 +4529,13 @@
       ]
     },
     "vfnmsub213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xae 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z18.d",
-        "fnmla z0.d, p6/m, z17.d, z16.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z18.d",
+        "fnmla z2.d, p6/m, z17.d, z16.d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4581,14 +4551,13 @@
       ]
     },
     "vfnmsub213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xaf 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z18.d",
-        "fnmla z0.s, p6/m, z17.s, z16.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z18.d",
+        "fnmla z2.s, p6/m, z17.s, z16.s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4596,14 +4565,13 @@
       ]
     },
     "vfnmsub213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xaf 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z18.d",
-        "fnmla z0.d, p6/m, z17.d, z16.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z18.d",
+        "fnmla z2.d, p6/m, z17.d, z16.d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4611,14 +4579,13 @@
       ]
     },
     "vfmadd231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xb8 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v16.16b",
+        "fmla v2.4s, v17.4s, v18.4s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4632,14 +4599,13 @@
       ]
     },
     "vfmadd231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xb8 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v16.16b",
+        "fmla v2.2d, v17.2d, v18.2d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4653,14 +4619,13 @@
       ]
     },
     "vfmadd231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xb9 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "fmla v0.4s, v17.4s, v18.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v16.16b",
+        "fmla v2.4s, v17.4s, v18.4s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4668,14 +4633,13 @@
       ]
     },
     "vfmadd231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xb9 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "fmla v0.2d, v17.2d, v18.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v16.16b",
+        "fmla v2.2d, v17.2d, v18.2d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4683,14 +4647,13 @@
       ]
     },
     "vfmsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xba 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z16.d",
-        "fnmls z0.s, p6/m, z17.s, z18.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z16.d",
+        "fnmls z2.s, p6/m, z17.s, z18.s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4704,14 +4667,13 @@
       ]
     },
     "vfmsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xba 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z16.d",
-        "fnmls z0.d, p6/m, z17.d, z18.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z16.d",
+        "fnmls z2.d, p6/m, z17.d, z18.d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4725,14 +4687,13 @@
       ]
     },
     "vfmsub231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xbb 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z16.d",
-        "fnmls z0.s, p6/m, z17.s, z18.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z16.d",
+        "fnmls z2.s, p6/m, z17.s, z18.s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4740,14 +4701,13 @@
       ]
     },
     "vfmsub231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xbb 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z16.d",
-        "fnmls z0.d, p6/m, z17.d, z18.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z16.d",
+        "fnmls z2.d, p6/m, z17.d, z18.d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4755,14 +4715,13 @@
       ]
     },
     "vfnmadd231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbc 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "fmls v0.4s, v17.4s, v18.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v16.16b",
+        "fmls v2.4s, v17.4s, v18.4s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4776,14 +4735,13 @@
       ]
     },
     "vfnmadd231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbc 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "fmls v0.2d, v17.2d, v18.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v16.16b",
+        "fmls v2.2d, v17.2d, v18.2d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4797,14 +4755,13 @@
       ]
     },
     "vfnmadd231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xbd 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "fmls v0.4s, v17.4s, v18.4s",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v16.16b",
+        "fmls v2.4s, v17.4s, v18.4s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4812,14 +4769,13 @@
       ]
     },
     "vfnmadd231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xbd 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v0.16b, v16.16b",
-        "fmls v0.2d, v17.2d, v18.2d",
-        "mov v2.16b, v0.16b",
+        "mov v2.16b, v16.16b",
+        "fmls v2.2d, v17.2d, v18.2d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -4827,14 +4783,13 @@
       ]
     },
     "vfnmsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbe 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z16.d",
-        "fnmla z0.s, p6/m, z17.s, z18.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z16.d",
+        "fnmla z2.s, p6/m, z17.s, z18.s",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4848,14 +4803,13 @@
       ]
     },
     "vfnmsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbe 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z16.d",
-        "fnmla z0.d, p6/m, z17.d, z18.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z16.d",
+        "fnmla z2.d, p6/m, z17.d, z18.d",
         "mov v16.16b, v2.16b"
       ]
     },
@@ -4869,14 +4823,13 @@
       ]
     },
     "vfnmsub231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xbf 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z16.d",
-        "fnmla z0.s, p6/m, z17.s, z18.s",
-        "mov z2.d, z0.d",
+        "mov z2.d, z16.d",
+        "fnmla z2.s, p6/m, z17.s, z18.s",
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
@@ -4884,14 +4837,13 @@
       ]
     },
     "vfnmsub231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xbf 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z0.d, z16.d",
-        "fnmla z0.d, p6/m, z17.d, z18.d",
-        "mov z2.d, z0.d",
+        "mov z2.d, z16.d",
+        "fnmla z2.d, p6/m, z17.d, z18.d",
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
@@ -5015,7 +4967,7 @@
       ]
     },
     "vfmaddsub231ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb6 256-bit"
       ],
@@ -5023,9 +4975,8 @@
         "ldr x0, [x28, #1840]",
         "ld1b {z2.b}, p7/z, [x0]",
         "eor z2.d, z16.d, z2.d",
-        "mov z0.d, z2.d",
-        "fmla z0.s, p7/m, z17.s, z18.s",
-        "mov z16.d, z0.d"
+        "mov z16.d, z2.d",
+        "fmla z16.s, p7/m, z17.s, z18.s"
       ]
     },
     "vfmaddsub231pd xmm0, xmm1, xmm2": {
@@ -5041,7 +4992,7 @@
       ]
     },
     "vfmaddsub231pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb6 256-bit"
       ],
@@ -5049,9 +5000,8 @@
         "ldr x0, [x28, #1856]",
         "ld1b {z2.b}, p7/z, [x0]",
         "eor z2.d, z16.d, z2.d",
-        "mov z0.d, z2.d",
-        "fmla z0.d, p7/m, z17.d, z18.d",
-        "mov z16.d, z0.d"
+        "mov z16.d, z2.d",
+        "fmla z16.d, p7/m, z17.d, z18.d"
       ]
     },
     "vfmsubadd231ps xmm0, xmm1, xmm2": {
@@ -5067,7 +5017,7 @@
       ]
     },
     "vfmsubadd231ps ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb7 256-bit"
       ],
@@ -5075,9 +5025,8 @@
         "ldr x0, [x28, #1872]",
         "ld1b {z2.b}, p7/z, [x0]",
         "eor z2.d, z16.d, z2.d",
-        "mov z0.d, z2.d",
-        "fmla z0.s, p7/m, z17.s, z18.s",
-        "mov z16.d, z0.d"
+        "mov z16.d, z2.d",
+        "fmla z16.s, p7/m, z17.s, z18.s"
       ]
     },
     "vfmsubadd231pd xmm0, xmm1, xmm2": {
@@ -5093,7 +5042,7 @@
       ]
     },
     "vfmsubadd231pd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb7 256-bit"
       ],
@@ -5101,9 +5050,8 @@
         "ldr x0, [x28, #1888]",
         "ld1b {z2.b}, p7/z, [x0]",
         "eor z2.d, z16.d, z2.d",
-        "mov z0.d, z2.d",
-        "fmla z0.d, p7/m, z17.d, z18.d",
-        "mov z16.d, z0.d"
+        "mov z16.d, z2.d",
+        "fmla z16.d, p7/m, z17.d, z18.d"
       ]
     },
     "vaesimc xmm0, xmm1": {


### PR DESCRIPTION
If the destination isn't any of the incoming sources then we can avoid
one of the moves at the end. This half works around the problem proposed
in https://github.com/FEX-Emu/FEX/issues/3794, but doesn't solve the entire problem.

To solve the other half of the moving problem means we need to solve the
SRA allocation problem for this temporary register with addsub/subadd, so it gets allocated
for both the FMA operation and the XOR operation.