### PR TITLE
fextl: Properly handle nullptr arguments in fextl::default_delete

### DIFF
--- a/FEXCore/include/FEXCore/fextl/memory.h
+++ b/FEXCore/include/FEXCore/fextl/memory.h
@@ -9,8 +9,10 @@ namespace fextl {
 template<class T>
 struct default_delete : public std::default_delete<T> {
   void operator()(T* ptr) const {
-    std::destroy_at(ptr);
-    FEXCore::Allocator::aligned_free(ptr);
+    if (ptr) {
+      std::destroy_at(ptr);
+      FEXCore::Allocator::aligned_free(ptr);
+    }
   }
 
   template<typename U>


### PR DESCRIPTION
`fextl::default_delete<...>{}(nullptr)` must be a no-op, reflecting behavior of std::default_delete.

Previously, `std::destroy_at` would invoke the destructor on null objects.
