### PR TITLE
Implement support for SSE4.1/AVX NT loads

### DIFF
--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -2569,7 +2569,19 @@ public:
   }
 
   // SVE contiguous non-temporal load (scalar plus immediate)
-  // XXX:
+  void ldnt1b(ZRegister zt, PRegister pg, Register rn, int32_t Imm = 0) {
+    SVEContiguousNontemporalLoad(0b00, zt, pg, rn, Imm);
+  }
+  void ldnt1h(ZRegister zt, PRegister pg, Register rn, int32_t Imm = 0) {
+    SVEContiguousNontemporalLoad(0b01, zt, pg, rn, Imm);
+  }
+  void ldnt1w(ZRegister zt, PRegister pg, Register rn, int32_t Imm = 0) {
+    SVEContiguousNontemporalLoad(0b10, zt, pg, rn, Imm);
+  }
+  void ldnt1d(ZRegister zt, PRegister pg, Register rn, int32_t Imm = 0) {
+    SVEContiguousNontemporalLoad(0b11, zt, pg, rn, Imm);
+  }
+
   // SVE contiguous non-temporal load (scalar plus scalar)
   // XXX:
   // SVE load multiple structures (scalar plus immediate)
@@ -4489,6 +4501,22 @@ private:
     if (is_store) {
       Instr |= 0x40100000U;
     }
+    dc32(Instr);
+  }
+
+  // SVE contiguous non-temporal load (scalar plus immediate)
+  void SVEContiguousNontemporalLoad(uint32_t msz, ZRegister zt, PRegister pg, Register rn, int32_t imm) {
+    LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
+    LOGMAN_THROW_AA_FMT(imm >= -8 && imm <= 7,
+                        "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
+
+    const auto imm4 = static_cast<uint32_t>(imm) & 0xF;
+    uint32_t Instr = 0b1010'0100'0000'0000'1110'0000'0000'0000;
+    Instr |= msz << 23;
+    Instr |= imm4 << 16;
+    Instr |= pg.Idx() << 10;
+    Instr |= Encode_rn(rn);
+    Instr |= zt.Idx();
     dc32(Instr);
   }
 

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -2320,5 +2320,31 @@ DEF_OP(VStoreNonTemporalPair) {
   stnp(ValueLow.Q(), ValueHigh.Q(), MemReg, Offset);
 }
 
+DEF_OP(VLoadNonTemporal) {
+  const auto Op = IROp->C<IR::IROp_VLoadNonTemporal>();
+  const auto OpSize = IROp->Size;
+
+  const auto Is256Bit = OpSize == Core::CPUState::XMM_AVX_REG_SIZE;
+  const auto Is128Bit = OpSize == Core::CPUState::XMM_SSE_REG_SIZE;
+
+  const auto Dst = GetVReg(Node);
+  const auto MemReg = GetReg(Op->Addr.ID());
+  const auto Offset = Op->Offset;
+
+  if (Is256Bit) {
+    LOGMAN_THROW_A_FMT(HostSupportsSVE256, "Need SVE256 support in order to use VStoreNonTemporal with 256-bit operation");
+    const auto GoverningPredicate = PRED_TMP_32B.Zeroing();
+    const auto OffsetScaled = Offset / 32;
+    ldnt1b(Dst.Z(), GoverningPredicate, MemReg, OffsetScaled);
+  } else if (Is128Bit && HostSupportsSVE128) {
+    const auto GoverningPredicate = PRED_TMP_16B.Zeroing();
+    const auto OffsetScaled = Offset / 16;
+    ldnt1b(Dst.Z(), GoverningPredicate, MemReg, OffsetScaled);
+  } else {
+    // Treat the non-temporal store as a regular vector store in this case for compatibility
+    ldr(Dst.Q(), MemReg, Offset);
+  }
+}
+
 #undef DEF_OP
 } // namespace FEXCore::CPU

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -818,9 +818,14 @@ void OpDispatchBuilder::AVX128_MOVVectorNT(OpcodeArgs) {
 
   if (Op->Dest.IsGPR()) {
     ///< MOVNTDQA load non-temporal comes from SSE4.1 and is extended by AVX/AVX2.
-    auto Src = AVX128_LoadSource_WithOpSize(Op, Op->Src[0], Op->Flags, !Is128Bit, MemoryAccessType::STREAM);
+    RefPair Src {};
+    Ref SrcAddr = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.LoadData = false});
+    Src.Low = _VLoadNonTemporal(OpSize::i128Bit, SrcAddr, 0);
+
     if (Is128Bit) {
       Src.High = LoadZeroVector(OpSize::i128Bit);
+    } else {
+      Src.High = _VLoadNonTemporal(OpSize::i128Bit, SrcAddr, 16);
     }
     AVX128_StoreResult_WithOpSize(Op, Op->Dest, Src);
   } else {

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -694,6 +694,18 @@
           "_Offset % RegisterSize == 0",
           "RegisterSize == FEXCore::IR::OpSize::i128Bit"
         ]
+      },
+      "FPR = VLoadNonTemporal u8:#RegisterSize, GPR:$Addr, i8:$Offset": {
+        "Desc": ["Does a non-temporal memory load of a vector.",
+                 "Matches arm64 SVE ldnt1b semantics.",
+                 "Specifically weak-memory model ordered to match x86 non-temporal stores."
+        ],
+        "HasSideEffects": true,
+        "DestSize": "RegisterSize",
+        "EmitValidation": [
+          "_Offset % RegisterSize == 0",
+          "RegisterSize == FEXCore::IR::OpSize::i128Bit || RegisterSize == FEXCore::IR::OpSize::i256Bit"
+        ]
       }
     },
     "Atomic": {

--- a/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -3982,6 +3982,24 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE load and broadcast element
   TEST_SINGLE(ld1rd(ZReg::z30, PReg::p6.Zeroing(), Reg::r29, 504), "ld1rd {z30.d}, p6/z, [x29, #504]");
 }
 
+TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE contiguous non-temporal load (scalar plus immediate)") {
+  TEST_SINGLE(ldnt1b(ZReg::z31, PReg::p6, Reg::r29, 0), "ldnt1b {z31.b}, p6/z, [x29]");
+  TEST_SINGLE(ldnt1b(ZReg::z31, PReg::p6, Reg::r29, -8), "ldnt1b {z31.b}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ldnt1b(ZReg::z31, PReg::p6, Reg::r29, 7), "ldnt1b {z31.b}, p6/z, [x29, #7, mul vl]");
+
+  TEST_SINGLE(ldnt1h(ZReg::z31, PReg::p6, Reg::r29, 0), "ldnt1h {z31.h}, p6/z, [x29]");
+  TEST_SINGLE(ldnt1h(ZReg::z31, PReg::p6, Reg::r29, -8), "ldnt1h {z31.h}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ldnt1h(ZReg::z31, PReg::p6, Reg::r29, 7), "ldnt1h {z31.h}, p6/z, [x29, #7, mul vl]");
+
+  TEST_SINGLE(ldnt1w(ZReg::z31, PReg::p6, Reg::r29, 0), "ldnt1w {z31.s}, p6/z, [x29]");
+  TEST_SINGLE(ldnt1w(ZReg::z31, PReg::p6, Reg::r29, -8), "ldnt1w {z31.s}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ldnt1w(ZReg::z31, PReg::p6, Reg::r29, 7), "ldnt1w {z31.s}, p6/z, [x29, #7, mul vl]");
+
+  TEST_SINGLE(ldnt1d(ZReg::z31, PReg::p6, Reg::r29, 0), "ldnt1d {z31.d}, p6/z, [x29]");
+  TEST_SINGLE(ldnt1d(ZReg::z31, PReg::p6, Reg::r29, -8), "ldnt1d {z31.d}, p6/z, [x29, #-8, mul vl]");
+  TEST_SINGLE(ldnt1d(ZReg::z31, PReg::p6, Reg::r29, 7), "ldnt1d {z31.d}, p6/z, [x29, #7, mul vl]");
+}
+
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE load multiple structures (scalar plus scalar)") {
   TEST_SINGLE(ld2b(ZReg::z31, ZReg::z0, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld2b {z31.b, z0.b}, p6/z, [x29, x30]");
   TEST_SINGLE(ld2b(ZReg::z26, ZReg::z27, PReg::p6.Zeroing(), Reg::r29, Reg::r30), "ld2b {z26.b, z27.b}, p6/z, [x29, x30]");

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -12,6 +12,28 @@
     ]
   },
   "Instructions": {
+    "vmovntdqa xmm0, [rax]": {
+      "ExpectedInstructionCount": 3,
+      "Comment": [
+        "Map 2 0b01 0x2a 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldnt1b {z16.b}, p6/z, [x4]",
+        "movi v2.2d, #0x0",
+        "str q2, [x28, #16]"
+      ]
+    },
+    "vmovntdqa ymm0, [rax]": {
+      "ExpectedInstructionCount": 3,
+      "Comment": [
+        "Map 2 0b01 0x2a 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldnt1b {z16.b}, p6/z, [x4]",
+        "ldnt1b {z2.b}, p6/z, [x4, #1, mul vl]",
+        "str q2, [x28, #16]"
+      ]
+    },
     "vmaskmovps xmm0, xmm1, [rax]": {
       "ExpectedInstructionCount": 6,
       "Comment": [

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -964,7 +964,7 @@
         "Map 2 0b01 0x2a 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q16, [x4]"
+        "ldnt1b {z16.b}, p6/z, [x4]"
       ]
     },
     "vmovntdqa ymm0, [rax]": {
@@ -973,7 +973,7 @@
         "Map 2 0b01 0x2a 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "ld1b {z16.b}, p7/z, [x4]"
+        "ldnt1b {z16.b}, p7/z, [x4]"
       ]
     },
     "vpackusdw xmm0, xmm1, xmm2": {


### PR DESCRIPTION
Implements support for both SSE4.1 128-bit NT load and AVX 128/256-bit NT loads

Only feature missing is doing a 256-bit load with AVX128 using LDNP for discontiguous registers, but we don't have a sane way to return results in two different vector registers today.

Fixes #3790