### PR TITLE
Threads: Setup the stack tracker to not need global initialization

### DIFF
--- a/FEXCore/include/FEXCore/Utils/Threads.h
+++ b/FEXCore/include/FEXCore/Utils/Threads.h
@@ -2,14 +2,12 @@
 #pragma once
 #include <FEXCore/fextl/memory.h>
 
-#include <functional>
-
 namespace FEXCore::Threads {
 using ThreadFunc = void* (*)(void* user_ptr);
 
 class Thread;
-using CreateThreadFunc = std::function<fextl::unique_ptr<Thread>(ThreadFunc Func, void* Arg)>;
-using CleanupAfterForkFunc = std::function<void()>;
+using CreateThreadFunc = fextl::unique_ptr<Thread> (*)(ThreadFunc Func, void* Arg);
+using CleanupAfterForkFunc = void (*)();
 
 struct Pointers {
   CreateThreadFunc CreateThread;

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -415,7 +415,7 @@ int main(int argc, char** argv, char** const envp) {
   }
 
   // Setup Thread handlers, so FEXCore can create threads.
-  FEX::LinuxEmulation::Threads::SetupThreadHandlers();
+  auto StackTracker = FEX::LinuxEmulation::Threads::SetupThreadHandlers();
 
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
 
@@ -588,7 +588,7 @@ int main(int argc, char** argv, char** const envp) {
   SyscallHandler.reset();
   SignalDelegation.reset();
 
-  FEX::LinuxEmulation::Threads::Shutdown();
+  FEX::LinuxEmulation::Threads::Shutdown(std::move(StackTracker));
 
   Loader.FreeSections();
 


### PR DESCRIPTION
Also removes the atexit handler installation
This now gets tracked by an object owned by FEXLoader (and shared with the pthreads interface)