### PR TITLE
Telemetry: Change how visibility of telemetry values work

### DIFF
--- a/FEXCore/Source/Utils/Telemetry.cpp
+++ b/FEXCore/Source/Utils/Telemetry.cpp
@@ -16,7 +16,7 @@
 
 namespace FEXCore::Telemetry {
 #ifndef FEX_DISABLE_TELEMETRY
-static std::array<Value, FEXCore::Telemetry::TelemetryType::TYPE_LAST> TelemetryValues = {{}};
+std::array<Value, FEXCore::Telemetry::TelemetryType::TYPE_LAST> TelemetryValues = {{}};
 const std::array<std::string_view, FEXCore::Telemetry::TelemetryType::TYPE_LAST> TelemetryNames {
   "64byte Split Locks",
   "16byte Split atomics",
@@ -80,8 +80,5 @@ void Shutdown(const fextl::string& ApplicationName) {
   }
 }
 
-Value& GetTelemetryValue(TelemetryType Type) {
-  return TelemetryValues.at(Type);
-}
 #endif
 } // namespace FEXCore::Telemetry

--- a/FEXCore/include/FEXCore/Utils/Telemetry.h
+++ b/FEXCore/include/FEXCore/Utils/Telemetry.h
@@ -4,10 +4,9 @@
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/fextl/string.h>
 
+#include <array>
 #include <atomic>
 #include <stdint.h>
-#include <type_traits>
-#include <filesystem>
 
 namespace FEXCore::Telemetry {
 enum TelemetryType {
@@ -64,7 +63,10 @@ private:
   std::atomic<uint64_t> Data;
 };
 
-FEX_DEFAULT_VISIBILITY Value& GetTelemetryValue(TelemetryType Type);
+FEX_DEFAULT_VISIBILITY extern std::array<Value, FEXCore::Telemetry::TelemetryType::TYPE_LAST> TelemetryValues;
+inline Value& GetTelemetryValue(TelemetryType Type) {
+  return FEXCore::Telemetry::TelemetryValues[Type];
+}
 
 FEX_DEFAULT_VISIBILITY void Initialize();
 FEX_DEFAULT_VISIBILITY void Shutdown(const fextl::string& ApplicationName);


### PR DESCRIPTION
Removes global initializer for telemetry values since their address is visible and PIC relative code loading handles the address fetching for us.