### PR TITLE
LogManager: Removes fextl::vector usage

### DIFF
--- a/FEXCore/Source/Utils/LogManager.cpp
+++ b/FEXCore/Source/Utils/LogManager.cpp
@@ -8,27 +8,21 @@ $end_info$
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/fextl/fmt.h>
-#include <FEXCore/fextl/vector.h>
-
-#include <cstdarg>
-#include <cstdio>
-#include <malloc.h>
 
 namespace LogMan {
 
 namespace Throw {
-  fextl::vector<ThrowHandler> Handlers;
-  void InstallHandler(ThrowHandler Handler) {
-    Handlers.emplace_back(Handler);
+  ThrowHandler Handler {};
+  void InstallHandler(ThrowHandler _Handler) {
+    Handler = _Handler;
   }
-  void UnInstallHandlers() {
-    Handlers.clear();
+  void UnInstallHandler() {
+    Handler = nullptr;
   }
 
   void MFmt(const char* fmt, const fmt::format_args& args) {
-    auto msg = fextl::fmt::vformat(fmt, args);
-
-    for (auto& Handler : Handlers) {
+    if (Handler) {
+      auto msg = fextl::fmt::vformat(fmt, args);
       Handler(msg.c_str());
     }
 
@@ -37,18 +31,17 @@ namespace Throw {
 } // namespace Throw
 
 namespace Msg {
-  fextl::vector<MsgHandler> Handlers;
-  void InstallHandler(MsgHandler Handler) {
-    Handlers.emplace_back(Handler);
+  MsgHandler Handler {};
+  void InstallHandler(MsgHandler _Handler) {
+    Handler = _Handler;
   }
-  void UnInstallHandlers() {
-    Handlers.clear();
+  void UnInstallHandler() {
+    Handler = nullptr;
   }
 
   void MFmtImpl(DebugLevels level, const char* fmt, const fmt::format_args& args) {
-    const auto msg = fextl::fmt::vformat(fmt, args);
-
-    for (auto& Handler : Handlers) {
+    if (Handler) {
+      const auto msg = fextl::fmt::vformat(fmt, args);
       Handler(level, msg.c_str());
     }
   }

--- a/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -39,7 +39,7 @@ constexpr DebugLevels MSG_LEVEL = INFO;
 namespace Throw {
   using ThrowHandler = void (*)(const char* Message);
   FEX_DEFAULT_VISIBILITY void InstallHandler(ThrowHandler Handler);
-  FEX_DEFAULT_VISIBILITY void UnInstallHandlers();
+  FEX_DEFAULT_VISIBILITY void UnInstallHandler();
 
   [[noreturn]]
   void MFmt(const char* fmt, const fmt::format_args& args);
@@ -90,7 +90,7 @@ namespace Throw {
 namespace Msg {
   using MsgHandler = void (*)(DebugLevels Level, const char* Message);
   FEX_DEFAULT_VISIBILITY void InstallHandler(MsgHandler Handler);
-  FEX_DEFAULT_VISIBILITY void UnInstallHandlers();
+  FEX_DEFAULT_VISIBILITY void UnInstallHandler();
 
   // Fmt-capable interface.
 

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -321,8 +321,8 @@ int main(int argc, char** argv, char** const envp) {
   ::SilentLog = SilentLog();
 
   if (::SilentLog) {
-    LogMan::Throw::UnInstallHandlers();
-    LogMan::Msg::UnInstallHandlers();
+    LogMan::Throw::UnInstallHandler();
+    LogMan::Msg::UnInstallHandler();
   } else {
     auto LogFile = OutputLog();
     // If stderr or stdout then we need to dup the FD
@@ -337,9 +337,6 @@ int main(int argc, char** argv, char** const envp) {
     } else if (LogFile == "stdout") {
       OutputFD = dup(STDOUT_FILENO);
     } else if (LogFile == "server") {
-      LogMan::Throw::UnInstallHandlers();
-      LogMan::Msg::UnInstallHandlers();
-
       FEXServerLogging::FEXServerFD = FEXServerClient::RequestLogFD(FEXServerClient::GetServerFD());
       if (FEXServerLogging::FEXServerFD != -1) {
         LogMan::Throw::InstallHandler(FEXServerLogging::AssertHandler);
@@ -597,8 +594,8 @@ int main(int argc, char** argv, char** const envp) {
 
   FEXCore::Config::Shutdown();
 
-  LogMan::Throw::UnInstallHandlers();
-  LogMan::Msg::UnInstallHandlers();
+  LogMan::Throw::UnInstallHandler();
+  LogMan::Msg::UnInstallHandler();
 
   FEXCore::Allocator::ClearHooks();
   FEXCore::Allocator::ReclaimMemoryRegion(Base48Bit);

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -361,8 +361,8 @@ int main(int argc, char** argv, char** const envp) {
 
   FEXCore::Config::Shutdown();
 
-  LogMan::Throw::UnInstallHandlers();
-  LogMan::Msg::UnInstallHandlers();
+  LogMan::Throw::UnInstallHandler();
+  LogMan::Msg::UnInstallHandler();
 
 #ifndef _WIN32
   FEXCore::Allocator::ClearHooks();


### PR DESCRIPTION
We never use more than one logging method at a time so this was overengineered for what it is doing.

Instead only allow one handler for messages and throw messages each which just is a pointer.

Removes a global initializer and an atexit handler being installed