### PR TITLE
man: Fixes newline issue with strenum

### DIFF
--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -148,9 +148,8 @@ def print_man_options(options):
             if (value_type == "strenum"):
                 Enums = op_vals["Enums"]
                 output_man.write("\\fBAvailable Options:\\fR\n")
-                for enum_op_key, enum_op_vals in Enums.items():
-                    output_man.write("{}, ".format(enum_op_vals))
-                output_man.write("\n")
+                output_man.write(", ".join(f"{enum_op_val}" for [_, enum_op_val] in Enums.items()))
+                output_man.write("\n.sp\n")
 
     output_man.write(".El\n")
 
@@ -179,9 +178,8 @@ def print_man_environment(options):
             if (value_type == "strenum"):
                 Enums = op_vals["Enums"]
                 output_man.write("\\fBAvailable Options:\\fR\n")
-                for enum_op_key, enum_op_vals in Enums.items():
-                    output_man.write("{}, ".format(enum_op_vals))
-                output_man.write("\n")
+                output_man.write(", ".join(f"{enum_op_val}" for [_, enum_op_val] in Enums.items()))
+                output_man.write("\n.sp\n")
 
     print_man_environment_tail()
     output_man.write(".El\n")


### PR DESCRIPTION
In the environment section this was causing the next environment variable line to be merged with the strenum options

Also makes it so strenum options doesn't have a spurious comma at the end of the list.

Before:
![Image_2024-07-30_16-55-57](https://github.com/user-attachments/assets/b8d42c46-76f7-455e-b33d-45675a72bae2)
After:
![Image_2024-07-30_16-56-09](https://github.com/user-attachments/assets/1bfc768d-9411-4b6b-b40a-93c68513901e)
