### PR TITLE
Ioctl32: Removes static fextl::vector in ioctlemulation

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/IoctlEmulation.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/IoctlEmulation.h
@@ -7,7 +7,6 @@ struct CpuStateFrame;
 }
 
 namespace FEX::HLE::x32 {
-void InitializeStaticIoctlHandlers();
 uint32_t ioctl32(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t request, uint32_t args);
 void CheckAndAddFDDuplication(int fd, int NewFD);
 } // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.cpp
@@ -96,8 +96,6 @@ void x32SyscallHandler::RegisterSyscallHandlers() {
   FEX::HLE::x32::RegisterTimer(this);
   FEX::HLE::x32::RegisterPassthrough(this);
 
-  FEX::HLE::x32::InitializeStaticIoctlHandlers();
-
 #if PRINT_MISSING_SYSCALLS
   for (auto& Syscall : SyscallNames) {
     if (Definitions[Syscall.first].Ptr == cvt(&UnimplementedSyscall)) {


### PR DESCRIPTION
Removes a global static initializer for the vector and its atexit handler.

This handler array can be consteval similar to the x86 tables so it can be generated entirely at compile time.