### PR TITLE
Syscalls: Updates for v6.10 

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Arm64/SyscallsEnum.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Arm64/SyscallsEnum.h
@@ -348,6 +348,7 @@ enum Syscalls_Arm64 {
   SYSCALL_Arm64_lsm_get_self_attr = 459,
   SYSCALL_Arm64_lsm_set_self_attr = 460,
   SYSCALL_Arm64_lsm_list_modules = 461,
+  SYSCALL_Arm64_mseal = 462,
   SYSCALL_Arm64_MAX = 512,
 
   // Unsupported syscalls on this host

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
@@ -618,6 +618,12 @@ void RegisterCommon(FEX::HLE::SyscallHandler* Handler) {
     REGISTER_SYSCALL_IMPL(lsm_set_self_attr, UnimplementedSyscallSafe);
     REGISTER_SYSCALL_IMPL(lsm_list_modules, UnimplementedSyscallSafe);
   }
+  if (Handler->IsHostKernelVersionAtLeast(6, 10, 0)) {
+    REGISTER_SYSCALL_IMPL_PASS_FLAGS(mseal, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+                                     SyscallPassthrough3<SYSCALL_DEF(mseal)>);
+  } else {
+    REGISTER_SYSCALL_IMPL(mseal, UnimplementedSyscallSafe);
+  }
 }
 
 namespace x64 {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/SyscallsEnum.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/SyscallsEnum.h
@@ -478,5 +478,6 @@ enum Syscalls_x86 {
   SYSCALL_x86_lsm_get_self_attr = 459,
   SYSCALL_x86_lsm_set_self_attr = 460,
   SYSCALL_x86_lsm_list_modules = 461,
+  SYSCALL_x86_mseal = 462,
   SYSCALL_x86_MAX = 512,
 };

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/SyscallsEnum.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/SyscallsEnum.h
@@ -398,6 +398,7 @@ enum Syscalls_x64 {
   SYSCALL_x64_lsm_get_self_attr = 459,
   SYSCALL_x64_lsm_set_self_attr = 460,
   SYSCALL_x64_lsm_list_modules = 461,
+  SYSCALL_x64_mseal = 462,
   SYSCALL_x64_MAX = 512,
 
   // Unsupported syscalls on this host


### PR DESCRIPTION
Only mseal was added and can be a simple passthrough for us. Which is
nice.