### PR TITLE
Arm64: Implement support for SVE bitperm

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -76,6 +76,8 @@
           "DISABLECRYPTO": "disablecrypto",
           "ENABLERPRES": "enablerpres",
           "DISABLERPRES": "disablerpres",
+          "ENABLESVEBITPERM": "enablesvebitperm",
+          "DISABLESVEBITPERM": "disablesvebitperm",
           "ENABLEPRESERVEALLABI": "enablepreserveallabi",
           "DISABLEPRESERVEALLABI": "disablepreserveallabi"
         },
@@ -97,6 +99,7 @@
           "\t{enable,disable}flagm2: Will force enable or disable flagm2 even if the host doesn't support it",
           "\t{enable,disable}crypto: Will force enable or disable crypto extensions even if the host doesn't support it",
           "\t{enable,disable}rpres: Will force enable or disable rpres even if the host doesn't support it",
+          "\t{enable,disable}svebitperm: Will force enable or disable svebitperm even if the host doesn't support it",
           "\t{enable,disable}preserveallabi: Will force enable or disable preserve_all abi even if the host doesn't support it"
         ]
       },

--- a/FEXCore/Source/Interface/Core/HostFeatures.cpp
+++ b/FEXCore/Source/Interface/Core/HostFeatures.cpp
@@ -95,6 +95,7 @@ static void OverrideFeatures(HostFeatures* Features, uint64_t ForceSVEWidth) {
   ENABLE_DISABLE_OPTION(SupportsFlagM, FlagM, FLAGM);
   ENABLE_DISABLE_OPTION(SupportsFlagM2, FlagM2, FLAGM2);
   ENABLE_DISABLE_OPTION(SupportsRPRES, RPRES, RPRES);
+  ENABLE_DISABLE_OPTION(SupportsSVEBitPerm, SVEBITPERM, SVEBITPERM);
   ENABLE_DISABLE_OPTION(SupportsPreserveAllABI, PRESERVEALLABI, PRESERVEALLABI);
   GET_SINGLE_OPTION(Crypto, CRYPTO);
 
@@ -152,6 +153,7 @@ HostFeatures::HostFeatures() {
   SupportsFlagM = Features.Has(vixl::CPUFeatures::Feature::kFlagM);
   SupportsFlagM2 = Features.Has(vixl::CPUFeatures::Feature::kAXFlag);
   SupportsRPRES = Features.Has(vixl::CPUFeatures::Feature::kRPRES);
+  SupportsSVEBitPerm = Features.Has(vixl::CPUFeatures::Feature::kSVEBitPerm);
 
   Supports3DNow = true;
   SupportsSSE4A = true;

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -39,6 +39,7 @@ public:
   bool SupportsRPRES {};
   bool SupportsPreserveAllABI {};
   bool SupportsAES256 {};
+  bool SupportsSVEBitPerm {};
 
   // Float exception behaviour
   bool SupportsAFP {};

--- a/Scripts/InstructionCountParser.py
+++ b/Scripts/InstructionCountParser.py
@@ -54,6 +54,7 @@ class HostFeatures(Flag) :
     FEATURE_FLAGM2 = (1 << 9)
     FEATURE_CRYPTO = (1 << 10)
     FEATURE_AES256 = (1 << 11)
+    FEATURE_SVEBITPERM = (1 << 12)
 
 HostFeaturesLookup = {
     "SVE128"  : HostFeatures.FEATURE_SVE128,
@@ -68,6 +69,7 @@ HostFeaturesLookup = {
     "FLAGM2"  : HostFeatures.FEATURE_FLAGM2,
     "CRYPTO"  : HostFeatures.FEATURE_CRYPTO,
     "AES256"  : HostFeatures.FEATURE_AES256,
+    "SVEBITPERM" : HostFeatures.FEATURE_SVEBITPERM,
 }
 
 def GetHostFeatures(data):

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -505,6 +505,8 @@ int main(int argc, char** argv, char** const envp) {
     FEATURE_FLAGM = (1U << 8),
     FEATURE_FLAGM2 = (1U << 9),
     FEATURE_CRYPTO = (1U << 10),
+    FEATURE_AES256 = (1U << 11),
+    FEATURE_SVEBITPERM = (1U << 12),
   };
 
   uint64_t SVEWidth = 0;
@@ -543,6 +545,9 @@ int main(int argc, char** argv, char** const envp) {
   if (TestHeaderData->EnabledHostFeatures & FEATURE_CRYPTO) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLECRYPTO);
   }
+  if (TestHeaderData->EnabledHostFeatures & FEATURE_SVEBITPERM) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLESVEBITPERM);
+  }
 
   // Always enable ARMv8.1 LSE atomics.
   HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEATOMICS);
@@ -576,6 +581,9 @@ int main(int argc, char** argv, char** const envp) {
   }
   if (TestHeaderData->DisabledHostFeatures & FEATURE_CRYPTO) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLECRYPTO);
+  }
+  if (TestHeaderData->DisabledHostFeatures & FEATURE_SVEBITPERM) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLESVEBITPERM);
   }
 
   // Always enable preserve_all abi.

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -8,7 +8,8 @@
     "DisabledHostFeatures": [
       "AFP",
       "SVE128",
-      "SVE256"
+      "SVE256",
+      "SVEBITPERM"
     ]
   },
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -7,7 +7,8 @@
       "FLAGM2"
     ],
     "DisabledHostFeatures": [
-      "AFP"
+      "AFP",
+      "SVEBITPERM"
     ]
   },
   "Instructions": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -8,7 +8,8 @@
     "DisabledHostFeatures": [
       "AFP",
       "FLAGM",
-      "FLAGM2"
+      "FLAGM2",
+      "SVEBITPERM"
     ]
   },
   "Instructions": {

--- a/unittests/InstructionCountCI/VEX_map2_svebitperm.json
+++ b/unittests/InstructionCountCI/VEX_map2_svebitperm.json
@@ -1,0 +1,65 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "SVE256",
+      "SVE128",
+      "SVEBITPERM"
+    ],
+    "DisabledHostFeatures": [
+      "AFP",
+      "FLAGM",
+      "FLAGM2"
+    ]
+  },
+  "Instructions": {
+    "pext eax, ebx, ecx": {
+      "ExpectedInstructionCount": 4,
+      "Comment": [
+        "Map 2 0b10 0xf5 32-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fmov s0, w7",
+        "fmov s1, w5",
+        "bext z0.s, z0.s, z1.s",
+        "mov w4, v0.s[0]"
+      ]
+    },
+    "pext rax, rbx, rcx": {
+      "ExpectedInstructionCount": 4,
+      "Comment": [
+        "Map 2 0b10 0xf5 64-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fmov d0, x7",
+        "fmov d1, x5",
+        "bext z0.d, z0.d, z1.d",
+        "mov x4, v0.d[0]"
+      ]
+    },
+    "pdep eax, ebx, ecx": {
+      "ExpectedInstructionCount": 4,
+      "Comment": [
+        "Map 2 0b11 0xf5 32-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fmov s0, w7",
+        "fmov s1, w5",
+        "bdep z0.s, z0.s, z1.s",
+        "mov w4, v0.s[0]"
+      ]
+    },
+    "pdep rax, rbx, rcx": {
+      "ExpectedInstructionCount": 4,
+      "Comment": [
+        "Map 2 0b11 0xf5 64-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fmov d0, x7",
+        "fmov d1, x5",
+        "bdep z0.d, z0.d, z1.d",
+        "mov x4, v0.d[0]"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
PEXT: 12 (With a loop!) -> 4 instructions
PDEP: 14 (With a loop!) -> 4 instructions

Cortex's bext/bdep instructions are pretty quick, 4 or 6 cycles depending on if it is Cortex-A versus Cortex-X. Bit of a shame that Cortex-X has a cycle penalty here, but it'll be significantly faster than the looping variant regardless.

Fixes #3851