### PR TITLE
AOTIR: Change std::unique_ptr to fextl::unique_ptr

### DIFF
--- a/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/FEXCore/Source/Interface/IR/AOTIR.h
@@ -83,7 +83,7 @@ struct AOTIRCacheEntry {
   AOTIRInlineIndex* Array;
   void* FilePtr;
   size_t Size;
-  std::unique_ptr<FEXCore::HLE::SourcecodeMap> SourcecodeMap;
+  fextl::unique_ptr<FEXCore::HLE::SourcecodeMap> SourcecodeMap;
   fextl::string FileId;
   fextl::string Filename;
   bool ContainsCode;


### PR DESCRIPTION
Originally brought up in #3618.
