### PR TITLE
AVX128: Fixes vmovq loading too much data

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -843,7 +843,13 @@ void OpDispatchBuilder::AVX128_MOVVectorNT(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::AVX128_MOVQ(OpcodeArgs) {
-  auto Src = AVX128_LoadSource_WithOpSize(Op, Op->Src[0], Op->Flags, false);
+  RefPair Src {};
+  if (Op->Src[0].IsGPR()) {
+    Src = AVX128_LoadSource_WithOpSize(Op, Op->Src[0], Op->Flags, false);
+  } else {
+    Src.Low = LoadSource_WithOpSize(FPRClass, Op, Op->Src[0], OpSize::i64Bit, Op->Flags);
+  }
+
   // This instruction is a bit special that if the destination is a register then it'll ZEXT the 64bit source to 256bit
   if (Op->Dest.IsGPR()) {
     // Zero bits [127:64] as well.

--- a/unittests/ASM/FEX_bugs/vmov_size_test.asm
+++ b/unittests/ASM/FEX_bugs/vmov_size_test.asm
@@ -1,0 +1,68 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0":  ["0x4142434445464748", "0", "0", "0"],
+    "XMM1":  ["0x4142434445464748", "0", "0x7172737475767778", "0x8182838485868788"],
+    "XMM2":  ["0x0000000041424344", "0", "0", "0"],
+    "XMM3":  ["0x0000000041424344", "0", "0x7172737475767778", "0x8182838485868788"]
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; FEX-Emu had a bug where vmovq was loading 128-bits worth of data instead of 64-bits.
+; This ensures that {v,}mov{d,q} all load the correct amount of data through a test that will fault if it loads too much.
+
+; Address at the last eight bytes
+mov rax, 0x100000000 + 4096-8
+
+; Address at the last 4 bytes
+mov rbx, 0x100000000 + 4096-4
+
+mov rcx, 0x4142434445464748
+
+; Store data using GPR
+mov [rax], rcx
+
+; Setup vector with data
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data]
+vmovaps ymm2, [rel .data]
+vmovaps ymm3, [rel .data]
+
+; 64-bit tests
+
+; Load with vmovq to ensure we don't try loading too much data
+vmovq xmm0, qword [rax]
+
+; Also test SSE2 version
+movq xmm1, qword [rax]
+
+; Also test MOVQ stores
+vmovq qword [rax], xmm0
+
+; Also test SSE2 version
+movq qword [rax], xmm1
+
+; 32-bit tests
+; Load with vmovq to ensure we don't try loading too much data
+vmovd xmm2, dword [rbx]
+
+; Also test SSE2 version
+movd xmm3, dword [rbx]
+
+; Also test MOVD stores
+vmovd dword [rbx], xmm2
+
+; Also test SSE2 version
+movd dword [rbx], xmm3
+
+hlt
+
+align 32
+.data:
+dq 0x5152535455565758, 0x6162636465666768
+dq 0x7172737475767778, 0x8182838485868788

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -3872,13 +3872,12 @@
       ]
     },
     "vmovq xmm0, qword [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0x6e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x4]",
-        "mov v16.8b, v2.8b",
+        "ldr d16, [x4]",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]


### PR DESCRIPTION
This was doing a 128-bit load from memory and then a 64-bit zero extend
which looked like a spurious move but it was trying to match the
behaviour of vmovq where it needed the zero extend.

Also adds a unit test to ensure that we aren't loading too much data by
loading right up against a page boundary.

Fixes https://github.com/FEX-Emu/FEX/issues/3787