### PR TITLE
Fix nasm warning in Rounding.asm

### DIFF
--- a/unittests/ASM/X87/Rounding.asm
+++ b/unittests/ASM/X87/Rounding.asm
@@ -12,6 +12,26 @@
 }
 %endif
 
+section .data
+align 8
+midpoint:
+  dq 1.5
+samidpoint:
+  dq 1.50001
+sbmidpoint:
+  dq 1.49999
+nmidpoint:
+  dq -1.5
+nsamidpoint:
+  dq -1.49999
+nsbmidpoint:
+  dq -1.50001
+
+section .bss
+align 8
+tmp resq 1
+
+section .text
 ; Rounding tests to ensure rounding modes are actually working
 
 ;; Mid-point
@@ -293,22 +313,3 @@ mov ax, word [rel tmp]
 or rsi, rax
 
 hlt
-
-section .data
-align 8
-midpoint:
-  dq 1.5
-samidpoint:
-  dq 1.50001
-sbmidpoint:
-  dq 1.49999
-nmidpoint:
-  dq -1.5
-nsamidpoint:
-  dq -1.49999
-nsbmidpoint:
-  dq -1.50001
-
-section .bss
-align 8
-tmp resq 1


### PR DESCRIPTION
Fixes this warning from nasm:
```
/home/pmatos/dev/FEX/build/unittests/ASM/X87/Rounding.asm_TMP.asm:316: warning: attempt to initialize memory in a nobits section: ignored [-w+other]
```

Fixed it pre-merge in Rounding_F64.asm, RoundingNeg.asm and RoundingPos.asm but somehow forgot it here.