### PR TITLE
Directly use the EC code bitmap for determining page arch

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -70,6 +70,14 @@ constexpr auto VTMP2 = ARMEmitter::VReg::v17;
 // Entry/Exit ABI
 constexpr auto EC_CALL_CHECKER_PC_REG = ARMEmitter::XReg::x9;
 constexpr auto EC_ENTRY_CPUAREA_REG = ARMEmitter::XReg::x17;
+
+// These structures are not included in the standard Windows headers, define the offsets of members we care about for EC here.
+constexpr size_t TEB_CPU_AREA_OFFSET = 0x1788;
+constexpr size_t TEB_PEB_OFFSET = 0x60;
+constexpr size_t PEB_EC_CODE_BITMAP_OFFSET = 0x368;
+constexpr size_t CPU_AREA_IN_SYSCALL_CALLBACK_OFFSET = 0x1;
+constexpr size_t CPU_AREA_EMULATOR_STACK_BASE_OFFSET = 0x8;
+constexpr size_t CPU_AREA_EMULATOR_DATA_OFFSET = 0x30;
 #endif
 
 // Predicate register temporaries (used when AVX support is enabled)

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -806,14 +806,6 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
   FEXCORE_PROFILE_SCOPED("CompileBlock");
   auto Thread = Frame->Thread;
 
-#ifdef _M_ARM_64EC
-  // If the target PC is EC code, mark it in the L2 and return straight to the dispatcher
-  // so it can handle the call/return.
-  if (Thread->LookupCache->CheckPageEC(GuestRIP)) {
-    return GuestRIP;
-  }
-#endif
-
   // Invalidate might take a unique lock on this, to guarantee that during invalidation no code gets compiled
   auto lk = GuardSignalDeferringSection<std::shared_lock>(CodeInvalidationMutex, Thread);
 

--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -62,14 +62,6 @@ void Dispatcher::EmitDispatcher() {
 
   ARMEmitter::ForwardLabel l_CTX;
   ARMEmitter::SingleUseForwardLabel l_Sleep;
-#ifdef _M_ARM_64EC
-  // These structures are not included in the standard Windows headers, define them here
-  static constexpr size_t TEBCPUAreaOffset = 0x1788;
-  static constexpr size_t CPUAreaInSyscallCallbackOffset = 0x1;
-  static constexpr size_t CPUAreaEmulatorStackLimitOffset = 0x8;
-  static constexpr size_t CPUAreaEmulatorDataOffset = 0x30;
-  ARMEmitter::SingleUseForwardLabel ExitEC;
-#endif
   ARMEmitter::SingleUseForwardLabel l_CompileBlock;
 
   // Push all the register we need to save
@@ -94,7 +86,7 @@ void Dispatcher::EmitDispatcher() {
   b(&LoopTop);
 
   AbsoluteLoopTopAddressEnterECFillSRA = GetCursorAddress<uint64_t>();
-  ldr(STATE, EC_ENTRY_CPUAREA_REG, CPUAreaEmulatorDataOffset);
+  ldr(STATE, EC_ENTRY_CPUAREA_REG, CPU_AREA_EMULATOR_DATA_OFFSET);
   FillStaticRegs();
 
   // Enter JIT
@@ -102,11 +94,11 @@ void Dispatcher::EmitDispatcher() {
 
   AbsoluteLoopTopAddressEnterEC = GetCursorAddress<uint64_t>();
   // Load ThreadState and write the target PC there
-  ldr(STATE, EC_ENTRY_CPUAREA_REG, CPUAreaEmulatorDataOffset);
+  ldr(STATE, EC_ENTRY_CPUAREA_REG, CPU_AREA_EMULATOR_DATA_OFFSET);
   str(EC_CALL_CHECKER_PC_REG, STATE_PTR(CpuStateFrame, State.rip));
 
   // Swap stacks to the emulator stack
-  ldr(TMP1, EC_ENTRY_CPUAREA_REG, CPUAreaEmulatorStackLimitOffset);
+  ldr(TMP1, EC_ENTRY_CPUAREA_REG, CPU_AREA_EMULATOR_STACK_BASE_OFFSET);
   add(ARMEmitter::Size::i64Bit, StaticRegisters[X86State::REG_RSP], ARMEmitter::Reg::rsp, 0);
   add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::rsp, TMP1, 0);
 
@@ -237,9 +229,9 @@ void Dispatcher::EmitDispatcher() {
     str(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
 
 #ifdef _M_ARM_64EC
-    ldr(ARMEmitter::XReg::x0, ARMEmitter::XReg::x18, TEBCPUAreaOffset);
+    ldr(ARMEmitter::XReg::x0, ARMEmitter::XReg::x18, TEB_CPU_AREA_OFFSET);
     LoadConstant(ARMEmitter::Size::i32Bit, ARMEmitter::Reg::r1, 1);
-    strb(ARMEmitter::WReg::w1, ARMEmitter::XReg::x0, CPUAreaInSyscallCallbackOffset);
+    strb(ARMEmitter::WReg::w1, ARMEmitter::XReg::x0, CPU_AREA_IN_SYSCALL_CALLBACK_OFFSET);
 #endif
 
     mov(ARMEmitter::XReg::x0, STATE);
@@ -259,8 +251,8 @@ void Dispatcher::EmitDispatcher() {
     FillStaticRegs();
 
 #ifdef _M_ARM_64EC
-    ldr(TMP2, ARMEmitter::XReg::x18, TEBCPUAreaOffset);
-    strb(ARMEmitter::WReg::zr, TMP2, CPUAreaInSyscallCallbackOffset);
+    ldr(TMP2, ARMEmitter::XReg::x18, TEB_CPU_AREA_OFFSET);
+    strb(ARMEmitter::WReg::zr, TMP2, CPU_AREA_IN_SYSCALL_CALLBACK_OFFSET);
 #endif
 
     ldr(TMP2, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
@@ -289,9 +281,9 @@ void Dispatcher::EmitDispatcher() {
     str(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));
 
 #ifdef _M_ARM_64EC
-    ldr(ARMEmitter::XReg::x0, ARMEmitter::XReg::x18, TEBCPUAreaOffset);
+    ldr(ARMEmitter::XReg::x0, ARMEmitter::XReg::x18, TEB_CPU_AREA_OFFSET);
     LoadConstant(ARMEmitter::Size::i32Bit, ARMEmitter::Reg::r1, 1);
-    strb(ARMEmitter::WReg::w1, ARMEmitter::XReg::x0, CPUAreaInSyscallCallbackOffset);
+    strb(ARMEmitter::WReg::w1, ARMEmitter::XReg::x0, CPU_AREA_IN_SYSCALL_CALLBACK_OFFSET);
 #endif
 
     ldr(ARMEmitter::XReg::x0, &l_CTX);
@@ -309,8 +301,8 @@ void Dispatcher::EmitDispatcher() {
     FillStaticRegs();
 
 #ifdef _M_ARM_64EC
-    ldr(TMP1, ARMEmitter::XReg::x18, TEBCPUAreaOffset);
-    strb(ARMEmitter::WReg::zr, TMP1, CPUAreaInSyscallCallbackOffset);
+    ldr(TMP1, ARMEmitter::XReg::x18, TEB_CPU_AREA_OFFSET);
+    strb(ARMEmitter::WReg::zr, TMP1, CPU_AREA_IN_SYSCALL_CALLBACK_OFFSET);
 #endif
 
     ldr(TMP1, STATE, offsetof(FEXCore::Core::CPUState, DeferredSignalRefCount));

--- a/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/FEXCore/Source/Interface/Core/LookupCache.h
@@ -13,9 +13,6 @@
 #include <stddef.h>
 #include <utility>
 #include <mutex>
-#ifdef _M_ARM_64EC
-#include <winnt.h>
-#endif
 
 namespace FEXCore {
 
@@ -69,24 +66,6 @@ public:
     // Failed to find
     return 0;
   }
-
-#ifdef _M_ARM_64EC
-  bool CheckPageEC(uint64_t Address) {
-    if (!RtlIsEcCode(Address)) {
-      return false;
-    }
-
-    std::lock_guard<std::recursive_mutex> lk(WriteLock);
-
-    // Mark L2 entry for this page as EC by setting the LSB, this can then be
-    // checked by the dispatcher to see if it needs to perform a call/return to
-    // EC code.
-    const auto PageIndex = (Address & (VirtualMemSize - 1)) >> 12;
-    const auto Pointers = reinterpret_cast<uintptr_t*>(PagePointer);
-    Pointers[PageIndex] |= 1;
-    return true;
-  }
-#endif
 
   fextl::map<uint64_t, fextl::vector<uint64_t>> CodePages;
 


### PR DESCRIPTION
The prior approach using the L2 cache was flawed as it assumed L2 page entries had a 1-1 correspondence with actual pages. While the L2 cache could be extended to handle aliases with EC, this could lead to thrashing etc. The cost of a lookup in the actual EC code bitmap is cheap enough to perform every time considering the infrequency of calls to ARM64EC code when compare to X86 L2 hits.