### PR TITLE
FEXCore: Add a generic spill/fill-all syscall ABI and use for Windows

### DIFF
--- a/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -39,9 +39,7 @@ enum class SyscallOSABI {
   OS_UNKNOWN,
   OS_LINUX64,
   OS_LINUX32,
-  OS_WIN64,
-  OS_WIN32,
-  OS_HANGOVER,
+  OS_GENERIC, // No JIT-side argument handling, spill/fill all regs.
 };
 
 class SyscallHandler;

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -398,7 +398,7 @@ static void Init() {
 class ECSyscallHandler : public FEXCore::HLE::SyscallHandler, public FEXCore::Allocator::FEXAllocOperators {
 public:
   ECSyscallHandler() {
-    OSABI = FEXCore::HLE::SyscallOSABI::OS_WIN32;
+    OSABI = FEXCore::HLE::SyscallOSABI::OS_GENERIC;
   }
 
   uint64_t HandleSyscall(FEXCore::Core::CpuStateFrame* Frame, FEXCore::HLE::SyscallArguments* Args) override {

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -363,7 +363,7 @@ __attribute__((naked)) extern "C" uint64_t SEHFrameTrampoline2Args(void* Arg0, v
 class WowSyscallHandler : public FEXCore::HLE::SyscallHandler, public FEXCore::Allocator::FEXAllocOperators {
 public:
   WowSyscallHandler() {
-    OSABI = FEXCore::HLE::SyscallOSABI::OS_WIN32;
+    OSABI = FEXCore::HLE::SyscallOSABI::OS_GENERIC;
   }
 
   static uint64_t HandleSyscallImpl(FEXCore::Core::CpuStateFrame* Frame, FEXCore::HLE::SyscallArguments* Args) {


### PR DESCRIPTION
Also drop the legacy hangover ABI as it has no users.