### PR TITLE
ArgumentLoader: Removes static fextl::vector usage

### DIFF
--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -11,13 +11,16 @@
 #include <stdint.h>
 
 namespace FEX::ArgLoader {
-fextl::vector<fextl::string> RemainingArgs;
-fextl::vector<fextl::string> ProgramArguments;
-
-static fextl::string Version = "FEX-Emu (" GIT_DESCRIBE_STRING ") ";
 void FEX::ArgLoader::ArgLoader::Load() {
+  RemainingArgs.clear();
+  ProgramArguments.clear();
+  if (Type == LoadType::WITHOUT_FEXLOADER_PARSER) {
+    LoadWithoutArguments();
+    return;
+  }
+
   optparse::OptionParser Parser {};
-  Parser.version(Version);
+  Parser.version("FEX-Emu (" GIT_DESCRIBE_STRING ") ");
   optparse::OptionGroup CPUGroup(Parser, "CPU Core options");
   optparse::OptionGroup EmulationGroup(Parser, "Emulation options");
   optparse::OptionGroup DebugGroup(Parser, "Debug options");
@@ -45,21 +48,14 @@ void FEX::ArgLoader::ArgLoader::Load() {
   ProgramArguments = Parser.parsed_args();
 }
 
-void LoadWithoutArguments(int _argc, char** _argv) {
+void FEX::ArgLoader::ArgLoader::LoadWithoutArguments() {
   // Skip argument 0, which will be the interpreter
-  for (int i = 1; i < _argc; ++i) {
-    RemainingArgs.emplace_back(_argv[i]);
+  for (int i = 1; i < argc; ++i) {
+    RemainingArgs.emplace_back(argv[i]);
   }
 
   // Put the interpreter in ProgramArguments
-  ProgramArguments.emplace_back(_argv[0]);
-}
-
-fextl::vector<fextl::string> Get() {
-  return RemainingArgs;
-}
-fextl::vector<fextl::string> GetParsedArgs() {
-  return ProgramArguments;
+  ProgramArguments.emplace_back(argv[0]);
 }
 
 } // namespace FEX::ArgLoader

--- a/Source/Common/ArgumentLoader.h
+++ b/Source/Common/ArgumentLoader.h
@@ -8,19 +8,39 @@
 namespace FEX::ArgLoader {
 class ArgLoader final : public FEXCore::Config::Layer {
 public:
-  explicit ArgLoader(int _argc, char** _argv)
-    : FEXCore::Config::Layer(FEXCore::Config::LayerType::LAYER_ARGUMENTS)
-    , argc {_argc}
-    , argv {_argv} {}
+  enum class LoadType {
+    WITH_FEXLOADER_PARSER,
+    WITHOUT_FEXLOADER_PARSER,
+  };
 
-  void Load();
+  explicit ArgLoader(LoadType Type, int argc, char** argv)
+    : FEXCore::Config::Layer(FEXCore::Config::LayerType::LAYER_ARGUMENTS)
+    , Type {Type}
+    , argc {argc}
+    , argv {argv} {
+    Load();
+  }
+
+  void Load() override;
+  void LoadWithoutArguments();
+  fextl::vector<fextl::string> Get() {
+    return RemainingArgs;
+  }
+  fextl::vector<fextl::string> GetParsedArgs() {
+    return ProgramArguments;
+  }
+
+  LoadType GetLoadType() const {
+    return Type;
+  }
 
 private:
+  LoadType Type;
   int argc {};
-  char** argv;
+  char** argv {};
+
+  fextl::vector<fextl::string> RemainingArgs {};
+  fextl::vector<fextl::string> ProgramArguments {};
 };
 
-void LoadWithoutArguments(int _argc, char** _argv);
-fextl::vector<fextl::string> Get();
-fextl::vector<fextl::string> GetParsedArgs();
 } // namespace FEX::ArgLoader

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -3,6 +3,9 @@
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/fextl/string.h>
 
+namespace FEX::ArgLoader {
+class ArgLoader;
+}
 /**
  * @brief This is a singleton for storing global configuration state
  */
@@ -28,18 +31,16 @@ struct ApplicationNames {
 /**
  * @brief Loads the FEX and application configurations for the application that is getting ready to run.
  *
- * @param NoFEXArguments Do we want to parse FEXLoader arguments, Or is this FEXInterpreter?
+ * @param ArgLoader Argument loader for argument based config options
  * @param LoadProgramConfig Do we want to load application specific configurations?
- * @param argc The `argc` passed to main(...)
- * @param argv The `argv` passed to main(...)
  * @param envp The `envp` passed to main(...)
  * @param ExecFDInterp If FEX was executed with binfmt_misc FD argument
  * @param ProgramFDFromEnv The execveat FD argument passed through FEX
  *
  * @return The application name and path structure
  */
-ApplicationNames
-LoadConfig(bool NoFEXArguments, bool LoadProgramConfig, int argc, char** argv, char** const envp, bool ExecFDInterp, int ProgramFDFromEnv);
+ApplicationNames LoadConfig(fextl::unique_ptr<FEX::ArgLoader::ArgLoader> ArgLoader, bool LoadProgramConfig, char** const envp,
+                            bool ExecFDInterp, int ProgramFDFromEnv);
 
 const char* GetHomeDirectory();
 

--- a/Source/Tools/FEXBash/FEXBash.cpp
+++ b/Source/Tools/FEXBash/FEXBash.cpp
@@ -27,14 +27,14 @@ int main(int argc, char** argv, char** const envp) {
   FEXCore::Config::Initialize();
   FEXCore::Config::AddLayer(FEX::Config::CreateGlobalMainLayer());
   FEXCore::Config::AddLayer(FEX::Config::CreateMainLayer());
-  FEX::ArgLoader::LoadWithoutArguments(argc, argv);
+  FEX::ArgLoader::ArgLoader ArgsLoader(FEX::ArgLoader::ArgLoader::LoadType::WITHOUT_FEXLOADER_PARSER, argc, argv);
   FEXCore::Config::AddLayer(FEX::Config::CreateEnvironmentLayer(envp));
   FEXCore::Config::Load();
 
   // Reload the meta layer
   FEXCore::Config::ReloadMetaLayer();
 
-  auto Args = FEX::ArgLoader::Get();
+  auto Args = ArgsLoader.Get();
 
   // Ensure FEXServer is setup before config options try to pull CONFIG_ROOTFS
   if (!FEXServerClient::SetupClient(argv[0])) {

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -274,15 +274,17 @@ int main(int argc, char** argv, char** const envp) {
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);
 
-  auto Program = FEX::Config::LoadConfig(IsInterpreter, true, argc, argv, envp, ExecutedWithFD, FEXFD);
+  auto ArgsLoader = fextl::make_unique<FEX::ArgLoader::ArgLoader>(
+    IsInterpreter ? FEX::ArgLoader::ArgLoader::LoadType::WITHOUT_FEXLOADER_PARSER : FEX::ArgLoader::ArgLoader::LoadType::WITH_FEXLOADER_PARSER,
+    argc, argv);
+  auto Args = ArgsLoader->Get();
+  auto ParsedArgs = ArgsLoader->GetParsedArgs();
+  auto Program = FEX::Config::LoadConfig(std::move(ArgsLoader), true, envp, ExecutedWithFD, FEXFD);
 
   if (Program.ProgramPath.empty() && FEXFD == -1) {
     // Early exit if we weren't passed an argument
     return 0;
   }
-
-  auto Args = FEX::ArgLoader::Get();
-  auto ParsedArgs = FEX::ArgLoader::GetParsedArgs();
 
   // Reload the meta layer
   FEXCore::Config::ReloadMetaLayer();

--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -1069,7 +1069,9 @@ bool ExtractEroFS(const fextl::string& Path, const fextl::string& RootFS, const 
 
 int main(int argc, char** argv, char** const envp) {
   CheckTTY();
-  FEX::Config::LoadConfig(true, false, argc, argv, envp, false, {});
+
+  auto ArgsLoader = fextl::make_unique<FEX::ArgLoader::ArgLoader>(FEX::ArgLoader::ArgLoader::LoadType::WITHOUT_FEXLOADER_PARSER, argc, argv);
+  FEX::Config::LoadConfig(std::move(ArgsLoader), false, envp, false, {});
 
   // Reload the meta layer
   FEXCore::Config::ReloadMetaLayer();

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -4,6 +4,7 @@
 #include "PipeScanner.h"
 #include "ProcessPipe.h"
 #include "SquashFS.h"
+#include "Common/ArgumentLoader.h"
 #include "Common/Config.h"
 #include "Common/FEXServerClient.h"
 
@@ -115,7 +116,8 @@ int main(int argc, char** argv, char** const envp) {
     DeparentSelf();
   }
 
-  FEX::Config::LoadConfig(true, false, argc, argv, envp, false, {});
+  auto ArgsLoader = fextl::make_unique<FEX::ArgLoader::ArgLoader>(FEX::ArgLoader::ArgLoader::LoadType::WITHOUT_FEXLOADER_PARSER, argc, argv);
+  FEX::Config::LoadConfig(std::move(ArgsLoader), false, envp, false, {});
 
   // Reload the meta layer
   FEXCore::Config::ReloadMetaLayer();

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -193,11 +193,12 @@ int main(int argc, char** argv, char** const envp) {
 
   FEX::Config::InitializeConfigs();
   FEXCore::Config::Initialize();
-  FEXCore::Config::AddLayer(fextl::make_unique<FEX::ArgLoader::ArgLoader>(argc, argv));
+  auto ArgsLoader = fextl::make_unique<FEX::ArgLoader::ArgLoader>(FEX::ArgLoader::ArgLoader::LoadType::WITH_FEXLOADER_PARSER, argc, argv);
+  auto Args = ArgsLoader->Get();
+  FEXCore::Config::AddLayer(std::move(ArgsLoader));
   FEXCore::Config::AddLayer(FEX::Config::CreateEnvironmentLayer(envp));
   FEXCore::Config::Load();
 
-  auto Args = FEX::ArgLoader::Get();
 
   if (Args.size() < 2) {
     LogMan::Msg::EFmt("Not enough arguments");


### PR DESCRIPTION
Removes a global initializer and atexit registration

Ownership of this data has always been the frontend and the config system, we just used these static vectors as a side-channel.