### PR TITLE
FEXCore: Removes CPUBackendFeatures

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -378,8 +378,6 @@ public:
     return ExitOnHLT;
   }
 
-  FEXCore::CPU::CPUBackendFeatures BackendFeatures;
-
 protected:
   void UpdateAtomicTSOEmulationConfig() {
     if (SupportsHardwareTSO) {

--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -34,11 +34,6 @@ namespace CodeSerialize {
 }
 
 namespace CPU {
-  struct CPUBackendFeatures {
-    bool SupportsFlags = false;
-    bool SupportsVTBL2 = false;
-  };
-
   class CPUBackend {
   public:
     struct CodeBuffer {

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -309,14 +309,6 @@ void ContextImpl::SetFlagsFromCompactedEFLAGS(FEXCore::Core::InternalThreadState
 
 bool ContextImpl::InitCore() {
   // Initialize the CPU core signal handlers & DispatcherConfig
-  switch (Config.Core) {
-  case FEXCore::Config::CONFIG_IRJIT: BackendFeatures = FEXCore::CPU::GetArm64JITBackendFeatures(); break;
-  case FEXCore::Config::CONFIG_CUSTOM:
-    // Do nothing
-    break;
-  default: LogMan::Msg::EFmt("Unknown core configuration"); return false;
-  }
-
   Dispatcher = FEXCore::CPU::Dispatcher::Create(this);
 
   // Set up the SignalDelegator config since core is initialized.

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JIT.cpp
@@ -885,11 +885,4 @@ fextl::unique_ptr<CPUBackend> CreateArm64JITCore(FEXCore::Context::ContextImpl* 
   return fextl::make_unique<Arm64JITCore>(ctx, Thread);
 }
 
-CPUBackendFeatures GetArm64JITBackendFeatures() {
-  return CPUBackendFeatures {
-    .SupportsFlags = true,
-    .SupportsVTBL2 = true,
-  };
-}
-
 } // namespace FEXCore::CPU

--- a/FEXCore/Source/Interface/Core/JIT/JITCore.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITCore.h
@@ -17,6 +17,5 @@ class CPUBackend;
 
 [[nodiscard]]
 fextl::unique_ptr<CPUBackend> CreateArm64JITCore(FEXCore::Context::ContextImpl* ctx, FEXCore::Core::InternalThreadState* Thread);
-CPUBackendFeatures GetArm64JITBackendFeatures();
 
 } // namespace FEXCore::CPU

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1432,13 +1432,10 @@ Ref OpDispatchBuilder::SHUFOpImpl(OpcodeArgs, size_t DstSize, size_t ElementSize
         return _VZip(DstSize, 8, DupSrc1, DupSrc2);
       }
       default:
-        // Use a TBL2 operation to handle this implementation. If the backend supports it.
-        if (CTX->BackendFeatures.SupportsVTBL2) {
-          auto LookupIndexes =
-            LoadAndCacheIndexedNamedVectorConstant(DstSize, FEXCore::IR::IndexNamedVectorConstant::INDEXED_NAMED_VECTOR_SHUFPS, Shuffle * 16);
-          return _VTBL2(DstSize, Src1, Src2, LookupIndexes);
-        }
-        break;
+        // Use a TBL2 operation to handle this implementation.
+        auto LookupIndexes =
+          LoadAndCacheIndexedNamedVectorConstant(DstSize, FEXCore::IR::IndexNamedVectorConstant::INDEXED_NAMED_VECTOR_SHUFPS, Shuffle * 16);
+        return _VTBL2(DstSize, Src1, Src2, LookupIndexes);
       }
     } else {
       switch (Shuffle & 0b11) {


### PR DESCRIPTION
We were only ever hardcoding true for TBL2 and Flags now. Get rid of it.