### PR TITLE
FEXCore: Refactor ExitHandler slightly

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -937,7 +937,7 @@ void ContextImpl::ExecutionThread(FEXCore::Core::InternalThreadState* Thread) {
     Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_SHUTDOWN;
 
     if (CustomExitHandler) {
-      CustomExitHandler(Thread->ThreadManager.TID, Thread->ExitReason);
+      CustomExitHandler(Thread, Thread->ExitReason);
     }
   }
 

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -102,7 +102,7 @@ using CodeRangeInvalidationFn = std::function<void(uint64_t start, uint64_t Leng
 using CustomCPUFactoryType = std::function<fextl::unique_ptr<CPU::CPUBackend>(Context*, Core::InternalThreadState* Thread)>;
 using CustomIREntrypointHandler = std::function<void(uintptr_t Entrypoint, IR::IREmitter*)>;
 
-using ExitHandler = std::function<void(uint64_t ThreadId, ExitReason)>;
+using ExitHandler = std::function<void(Core::InternalThreadState* Thread, ExitReason)>;
 
 using AOTIRCodeFileWriterFn = std::function<void(const fextl::string& fileid, const fextl::string& filename)>;
 using AOTIRLoaderCBFn = std::function<int(const fextl::string&)>;

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -515,7 +515,7 @@ int main(int argc, char** argv, char** const envp) {
 
   // There might already be an exit handler, leave it installed
   if (!CTX->GetExitHandler()) {
-    CTX->SetExitHandler([&](uint64_t thread, FEXCore::Context::ExitReason reason) {
+    CTX->SetExitHandler([&](FEXCore::Core::InternalThreadState* Thread, FEXCore::Context::ExitReason reason) {
       if (reason != FEXCore::Context::ExitReason::EXIT_DEBUG) {
         ShutdownReason = reason;
         SyscallHandler->TM.Stop();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -121,7 +121,7 @@ GdbServer::GdbServer(FEXCore::Context::Context* ctx, FEX::HLE::SignalDelegator* 
   // Pass all signals by default
   std::fill(PassSignals.begin(), PassSignals.end(), true);
 
-  ctx->SetExitHandler([this](uint64_t ThreadId, FEXCore::Context::ExitReason ExitReason) {
+  ctx->SetExitHandler([this](FEXCore::Core::InternalThreadState* Thread, FEXCore::Context::ExitReason ExitReason) {
     if (ExitReason == FEXCore::Context::ExitReason::EXIT_DEBUG) {
       this->Break(SIGTRAP);
     }


### PR DESCRIPTION
Instead of passing the TID back to the exit handler, just pass the whole thread object. This will allow some cleanups with the frontend thread tracking soon

NFC