### PR TITLE
VDSO: Stop using a vector for a static

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -195,7 +195,7 @@ public:
   // returns false if a handler was already registered
   CustomIRResult AddCustomIREntrypoint(uintptr_t Entrypoint, CustomIREntrypointHandler Handler, void* Creator = nullptr, void* Data = nullptr);
 
-  void AppendThunkDefinitions(const fextl::vector<FEXCore::IR::ThunkDefinition>& Definitions) override;
+  void AppendThunkDefinitions(std::span<const FEXCore::IR::ThunkDefinition> Definitions) override;
 
 public:
   friend class FEXCore::HLE::SyscallHandler;

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -1021,7 +1021,7 @@ void ContextImpl::UnloadAOTIRCacheEntry(IR::AOTIRCacheEntry* Entry) {
   IRCaptureCache.UnloadAOTIRCacheEntry(Entry);
 }
 
-void ContextImpl::AppendThunkDefinitions(const fextl::vector<FEXCore::IR::ThunkDefinition>& Definitions) {
+void ContextImpl::AppendThunkDefinitions(std::span<const FEXCore::IR::ThunkDefinition> Definitions) {
   if (ThunkHandler) {
     ThunkHandler->AppendThunkDefinitions(Definitions);
   }

--- a/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -373,7 +373,7 @@ struct ThunkHandler_impl final : public ThunkHandler {
     Thread = _Thread;
   }
 
-  void AppendThunkDefinitions(const fextl::vector<FEXCore::IR::ThunkDefinition>& Definitions) override {
+  void AppendThunkDefinitions(std::span<const FEXCore::IR::ThunkDefinition> Definitions) override {
     for (auto& Definition : Definitions) {
       Thunks.emplace(Definition.Sum, Definition.ThunkFunction);
     }

--- a/FEXCore/Source/Interface/HLE/Thunks/Thunks.h
+++ b/FEXCore/Source/Interface/HLE/Thunks/Thunks.h
@@ -35,6 +35,6 @@ public:
 
   static fextl::unique_ptr<ThunkHandler> Create();
 
-  virtual void AppendThunkDefinitions(const fextl::vector<FEXCore::IR::ThunkDefinition>& Definitions) = 0;
+  virtual void AppendThunkDefinitions(std::span<const FEXCore::IR::ThunkDefinition> Definitions) = 0;
 };
 }; // namespace FEXCore

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -16,6 +16,7 @@
 #include <ostream>
 #include <mutex>
 #include <shared_mutex>
+#include <span>
 
 namespace FEXCore {
 class CodeLoader;
@@ -264,7 +265,7 @@ public:
    * @param CTX A valid non-null context instance.
    * @param Definitions A vector of thunk definitions that the frontend controls
    */
-  FEX_DEFAULT_VISIBILITY virtual void AppendThunkDefinitions(const fextl::vector<FEXCore::IR::ThunkDefinition>& Definitions) = 0;
+  FEX_DEFAULT_VISIBILITY virtual void AppendThunkDefinitions(std::span<const FEXCore::IR::ThunkDefinition> Definitions) = 0;
 
   FEX_DEFAULT_VISIBILITY virtual void GetVDSOSigReturn(VDSOSigReturn* VDSOPointers) = 0;
 

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
@@ -10,6 +10,7 @@
 #include <FEXCore/fextl/fmt.h>
 #include <FEXHeaderUtils/Syscalls.h>
 
+#include <array>
 #include <dlfcn.h>
 #include <elf.h>
 #include <fcntl.h>
@@ -433,7 +434,7 @@ void LoadHostVDSO() {
   dlclose(vdso);
 }
 
-static fextl::vector<FEXCore::IR::ThunkDefinition> VDSODefinitions = {
+static std::array<FEXCore::IR::ThunkDefinition, 6> VDSODefinitions = {{
   {
     // sha256(libVDSO:time)
     {0x37, 0x63, 0x46, 0xb0, 0x79, 0x06, 0x5f, 0x9d, 0x00, 0xb6, 0x8d, 0xfd, 0x9e, 0x4a, 0x62, 0xcd,
@@ -472,7 +473,7 @@ static fextl::vector<FEXCore::IR::ThunkDefinition> VDSODefinitions = {
      0xbb, 0x50, 0x49, 0x55, 0x6b, 0x0c, 0x9f, 0x50, 0x37, 0xf5, 0x9d, 0xb0, 0x38, 0x58, 0x57, 0x12},
     nullptr,
   },
-};
+}};
 
 void LoadGuestVDSOSymbols(bool Is64Bit, char* VDSOBase) {
   // We need to load symbols we care about.
@@ -594,7 +595,7 @@ uint64_t GetVSyscallEntry(const void* VDSOBase) {
   return 0;
 }
 
-const fextl::vector<FEXCore::IR::ThunkDefinition>& GetVDSOThunkDefinitions() {
+const std::span<FEXCore::IR::ThunkDefinition> GetVDSOThunkDefinitions() {
   return VDSODefinitions;
 }
 

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.h
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.h
@@ -15,6 +15,6 @@ void* LoadVDSOThunks(bool Is64Bit, FEX::HLE::SyscallHandler* const Handler);
 
 uint64_t GetVSyscallEntry(const void* VDSOBase);
 
-const fextl::vector<FEXCore::IR::ThunkDefinition>& GetVDSOThunkDefinitions();
+const std::span<FEXCore::IR::ThunkDefinition> GetVDSOThunkDefinitions();
 const FEXCore::Context::VDSOSigReturn& GetVDSOSymbols();
 } // namespace FEX::VDSO


### PR DESCRIPTION
This causes a global initializer that registers an atexit handler.

Be smarter, use an std::array and pass its data around using a span instead.

Removes the global initializer and removes the atexit installation