### PR TITLE
IR: gather x87-ness automatically

### DIFF
--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -53,6 +53,7 @@ class OpDefinition:
     SSAArgNum: int
     NonSSAArgNum: int
     DynamicDispatch: bool
+    X87: bool
     JITDispatch: bool
     JITDispatchOverride: str
     TiedSource: int
@@ -76,6 +77,7 @@ class OpDefinition:
         self.SSAArgNum = 0
         self.NonSSAArgNum = 0
         self.DynamicDispatch = False
+        self.X87 = False
         self.JITDispatch = True
         self.JITDispatchOverride = None
         self.TiedSource = -1
@@ -249,6 +251,13 @@ def parse_ops(ops):
 
             if "JITDispatchOverride" in op_val:
                 OpDef.JITDispatchOverride = op_val["JITDispatchOverride"]
+
+            if "X87" in op_val:
+                OpDef.X87 = op_val["X87"]
+
+                # X87 implies !JITDispatch
+                assert("JITDispatch" not in op_val)
+                OpDef.JITDispatch = False
 
             if "TiedSource" in op_val:
                 OpDef.TiedSource = op_val["TiedSource"]

--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -698,6 +698,11 @@ def print_ir_allocator_helpers():
             if op.ImplicitFlagClobber:
                 output_file.write("\t\tSaveNZCV(IROps::OP_{});".format(op.Name.upper()))
 
+            # We gather the "has x87?" flag as we go. This saves the user from
+            # having to keep track of whether they emitted any x87.
+            if op.X87:
+                output_file.write("\t\tRecordX87Use();\n")
+
             output_file.write("\t\tauto Op = AllocateOp<IROp_{}, IROps::OP_{}>();\n".format(op.Name, op.Name.upper()))
 
             if op.SSAArgNum != 0:

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4010,6 +4010,7 @@ void OpDispatchBuilder::BeginFunction(uint64_t RIP, const fextl::vector<FEXCore:
   auto Block = GetNewJumpBlock(RIP);
   SetCurrentCodeBlock(Block);
   IRHeader.first->Blocks = Block->Wrapped(DualListData.ListBegin());
+  CurrentHeader = IRHeader.first;
 }
 
 void OpDispatchBuilder::Finalize() {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1191,6 +1191,10 @@ public:
   }
 
 protected:
+  void RecordX87Use() override {
+    CurrentHeader->HasX87 = true;
+  }
+
   void SaveNZCV(IROps Op = OP_DUMMY) override {
     /* Some opcodes are conservatively marked as clobbering flags, but in fact
      * do not clobber flags in certain conditions. Check for that here as an
@@ -2050,6 +2054,7 @@ private:
 
   bool Multiblock {};
   uint64_t Entry;
+  IROp_IRHeader* CurrentHeader {};
 
   Ref _StoreMemAutoTSO(FEXCore::IR::RegisterClassType Class, uint8_t Size, Ref Addr, Ref Value, uint8_t Align = 1) {
     if (CTX->IsAtomicTSOEnabled()) {

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -168,7 +168,7 @@
         "SwitchGen": false,
         "JITDispatchOverride": "NoOp"
       },
-      "IRHeader SSA:$Blocks, u64:$OriginalRIP, u32:$BlockCount, u32:$NumHostInstructions": {
+      "IRHeader SSA:$Blocks, u64:$OriginalRIP, u32:$BlockCount, u32:$NumHostInstructions, i1:$HasX87{false}": {
         "SwitchGen": false,
         "JITDispatchOverride": "NoOp"
       },

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -2570,103 +2570,103 @@
     "F80": {
       "FPR = F80Add FPR:$X80Src1, FPR:$X80Src2": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80Sub FPR:$X80Src1, FPR:$X80Src2": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80Mul FPR:$X80Src1, FPR:$X80Src2": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80Div FPR:$X80Src1, FPR:$X80Src2": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80ATAN FPR:$X80Src1, FPR:$X80Src2": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80FPREM FPR:$X80Src1, FPR:$X80Src2": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80FPREM1 FPR:$X80Src1, FPR:$X80Src2": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80SCALE FPR:$X80Src1, FPR:$X80Src2": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80CVT u8:#Size, FPR:$X80Src": {
         "DestSize": "Size",
-        "JITDispatch": false
+        "X87": true
       },
       "GPR = F80CVTInt u8:#Size, FPR:$X80Src, i1:$Truncate": {
         "DestSize": "Size",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80CVTTo FPR:$X80Src, u8:$SrcSize": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80CVTToInt GPR:$Src, u8:$SrcSize": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80Round FPR:$X80Src": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80F2XM1 FPR:$X80Src": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80TAN FPR:$X80Src": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80SIN FPR:$X80Src": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80COS FPR:$X80Src": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80SQRT FPR:$X80Src": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80XTRACT_EXP FPR:$X80Src": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80XTRACT_SIG FPR:$X80Src": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "GPR = F80Cmp FPR:$X80Src1, FPR:$X80Src2, u32:$Flags": {
         "Desc": ["Does a scalar unordered compare and stores the asked for flags in to a GPR",
                  "Ordering flag result is true if either float input is NaN"
                 ],
         "DestSize": "4",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80BCDLoad FPR:$X80Src": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
       "FPR = F80BCDStore FPR:$X80Src": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       },
 
       "FPR = F80FYL2X FPR:$X80Src1, FPR:$X80Src2": {
         "DestSize": "16",
-        "JITDispatch": false
+        "X87": true
       }
     },
     "Backend": {

--- a/FEXCore/Source/Interface/IR/IREmitter.h
+++ b/FEXCore/Source/Interface/IR/IREmitter.h
@@ -343,9 +343,9 @@ protected:
     return Ptr;
   }
 
-  virtual void SaveNZCV(IROps Op) {
-    // Overriden by dispatcher, stubbed for IR tests
-  }
+  // Overriden by dispatcher, stubbed for IR tests
+  virtual void RecordX87Use() {}
+  virtual void SaveNZCV(IROps Op) {}
 
   Ref CurrentWriteCursor = nullptr;
 


### PR DESCRIPTION
#3547 manually tracks when x87 is used. This seems verbose and error prone. Better to autogenerate, I think.

@pmatos What do you think?