### PR TITLE
Arm64: Implements support for DAZ using AFP.FIZ 

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -102,7 +102,9 @@ protected:
   //       and FPRs are being spilled or filled. If only GPRs are spilled/filled, then
   //       TMP4 is left alone.
   void SpillStaticRegs(ARMEmitter::Register TmpReg, bool FPRs = true, uint32_t GPRSpillMask = ~0U, uint32_t FPRSpillMask = ~0U);
-  void FillStaticRegs(bool FPRs = true, uint32_t GPRFillMask = ~0U, uint32_t FPRFillMask = ~0U);
+  void FillStaticRegs(bool FPRs = true, uint32_t GPRFillMask = ~0U, uint32_t FPRFillMask = ~0U,
+                      std::optional<ARMEmitter::Register> OptionalReg = std::nullopt,
+                      std::optional<ARMEmitter::Register> OptionalReg2 = std::nullopt);
 
   // Register 0-18 + 29 + 30 are caller saved
   static constexpr uint32_t CALLER_GPR_MASK = 0b0110'0000'0000'0111'1111'1111'1111'1111U;

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/BranchOps.cpp
@@ -184,7 +184,7 @@ DEF_OP(Syscall) {
   if ((Flags & FEXCore::IR::SyscallFlags::NORETURN) != FEXCore::IR::SyscallFlags::NORETURN) {
     // Result is now in x0
     // Fix the stack and any values that were stepped on
-    FillStaticRegs(true, GPRSpillMask, FPRSpillMask);
+    FillStaticRegs(true, GPRSpillMask, FPRSpillMask, ARMEmitter::Reg::r1, ARMEmitter::Reg::r2);
 
     // Now the registers we've spilled are back in their original host registers
     // We can safely claim we are no longer in a syscall
@@ -285,7 +285,7 @@ DEF_OP(InlineSyscall) {
   if ((Op->Flags & FEXCore::IR::SyscallFlags::NORETURN) != FEXCore::IR::SyscallFlags::NORETURN) {
     // Now that we are done in the syscall we need to carefully peel back the state
     // First unspill the registers from before
-    FillStaticRegs(false, SpillMask);
+    FillStaticRegs(false, SpillMask, ~0U, ARMEmitter::Reg::r8, ARMEmitter::Reg::r1);
 
     // Now the registers we've spilled are back in their original host registers
     // We can safely claim we are no longer in a syscall

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -98,6 +98,7 @@ DEF_OP(GetRoundingMode) {
 DEF_OP(SetRoundingMode) {
   auto Op = IROp->C<IR::IROp_SetRoundingMode>();
   auto Src = GetReg(Op->RoundMode.ID());
+  auto MXCSR = GetReg(Op->MXCSR.ID());
 
   // As above, setup the rounding flags in [31:30]
   rbit(ARMEmitter::Size::i32Bit, TMP2, Src);
@@ -115,6 +116,11 @@ DEF_OP(SetRoundingMode) {
   // Insert the FTZ flag
   lsr(ARMEmitter::Size::i64Bit, TMP2, Src, 2);
   bfi(ARMEmitter::Size::i64Bit, TMP1, TMP2, 24, 1);
+
+  if (Op->SetDAZ && HostSupportsAFP) {
+    // Extract DAZ from MXCSR and insert to in FPCR.FIZ
+    bfxil(ARMEmitter::Size::i64Bit, TMP1, MXCSR, 6, 1);
+  }
 
   // Now save the new FPCR
   msr(ARMEmitter::SystemRegister::FPCR, TMP1);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -233,7 +233,7 @@ DEF_OP(ProcessorID) {
 
   // Now that we are done in the syscall we need to carefully peel back the state
   // First unspill the registers from before
-  FillStaticRegs(false, SpillMask);
+  FillStaticRegs(false, SpillMask, ~0U, ARMEmitter::Reg::r8, ARMEmitter::Reg::r2);
 
   // Now the registers we've spilled are back in their original host registers
   // We can safely claim we are no longer in a syscall

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2599,10 +2599,11 @@ void OpDispatchBuilder::SaveAVXState(Ref MemBase) {
 }
 
 Ref OpDispatchBuilder::GetMXCSR() {
-  // Default MXCSR Value
-  Ref MXCSR = _Constant(0x1F80);
-  Ref RoundingMode = _GetRoundingMode();
-  return _Bfi(OpSize::i32Bit, 3, 13, MXCSR, RoundingMode);
+  Ref MXCSR = _LoadContext(OpSize::i32Bit, GPRClass, offsetof(FEXCore::Core::CPUState, mxcsr));
+  // Mask out unsupported bits
+  // Keeps FZ, RC, exception masks, and DAZ
+  MXCSR = _And(OpSize::i32Bit, MXCSR, _Constant(0xFFC0));
+  return MXCSR;
 }
 
 void OpDispatchBuilder::FXRStoreOp(OpcodeArgs) {
@@ -2711,9 +2712,13 @@ void OpDispatchBuilder::RestoreSSEState(Ref MemBase) {
 }
 
 void OpDispatchBuilder::RestoreMXCSRState(Ref MXCSR) {
+  // Mask out unsupported bits
+  MXCSR = _And(OpSize::i32Bit, MXCSR, _Constant(0xFFC0));
+
+  _StoreContext(OpSize::i32Bit, GPRClass, MXCSR, offsetof(FEXCore::Core::CPUState, mxcsr));
   // We only support the rounding mode and FTZ bit being set
   Ref RoundingMode = _Bfe(OpSize::i32Bit, 3, 13, MXCSR);
-  _SetRoundingMode(RoundingMode);
+  _SetRoundingMode(RoundingMode, true, MXCSR);
 }
 
 void OpDispatchBuilder::RestoreAVXState(Ref MemBase) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -48,7 +48,7 @@ void OpDispatchBuilder::FNINITF64(OpcodeArgs) {
   auto NewFCW = _Constant(16, 0x037F);
   // Init host rounding mode to zero
   auto Zero = _Constant(0);
-  _SetRoundingMode(Zero);
+  _SetRoundingMode(Zero, false, Zero);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 
   // Init FSW to 0
@@ -71,7 +71,7 @@ void OpDispatchBuilder::X87LDENVF64(OpcodeArgs) {
   // ignore the rounding precision, we're always 64-bit in F64.
   // extract rounding mode
   Ref roundingMode = _Bfe(OpSize::i32Bit, 3, 10, NewFCW);
-  _SetRoundingMode(roundingMode);
+  _SetRoundingMode(roundingMode, false, roundingMode);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 
   auto NewFSW = _LoadMem(GPRClass, Size, Mem, _Constant(Size * 1), Size, MEM_OFFSET_SXTX, 1);
@@ -89,7 +89,7 @@ void OpDispatchBuilder::X87FLDCWF64(OpcodeArgs) {
   // ignore the rounding precision, we're always 64-bit in F64.
   // extract rounding mode
   Ref roundingMode = _Bfe(OpSize::i32Bit, 3, 10, NewFCW);
-  _SetRoundingMode(roundingMode);
+  _SetRoundingMode(roundingMode, false, roundingMode);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 }
 
@@ -783,7 +783,7 @@ void OpDispatchBuilder::X87FRSTORF64(OpcodeArgs) {
   auto roundMask = _Constant(3);
   roundingMode = _Lshr(OpSize::i32Bit, roundingMode, roundShift);
   roundingMode = _And(OpSize::i32Bit, roundingMode, roundMask);
-  _SetRoundingMode(roundingMode);
+  _SetRoundingMode(roundingMode, false, roundingMode);
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
   _StoreContext(2, GPRClass, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -226,7 +226,7 @@
         "DestSize": "4"
       },
 
-      "SetRoundingMode GPR:$RoundMode": {
+      "SetRoundingMode GPR:$RoundMode, i1:$SetDAZ, GPR:$MXCSR": {
         "Desc": ["Sets the current rounding mode options for the thread"
                 ],
         "HasSideEffects": true

--- a/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/FEXCore/include/FEXCore/Core/CoreState.h
@@ -104,7 +104,7 @@ struct CPUState {
   // Raw segment register indexes
   uint16_t es_idx {}, cs_idx {}, ss_idx {}, ds_idx {};
   uint16_t gs_idx {}, fs_idx {};
-  uint16_t _pad2[2];
+  uint32_t mxcsr {};
 
   // Segment registers holding base addresses
   uint32_t es_cached {}, cs_cached {}, ss_cached {}, ds_cached {};
@@ -162,6 +162,10 @@ struct CPUState {
     // we encode DF as 1/-1 within the JIT, so we have to write 0x1 here to
     // zero DF.
     flags[X86State::RFLAG_DF_RAW_LOC] = 0x1;
+
+    // Default mxcsr value
+    // All exception masks enabled.
+    mxcsr = 0x1F80;
   }
 };
 static_assert(std::is_trivially_copyable_v<CPUState>, "Needs to be trivial");

--- a/Scripts/json_config_parse.py
+++ b/Scripts/json_config_parse.py
@@ -73,8 +73,8 @@ class HostFeatures(Flag) :
     FEATURE_BMI2   = (1 << 7)
     FEATURE_CLWB   = (1 << 8)
     FEATURE_LINUX  = (1 << 9)
-    FEATURE_AVX2   = (1 << 10)
-    FEATURE_AES256 = (1 << 11)
+    FEATURE_AES256 = (1 << 10)
+    FEATURE_AFP    = (1 << 11)
 
 RegStringLookup = {
     "NONE":  Regs.REG_NONE,
@@ -147,8 +147,8 @@ HostFeaturesLookup = {
     "BMI2"   : HostFeatures.FEATURE_BMI2,
     "CLWB"   : HostFeatures.FEATURE_CLWB,
     "LINUX"  : HostFeatures.FEATURE_LINUX,
-    "AVX2"   : HostFeatures.FEATURE_AVX2,
     "AES256" : HostFeatures.FEATURE_AES256,
+    "AFP"    : HostFeatures.FEATURE_AFP,
 }
 
 def parse_hexstring(s):

--- a/Source/Tools/CommonTools/HarnessHelpers.h
+++ b/Source/Tools/CommonTools/HarnessHelpers.h
@@ -308,6 +308,7 @@ public:
     FEATURE_CLWB = (1 << 8),
     FEATURE_LINUX = (1 << 9),
     FEATURE_AES256 = (1 << 10),
+    FEATURE_AFP = (1 << 11),
   };
 
   bool Requires3DNow() const {
@@ -342,6 +343,9 @@ public:
   }
   bool RequiresAES256() const {
     return BaseConfig.OptionHostFeatures & HostFeatures::FEATURE_AES256;
+  }
+  bool RequiresAFP() const {
+    return BaseConfig.OptionHostFeatures & HostFeatures::FEATURE_AFP;
   }
 
 private:
@@ -511,6 +515,9 @@ public:
   }
   bool RequiresAES256() const {
     return Config.RequiresAES256();
+  }
+  bool RequiresAFP() const {
+    return Config.RequiresAFP();
   }
 
 private:

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -266,7 +266,8 @@ int main(int argc, char** argv, char** const envp) {
                          (!SupportsAVX && Loader.RequiresAVX()) || (!HostFeatures.SupportsRAND && Loader.RequiresRAND()) ||
                          (!HostFeatures.SupportsSHA && Loader.RequiresSHA()) || (!HostFeatures.SupportsCLZERO && Loader.RequiresCLZERO()) ||
                          (!HostFeatures.SupportsBMI1 && Loader.RequiresBMI1()) || (!HostFeatures.SupportsBMI2 && Loader.RequiresBMI2()) ||
-                         (!HostFeatures.SupportsCLWB && Loader.RequiresCLWB()) || (!HostFeatures.SupportsAES256 && Loader.RequiresAES256());
+                         (!HostFeatures.SupportsCLWB && Loader.RequiresCLWB()) ||
+                         (!HostFeatures.SupportsAES256 && Loader.RequiresAES256()) || (!HostFeatures.SupportsAFP && Loader.RequiresAFP());
 
 #ifdef _WIN32
   TestUnsupported |= Loader.RequiresLinux();

--- a/unittests/ASM/DAZTest.asm
+++ b/unittests/ASM/DAZTest.asm
@@ -1,0 +1,37 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AFP"],
+  "RegData": {
+    "XMM0": ["0x0108000040e00000", "0xd1d2d3d4d5d6d7d8", "0", "0"],
+    "XMM1": ["0x00cfffff40e00000", "0xd1d2d3d4d5d6d7d8", "0", "0"]
+  }
+}
+%endif
+
+vmovaps ymm1, [rel .data_three]
+vmovaps ymm2, [rel .data_four]
+
+; Do an add without DAZ
+vaddps xmm0, xmm1, xmm2
+
+; Set DAZ
+stmxcsr [rel .data_mxcsr]
+or dword [rel .data_mxcsr], (1 << 6)
+ldmxcsr [rel .data_mxcsr]
+
+; Do an add with DAZ
+vaddps xmm1, xmm1, xmm2
+
+hlt
+align 32
+
+.data_three:
+dd 3.0, 0x00cfffff
+dq 0xa1a2a3a4a5a6a7a8, 0xb1b2b3b4b5b6b7b8, 0xc1c2c3c4c5c6c7c8
+
+.data_four:
+dd 4.0, 0x00400000
+dq 0xd1d2d3d4d5d6d7d8, 0xe1e2e3e4e5e6e7e8, 0xf1f2f3f4f5f6f7f8
+
+.data_mxcsr:
+dd 0

--- a/unittests/ASM/VEX/vldmxcsr.asm
+++ b/unittests/ASM/VEX/vldmxcsr.asm
@@ -2,7 +2,7 @@
 {
   "HostFeatures": ["AVX"],
   "RegData": {
-    "RAX": "0xFF80"
+    "RAX": "0xFFC0"
   },
   "MemoryRegions": {
     "0x100000000": "4096"

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -1186,7 +1186,7 @@
       ]
     },
     "fxsave [rax]": {
-      "ExpectedInstructionCount": 56,
+      "ExpectedInstructionCount": 52,
       "Comment": "GROUP15 0x0F 0xAE /0",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #1296]",
@@ -1236,12 +1236,8 @@
         "str q29, [x4, #368]",
         "str q30, [x4, #384]",
         "str q31, [x4, #400]",
-        "mov w20, #0x1f80",
-        "mrs x21, fpcr",
-        "ubfx x21, x21, #22, #3",
-        "rbit w0, w21",
-        "bfi x21, x0, #30, #2",
-        "bfi w20, w21, #13, #3",
+        "ldr w20, [x28, #940]",
+        "and w20, w20, #0xffc0",
         "str w20, [x4, #24]",
         "mov w20, #0xffff",
         "str w20, [x4, #28]"
@@ -1262,7 +1258,7 @@
       ]
     },
     "fxrstor [rax]": {
-      "ExpectedInstructionCount": 56,
+      "ExpectedInstructionCount": 58,
       "Comment": "GROUP15 0x0F 0xAE /1",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
@@ -1304,12 +1300,14 @@
         "ldr q30, [x4, #384]",
         "ldr q31, [x4, #400]",
         "ldr w21, [x4, #24]",
-        "ubfx w21, w21, #13, #3",
-        "rbit w1, w21",
+        "and w21, w21, #0xffc0",
+        "str w21, [x28, #940]",
+        "ubfx w22, w21, #13, #3",
+        "rbit w1, w22",
         "lsr w1, w1, #30",
         "mrs x0, fpcr",
         "bfi x0, x1, #22, #2",
-        "lsr x1, x21, #2",
+        "lsr x1, x22, #2",
         "bfi x0, x1, #24, #1",
         "msr fpcr, x0",
         "strb w20, [x28, #1298]",
@@ -1338,16 +1336,18 @@
       ]
     },
     "ldmxcsr [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP15 0x0F 0xAE /2",
       "ExpectedArm64ASM": [
         "ldr w20, [x4]",
-        "ubfx w20, w20, #13, #3",
-        "rbit w1, w20",
+        "and w20, w20, #0xffc0",
+        "str w20, [x28, #940]",
+        "ubfx w21, w20, #13, #3",
+        "rbit w1, w21",
         "lsr w1, w1, #30",
         "mrs x0, fpcr",
         "bfi x0, x1, #22, #2",
-        "lsr x1, x20, #2",
+        "lsr x1, x21, #2",
         "bfi x0, x1, #24, #1",
         "msr fpcr, x0"
       ]
@@ -1368,15 +1368,11 @@
       ]
     },
     "stmxcsr [rax]": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP15 0x0F 0xAE /3",
       "ExpectedArm64ASM": [
-        "mov w20, #0x1f80",
-        "mrs x21, fpcr",
-        "ubfx x21, x21, #22, #3",
-        "rbit w0, w21",
-        "bfi x21, x0, #30, #2",
-        "bfi w20, w21, #13, #3",
+        "ldr w20, [x28, #940]",
+        "and w20, w20, #0xffc0",
         "str w20, [x4]"
       ]
     },
@@ -1396,7 +1392,7 @@
       ]
     },
     "xsave [rax]": {
-      "ExpectedInstructionCount": 102,
+      "ExpectedInstructionCount": 98,
       "Comment": "GROUP15 0x0F 0xAE /4",
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #1",
@@ -1489,13 +1485,9 @@
         "str q2, [x4, #816]",
         "ubfx x20, x4, #1, #2",
         "cbnz x20, #+0x8",
-        "b #+0x28",
-        "mov w20, #0x1f80",
-        "mrs x21, fpcr",
-        "ubfx x21, x21, #22, #3",
-        "rbit w0, w21",
-        "bfi x21, x0, #30, #2",
-        "bfi w20, w21, #13, #3",
+        "b #+0x18",
+        "ldr w20, [x28, #940]",
+        "and w20, w20, #0xffc0",
         "str w20, [x4, #24]",
         "mov w20, #0xffff",
         "str w20, [x4, #28]",
@@ -1511,7 +1503,7 @@
       ]
     },
     "xrstor [rax]": {
-      "ExpectedInstructionCount": 165,
+      "ExpectedInstructionCount": 167,
       "Comment": "GROUP15 0x0F 0xAE /5",
       "ExpectedArm64ASM": [
         "sub sp, sp, #0x40 (64)",
@@ -1667,14 +1659,16 @@
         "ldr x20, [x4, #512]",
         "ubfx x20, x20, #1, #2",
         "cbnz x20, #+0x8",
-        "b #+0x2c",
+        "b #+0x34",
         "ldr w20, [x4, #24]",
-        "ubfx w20, w20, #13, #3",
-        "rbit w1, w20",
+        "and w20, w20, #0xffc0",
+        "str w20, [x28, #940]",
+        "ubfx w21, w20, #13, #3",
+        "rbit w1, w21",
         "lsr w1, w1, #30",
         "mrs x0, fpcr",
         "bfi x0, x1, #22, #2",
-        "lsr x1, x20, #2",
+        "lsr x1, x21, #2",
         "bfi x0, x1, #24, #1",
         "msr fpcr, x0",
         "b #+0x4",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -1370,7 +1370,7 @@
       ]
     },
     "fxsave [rax]": {
-      "ExpectedInstructionCount": 56,
+      "ExpectedInstructionCount": 52,
       "Comment": "GROUP15 0x0F 0xAE /0",
       "ExpectedArm64ASM": [
         "ldrh w20, [x28, #1296]",
@@ -1420,12 +1420,8 @@
         "str q29, [x4, #368]",
         "str q30, [x4, #384]",
         "str q31, [x4, #400]",
-        "mov w20, #0x1f80",
-        "mrs x21, fpcr",
-        "ubfx x21, x21, #22, #3",
-        "rbit w0, w21",
-        "bfi x21, x0, #30, #2",
-        "bfi w20, w21, #13, #3",
+        "ldr w20, [x28, #940]",
+        "and w20, w20, #0xffc0",
         "str w20, [x4, #24]",
         "mov w20, #0xffff",
         "str w20, [x4, #28]"
@@ -1446,7 +1442,7 @@
       ]
     },
     "fxrstor [rax]": {
-      "ExpectedInstructionCount": 56,
+      "ExpectedInstructionCount": 58,
       "Comment": "GROUP15 0x0F 0xAE /1",
       "ExpectedArm64ASM": [
         "ldrh w20, [x4]",
@@ -1488,12 +1484,14 @@
         "ldr q30, [x4, #384]",
         "ldr q31, [x4, #400]",
         "ldr w21, [x4, #24]",
-        "ubfx w21, w21, #13, #3",
-        "rbit w1, w21",
+        "and w21, w21, #0xffc0",
+        "str w21, [x28, #940]",
+        "ubfx w22, w21, #13, #3",
+        "rbit w1, w22",
         "lsr w1, w1, #30",
         "mrs x0, fpcr",
         "bfi x0, x1, #22, #2",
-        "lsr x1, x21, #2",
+        "lsr x1, x22, #2",
         "bfi x0, x1, #24, #1",
         "msr fpcr, x0",
         "strb w20, [x28, #1298]",
@@ -1522,16 +1520,18 @@
       ]
     },
     "ldmxcsr [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 11,
       "Comment": "GROUP15 0x0F 0xAE /2",
       "ExpectedArm64ASM": [
         "ldr w20, [x4]",
-        "ubfx w20, w20, #13, #3",
-        "rbit w1, w20",
+        "and w20, w20, #0xffc0",
+        "str w20, [x28, #940]",
+        "ubfx w21, w20, #13, #3",
+        "rbit w1, w21",
         "lsr w1, w1, #30",
         "mrs x0, fpcr",
         "bfi x0, x1, #22, #2",
-        "lsr x1, x20, #2",
+        "lsr x1, x21, #2",
         "bfi x0, x1, #24, #1",
         "msr fpcr, x0"
       ]
@@ -1552,15 +1552,11 @@
       ]
     },
     "stmxcsr [rax]": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 3,
       "Comment": "GROUP15 0x0F 0xAE /3",
       "ExpectedArm64ASM": [
-        "mov w20, #0x1f80",
-        "mrs x21, fpcr",
-        "ubfx x21, x21, #22, #3",
-        "rbit w0, w21",
-        "bfi x21, x0, #30, #2",
-        "bfi w20, w21, #13, #3",
+        "ldr w20, [x28, #940]",
+        "and w20, w20, #0xffc0",
         "str w20, [x4]"
       ]
     },
@@ -1580,7 +1576,7 @@
       ]
     },
     "xsave [rax]": {
-      "ExpectedInstructionCount": 102,
+      "ExpectedInstructionCount": 98,
       "Comment": "GROUP15 0x0F 0xAE /4",
       "ExpectedArm64ASM": [
         "ubfx x20, x4, #0, #1",
@@ -1673,13 +1669,9 @@
         "str q2, [x4, #816]",
         "ubfx x20, x4, #1, #2",
         "cbnz x20, #+0x8",
-        "b #+0x28",
-        "mov w20, #0x1f80",
-        "mrs x21, fpcr",
-        "ubfx x21, x21, #22, #3",
-        "rbit w0, w21",
-        "bfi x21, x0, #30, #2",
-        "bfi w20, w21, #13, #3",
+        "b #+0x18",
+        "ldr w20, [x28, #940]",
+        "and w20, w20, #0xffc0",
         "str w20, [x4, #24]",
         "mov w20, #0xffff",
         "str w20, [x4, #28]",
@@ -1695,7 +1687,7 @@
       ]
     },
     "xrstor [rax]": {
-      "ExpectedInstructionCount": 165,
+      "ExpectedInstructionCount": 167,
       "Comment": "GROUP15 0x0F 0xAE /5",
       "ExpectedArm64ASM": [
         "sub sp, sp, #0x40 (64)",
@@ -1851,14 +1843,16 @@
         "ldr x20, [x4, #512]",
         "ubfx x20, x20, #1, #2",
         "cbnz x20, #+0x8",
-        "b #+0x2c",
+        "b #+0x34",
         "ldr w20, [x4, #24]",
-        "ubfx w20, w20, #13, #3",
-        "rbit w1, w20",
+        "and w20, w20, #0xffc0",
+        "str w20, [x28, #940]",
+        "ubfx w21, w20, #13, #3",
+        "rbit w1, w21",
         "lsr w1, w1, #30",
         "mrs x0, fpcr",
         "bfi x0, x1, #22, #2",
-        "lsr x1, x20, #2",
+        "lsr x1, x21, #2",
         "bfi x0, x1, #24, #1",
         "msr fpcr, x0",
         "b #+0x4",

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -578,34 +578,32 @@
       ]
     },
     "vldmxcsr [rax]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 11,
       "Comment": [
         "Map group 15 0b010"
       ],
       "ExpectedArm64ASM": [
         "ldr w20, [x4]",
-        "ubfx w20, w20, #13, #3",
-        "rbit w1, w20",
+        "and w20, w20, #0xffc0",
+        "str w20, [x28, #940]",
+        "ubfx w21, w20, #13, #3",
+        "rbit w1, w21",
         "lsr w1, w1, #30",
         "mrs x0, fpcr",
         "bfi x0, x1, #22, #2",
-        "lsr x1, x20, #2",
+        "lsr x1, x21, #2",
         "bfi x0, x1, #24, #1",
         "msr fpcr, x0"
       ]
     },
     "vstmxcsr [rax]": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map group 15 0b011"
       ],
       "ExpectedArm64ASM": [
-        "mov w20, #0x1f80",
-        "mrs x21, fpcr",
-        "ubfx x21, x21, #22, #3",
-        "rbit w0, w21",
-        "bfi x21, x0, #30, #2",
-        "bfi w20, w21, #13, #3",
+        "ldr w20, [x28, #940]",
+        "and w20, w20, #0xffc0",
         "str w20, [x4]"
       ]
     },


### PR DESCRIPTION
When AFP is supported then we can actually support DAZ. This might also
fix the audio corruption in Animal Well but I can't test it until Steam
is running on Oryon. Requires a bit of plumbing for MXCSR which we were
hacking around before but now we actually want to store the value.

Fixes https://github.com/FEX-Emu/FEX/issues/3856