### PR TITLE
OpcodeDispatcher: Force noinline for the function call in the Bind helper

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -288,7 +288,7 @@ public:
    */
   template<auto Fn, auto... Args>
   void Bind(OpcodeArgs) {
-    (this->*Fn)(Op, Args...);
+    [[clang::noinline]] (this->*Fn)(Op, Args...);
   };
 
   void UnhandledOp(OpcodeArgs);


### PR DESCRIPTION
Clang was inlining a few of the functions it was calling. So force it never to inline since this is suppose to be a little shim trampoline only.