### PR TITLE
ARM64EC frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(FEX)
+project(FEX C CXX ASM)
 
 INCLUDE (CheckIncludeFiles)
 CHECK_INCLUDE_FILES ("gdb/jit-reader.h" HAVE_GDB_JIT_READER_H)

--- a/Source/Windows/ARM64EC/BTInterface.h
+++ b/Source/Windows/ARM64EC/BTInterface.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <windef.h>
+#include <ntstatus.h>
+#include <winternl.h>
+
+extern "C" {
+void STDMETHODCALLTYPE ProcessInit();
+void STDMETHODCALLTYPE ProcessTerm();
+NTSTATUS STDMETHODCALLTYPE ThreadInit();
+NTSTATUS STDMETHODCALLTYPE ThreadTerm(HANDLE Thread);
+NTSTATUS STDMETHODCALLTYPE ResetToConsistentState(EXCEPTION_POINTERS* Ptrs, ARM64_NT_CONTEXT* Context, BOOLEAN* Continue);
+void STDMETHODCALLTYPE BTCpu64FlushInstructionCache(const void* Address, SIZE_T Size);
+void STDMETHODCALLTYPE NotifyMemoryAlloc(void* Address, SIZE_T Size, ULONG Type, ULONG Prot);
+void STDMETHODCALLTYPE NotifyMemoryFree(void* Address, SIZE_T Size, ULONG FreeType);
+void STDMETHODCALLTYPE NotifyMemoryProtect(void* Address, SIZE_T Size, ULONG NewProt);
+void STDMETHODCALLTYPE NotifyUnmapViewOfSection(void* Address);
+BOOLEAN STDMETHODCALLTYPE BTCpu64IsProcessorFeaturePresent(UINT Feature);
+void STDMETHODCALLTYPE UpdateProcessorInformation(SYSTEM_CPU_INFORMATION* Info);
+}

--- a/Source/Windows/ARM64EC/CMakeLists.txt
+++ b/Source/Windows/ARM64EC/CMakeLists.txt
@@ -1,0 +1,28 @@
+add_library(arm64ecfex SHARED
+  Module.cpp
+  Module.S
+  libarm64ecfex.def
+)
+patch_library_wine(arm64ecfex)
+
+target_include_directories(arm64ecfex PRIVATE
+  "${CMAKE_SOURCE_DIR}/Source/Windows/include/"
+  "${CMAKE_SOURCE_DIR}/Source/"
+  "${CMAKE_SOURCE_DIR}/Source/Windows/"
+)
+
+target_link_libraries(arm64ecfex
+  PRIVATE
+  FEXCore
+  FEXCore_Base
+  Common
+  CommonTools
+  CommonWindows
+  ntdll_ex
+  ntdll
+)
+
+install(TARGETS arm64ecfex
+  RUNTIME
+  DESTINATION lib
+  COMPONENT runtime)

--- a/Source/Windows/ARM64EC/Module.S
+++ b/Source/Windows/ARM64EC/Module.S
@@ -37,6 +37,15 @@ enter_jit:
   ldr x16, [x17, #0x40] // ChpeV2CpuAreaInfo->EmulatorData[2] - DispatcherLoopTopEnterEC
   br x16 // DispatcherLoopTopEnterEC(RIP:x9, CPUArea:x17)
 
+  // Invoked by KiUserEmulationDispatcher after e.g. an NtContinue to x86 code
+  // Expects a CONTEXT pointer in x0
+.global BeginSimulation
+BeginSimulation:
+  bl "#SyncThreadContext"
+  ldr x17, [x18, #0x1788] // TEB->ChpeV2CpuAreaInfo
+  ldr x16, [x17, #0x48] // ChpeV2CpuAreaInfo->EmulatorData[3] - DispatcherLoopTopEnterECFillSRA
+  br x16 // DispatcherLoopTopEnterECFillSRA(CPUArea:x17)
+
   // Called into by FEXCore
   // Expects the target code address in x9
 .global ExitFunctionEC

--- a/Source/Windows/ARM64EC/Module.S
+++ b/Source/Windows/ARM64EC/Module.S
@@ -1,0 +1,62 @@
+.text
+.balign 16
+
+  // __os_arm64x_x64_jump in ARM64EC docs
+  // Expects target code address in x9
+.globl DispatchJump
+DispatchJump:
+  str lr, [sp, #-8]! // Push return address to stack, this will be popped by the x86 RET instr.
+  b check_target_ec
+
+  // __os_arm64x_dispatch_ret in ARM64EC docs
+  // Expects target code address in lr
+.globl RetToEntryThunk
+RetToEntryThunk:
+  mov x9, lr
+
+check_target_ec:
+  // Check if target is in fact x86 code
+  ldr x16, [x18, #0x60] // TEB->PEB
+  ldr x16, [x16, #0x368] // PEB->EcCodeBitMap
+  lsr x17, x9, #15
+  and x17, x17, #0x1fffffffffff8
+  ldr x16, [x16, x17]
+  lsr x17, x9, #12
+  lsr x16, x16, x17
+  tbnz x16, #0, ExitFunctionEC
+  b enter_jit
+
+  // __os_arm64x_dispatch_call_no_redirect in ARM64EC docs
+  // Expects target code address in x9, and to be called using a 'blr x16' instruction.
+.globl ExitToX64
+ExitToX64:
+  str lr, [sp, #-8]! // Push return address to stack, this will be popped by the x86 RET instr.
+
+enter_jit:
+  ldr x17, [x18, #0x1788] // TEB->ChpeV2CpuAreaInfo
+  ldr x16, [x17, #0x40] // ChpeV2CpuAreaInfo->EmulatorData[2] - DispatcherLoopTopEnterEC
+  br x16 // DispatcherLoopTopEnterEC(RIP:x9, CPUArea:x17)
+
+  // Called into by FEXCore
+  // Expects the target code address in x9
+.global ExitFunctionEC
+ExitFunctionEC:
+  // Either return to an exit thunk (return to ARM64EC function) or call an entry thunk (call to ARM64EC function).
+  // It is assumed that a 'blr x16' instruction is only ever used to call into x86 code from an exit thunk, and that all
+  // exported ARM64EC functions have a 4-byte offset to their entry thunk immediately before their first instruction.
+  mov x17, x9
+  mov w16, #0x200
+  movk w16, #0xd63f, lsl 16 // blr x16
+  ldursw x23, [x17, #-0x4] // Load either the entry thunk offset or the calling instruction.
+  cmp w23, w16
+  beq ret_sp_aligned
+
+  and x23, x23, #-0x4
+  add x17, x17, x23 // Resolve entry thunk address.
+
+  mov x4, sp
+  ldr lr, [x4], #0x8 // Pop the return address into lr.
+  mov sp, x4
+
+ret_sp_aligned:
+  br x17

--- a/Source/Windows/ARM64EC/Module.S
+++ b/Source/Windows/ARM64EC/Module.S
@@ -55,8 +55,17 @@ ExitFunctionEC:
   add x17, x17, x23 // Resolve entry thunk address.
 
   mov x4, sp
+  tbz x4, #3, ret_sp_misaligned
   ldr lr, [x4], #0x8 // Pop the return address into lr.
   mov sp, x4
 
 ret_sp_aligned:
+  br x17
+
+ret_sp_misaligned:
+  // In the case of the x64 caller leaving sp only 8-byte aligned, leave the return address on the stack to keep 16-byte
+  // alignment and have the callee return to an x86 ret instruction. FEX can then return to the actual caller keeping
+  // the misaligned RSP.
+  adrp lr, X64ReturnInstr
+  ldr lr, [lr, #:lo12:X64ReturnInstr]
   br x17

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -43,6 +43,7 @@ $end_info$
 #include <wine/debug.h>
 
 class ECSyscallHandler;
+void* X64ReturnInstr; // See Module.S
 extern void* ExitFunctionEC;
 
 struct ThreadCPUArea {
@@ -166,6 +167,9 @@ void ProcessInit() {
   CTX->InitCore();
   InvalidationTracker.emplace(*CTX, Threads);
   CPUFeatures.emplace(*CTX);
+
+  X64ReturnInstr = ::VirtualAlloc(nullptr, FEXCore::Utils::FEX_PAGE_SIZE, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+  *reinterpret_cast<uint8_t*>(X64ReturnInstr) = 0xc3;
 }
 
 void ProcessTerm() {}

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: MIT
+/*
+$info$
+tags: Bin|ARM64EC
+desc: Implements the ARM64EC BT module API using FEXCore
+$end_info$
+*/
+
+#include <FEXCore/fextl/fmt.h>
+#include <FEXCore/Core/X86Enums.h>
+#include <FEXCore/Core/SignalDelegator.h>
+#include <FEXCore/Core/Context.h>
+#include <FEXCore/Core/CoreState.h>
+#include <FEXCore/Debug/InternalThreadState.h>
+#include <FEXCore/HLE/SyscallHandler.h>
+#include <FEXCore/Config/Config.h>
+#include <FEXCore/Utils/Allocator.h>
+#include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/Threads.h>
+#include <FEXCore/Utils/EnumOperators.h>
+#include <FEXCore/Utils/EnumUtils.h>
+#include <FEXCore/Utils/FPState.h>
+#include <FEXCore/Utils/ArchHelpers/Arm64.h>
+#include <FEXCore/Utils/MathUtils.h>
+#include <FEXCore/Utils/TypeDefines.h>
+
+#include "Common/Config.h"
+#include "Common/InvalidationTracker.h"
+#include "Common/CPUFeatures.h"
+#include "DummyHandlers.h"
+#include "BTInterface.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <type_traits>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+#include <ntstatus.h>
+#include <windef.h>
+#include <winternl.h>
+#include <wine/debug.h>
+
+class ECSyscallHandler;
+extern void* ExitFunctionEC;
+
+struct ThreadCPUArea {
+  static constexpr size_t TEBCPUAreaOffset = 0x1788;
+  CHPE_V2_CPU_AREA_INFO* Area;
+
+  explicit ThreadCPUArea(_TEB* TEB)
+    : Area(*reinterpret_cast<CHPE_V2_CPU_AREA_INFO**>(reinterpret_cast<uintptr_t>(TEB) + TEBCPUAreaOffset)) {}
+
+  uint64_t EmulatorStackLimit() const {
+    return Area->EmulatorStackLimit;
+  }
+
+  uint64_t EmulatorStackBase() const {
+    return Area->EmulatorStackBase;
+  }
+
+  FEXCore::Core::CpuStateFrame*& StateFrame() const {
+    return reinterpret_cast<FEXCore::Core::CpuStateFrame*&>(Area->EmulatorData[0]);
+  }
+
+  FEXCore::Core::InternalThreadState*& ThreadState() const {
+    return reinterpret_cast<FEXCore::Core::InternalThreadState*&>(Area->EmulatorData[1]);
+  }
+
+  uint64_t& DispatcherLoopTopEnterEC() const {
+    return reinterpret_cast<uint64_t&>(Area->EmulatorData[2]);
+  }
+
+  uint64_t& DispatcherLoopTopEnterECFillSRA() const {
+    return reinterpret_cast<uint64_t&>(Area->EmulatorData[3]);
+  }
+};
+
+namespace {
+fextl::unique_ptr<FEXCore::Context::Context> CTX;
+fextl::unique_ptr<FEX::DummyHandlers::DummySignalDelegator> SignalDelegator;
+fextl::unique_ptr<ECSyscallHandler> SyscallHandler;
+std::optional<FEX::Windows::InvalidationTracker> InvalidationTracker;
+std::optional<FEX::Windows::CPUFeatures> CPUFeatures;
+
+std::recursive_mutex ThreadCreationMutex;
+// Map of TIDs to their FEX thread state, `ThreadCreationMutex` must be locked when accessing
+std::unordered_map<DWORD, FEXCore::Core::InternalThreadState*> Threads;
+
+
+std::pair<NTSTATUS, ThreadCPUArea> GetThreadCPUArea(HANDLE Thread) {
+  THREAD_BASIC_INFORMATION Info;
+  const NTSTATUS Err = NtQueryInformationThread(Thread, ThreadBasicInformation, &Info, sizeof(Info), nullptr);
+  return {Err, ThreadCPUArea(reinterpret_cast<_TEB*>(Info.TebBaseAddress))};
+}
+
+ThreadCPUArea GetCPUArea() {
+  return ThreadCPUArea(NtCurrentTeb());
+}
+
+} // namespace
+
+namespace Logging {
+static void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
+  const auto Output = fextl::fmt::format("[{}][{:X}] {}\n", LogMan::DebugLevelStr(Level), GetCurrentThreadId(), Message);
+  __wine_dbg_output(Output.c_str());
+}
+
+static void AssertHandler(const char* Message) {
+  const auto Output = fextl::fmt::format("[ASSERT] {}\n", Message);
+  __wine_dbg_output(Output.c_str());
+}
+
+static void Init() {
+  LogMan::Throw::InstallHandler(AssertHandler);
+  LogMan::Msg::InstallHandler(MsgHandler);
+}
+} // namespace Logging
+
+class ECSyscallHandler : public FEXCore::HLE::SyscallHandler, public FEXCore::Allocator::FEXAllocOperators {
+public:
+  ECSyscallHandler() {
+    OSABI = FEXCore::HLE::SyscallOSABI::OS_WIN32;
+  }
+
+  uint64_t HandleSyscall(FEXCore::Core::CpuStateFrame* Frame, FEXCore::HLE::SyscallArguments* Args) override {
+    return 0;
+  }
+
+  FEXCore::HLE::SyscallABI GetSyscallABI(uint64_t Syscall) override {
+    return {.NumArgs = 0, .HasReturn = false, .HostSyscallNumber = -1};
+  }
+
+  FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestAddr) override {
+    return {0, 0};
+  }
+
+  void MarkGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) override {
+    InvalidationTracker->ReprotectRWXIntervals(Start, Length);
+  }
+};
+
+void ProcessInit() {
+  Logging::Init();
+  FEX::Config::InitializeConfigs();
+  FEXCore::Config::Initialize();
+  FEXCore::Config::AddLayer(FEX::Config::CreateGlobalMainLayer());
+  FEXCore::Config::AddLayer(FEX::Config::CreateMainLayer());
+  FEXCore::Config::Load();
+  FEXCore::Config::ReloadMetaLayer();
+
+  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS64BIT_MODE, "1");
+
+  // Not applicable to Windows
+  FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
+
+  FEXCore::Context::InitializeStaticTables(FEXCore::Context::MODE_64BIT);
+
+  SignalDelegator = fextl::make_unique<FEX::DummyHandlers::DummySignalDelegator>();
+  SyscallHandler = fextl::make_unique<ECSyscallHandler>();
+
+  CTX = FEXCore::Context::Context::CreateNewContext();
+  CTX->SetSignalDelegator(SignalDelegator.get());
+  CTX->SetSyscallHandler(SyscallHandler.get());
+  CTX->InitCore();
+  InvalidationTracker.emplace(*CTX, Threads);
+  CPUFeatures.emplace(*CTX);
+}
+
+void ProcessTerm() {}
+
+void NotifyMemoryAlloc(void* Address, SIZE_T Size, ULONG Type, ULONG Prot) {
+  if (!InvalidationTracker || !GetCPUArea().ThreadState()) {
+    return;
+  }
+
+  std::scoped_lock Lock(ThreadCreationMutex);
+  InvalidationTracker->HandleMemoryProtectionNotification(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), Prot);
+}
+
+void NotifyMemoryFree(void* Address, SIZE_T Size, ULONG FreeType) {
+  if (!InvalidationTracker || !GetCPUArea().ThreadState()) {
+    return;
+  }
+
+  std::scoped_lock Lock(ThreadCreationMutex);
+  if (!Size) {
+    InvalidationTracker->InvalidateContainingSection(reinterpret_cast<uint64_t>(Address), true);
+  } else if (FreeType & MEM_DECOMMIT) {
+    InvalidationTracker->InvalidateAlignedInterval(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), true);
+  }
+}
+
+void NotifyMemoryProtect(void* Address, SIZE_T Size, ULONG NewProt) {
+  if (!InvalidationTracker || !GetCPUArea().ThreadState()) {
+    return;
+  }
+
+  std::scoped_lock Lock(ThreadCreationMutex);
+  InvalidationTracker->HandleMemoryProtectionNotification(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), NewProt);
+}
+
+void NotifyUnmapViewOfSection(void* Address) {
+  if (!InvalidationTracker || !GetCPUArea().ThreadState()) {
+    return;
+  }
+
+  std::scoped_lock Lock(ThreadCreationMutex);
+  InvalidationTracker->InvalidateContainingSection(reinterpret_cast<uint64_t>(Address), true);
+}
+
+void BTCpu64FlushInstructionCache(const void* Address, SIZE_T Size) {
+  if (!InvalidationTracker || !GetCPUArea().ThreadState()) {
+    return;
+  }
+
+  std::scoped_lock Lock(ThreadCreationMutex);
+  InvalidationTracker->InvalidateAlignedInterval(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), false);
+}
+
+NTSTATUS ThreadInit() {
+  const auto CPUArea = GetCPUArea();
+
+  auto* Thread = CTX->CreateThread(0, 0);
+  Thread->CurrentFrame->Pointers.Common.ExitFunctionEC = reinterpret_cast<uintptr_t>(&ExitFunctionEC);
+  CPUArea.StateFrame() = Thread->CurrentFrame;
+
+  uint64_t EnterEC = Thread->CurrentFrame->Pointers.Common.DispatcherLoopTopEnterEC;
+  CPUArea.DispatcherLoopTopEnterEC() = EnterEC;
+
+  uint64_t EnterECFillSRA = Thread->CurrentFrame->Pointers.Common.DispatcherLoopTopEnterECFillSRA;
+  CPUArea.DispatcherLoopTopEnterECFillSRA() = EnterECFillSRA;
+
+  {
+    std::scoped_lock Lock(ThreadCreationMutex);
+    Threads.emplace(GetCurrentThreadId(), Thread);
+  }
+
+  CPUArea.ThreadState() = Thread;
+  return STATUS_SUCCESS;
+}
+
+NTSTATUS ThreadTerm(HANDLE Thread) {
+  const auto [Err, CPUArea] = GetThreadCPUArea(Thread);
+  if (Err) {
+    return Err;
+  }
+  auto* OldThreadState = CPUArea.ThreadState();
+  CPUArea.ThreadState() = nullptr;
+
+  {
+    THREAD_BASIC_INFORMATION Info;
+    if (NTSTATUS Err = NtQueryInformationThread(Thread, ThreadBasicInformation, &Info, sizeof(Info), nullptr); Err) {
+      return Err;
+    }
+
+    const auto ThreadTID = reinterpret_cast<uint64_t>(Info.ClientId.UniqueThread);
+    std::scoped_lock Lock(ThreadCreationMutex);
+    Threads.erase(ThreadTID);
+  }
+
+  CTX->DestroyThread(OldThreadState);
+  return STATUS_SUCCESS;
+}
+
+BOOLEAN BTCpu64IsProcessorFeaturePresent(UINT Feature) {
+  return CPUFeatures->IsFeaturePresent(Feature) ? TRUE : FALSE;
+}
+
+void UpdateProcessorInformation(SYSTEM_CPU_INFORMATION* Info) {
+  CPUFeatures->UpdateInformation(Info);
+}

--- a/Source/Windows/ARM64EC/libarm64ecfex.def
+++ b/Source/Windows/ARM64EC/libarm64ecfex.def
@@ -1,0 +1,21 @@
+LIBRARY libarm64ecfex.dll
+
+EXPORTS
+  BTCpu64FlushInstructionCache
+  BTCpu64IsProcessorFeaturePresent
+  DispatchJump DATA
+  RetToEntryThunk DATA
+  ExitToX64 DATA
+  BeginSimulation DATA
+;  FlushInstructionCacheHeavy
+;  NotifyMapViewOfSection
+  NotifyMemoryAlloc
+  NotifyMemoryFree
+  NotifyMemoryProtect
+  NotifyUnmapViewOfSection
+  ProcessInit
+  ProcessTerm
+;  ResetToConsistentState
+  ThreadInit
+  ThreadTerm
+  UpdateProcessorInformation

--- a/Source/Windows/ARM64EC/libarm64ecfex.def
+++ b/Source/Windows/ARM64EC/libarm64ecfex.def
@@ -15,7 +15,7 @@ EXPORTS
   NotifyUnmapViewOfSection
   ProcessInit
   ProcessTerm
-;  ResetToConsistentState
+  ResetToConsistentState
   ThreadInit
   ThreadTerm
   UpdateProcessorInformation

--- a/Source/Windows/CMakeLists.txt
+++ b/Source/Windows/CMakeLists.txt
@@ -24,6 +24,8 @@ build_implib(wow64)
 
 add_subdirectory(Common)
 
-if (_M_ARM_64 AND (NOT _M_ARM_64EC))
+if (_M_ARM_64EC)
+  add_subdirectory(ARM64EC)
+elseif (_M_ARM_64)
   add_subdirectory(WOW64)
 endif()

--- a/Source/Windows/WOW64/CMakeLists.txt
+++ b/Source/Windows/WOW64/CMakeLists.txt
@@ -23,5 +23,5 @@ target_link_libraries(wow64fex
 
 install(TARGETS wow64fex
   RUNTIME
-  DESTINATION bin
+  DESTINATION lib
   COMPONENT runtime)

--- a/Source/Windows/include/winnt.h
+++ b/Source/Windows/include/winnt.h
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: Copyright (C) the Wine project
+
+#pragma once
+
+#include_next <winnt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _IMAGE_LOAD_CONFIG_CODE_INTEGRITY {
+  WORD Flags;
+  WORD Catalog;
+  DWORD CatalogOffset;
+  DWORD Reserved;
+} IMAGE_LOAD_CONFIG_CODE_INTEGRITY, *PIMAGE_LOAD_CONFIG_CODE_INTEGRITY;
+
+typedef struct __IMAGE_LOAD_CONFIG_DIRECTORY64 {
+  DWORD Size; /* 000 */
+  DWORD TimeDateStamp;
+  WORD MajorVersion;
+  WORD MinorVersion;
+  DWORD GlobalFlagsClear;
+  DWORD GlobalFlagsSet; /* 010 */
+  DWORD CriticalSectionDefaultTimeout;
+  ULONGLONG DeCommitFreeBlockThreshold;
+  ULONGLONG DeCommitTotalFreeThreshold; /* 020 */
+  ULONGLONG LockPrefixTable;
+  ULONGLONG MaximumAllocationSize; /* 030 */
+  ULONGLONG VirtualMemoryThreshold;
+  ULONGLONG ProcessAffinityMask; /* 040 */
+  DWORD ProcessHeapFlags;
+  WORD CSDVersion;
+  WORD DependentLoadFlags;
+  ULONGLONG EditList; /* 050 */
+  ULONGLONG SecurityCookie;
+  ULONGLONG SEHandlerTable; /* 060 */
+  ULONGLONG SEHandlerCount;
+  ULONGLONG GuardCFCheckFunctionPointer; /* 070 */
+  ULONGLONG GuardCFDispatchFunctionPointer;
+  ULONGLONG GuardCFFunctionTable; /* 080 */
+  ULONGLONG GuardCFFunctionCount;
+  DWORD GuardFlags; /* 090 */
+  IMAGE_LOAD_CONFIG_CODE_INTEGRITY CodeIntegrity;
+  ULONGLONG GuardAddressTakenIatEntryTable; /* 0a0 */
+  ULONGLONG GuardAddressTakenIatEntryCount;
+  ULONGLONG GuardLongJumpTargetTable; /* 0b0 */
+  ULONGLONG GuardLongJumpTargetCount;
+  ULONGLONG DynamicValueRelocTable; /* 0c0 */
+  ULONGLONG CHPEMetadataPointer;
+  ULONGLONG GuardRFFailureRoutine; /* 0d0 */
+  ULONGLONG GuardRFFailureRoutineFunctionPointer;
+  DWORD DynamicValueRelocTableOffset; /* 0e0 */
+  WORD DynamicValueRelocTableSection;
+  WORD Reserved2;
+  ULONGLONG GuardRFVerifyStackPointerFunctionPointer;
+  DWORD HotPatchTableOffset; /* 0f0 */
+  DWORD Reserved3;
+  ULONGLONG EnclaveConfigurationPointer;
+  ULONGLONG VolatileMetadataPointer; /* 100 */
+  ULONGLONG GuardEHContinuationTable;
+  ULONGLONG GuardEHContinuationCount; /* 110 */
+  ULONGLONG GuardXFGCheckFunctionPointer;
+  ULONGLONG GuardXFGDispatchFunctionPointer; /* 120 */
+  ULONGLONG GuardXFGTableDispatchFunctionPointer;
+  ULONGLONG CastGuardOsDeterminedFailureMode; /* 130 */
+  ULONGLONG GuardMemcpyFunctionPointer;
+} _IMAGE_LOAD_CONFIG_DIRECTORY64, *_PIMAGE_LOAD_CONFIG_DIRECTORY64;
+
+typedef struct _IMAGE_CHPE_RANGE_ENTRY {
+  union {
+    ULONG StartOffset;
+    struct {
+      ULONG NativeCode  : 1;
+      ULONG AddressBits : 31;
+    } DUMMYSTRUCTNAME;
+  } DUMMYUNIONNAME;
+  ULONG Length;
+} IMAGE_CHPE_RANGE_ENTRY, *PIMAGE_CHPE_RANGE_ENTRY;
+
+typedef struct _IMAGE_ARM64EC_METADATA {
+  ULONG Version;
+  ULONG CodeMap;
+  ULONG CodeMapCount;
+  ULONG CodeRangesToEntryPoints;
+  ULONG RedirectionMetadata;
+  ULONG __os_arm64x_dispatch_call_no_redirect;
+  ULONG __os_arm64x_dispatch_ret;
+  ULONG __os_arm64x_dispatch_call;
+  ULONG __os_arm64x_dispatch_icall;
+  ULONG __os_arm64x_dispatch_icall_cfg;
+  ULONG AlternateEntryPoint;
+  ULONG AuxiliaryIAT;
+  ULONG CodeRangesToEntryPointsCount;
+  ULONG RedirectionMetadataCount;
+  ULONG GetX64InformationFunctionPointer;
+  ULONG SetX64InformationFunctionPointer;
+  ULONG ExtraRFETable;
+  ULONG ExtraRFETableSize;
+  ULONG __os_arm64x_dispatch_fptr;
+  ULONG AuxiliaryIATCopy;
+  ULONG __os_arm64x_helper0;
+  ULONG __os_arm64x_helper1;
+  ULONG __os_arm64x_helper2;
+  ULONG __os_arm64x_helper3;
+  ULONG __os_arm64x_helper4;
+  ULONG __os_arm64x_helper5;
+  ULONG __os_arm64x_helper6;
+  ULONG __os_arm64x_helper7;
+  ULONG __os_arm64x_helper8;
+} IMAGE_ARM64EC_METADATA;
+
+typedef struct _IMAGE_ARM64EC_REDIRECTION_ENTRY {
+  ULONG Source;
+  ULONG Destination;
+} IMAGE_ARM64EC_REDIRECTION_ENTRY;
+
+typedef struct _IMAGE_ARM64EC_CODE_RANGE_ENTRY_POINT {
+  ULONG StartRva;
+  ULONG EndRva;
+  ULONG EntryPoint;
+} IMAGE_ARM64EC_CODE_RANGE_ENTRY_POINT;
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/Source/Windows/include/winternl.h
+++ b/Source/Windows/include/winternl.h
@@ -13,6 +13,20 @@ extern "C" {
 
 #define WOW64_TLS_MAX_NUMBER 19
 
+#ifdef _M_ARM_64EC
+typedef struct _CHPE_V2_CPU_AREA_INFO {
+  BOOLEAN InSimulation;             /* 000 */
+  BOOLEAN InSyscallCallback;        /* 001 */
+  ULONG64 EmulatorStackBase;        /* 008 */
+  ULONG64 EmulatorStackLimit;       /* 010 */
+  ARM64EC_NT_CONTEXT* ContextAmd64; /* 018 */
+  ULONG* SuspendDoorbell;           /* 020 */
+  ULONG64 LoadingModuleModflag;     /* 028 */
+  void* EmulatorData[4];            /* 030 */
+  ULONG64 EmulatorDataInline;       /* 050 */
+} CHPE_V2_CPU_AREA_INFO, *PCHPE_V2_CPU_AREA_INFO;
+#endif
+
 typedef struct _THREAD_BASIC_INFORMATION {
   NTSTATUS ExitStatus;
   PVOID TebBaseAddress;

--- a/Source/Windows/include/winternl.h
+++ b/Source/Windows/include/winternl.h
@@ -108,6 +108,7 @@ void WINAPI Wow64ProcessPendingCrossProcessItems(void);
 NTSTATUS WINAPI RtlWow64SetThreadContext(HANDLE, const WOW64_CONTEXT*);
 NTSTATUS WINAPI RtlWow64GetThreadContext(HANDLE, WOW64_CONTEXT*);
 NTSTATUS WINAPI RtlWow64GetCurrentCpuArea(USHORT*, void**, void**);
+NTSYSAPI PVOID WINAPI RtlImageDirectoryEntryToData(HMODULE, BOOL, WORD, ULONG*);
 
 NTSTATUS WINAPI NtSuspendThread(HANDLE, PULONG);
 NTSTATUS WINAPI NtGetContextThread(HANDLE, CONTEXT*);


### PR DESCRIPTION
This implements an ARM64EC JIT module compatible with [this](https://github.com/bylaws/wine/tree/arm64ec) fork of wine, allowing for much reduced overhead when compared to running x64 wine under FEXLoader as native ARM64 windows system libraries (dxvk, msvcrt) etc can be used. Currently the dependency on kernel32/the system CRT prevents compatibility with windows or upstream wine, and some API function signatures differ, but I am currently looking into this.

A brief summary of ARM64EC can be found [here](https://learn.microsoft.com/en-us/windows/arm/arm64ec):
>Code built as Arm64EC is interoperable with x64 code running under emulation within the same process. The > Arm64EC code in the process runs with native performance, while any x64 code runs using emulation that comes built-in with Windows 11. Even if your app relies on existing dependencies or plugins that don't yet support Arm, you can start to rebuild parts of your app as Arm64EC to gain the benefits of native performance.

>Arm64EC guarantees interoperability with x64 by following x64 software conventions including calling convention, stack usage, data structure layout, and preprocessor definitions. However, Arm64EC code is not compatible with code built as Arm64, which uses a different set of software conventions.

>The Windows 11 on Arm operating system itself relies heavily on Arm64EC's interoperability to enable running x64 applications. Most operating system code loaded by an x64 app running on Windows 11 on Arm will have been compiled as Arm64EC, enabling native performance for that code without the application knowing.

Other Docs: 
https://wiki.winehq.org/ARM64ECToolchain
https://learn.microsoft.com/en-us/windows/arm/arm64ec-abi
https://learn.microsoft.com/en-us/cpp/build/arm64ec-windows-abi-conventions