### PR TITLE
 OpcodeDispatcher: Avoid template monomorphization to reduce FEXLoader binary size

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1092,6 +1092,7 @@ public:
   void AVX128_UCOMISx(OpcodeArgs);
   template<FEXCore::IR::IROps IROp, size_t ElementSize>
   void AVX128_VectorScalarInsertALU(OpcodeArgs);
+  void AVX128_VectorScalarInsertALU(OpcodeArgs, FEXCore::IR::IROps IROp, size_t ElementSize);
   Ref AVX128_VFCMPImpl(size_t ElementSize, Ref Src1, Ref Src2, uint8_t CompType);
   template<size_t ElementSize>
   void AVX128_VFCMP(OpcodeArgs);
@@ -1102,6 +1103,7 @@ public:
   void AVX128_PExtr(OpcodeArgs);
   template<size_t ElementSize, size_t DstElementSize, bool Signed>
   void AVX128_ExtendVectorElements(OpcodeArgs);
+  void AVX128_ExtendVectorElements(OpcodeArgs, size_t ElementSize, size_t DstElementSize, bool Signed);
   template<size_t ElementSize>
   void AVX128_MOVMSK(OpcodeArgs);
   void AVX128_MOVMSKB(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -731,8 +731,10 @@ public:
   Ref ReconstructX87StateFromFSW(Ref FSW);
   template<size_t width>
   void FLD(OpcodeArgs);
+  void FLD(OpcodeArgs, size_t width);
   template<NamedVectorConstant constant>
   void FLD_Const(OpcodeArgs);
+  void FLD_Const(OpcodeArgs, NamedVectorConstant constant);
 
   void FBLD(OpcodeArgs);
   void FBSTP(OpcodeArgs);
@@ -741,11 +743,13 @@ public:
 
   template<size_t width>
   void FST(OpcodeArgs);
+  void FST(OpcodeArgs, size_t width);
 
   void FST(OpcodeArgs);
 
   template<bool Truncate>
   void FIST(OpcodeArgs);
+  void FIST(OpcodeArgs, bool Truncate);
 
   enum class OpResult {
     RES_ST0,
@@ -772,10 +776,13 @@ public:
 
   template<FEXCore::IR::IROps IROp>
   void X87UnaryOp(OpcodeArgs);
+  void X87UnaryOp(OpcodeArgs, FEXCore::IR::IROps IROp);
   template<FEXCore::IR::IROps IROp>
   void X87BinaryOp(OpcodeArgs);
+  void X87BinaryOp(OpcodeArgs, FEXCore::IR::IROps IROp);
   template<bool Inc>
   void X87ModifySTP(OpcodeArgs);
+  void X87ModifySTP(OpcodeArgs, bool Inc);
   void X87SinCos(OpcodeArgs);
   void X87FYL2X(OpcodeArgs);
   void X87TAN(OpcodeArgs);
@@ -806,8 +813,10 @@ public:
   // F64 X87 Ops
   template<size_t width>
   void FLDF64(OpcodeArgs);
-  template<uint64_t num>
+  void FLDF64(OpcodeArgs, size_t width);
+  template<size_t width>
   void FLDF64_Const(OpcodeArgs);
+  void FLDF64_Const(OpcodeArgs, uint64_t num);
 
   void FBLDF64(OpcodeArgs);
   void FBSTPF64(OpcodeArgs);
@@ -816,11 +825,13 @@ public:
 
   template<size_t width>
   void FSTF64(OpcodeArgs);
+  void FSTF64(OpcodeArgs, size_t width);
 
   void FSTF64(OpcodeArgs);
 
   template<bool Truncate>
   void FISTF64(OpcodeArgs);
+  void FISTF64(OpcodeArgs, bool Truncate);
 
   template<size_t width, bool Integer, OpResult ResInST0>
   void FADDF64(OpcodeArgs);
@@ -843,8 +854,10 @@ public:
   void FSQRTF64(OpcodeArgs);
   template<FEXCore::IR::IROps IROp>
   void X87UnaryOpF64(OpcodeArgs);
+  void X87UnaryOpF64(OpcodeArgs, FEXCore::IR::IROps IROp);
   template<FEXCore::IR::IROps IROp>
   void X87BinaryOpF64(OpcodeArgs);
+  void X87BinaryOpF64(OpcodeArgs, FEXCore::IR::IROps IROp);
   void X87SinCosF64(OpcodeArgs);
   void X87FLDCWF64(OpcodeArgs);
   void X87FYL2XF64(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -293,6 +293,7 @@ public:
   void INTOp(OpcodeArgs);
   template<bool IsSyscallInst>
   void SyscallOp(OpcodeArgs);
+  void SyscallOp(OpcodeArgs, bool IsSyscallInst);
   void ThunkOp(OpcodeArgs);
   void LEAOp(OpcodeArgs);
   void NOPOp(OpcodeArgs);
@@ -357,6 +358,7 @@ public:
   void ASHROp(OpcodeArgs);
   template<bool Left, bool IsImmediate, bool Is1Bit>
   void RotateOp(OpcodeArgs);
+  void RotateOp(OpcodeArgs, bool Left, bool IsImmediate, bool Is1Bit);
   void RCROp1Bit(OpcodeArgs);
   void RCROp8x1Bit(OpcodeArgs);
   void RCROp(OpcodeArgs);
@@ -367,6 +369,7 @@ public:
 
   template<uint32_t SrcIndex, enum BTAction Action>
   void BTOp(OpcodeArgs);
+  void BTOp(OpcodeArgs, uint32_t SrcIndex, enum BTAction Action);
 
   void IMUL1SrcOp(OpcodeArgs);
   void IMUL2SrcOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -753,12 +753,16 @@ public:
   };
   template<size_t width, bool Integer, OpResult ResInST0>
   void FADD(OpcodeArgs);
+  void FADD(OpcodeArgs, size_t width, bool Integer, OpResult ResInST0);
   template<size_t width, bool Integer, OpResult ResInST0>
   void FMUL(OpcodeArgs);
+  void FMUL(OpcodeArgs, size_t width, bool Integer, OpResult ResInST0);
   template<size_t width, bool Integer, bool reverse, OpResult ResInST0>
   void FDIV(OpcodeArgs);
+  void FDIV(OpcodeArgs, size_t width, bool Integer, bool reverse, OpResult ResInST0);
   template<size_t width, bool Integer, bool reverse, OpResult ResInST0>
   void FSUB(OpcodeArgs);
+  void FSUB(OpcodeArgs, size_t width, bool Integer, bool reverse, OpResult ResInST0);
   void FCHS(OpcodeArgs);
   void FABS(OpcodeArgs);
   void FTST(OpcodeArgs);
@@ -797,6 +801,7 @@ public:
   };
   template<size_t width, bool Integer, FCOMIFlags whichflags, bool poptwice>
   void FCOMI(OpcodeArgs);
+  void FCOMI(OpcodeArgs, size_t width, bool Integer, FCOMIFlags whichflags, bool poptwice);
 
   // F64 X87 Ops
   template<size_t width>
@@ -819,12 +824,16 @@ public:
 
   template<size_t width, bool Integer, OpResult ResInST0>
   void FADDF64(OpcodeArgs);
+  void FADDF64(OpcodeArgs, size_t width, bool Integer, OpResult ResInST0);
   template<size_t width, bool Integer, OpResult ResInST0>
   void FMULF64(OpcodeArgs);
+  void FMULF64(OpcodeArgs, size_t width, bool Integer, OpResult ResInST0);
   template<size_t width, bool Integer, bool reverse, OpResult ResInST0>
   void FDIVF64(OpcodeArgs);
+  void FDIVF64(OpcodeArgs, size_t width, bool Integer, bool reverse, OpResult ResInST0);
   template<size_t width, bool Integer, bool reverse, OpResult ResInST0>
   void FSUBF64(OpcodeArgs);
+  void FSUBF64(OpcodeArgs, size_t width, bool Integer, bool reverse, OpResult ResInST0);
   void FCHSF64(OpcodeArgs);
   void FABSF64(OpcodeArgs);
   void FTSTF64(OpcodeArgs);
@@ -848,6 +857,7 @@ public:
 
   template<size_t width, bool Integer, FCOMIFlags whichflags, bool poptwice>
   void FCOMIF64(OpcodeArgs);
+  void FCOMIF64(OpcodeArgs, size_t width, bool Integer, FCOMIFlags whichflags, bool poptwice);
 
   void FXSaveOp(OpcodeArgs);
   void FXRStoreOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -123,8 +123,7 @@ Ref OpDispatchBuilder::ReconstructX87StateFromFSW(Ref FSW) {
   return Top;
 }
 
-template<size_t width>
-void OpDispatchBuilder::FLD(OpcodeArgs) {
+void OpDispatchBuilder::FLD(OpcodeArgs, size_t width) {
   // Update TOP
   auto orig_top = GetX87Top();
   auto mask = _Constant(7);
@@ -145,7 +144,7 @@ void OpDispatchBuilder::FLD(OpcodeArgs) {
   Ref converted = data;
 
   // Convert to 80bit float
-  if constexpr (width == 32 || width == 64) {
+  if (width == 32 || width == 64) {
     converted = _F80CVTTo(data, width / 8);
   }
 
@@ -155,6 +154,11 @@ void OpDispatchBuilder::FLD(OpcodeArgs) {
   // Write to ST[TOP]
   _StoreContextIndexed(converted, top, 16, MMBaseOffset(), 16, FPRClass);
   //_StoreContext(converted, 16, offsetof(FEXCore::Core::CPUState, mm[7][0]));
+}
+
+template<size_t width>
+void OpDispatchBuilder::FLD(OpcodeArgs) {
+  FLD(Op, width);
 }
 
 template void OpDispatchBuilder::FLD<32>(OpcodeArgs);
@@ -189,8 +193,7 @@ void OpDispatchBuilder::FBSTP(OpcodeArgs) {
   SetX87Top(top);
 }
 
-template<NamedVectorConstant constant>
-void OpDispatchBuilder::FLD_Const(OpcodeArgs) {
+void OpDispatchBuilder::FLD_Const(OpcodeArgs, NamedVectorConstant constant) {
   // Update TOP
   auto orig_top = GetX87Top();
   auto top = _And(OpSize::i32Bit, _Sub(OpSize::i32Bit, orig_top, _Constant(1)), _Constant(7));
@@ -201,6 +204,11 @@ void OpDispatchBuilder::FLD_Const(OpcodeArgs) {
 
   // Write to ST[TOP]
   _StoreContextIndexed(data, top, 16, MMBaseOffset(), 16, FPRClass);
+}
+
+template<NamedVectorConstant constant>
+void OpDispatchBuilder::FLD_Const(OpcodeArgs) {
+  FLD_Const(Op, constant);
 }
 
 template void OpDispatchBuilder::FLD_Const<NamedVectorConstant::NAMED_VECTOR_X87_ONE>(OpcodeArgs);     // 1.0
@@ -254,13 +262,12 @@ void OpDispatchBuilder::FILD(OpcodeArgs) {
   _StoreContextIndexed(converted, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
-template<size_t width>
-void OpDispatchBuilder::FST(OpcodeArgs) {
+void OpDispatchBuilder::FST(OpcodeArgs, size_t width) {
   auto orig_top = GetX87Top();
   auto data = _LoadContextIndexed(orig_top, 16, MMBaseOffset(), 16, FPRClass);
-  if constexpr (width == 80) {
+  if (width == 80) {
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, data, 10, 1);
-  } else if constexpr (width == 32 || width == 64) {
+  } else if (width == 32 || width == 64) {
     auto result = _F80CVT(width / 8, data);
     StoreResult_WithOpSize(FPRClass, Op, Op->Dest, result, width / 8, 1);
   }
@@ -274,12 +281,16 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
   }
 }
 
+template<size_t width>
+void OpDispatchBuilder::FST(OpcodeArgs) {
+  FST(Op, width);
+}
+
 template void OpDispatchBuilder::FST<32>(OpcodeArgs);
 template void OpDispatchBuilder::FST<64>(OpcodeArgs);
 template void OpDispatchBuilder::FST<80>(OpcodeArgs);
 
-template<bool Truncate>
-void OpDispatchBuilder::FIST(OpcodeArgs) {
+void OpDispatchBuilder::FIST(OpcodeArgs, bool Truncate) {
   auto Size = GetSrcSize(Op);
 
   auto orig_top = GetX87Top();
@@ -295,6 +306,11 @@ void OpDispatchBuilder::FIST(OpcodeArgs) {
     auto top = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, orig_top, _Constant(1)), _Constant(7));
     SetX87Top(top);
   }
+}
+
+template<bool Truncate>
+void OpDispatchBuilder::FIST(OpcodeArgs) {
+  FIST(Op, Truncate);
 }
 
 template void OpDispatchBuilder::FIST<false>(OpcodeArgs);
@@ -797,14 +813,13 @@ void OpDispatchBuilder::FST(OpcodeArgs) {
   }
 }
 
-template<FEXCore::IR::IROps IROp>
-void OpDispatchBuilder::X87UnaryOp(OpcodeArgs) {
+void OpDispatchBuilder::X87UnaryOp(OpcodeArgs, FEXCore::IR::IROps IROp) {
   auto top = GetX87Top();
   auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   DeriveOp(result, IROp, _F80Round(a));
 
-  if constexpr (IROp == IR::OP_F80SIN || IROp == IR::OP_F80COS) {
+  if (IROp == IR::OP_F80SIN || IROp == IR::OP_F80COS) {
     // TODO: ACCURACY: should check source is in range –2^63 to +2^63
     SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
   }
@@ -813,13 +828,17 @@ void OpDispatchBuilder::X87UnaryOp(OpcodeArgs) {
   _StoreContextIndexed(result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
+template<FEXCore::IR::IROps IROp>
+void OpDispatchBuilder::X87UnaryOp(OpcodeArgs) {
+  X87UnaryOp(Op, IROp);
+}
+
 template void OpDispatchBuilder::X87UnaryOp<IR::OP_F80F2XM1>(OpcodeArgs);
 template void OpDispatchBuilder::X87UnaryOp<IR::OP_F80SQRT>(OpcodeArgs);
 template void OpDispatchBuilder::X87UnaryOp<IR::OP_F80SIN>(OpcodeArgs);
 template void OpDispatchBuilder::X87UnaryOp<IR::OP_F80COS>(OpcodeArgs);
 
-template<FEXCore::IR::IROps IROp>
-void OpDispatchBuilder::X87BinaryOp(OpcodeArgs) {
+void OpDispatchBuilder::X87BinaryOp(OpcodeArgs, FEXCore::IR::IROps IROp) {
   auto top = GetX87Top();
 
   auto mask = _Constant(7);
@@ -830,7 +849,7 @@ void OpDispatchBuilder::X87BinaryOp(OpcodeArgs) {
 
   DeriveOp(result, IROp, _F80Add(a, st1));
 
-  if constexpr (IROp == IR::OP_F80FPREM || IROp == IR::OP_F80FPREM1) {
+  if (IROp == IR::OP_F80FPREM || IROp == IR::OP_F80FPREM1) {
     // TODO: Set C0 to Q2, C3 to Q1, C1 to Q0
     SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(_Constant(0));
   }
@@ -839,12 +858,16 @@ void OpDispatchBuilder::X87BinaryOp(OpcodeArgs) {
   _StoreContextIndexed(result, top, 16, MMBaseOffset(), 16, FPRClass);
 }
 
+template<FEXCore::IR::IROps IROp>
+void OpDispatchBuilder::X87BinaryOp(OpcodeArgs) {
+  X87BinaryOp(Op, IROp);
+}
+
 template void OpDispatchBuilder::X87BinaryOp<IR::OP_F80FPREM1>(OpcodeArgs);
 template void OpDispatchBuilder::X87BinaryOp<IR::OP_F80FPREM>(OpcodeArgs);
 template void OpDispatchBuilder::X87BinaryOp<IR::OP_F80SCALE>(OpcodeArgs);
 
-template<bool Inc>
-void OpDispatchBuilder::X87ModifySTP(OpcodeArgs) {
+void OpDispatchBuilder::X87ModifySTP(OpcodeArgs, bool Inc) {
   auto orig_top = GetX87Top();
   if (Inc) {
     auto top = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, orig_top, _Constant(1)), _Constant(7));
@@ -853,6 +876,11 @@ void OpDispatchBuilder::X87ModifySTP(OpcodeArgs) {
     auto top = _And(OpSize::i32Bit, _Sub(OpSize::i32Bit, orig_top, _Constant(1)), _Constant(7));
     SetX87Top(top);
   }
+}
+
+template<bool Inc>
+void OpDispatchBuilder::X87ModifySTP(OpcodeArgs) {
+  X87ModifySTP(Op, Inc);
 }
 
 template void OpDispatchBuilder::X87ModifySTP<false>(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -300,8 +300,7 @@ void OpDispatchBuilder::FIST(OpcodeArgs) {
 template void OpDispatchBuilder::FIST<false>(OpcodeArgs);
 template void OpDispatchBuilder::FIST<true>(OpcodeArgs);
 
-template<size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
-void OpDispatchBuilder::FADD(OpcodeArgs) {
+void OpDispatchBuilder::FADD(OpcodeArgs, size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0) {
   auto top = GetX87Top();
   Ref StackLocation = top;
 
@@ -312,8 +311,8 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
 
   if (!Op->Src[0].IsNone()) {
     // Memory arg
-    if constexpr (width == 16 || width == 32 || width == 64) {
-      if constexpr (Integer) {
+    if (width == 16 || width == 32 || width == 64) {
+      if (Integer) {
         arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTToInt(arg, width / 8);
       } else {
@@ -325,7 +324,7 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
     arg = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, offset), mask);
-    if constexpr (ResInST0 == OpResult::RES_STI) {
+    if (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
     b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
@@ -346,6 +345,11 @@ void OpDispatchBuilder::FADD(OpcodeArgs) {
   _StoreContextIndexed(result, StackLocation, 16, MMBaseOffset(), 16, FPRClass);
 }
 
+template<size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
+void OpDispatchBuilder::FADD(OpcodeArgs) {
+  FADD(Op, width, Integer, ResInST0);
+}
+
 template void OpDispatchBuilder::FADD<32, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FADD<64, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FADD<80, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
@@ -354,8 +358,7 @@ template void OpDispatchBuilder::FADD<80, false, OpDispatchBuilder::OpResult::RE
 template void OpDispatchBuilder::FADD<16, true, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FADD<32, true, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 
-template<size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
-void OpDispatchBuilder::FMUL(OpcodeArgs) {
+void OpDispatchBuilder::FMUL(OpcodeArgs, size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0) {
   auto top = GetX87Top();
   Ref StackLocation = top;
   Ref arg {};
@@ -366,8 +369,8 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
   if (!Op->Src[0].IsNone()) {
     // Memory arg
 
-    if constexpr (width == 16 || width == 32 || width == 64) {
-      if constexpr (Integer) {
+    if (width == 16 || width == 32 || width == 64) {
+      if (Integer) {
         arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTToInt(arg, width / 8);
       } else {
@@ -379,7 +382,7 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
     arg = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, offset), mask);
-    if constexpr (ResInST0 == OpResult::RES_STI) {
+    if (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
 
@@ -402,6 +405,11 @@ void OpDispatchBuilder::FMUL(OpcodeArgs) {
   _StoreContextIndexed(result, StackLocation, 16, MMBaseOffset(), 16, FPRClass);
 }
 
+template<size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
+void OpDispatchBuilder::FMUL(OpcodeArgs) {
+  FMUL(Op, width, Integer, ResInST0);
+}
+
 template void OpDispatchBuilder::FMUL<32, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FMUL<64, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FMUL<80, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
@@ -410,8 +418,7 @@ template void OpDispatchBuilder::FMUL<80, false, OpDispatchBuilder::OpResult::RE
 template void OpDispatchBuilder::FMUL<16, true, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FMUL<32, true, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 
-template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
-void OpDispatchBuilder::FDIV(OpcodeArgs) {
+void OpDispatchBuilder::FDIV(OpcodeArgs, size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0) {
   auto top = GetX87Top();
   Ref StackLocation = top;
   Ref arg {};
@@ -422,8 +429,8 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
   if (!Op->Src[0].IsNone()) {
     // Memory arg
 
-    if constexpr (width == 16 || width == 32 || width == 64) {
-      if constexpr (Integer) {
+    if (width == 16 || width == 32 || width == 64) {
+      if (Integer) {
         arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTToInt(arg, width / 8);
       } else {
@@ -435,7 +442,7 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
     arg = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, offset), mask);
-    if constexpr (ResInST0 == OpResult::RES_STI) {
+    if (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
 
@@ -445,7 +452,7 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
   auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   Ref result {};
-  if constexpr (reverse) {
+  if (reverse) {
     result = _F80Div(b, a);
   } else {
     result = _F80Div(a, b);
@@ -461,6 +468,11 @@ void OpDispatchBuilder::FDIV(OpcodeArgs) {
 
   // Write to ST[TOP]
   _StoreContextIndexed(result, StackLocation, 16, MMBaseOffset(), 16, FPRClass);
+}
+
+template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
+void OpDispatchBuilder::FDIV(OpcodeArgs) {
+  FDIV(Op, width, Integer, reverse, ResInST0);
 }
 
 template void OpDispatchBuilder::FDIV<32, false, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
@@ -481,8 +493,7 @@ template void OpDispatchBuilder::FDIV<16, true, true, OpDispatchBuilder::OpResul
 template void OpDispatchBuilder::FDIV<32, true, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FDIV<32, true, true, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 
-template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
-void OpDispatchBuilder::FSUB(OpcodeArgs) {
+void OpDispatchBuilder::FSUB(OpcodeArgs, size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0) {
   auto top = GetX87Top();
   Ref StackLocation = top;
   Ref arg {};
@@ -493,8 +504,8 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
   if (!Op->Src[0].IsNone()) {
     // Memory arg
 
-    if constexpr (width == 16 || width == 32 || width == 64) {
-      if constexpr (Integer) {
+    if (width == 16 || width == 32 || width == 64) {
+      if (Integer) {
         arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTToInt(arg, width / 8);
       } else {
@@ -506,7 +517,7 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
     arg = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, offset), mask);
-    if constexpr (ResInST0 == OpResult::RES_STI) {
+    if (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
     b = _LoadContextIndexed(arg, 16, MMBaseOffset(), 16, FPRClass);
@@ -515,7 +526,7 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
   auto a = _LoadContextIndexed(top, 16, MMBaseOffset(), 16, FPRClass);
 
   Ref result {};
-  if constexpr (reverse) {
+  if (reverse) {
     result = _F80Sub(b, a);
   } else {
     result = _F80Sub(a, b);
@@ -532,6 +543,11 @@ void OpDispatchBuilder::FSUB(OpcodeArgs) {
 
   // Write to ST[TOP]
   _StoreContextIndexed(result, StackLocation, 16, MMBaseOffset(), 16, FPRClass);
+}
+
+template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
+void OpDispatchBuilder::FSUB(OpcodeArgs) {
+  FSUB(Op, width, Integer, reverse, ResInST0);
 }
 
 template void OpDispatchBuilder::FSUB<32, false, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
@@ -647,8 +663,7 @@ void OpDispatchBuilder::FNINIT(OpcodeArgs) {
   _StoreContext(1, GPRClass, Zero, offsetof(FEXCore::Core::CPUState, AbridgedFTW));
 }
 
-template<size_t width, bool Integer, OpDispatchBuilder::FCOMIFlags whichflags, bool poptwice>
-void OpDispatchBuilder::FCOMI(OpcodeArgs) {
+void OpDispatchBuilder::FCOMI(OpcodeArgs, size_t width, bool Integer, OpDispatchBuilder::FCOMIFlags whichflags, bool poptwice) {
   auto top = GetX87Top();
   auto mask = _Constant(7);
 
@@ -657,8 +672,8 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
 
   if (!Op->Src[0].IsNone()) {
     // Memory arg
-    if constexpr (width == 16 || width == 32 || width == 64) {
-      if constexpr (Integer) {
+    if (width == 16 || width == 32 || width == 64) {
+      if (Integer) {
         arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
         b = _F80CVTToInt(arg, width / 8);
       } else {
@@ -683,7 +698,7 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
   HostFlag_CF = _Or(OpSize::i32Bit, HostFlag_CF, HostFlag_Unordered);
   HostFlag_ZF = _Or(OpSize::i32Bit, HostFlag_ZF, HostFlag_Unordered);
 
-  if constexpr (whichflags == FCOMIFlags::FLAGS_X87) {
+  if (whichflags == FCOMIFlags::FLAGS_X87) {
     SetRFLAG<FEXCore::X86State::X87FLAG_C0_LOC>(HostFlag_CF);
     SetRFLAG<FEXCore::X86State::X87FLAG_C1_LOC>(_Constant(0));
     SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(HostFlag_Unordered);
@@ -702,7 +717,7 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
     SetRFLAG<FEXCore::X86State::RFLAG_PF_RAW_LOC>(PF);
   }
 
-  if constexpr (poptwice) {
+  if (poptwice) {
     // if we are popping then we must first mark this location as empty
     SetX87ValidTag(top, false);
     top = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, _Constant(1)), mask);
@@ -717,6 +732,11 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs) {
     top = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
+}
+
+template<size_t width, bool Integer, OpDispatchBuilder::FCOMIFlags whichflags, bool poptwice>
+void OpDispatchBuilder::FCOMI(OpcodeArgs) {
+  FCOMI(Op, width, Integer, whichflags, poptwice);
 }
 
 template void OpDispatchBuilder::FCOMI<32, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -259,8 +259,7 @@ void OpDispatchBuilder::FISTF64(OpcodeArgs) {
 template void OpDispatchBuilder::FISTF64<false>(OpcodeArgs);
 template void OpDispatchBuilder::FISTF64<true>(OpcodeArgs);
 
-template<size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
-void OpDispatchBuilder::FADDF64(OpcodeArgs) {
+void OpDispatchBuilder::FADDF64(OpcodeArgs, size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0) {
   auto top = GetX87Top();
   Ref StackLocation = top;
 
@@ -271,23 +270,23 @@ void OpDispatchBuilder::FADDF64(OpcodeArgs) {
 
   if (!Op->Src[0].IsNone()) {
     // Memory arg
-    if constexpr (Integer) {
+    if (Integer) {
       arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       if (width == 16) {
         arg = _Sbfe(OpSize::i64Bit, 16, 0, arg);
       }
       b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
-    } else if constexpr (width == 32) {
+    } else if (width == 32) {
       arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       b = _Float_FToF(8, 4, arg);
-    } else if constexpr (width == 64) {
+    } else if (width == 64) {
       b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
     arg = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, offset), mask);
-    if constexpr (ResInST0 == OpResult::RES_STI) {
+    if (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
     b = _LoadContextIndexed(arg, 8, MMBaseOffset(), 16, FPRClass);
@@ -307,6 +306,11 @@ void OpDispatchBuilder::FADDF64(OpcodeArgs) {
   _StoreContextIndexed(result, StackLocation, 8, MMBaseOffset(), 16, FPRClass);
 }
 
+template<size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
+void OpDispatchBuilder::FADDF64(OpcodeArgs) {
+  FADDF64(Op, width, Integer, ResInST0);
+}
+
 template void OpDispatchBuilder::FADDF64<32, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FADDF64<64, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FADDF64<80, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
@@ -315,8 +319,7 @@ template void OpDispatchBuilder::FADDF64<80, false, OpDispatchBuilder::OpResult:
 template void OpDispatchBuilder::FADDF64<16, true, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FADDF64<32, true, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 
-template<size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
-void OpDispatchBuilder::FMULF64(OpcodeArgs) {
+void OpDispatchBuilder::FMULF64(OpcodeArgs, size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0) {
   auto top = GetX87Top();
   Ref StackLocation = top;
   Ref arg {};
@@ -326,23 +329,23 @@ void OpDispatchBuilder::FMULF64(OpcodeArgs) {
 
   if (!Op->Src[0].IsNone()) {
     // Memory arg
-    if constexpr (Integer) {
+    if (Integer) {
       arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       if (width == 16) {
         arg = _Sbfe(OpSize::i64Bit, 16, 0, arg);
       }
       b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
-    } else if constexpr (width == 32) {
+    } else if (width == 32) {
       arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       b = _Float_FToF(8, 4, arg);
-    } else if constexpr (width == 64) {
+    } else if (width == 64) {
       b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
     arg = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, offset), mask);
-    if constexpr (ResInST0 == OpResult::RES_STI) {
+    if (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
 
@@ -365,6 +368,11 @@ void OpDispatchBuilder::FMULF64(OpcodeArgs) {
   _StoreContextIndexed(result, StackLocation, 8, MMBaseOffset(), 16, FPRClass);
 }
 
+template<size_t width, bool Integer, OpDispatchBuilder::OpResult ResInST0>
+void OpDispatchBuilder::FMULF64(OpcodeArgs) {
+  FMULF64(Op, width, Integer, ResInST0);
+}
+
 template void OpDispatchBuilder::FMULF64<32, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FMULF64<64, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FMULF64<80, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
@@ -373,8 +381,7 @@ template void OpDispatchBuilder::FMULF64<80, false, OpDispatchBuilder::OpResult:
 template void OpDispatchBuilder::FMULF64<16, true, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FMULF64<32, true, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 
-template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
-void OpDispatchBuilder::FDIVF64(OpcodeArgs) {
+void OpDispatchBuilder::FDIVF64(OpcodeArgs, size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0) {
   auto top = GetX87Top();
   Ref StackLocation = top;
   Ref arg {};
@@ -384,23 +391,23 @@ void OpDispatchBuilder::FDIVF64(OpcodeArgs) {
 
   if (!Op->Src[0].IsNone()) {
     // Memory arg
-    if constexpr (Integer) {
+    if (Integer) {
       arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       if (width == 16) {
         arg = _Sbfe(OpSize::i64Bit, 16, 0, arg);
       }
       b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
-    } else if constexpr (width == 32) {
+    } else if (width == 32) {
       arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       b = _Float_FToF(8, 4, arg);
-    } else if constexpr (width == 64) {
+    } else if (width == 64) {
       b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
     arg = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, offset), mask);
-    if constexpr (ResInST0 == OpResult::RES_STI) {
+    if (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
 
@@ -410,7 +417,7 @@ void OpDispatchBuilder::FDIVF64(OpcodeArgs) {
   auto a = _LoadContextIndexed(top, 8, MMBaseOffset(), 16, FPRClass);
 
   Ref result {};
-  if constexpr (reverse) {
+  if (reverse) {
     result = _VFDiv(8, 8, b, a);
   } else {
     result = _VFDiv(8, 8, a, b);
@@ -426,6 +433,11 @@ void OpDispatchBuilder::FDIVF64(OpcodeArgs) {
 
   // Write to ST[TOP]
   _StoreContextIndexed(result, StackLocation, 8, MMBaseOffset(), 16, FPRClass);
+}
+
+template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
+void OpDispatchBuilder::FDIVF64(OpcodeArgs) {
+  FDIVF64(Op, width, Integer, reverse, ResInST0);
 }
 
 template void OpDispatchBuilder::FDIVF64<32, false, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
@@ -446,8 +458,7 @@ template void OpDispatchBuilder::FDIVF64<16, true, true, OpDispatchBuilder::OpRe
 template void OpDispatchBuilder::FDIVF64<32, true, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 template void OpDispatchBuilder::FDIVF64<32, true, true, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
 
-template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
-void OpDispatchBuilder::FSUBF64(OpcodeArgs) {
+void OpDispatchBuilder::FSUBF64(OpcodeArgs, size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0) {
   auto top = GetX87Top();
   Ref StackLocation = top;
   Ref arg {};
@@ -457,23 +468,23 @@ void OpDispatchBuilder::FSUBF64(OpcodeArgs) {
 
   if (!Op->Src[0].IsNone()) {
     // Memory arg
-    if constexpr (Integer) {
+    if (Integer) {
       arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       if (width == 16) {
         arg = _Sbfe(OpSize::i64Bit, 16, 0, arg);
       }
       b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
-    } else if constexpr (width == 32) {
+    } else if (width == 32) {
       arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       b = _Float_FToF(8, 4, arg);
-    } else if constexpr (width == 64) {
+    } else if (width == 64) {
       b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   } else {
     // Implicit arg
     auto offset = _Constant(Op->OP & 7);
     arg = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, offset), mask);
-    if constexpr (ResInST0 == OpResult::RES_STI) {
+    if (ResInST0 == OpResult::RES_STI) {
       StackLocation = arg;
     }
 
@@ -483,7 +494,7 @@ void OpDispatchBuilder::FSUBF64(OpcodeArgs) {
   auto a = _LoadContextIndexed(top, 8, MMBaseOffset(), 16, FPRClass);
 
   Ref result {};
-  if constexpr (reverse) {
+  if (reverse) {
     result = _VFSub(8, 8, b, a);
   } else {
     result = _VFSub(8, 8, a, b);
@@ -500,6 +511,11 @@ void OpDispatchBuilder::FSUBF64(OpcodeArgs) {
 
   // Write to ST[TOP]
   _StoreContextIndexed(result, StackLocation, 8, MMBaseOffset(), 16, FPRClass);
+}
+
+template<size_t width, bool Integer, bool reverse, OpDispatchBuilder::OpResult ResInST0>
+void OpDispatchBuilder::FSUBF64(OpcodeArgs) {
+  FSUBF64(Op, width, Integer, reverse, ResInST0);
 }
 
 template void OpDispatchBuilder::FSUBF64<32, false, false, OpDispatchBuilder::OpResult::RES_ST0>(OpcodeArgs);
@@ -584,8 +600,7 @@ void OpDispatchBuilder::FXTRACTF64(OpcodeArgs) {
 }
 
 
-template<size_t width, bool Integer, OpDispatchBuilder::FCOMIFlags whichflags, bool poptwice>
-void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
+void OpDispatchBuilder::FCOMIF64(OpcodeArgs, size_t width, bool Integer, OpDispatchBuilder::FCOMIFlags whichflags, bool poptwice) {
   auto top = GetX87Top();
   auto mask = _Constant(7);
 
@@ -594,16 +609,16 @@ void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
 
   if (!Op->Src[0].IsNone()) {
     // Memory arg
-    if constexpr (Integer) {
+    if (Integer) {
       arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
       if (width == 16) {
         arg = _Sbfe(OpSize::i64Bit, 16, 0, arg);
       }
       b = _Float_FromGPR_S(8, width == 64 ? 8 : 4, arg);
-    } else if constexpr (width == 32) {
+    } else if (width == 32) {
       arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
       b = _Float_FToF(8, 4, arg);
-    } else if constexpr (width == 64) {
+    } else if (width == 64) {
       b = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
     }
   } else {
@@ -615,7 +630,7 @@ void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
 
   auto a = _LoadContextIndexed(top, 8, MMBaseOffset(), 16, FPRClass);
 
-  if constexpr (whichflags == FCOMIFlags::FLAGS_X87) {
+  if (whichflags == FCOMIFlags::FLAGS_X87) {
     // We are going to clobber NZCV, make sure it's in a GPR first.
     GetNZCV();
 
@@ -626,7 +641,7 @@ void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
     Comiss(8, a, b, true /* InvalidateAF */);
   }
 
-  if constexpr (poptwice) {
+  if (poptwice) {
     // if we are popping then we must first mark this location as empty
     SetX87ValidTag(top, false);
     top = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, _Constant(1)), mask);
@@ -641,6 +656,11 @@ void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
     top = _And(OpSize::i32Bit, _Add(OpSize::i32Bit, top, _Constant(1)), mask);
     SetX87Top(top);
   }
+}
+
+template<size_t width, bool Integer, OpDispatchBuilder::FCOMIFlags whichflags, bool poptwice>
+void OpDispatchBuilder::FCOMIF64(OpcodeArgs) {
+  FCOMIF64(Op, width, Integer, whichflags, poptwice);
 }
 
 template void OpDispatchBuilder::FCOMIF64<32, false, OpDispatchBuilder::FCOMIFlags::FLAGS_X87, false>(OpcodeArgs);


### PR DESCRIPTION
Template functions are compiled once per set of template arguments (as if they were entirely separate functions). Moving all logic to an inner function and turning the templates into thin wrappers avoids binary size overhead.

In total, reduces FEXLoader size by 5.5% (45.1 MB -> 42.6 MB).