### PR TITLE
Fix all the warnings

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -99,7 +99,7 @@ DEF_OP(LoadRegister) {
       }
     }
   } else if (Op->Class == IR::FPRClass) {
-    const auto regSize = HostSupportsAVX256 ? Core::CPUState::XMM_AVX_REG_SIZE : Core::CPUState::XMM_SSE_REG_SIZE;
+    [[maybe_unused]] const auto regSize = HostSupportsAVX256 ? Core::CPUState::XMM_AVX_REG_SIZE : Core::CPUState::XMM_SSE_REG_SIZE;
     LOGMAN_THROW_A_FMT(Op->Reg < StaticFPRegisters.size(), "out of range reg");
     LOGMAN_THROW_A_FMT(OpSize == regSize, "expected sized");
 
@@ -120,8 +120,6 @@ DEF_OP(LoadRegister) {
 
 DEF_OP(StoreRegister) {
   const auto Op = IROp->C<IR::IROp_StoreRegister>();
-  const auto OpSize = IROp->Size;
-
 
   if (Op->Class == IR::GPRClass) {
     unsigned Reg = Op->Reg == Core::CPUState::PF_AS_GREG ? (StaticRegisters.size() - 2) :
@@ -137,9 +135,9 @@ DEF_OP(StoreRegister) {
       mov(ARMEmitter::Size::i64Bit, reg, Src);
     }
   } else if (Op->Class == IR::FPRClass) {
-    const auto regSize = HostSupportsAVX256 ? Core::CPUState::XMM_AVX_REG_SIZE : Core::CPUState::XMM_SSE_REG_SIZE;
+    [[maybe_unused]] const auto regSize = HostSupportsAVX256 ? Core::CPUState::XMM_AVX_REG_SIZE : Core::CPUState::XMM_SSE_REG_SIZE;
     LOGMAN_THROW_A_FMT(Op->Reg < StaticFPRegisters.size(), "reg out of range");
-    LOGMAN_THROW_A_FMT(OpSize == regSize, "expected sized");
+    LOGMAN_THROW_A_FMT(IROp->Size == regSize, "expected sized");
 
     const auto guest = StaticFPRegisters[Op->Reg];
     const auto host = GetVReg(Op->Value.ID());
@@ -2308,7 +2306,7 @@ DEF_OP(VStoreNonTemporalPair) {
   const auto Op = IROp->C<IR::IROp_VStoreNonTemporalPair>();
   const auto OpSize = IROp->Size;
 
-  const auto Is128Bit = OpSize == Core::CPUState::XMM_SSE_REG_SIZE;
+  [[maybe_unused]] const auto Is128Bit = OpSize == Core::CPUState::XMM_SSE_REG_SIZE;
   LOGMAN_THROW_A_FMT(Is128Bit, "This IR operation only operates at 128-bit wide");
 
   const auto ValueLow = GetVReg(Op->ValueLow.ID());

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MoveOps.cpp
@@ -53,7 +53,7 @@ DEF_OP(Copy) {
 DEF_OP(Swap1) {
   auto Op = IROp->C<IR::IROp_Swap1>();
   auto A = GetReg(Op->A.ID()), B = GetReg(Op->B.ID());
-  LOGMAN_THROW_AA_FMT(B == GetReg(Node), "Invariant");
+  LOGMAN_THROW_A_FMT(B == GetReg(Node), "Invariant");
 
   mov(ARMEmitter::Size::i64Bit, TMP1, A);
   mov(ARMEmitter::Size::i64Bit, A, B);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -508,7 +508,7 @@ OpDispatchBuilder::RefPair OpDispatchBuilder::AVX128_LoadSource_WithOpSize(
 
 OpDispatchBuilder::RefVSIB
 OpDispatchBuilder::AVX128_LoadVSIB(const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, uint32_t Flags, bool NeedsHigh) {
-  const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
+  [[maybe_unused]] const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
   LOGMAN_THROW_A_FMT(Operand.IsSIB() && IsVSIB, "Trying to load VSIB for something that isn't the correct type!");
 
   // VSIB is a very special case which has a ton of encoded data.
@@ -1012,7 +1012,6 @@ template<size_t DstElementSize>
 void OpDispatchBuilder::AVX128_InsertCVTGPR_To_FPR(OpcodeArgs) {
   const auto SrcSize = GetSrcSize(Op);
   const auto DstSize = GetDstSize(Op);
-  const auto Is128Bit = DstSize == Core::CPUState::XMM_SSE_REG_SIZE;
 
   auto Src1 = AVX128_LoadSource_WithOpSize(Op, Op->Src[0], Op->Flags, false);
 
@@ -1036,8 +1035,9 @@ void OpDispatchBuilder::AVX128_InsertCVTGPR_To_FPR(OpcodeArgs) {
     Result.Low = _VSToFVectorInsert(IR::SizeToOpSize(DstSize), DstElementSize, DstElementSize, Src1.Low, Src2.Low, false, false);
   }
 
-  Result.High = LoadZeroVector(OpSize::i128Bit);
+  [[maybe_unused]] const auto Is128Bit = DstSize == Core::CPUState::XMM_SSE_REG_SIZE;
   LOGMAN_THROW_A_FMT(Is128Bit, "Programming Error: This should never occur!");
+  Result.High = LoadZeroVector(OpSize::i128Bit);
 
   AVX128_StoreResult_WithOpSize(Op, Op->Dest, Result);
 }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -5161,7 +5161,7 @@ template void OpDispatchBuilder::VFMSUBADD<2, 1, 3>(OpcodeArgs);
 template void OpDispatchBuilder::VFMSUBADD<2, 3, 1>(OpcodeArgs);
 
 OpDispatchBuilder::RefVSIB OpDispatchBuilder::LoadVSIB(const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, uint32_t Flags) {
-  const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
+  [[maybe_unused]] const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
   LOGMAN_THROW_A_FMT(Operand.IsSIB() && IsVSIB, "Trying to load VSIB for something that isn't the correct type!");
 
   // VSIB is a very special case which has a ton of encoded data.

--- a/Source/Common/JSONPool.cpp
+++ b/Source/Common/JSONPool.cpp
@@ -6,18 +6,18 @@ json_t* PoolInit(jsonPool_t* Pool);
 json_t* PoolAlloc(jsonPool_t* Pool);
 
 JsonAllocator::JsonAllocator()
-  : PoolObject {
+  : jsonPool_t {
       .init = FEX::JSON::PoolInit,
       .alloc = FEX::JSON::PoolAlloc,
     } {}
 
 json_t* PoolInit(jsonPool_t* Pool) {
-  JsonAllocator* alloc = reinterpret_cast<JsonAllocator*>(Pool);
+  JsonAllocator* alloc = static_cast<JsonAllocator*>(Pool);
   return &*alloc->json_objects.emplace(alloc->json_objects.end());
 }
 
 json_t* PoolAlloc(jsonPool_t* Pool) {
-  JsonAllocator* alloc = reinterpret_cast<JsonAllocator*>(Pool);
+  JsonAllocator* alloc = static_cast<JsonAllocator*>(Pool);
   return &*alloc->json_objects.emplace(alloc->json_objects.end());
 }
 } // namespace FEX::JSON

--- a/Source/Common/JSONPool.h
+++ b/Source/Common/JSONPool.h
@@ -6,13 +6,11 @@
 #include <tiny-json.h>
 
 namespace FEX::JSON {
-struct JsonAllocator {
-  jsonPool_t PoolObject;
+struct JsonAllocator : jsonPool_t {
   fextl::list<json_t> json_objects;
 
   JsonAllocator();
 };
-static_assert(offsetof(JsonAllocator, PoolObject) == 0, "This needs to be at offset zero");
 
 template<typename T>
 const json_t* CreateJSON(T& Container, JsonAllocator& Allocator) {
@@ -20,6 +18,6 @@ const json_t* CreateJSON(T& Container, JsonAllocator& Allocator) {
     return nullptr;
   }
 
-  return json_createWithPool(&Container.at(0), &Allocator.PoolObject);
+  return json_createWithPool(&Container.at(0), &Allocator);
 }
 } // namespace FEX::JSON

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Ioctl/drm.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Ioctl/drm.h
@@ -60,18 +60,15 @@ namespace DRM {
     }
 
     fex_drm_version(struct drm_version val)
-      : name {val.name}
-      , date {val.date}
-      , desc {val.desc} {
+      : name {auto_compat_ptr {val.name}}
+      , date {auto_compat_ptr {val.date}}
+      , desc {auto_compat_ptr {val.desc}} {
       version_major = val.version_major;
       version_minor = val.version_minor;
       version_patchlevel = val.version_patchlevel;
       name_len = val.name_len;
-      name = val.name;
       date_len = val.date_len;
-      date = val.date;
       desc_len = val.desc_len;
-      desc = val.desc;
     }
   };
 
@@ -89,7 +86,7 @@ namespace DRM {
     }
 
     fex_drm_unique(struct drm_unique val)
-      : unique {val.unique} {
+      : unique {auto_compat_ptr {val.unique}} {
       unique_len = val.unique_len;
     }
   };
@@ -116,7 +113,7 @@ namespace DRM {
     }
 
     fex_drm_map(struct drm_map val)
-      : handle {val.handle} {
+      : handle {auto_compat_ptr {val.handle}} {
       CPYT(offset);
       CPYT(size);
       CPYT(type);
@@ -227,7 +224,7 @@ namespace DRM {
     }
 
     fex_drm_buf_info(struct drm_buf_info val)
-      : list {val.list} {
+      : list {auto_compat_ptr {val.list}} {
       CPYF(count);
     }
   };
@@ -250,7 +247,7 @@ namespace DRM {
     }
 
     fex_drm_buf_pub(struct drm_buf_pub val)
-      : address {val.address} {
+      : address {auto_compat_ptr {val.address}} {
       CPYF(idx);
       CPYF(total);
       CPYF(used);
@@ -282,11 +279,11 @@ namespace DRM {
 
     fex_drm_buf_map(struct drm_buf_map val)
 #ifdef __cplusplus
-      : virt {val.virt}
+      : virt {auto_compat_ptr {val.virt}}
 #else
-      : virtual {val.virtual}
+      : virtual {auto_compat_ptr {val.virtual}}
 #endif
-      , list {val.list} {
+      , list {auto_compat_ptr {val.list}} {
       CPYF(count);
     }
   };
@@ -305,7 +302,7 @@ namespace DRM {
     }
 
     fex_drm_buf_free(struct drm_buf_free val)
-      : list {val.list} {
+      : list {auto_compat_ptr {val.list}} {
       CPYF(count);
     }
   };
@@ -324,7 +321,7 @@ namespace DRM {
     }
 
     fex_drm_ctx_priv_map(struct drm_ctx_priv_map val)
-      : handle {val.handle} {
+      : handle {auto_compat_ptr {val.handle}} {
       CPYF(ctx_id);
     }
   };
@@ -342,7 +339,7 @@ namespace DRM {
     }
 
     fex_drm_ctx_res(struct drm_ctx_res val)
-      : contexts {val.contexts} {
+      : contexts {auto_compat_ptr {val.contexts}} {
       CPYF(count);
     }
   };
@@ -377,10 +374,10 @@ namespace DRM {
     }
 
     fex_drm_dma(struct drm_dma val)
-      : send_indices {val.send_indices}
-      , send_sizes {val.send_sizes}
-      , request_indices {val.request_indices}
-      , request_sizes {val.request_sizes} {
+      : send_indices {auto_compat_ptr {val.send_indices}}
+      , send_sizes {auto_compat_ptr {val.send_sizes}}
+      , request_indices {auto_compat_ptr {val.request_indices}}
+      , request_sizes {auto_compat_ptr {val.request_sizes}} {
       CPYF(context);
       CPYF(send_count);
       CPYF(flags);
@@ -763,7 +760,7 @@ namespace RADEON {
     }
 
     fex_drm_radeon_clear_t(drm_radeon_clear_t val)
-      : depth_boxes {val.depth_boxes} {
+      : depth_boxes {auto_compat_ptr {val.depth_boxes}} {
       flags = val.flags;
       clear_color = val.clear_color;
       clear_depth = val.clear_depth;
@@ -784,7 +781,7 @@ namespace RADEON {
     }
 
     fex_drm_radeon_stipple_t(drm_radeon_stipple_t val)
-      : mask {val.mask} {}
+      : mask {auto_compat_ptr {val.mask}} {}
   };
 
   struct FEX_ANNOTATE("alias-x86_32-drm_radeon_texture") FEX_ANNOTATE("fex-match") fex_drm_radeon_texture_t {
@@ -809,7 +806,7 @@ namespace RADEON {
     }
 
     fex_drm_radeon_texture_t(drm_radeon_texture_t val)
-      : image {val.image} {
+      : image {auto_compat_ptr {val.image}} {
       offset = val.offset;
       pitch = val.pitch;
       format = val.format;
@@ -840,8 +837,8 @@ namespace RADEON {
     }
 
     fex_drm_radeon_vertex2_t(drm_radeon_vertex2_t val)
-      : state {val.state}
-      , prim {val.prim} {
+      : state {auto_compat_ptr {val.state}}
+      , prim {auto_compat_ptr {val.prim}} {
       idx = val.idx;
       discard = val.discard;
       nr_states = val.nr_states;
@@ -867,8 +864,8 @@ namespace RADEON {
     }
 
     fex_drm_radeon_cmd_buffer_t(drm_radeon_cmd_buffer_t val)
-      : buf {val.buf}
-      , boxes {val.boxes} {
+      : buf {auto_compat_ptr {val.buf}}
+      , boxes {auto_compat_ptr {val.boxes}} {
       val.bufsz = bufsz;
       val.nbox = nbox;
     }
@@ -888,7 +885,7 @@ namespace RADEON {
     }
 
     fex_drm_radeon_getparam_t(drm_radeon_getparam_t val)
-      : value {val.value} {
+      : value {auto_compat_ptr {val.value}} {
       val.param = param;
     }
   };
@@ -911,7 +908,7 @@ namespace RADEON {
     }
 
     fex_drm_radeon_mem_alloc_t(drm_radeon_mem_alloc_t val)
-      : region_offset {val.region_offset} {
+      : region_offset {auto_compat_ptr {val.region_offset}} {
       val.region = region;
       val.alignment = alignment;
       val.size = size;
@@ -930,7 +927,7 @@ namespace RADEON {
     }
 
     fex_drm_radeon_irq_emit_t(drm_radeon_irq_emit_t val)
-      : irq_seq {val.irq_seq} {}
+      : irq_seq {auto_compat_ptr {val.irq_seq}} {}
   };
 
   struct FEX_ANNOTATE("alias-x86_32-drm_radeon_setparam") FEX_ANNOTATE("fex-match") FEX_PACKED fex_drm_radeon_setparam_t {
@@ -959,7 +956,6 @@ namespace MSM {
     compat_int64_t tv_sec;
     compat_int64_t tv_nsec;
 
-    fex_drm_msm_timespec() = delete;
     operator drm_msm_timespec() const {
       drm_msm_timespec val {};
       val.tv_sec = tv_sec;
@@ -967,10 +963,15 @@ namespace MSM {
       return val;
     }
 
-    fex_drm_msm_timespec(struct drm_msm_timespec val) {
-      tv_sec = val.tv_sec;
-      tv_nsec = val.tv_nsec;
+    static fex_drm_msm_timespec FromHost(struct drm_msm_timespec val) {
+      fex_drm_msm_timespec ret;
+      ret.tv_sec = val.tv_sec;
+      ret.tv_nsec = val.tv_nsec;
+      return ret;
     }
+
+  private:
+    fex_drm_msm_timespec() = default;
   };
 
   struct FEX_ANNOTATE("alias-x86_32-drm_msm_wait_fence") FEX_ANNOTATE("fex-match") FEX_PACKED fex_drm_msm_wait_fence {
@@ -991,7 +992,7 @@ namespace MSM {
     }
 
     fex_drm_msm_wait_fence(struct drm_msm_wait_fence val)
-      : timeout {val.timeout} {
+      : timeout {fex_drm_msm_timespec::FromHost(val.timeout)} {
       fence = val.fence;
       flags = val.flags;
       queueid = val.queueid;
@@ -1024,7 +1025,7 @@ namespace I915 {
     }
 
     fex_drm_i915_batchbuffer_t(drm_i915_batchbuffer_t val)
-      : cliprects {val.cliprects} {
+      : cliprects {auto_compat_ptr {val.cliprects}} {
       CPYF(start);
       CPYF(used);
       CPYF(DR1);
@@ -1045,7 +1046,7 @@ namespace I915 {
     }
 
     fex_drm_i915_irq_emit_t(drm_i915_irq_emit_t val)
-      : irq_seq {val.irq_seq} {}
+      : irq_seq {auto_compat_ptr {val.irq_seq}} {}
   };
 
   struct FEX_ANNOTATE("alias-x86_32-drm_i915_getparam") FEX_ANNOTATE("fex-match") fex_drm_i915_getparam_t {
@@ -1061,7 +1062,7 @@ namespace I915 {
     }
 
     fex_drm_i915_getparam_t(drm_i915_getparam_t val)
-      : value {val.value} {
+      : value {auto_compat_ptr {val.value}} {
       CPYF(param);
     }
   };
@@ -1083,7 +1084,7 @@ namespace I915 {
     }
 
     fex_drm_i915_mem_alloc_t(drm_i915_mem_alloc_t val)
-      : region_offset {val.region_offset} {
+      : region_offset {auto_compat_ptr {val.region_offset}} {
       CPYT(region);
       CPYT(alignment);
       CPYT(size);
@@ -1112,8 +1113,8 @@ namespace I915 {
     }
 
     fex_drm_i915_cmdbuffer_t(drm_i915_cmdbuffer_t val)
-      : buf {val.buf}
-      , cliprects {val.cliprects} {
+      : buf {auto_compat_ptr {val.buf}}
+      , cliprects {auto_compat_ptr {val.cliprects}} {
       CPYT(sz);
       CPYT(DR1);
       CPYT(DR4);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
@@ -103,7 +103,7 @@ uint64_t _ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first
     uint32_t semnum = second;
     // Upper 16bits used for a different flag?
     int32_t cmd = third & 0xFF;
-    compat_ptr<semun_32> semun(ptr);
+    auto_compat_ptr<semun_32> semun(ptr);
     bool IPC64 = third & 0x100;
     switch (cmd) {
     case IPC_SET: {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Socket.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Socket.cpp
@@ -304,7 +304,7 @@ void ConvertHeaderToGuest(struct msghdr32* Guest, struct msghdr* Host) {
   }
 }
 
-static uint64_t RecvMMsg(int sockfd, compat_ptr<mmsghdr_32> msgvec, uint32_t vlen, int flags, struct timespec* timeout_ts) {
+static uint64_t RecvMMsg(int sockfd, auto_compat_ptr<mmsghdr_32> msgvec, uint32_t vlen, int flags, struct timespec* timeout_ts) {
   fextl::vector<iovec> Host_iovec;
   fextl::vector<struct mmsghdr> HostMHeader(vlen);
   for (size_t i = 0; i < vlen; ++i) {
@@ -321,7 +321,7 @@ static uint64_t RecvMMsg(int sockfd, compat_ptr<mmsghdr_32> msgvec, uint32_t vle
   SYSCALL_ERRNO();
 }
 
-static uint64_t SendMMsg(int sockfd, compat_ptr<mmsghdr_32> msgvec, uint32_t vlen, int flags) {
+static uint64_t SendMMsg(int sockfd, auto_compat_ptr<mmsghdr_32> msgvec, uint32_t vlen, int flags) {
   fextl::vector<iovec> Host_iovec;
   fextl::vector<struct mmsghdr> HostMmsg(vlen);
 
@@ -407,7 +407,7 @@ static uint64_t SendMMsg(int sockfd, compat_ptr<mmsghdr_32> msgvec, uint32_t vle
   SYSCALL_ERRNO();
 }
 
-static uint64_t SetSockOpt(int sockfd, int level, int optname, compat_ptr<void> optval, int optlen) {
+static uint64_t SetSockOpt(int sockfd, int level, int optname, auto_compat_ptr<void> optval, int optlen) {
   uint64_t Result {};
 
   if (level == SOL_SOCKET) {
@@ -534,7 +534,7 @@ static uint64_t SetSockOpt(int sockfd, int level, int optname, compat_ptr<void> 
   SYSCALL_ERRNO();
 }
 
-static uint64_t GetSockOpt(int sockfd, int level, int optname, compat_ptr<void> optval, compat_ptr<socklen_t> optlen) {
+static uint64_t GetSockOpt(int sockfd, int level, int optname, auto_compat_ptr<void> optval, auto_compat_ptr<socklen_t> optlen) {
   uint64_t Result {};
   if (level == SOL_SOCKET) {
     switch (optname) {
@@ -748,12 +748,12 @@ void RegisterSocket(FEX::HLE::SyscallHandler* Handler) {
   });
 
   REGISTER_SYSCALL_IMPL_X32(sendmmsg,
-                            [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, compat_ptr<mmsghdr_32> msgvec, uint32_t vlen,
+                            [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, auto_compat_ptr<mmsghdr_32> msgvec, uint32_t vlen,
                                int flags) -> uint64_t { return SendMMsg(sockfd, msgvec, vlen, flags); });
 
   REGISTER_SYSCALL_IMPL_X32(recvmmsg,
-                            [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, compat_ptr<mmsghdr_32> msgvec, uint32_t vlen, int flags,
-                               timespec32* timeout_ts) -> uint64_t {
+                            [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, auto_compat_ptr<mmsghdr_32> msgvec, uint32_t vlen,
+                               int flags, timespec32* timeout_ts) -> uint64_t {
                               struct timespec tp64 {};
                               struct timespec* timed_ptr {};
                               if (timeout_ts) {
@@ -771,7 +771,7 @@ void RegisterSocket(FEX::HLE::SyscallHandler* Handler) {
                             });
 
   REGISTER_SYSCALL_IMPL_X32(recvmmsg_time64,
-                            [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, compat_ptr<mmsghdr_32> msgvec, uint32_t vlen, int flags,
+                            [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, auto_compat_ptr<mmsghdr_32> msgvec, uint32_t vlen, int flags,
                                struct timespec* timeout_ts) -> uint64_t { return RecvMMsg(sockfd, msgvec, vlen, flags, timeout_ts); });
 
   REGISTER_SYSCALL_IMPL_X32(recvmsg, [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, struct msghdr32* msg, int flags) -> uint64_t {
@@ -779,11 +779,11 @@ void RegisterSocket(FEX::HLE::SyscallHandler* Handler) {
   });
 
   REGISTER_SYSCALL_IMPL_X32(setsockopt,
-                            [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, int level, int optname, compat_ptr<void> optval,
+                            [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, int level, int optname, auto_compat_ptr<void> optval,
                                socklen_t optlen) -> uint64_t { return SetSockOpt(sockfd, level, optname, optval, optlen); });
 
   REGISTER_SYSCALL_IMPL_X32(getsockopt,
-                            [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, int level, int optname, compat_ptr<void> optval,
-                               compat_ptr<socklen_t> optlen) -> uint64_t { return GetSockOpt(sockfd, level, optname, optval, optlen); });
+                            [](FEXCore::Core::CpuStateFrame* Frame, int sockfd, int level, int optname, auto_compat_ptr<void> optval,
+                               auto_compat_ptr<socklen_t> optlen) -> uint64_t { return GetSockOpt(sockfd, level, optname, optval, optlen); });
 }
 } // namespace FEX::HLE::x32


### PR DESCRIPTION
Fixes all warnings I found in my local build configuration, excluding those from External/.

Two few patches are worth highlighting (others are trivial):
* de258ced20f9351b55281fd87accc5cbe91e0938: Adds an **internal** `unique_ptr` replacement, side-stepping the issues mentioned in a prior attempt in #3618 . By dropping movability, this becames a mere auto-deleting wrapper for non-transferable memory, which makes it much easier to reliably implement while allowing the rest of the code to continue using `std::unique_ptr`.
* 68936a0dce59e34fccb5819bc29e8776978676e2: Structs embedding `compat_ptr` can't use custom constructors without triggering warnings. Luckily we only need the constructors when *initializing data* or when *calling functions*, which can both be served by a utility class instead.
