### PR TITLE
ARM64EC: Support the JIT API as is used by Windows

### DIFF
--- a/Source/Windows/ARM64EC/BTInterface.h
+++ b/Source/Windows/ARM64EC/BTInterface.h
@@ -11,11 +11,15 @@ void STDMETHODCALLTYPE ProcessTerm(HANDLE Handle, BOOL After, NTSTATUS Status);
 NTSTATUS STDMETHODCALLTYPE ThreadInit();
 NTSTATUS STDMETHODCALLTYPE ThreadTerm(HANDLE Thread, LONG ExitCode);
 NTSTATUS STDMETHODCALLTYPE ResetToConsistentState(EXCEPTION_RECORD* Exception, CONTEXT* GuestContext, ARM64_NT_CONTEXT* NativeContext);
-void STDMETHODCALLTYPE BTCpu64FlushInstructionCache(const void* Address, SIZE_T Size);
 void STDMETHODCALLTYPE NotifyMemoryAlloc(void* Address, SIZE_T Size, ULONG Type, ULONG Prot, BOOL After, NTSTATUS Status);
 void STDMETHODCALLTYPE NotifyMemoryFree(void* Address, SIZE_T Size, ULONG FreeType, BOOL After, NTSTATUS Status);
 void STDMETHODCALLTYPE NotifyMemoryProtect(void* Address, SIZE_T Size, ULONG NewProt, BOOL After, NTSTATUS Status);
+NTSTATUS STDMETHODCALLTYPE NotifyMapViewOfSection(void* Unk1, void* Address, void* Unk2, SIZE_T Size, ULONG AllocType, ULONG Prot);
 void STDMETHODCALLTYPE NotifyUnmapViewOfSection(void* Address, BOOL After, NTSTATUS Status);
+void STDMETHODCALLTYPE FlushInstructionCacheHeavy(const void* Address, SIZE_T Size);
+void STDMETHODCALLTYPE BTCpu64FlushInstructionCache(const void* Address, SIZE_T Size);
+void STDMETHODCALLTYPE BTCpu64NotifyMemoryDirty(void* Address, SIZE_T Size);
+void STDMETHODCALLTYPE BTCpu64NotifyReadFile(HANDLE Handle, void* Address, SIZE_T Size, BOOL After, NTSTATUS Status);
 BOOLEAN STDMETHODCALLTYPE BTCpu64IsProcessorFeaturePresent(UINT Feature);
 void STDMETHODCALLTYPE UpdateProcessorInformation(SYSTEM_CPU_INFORMATION* Info);
 }

--- a/Source/Windows/ARM64EC/BTInterface.h
+++ b/Source/Windows/ARM64EC/BTInterface.h
@@ -6,16 +6,16 @@
 #include <winternl.h>
 
 extern "C" {
-void STDMETHODCALLTYPE ProcessInit();
-void STDMETHODCALLTYPE ProcessTerm();
+NTSTATUS STDMETHODCALLTYPE ProcessInit();
+void STDMETHODCALLTYPE ProcessTerm(HANDLE Handle, BOOL After, NTSTATUS Status);
 NTSTATUS STDMETHODCALLTYPE ThreadInit();
-NTSTATUS STDMETHODCALLTYPE ThreadTerm(HANDLE Thread);
-NTSTATUS STDMETHODCALLTYPE ResetToConsistentState(EXCEPTION_POINTERS* Ptrs, ARM64_NT_CONTEXT* Context, BOOLEAN* Continue);
+NTSTATUS STDMETHODCALLTYPE ThreadTerm(HANDLE Thread, LONG ExitCode);
+NTSTATUS STDMETHODCALLTYPE ResetToConsistentState(EXCEPTION_RECORD* Exception, CONTEXT* GuestContext, ARM64_NT_CONTEXT* NativeContext);
 void STDMETHODCALLTYPE BTCpu64FlushInstructionCache(const void* Address, SIZE_T Size);
-void STDMETHODCALLTYPE NotifyMemoryAlloc(void* Address, SIZE_T Size, ULONG Type, ULONG Prot);
-void STDMETHODCALLTYPE NotifyMemoryFree(void* Address, SIZE_T Size, ULONG FreeType);
-void STDMETHODCALLTYPE NotifyMemoryProtect(void* Address, SIZE_T Size, ULONG NewProt);
-void STDMETHODCALLTYPE NotifyUnmapViewOfSection(void* Address);
+void STDMETHODCALLTYPE NotifyMemoryAlloc(void* Address, SIZE_T Size, ULONG Type, ULONG Prot, BOOL After, NTSTATUS Status);
+void STDMETHODCALLTYPE NotifyMemoryFree(void* Address, SIZE_T Size, ULONG FreeType, BOOL After, NTSTATUS Status);
+void STDMETHODCALLTYPE NotifyMemoryProtect(void* Address, SIZE_T Size, ULONG NewProt, BOOL After, NTSTATUS Status);
+void STDMETHODCALLTYPE NotifyUnmapViewOfSection(void* Address, BOOL After, NTSTATUS Status);
 BOOLEAN STDMETHODCALLTYPE BTCpu64IsProcessorFeaturePresent(UINT Feature);
 void STDMETHODCALLTYPE UpdateProcessorInformation(SYSTEM_CPU_INFORMATION* Info);
 }

--- a/Source/Windows/ARM64EC/Module.S
+++ b/Source/Windows/ARM64EC/Module.S
@@ -41,6 +41,9 @@ enter_jit:
   // Expects a CONTEXT pointer in x0
 .global BeginSimulation
 BeginSimulation:
+  ldr x17, [x18, #0x1788] // TEB->ChpeV2CpuAreaInfo
+  ldr x16, [x17, #0x8] // ChpeV2CpuAreaInfo->EmulatorStackBase
+  mov sp, x16
   bl "#SyncThreadContext"
   ldr x17, [x18, #0x1788] // TEB->ChpeV2CpuAreaInfo
   ldr x16, [x17, #0x48] // ChpeV2CpuAreaInfo->EmulatorData[3] - DispatcherLoopTopEnterECFillSRA

--- a/Source/Windows/ARM64EC/Module.S
+++ b/Source/Windows/ARM64EC/Module.S
@@ -81,3 +81,20 @@ ret_sp_misaligned:
   adrp lr, X64ReturnInstr
   ldr lr, [lr, #:lo12:X64ReturnInstr]
   br x17
+
+  // Calls NtContinue directly to allow continuing from a full native context, as the NTDLL NtContinue export takes in
+  // an x64 context with EC and the conversion to that loses the ARM64EC ABI-disallowed registers that FEX uses.
+.global "#NtContinueNative"
+"#NtContinueNative":
+  adrp x16, WineSyscallDispatcher
+  ldr x16, [x16, #:lo12:WineSyscallDispatcher]
+  cbz x16, direct_syscall
+wine_syscall:
+  mov x9, x30
+  adrp x8, WineNtContinueSyscallId
+  ldr x8, [x8, #:lo12:WineNtContinueSyscallId]
+  blr x16
+  ret
+direct_syscall:
+  svc #0x43
+  ret

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -385,6 +385,7 @@ static void RethrowGuestException(const EXCEPTION_RECORD& Rec, ARM64_NT_CONTEXT&
   uint64_t GuestSp = Context.X[Config.SRAGPRMapping[static_cast<size_t>(FEXCore::X86State::REG_RSP)]];
   struct DispatchArgs {
     ARM64_NT_CONTEXT Context;
+    uint64_t Pad[4]; // Only present on newer Windows versions, likely for SVE.
     EXCEPTION_RECORD Rec;
     uint64_t Align;
     uint64_t Redzone[2];

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -408,13 +408,13 @@ extern "C" void SyncThreadContext(CONTEXT* Context) {
 }
 
 void ProcessInit() {
-  FEX::Windows::Logging::Init();
   FEX::Config::InitializeConfigs();
   FEXCore::Config::Initialize();
   FEXCore::Config::AddLayer(FEX::Config::CreateGlobalMainLayer());
   FEXCore::Config::AddLayer(FEX::Config::CreateMainLayer());
   FEXCore::Config::Load();
   FEXCore::Config::ReloadMetaLayer();
+  FEX::Windows::Logging::Init();
 
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS64BIT_MODE, "1");
 

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -28,6 +28,7 @@ $end_info$
 #include "Common/InvalidationTracker.h"
 #include "Common/TSOHandlerConfig.h"
 #include "Common/CPUFeatures.h"
+#include "Common/Logging.h"
 #include "DummyHandlers.h"
 #include "BTInterface.h"
 
@@ -378,23 +379,6 @@ static void RethrowGuestException(const EXCEPTION_RECORD& Rec, ARM64_NT_CONTEXT&
 }
 } // namespace Exception
 
-namespace Logging {
-static void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
-  const auto Output = fextl::fmt::format("[{}][{:X}] {}\n", LogMan::DebugLevelStr(Level), GetCurrentThreadId(), Message);
-  __wine_dbg_output(Output.c_str());
-}
-
-static void AssertHandler(const char* Message) {
-  const auto Output = fextl::fmt::format("[ASSERT] {}\n", Message);
-  __wine_dbg_output(Output.c_str());
-}
-
-static void Init() {
-  LogMan::Throw::InstallHandler(AssertHandler);
-  LogMan::Msg::InstallHandler(MsgHandler);
-}
-} // namespace Logging
-
 class ECSyscallHandler : public FEXCore::HLE::SyscallHandler, public FEXCore::Allocator::FEXAllocOperators {
 public:
   ECSyscallHandler() {
@@ -424,7 +408,7 @@ extern "C" void SyncThreadContext(CONTEXT* Context) {
 }
 
 void ProcessInit() {
-  Logging::Init();
+  FEX::Windows::Logging::Init();
   FEX::Config::InitializeConfigs();
   FEXCore::Config::Initialize();
   FEXCore::Config::AddLayer(FEX::Config::CreateGlobalMainLayer());

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -243,55 +243,64 @@ static bool HandleUnalignedAccess(ARM64_NT_CONTEXT& Context) {
 static void LoadStateFromECContext(FEXCore::Core::InternalThreadState* Thread, CONTEXT& Context) {
   auto& State = Thread->CurrentFrame->State;
 
-  // General register state
-  State.gregs[FEXCore::X86State::REG_RAX] = Context.Rax;
-  State.gregs[FEXCore::X86State::REG_RCX] = Context.Rcx;
-  State.gregs[FEXCore::X86State::REG_RDX] = Context.Rdx;
-  State.gregs[FEXCore::X86State::REG_RBX] = Context.Rbx;
-  State.gregs[FEXCore::X86State::REG_RSP] = Context.Rsp;
-  State.gregs[FEXCore::X86State::REG_RBP] = Context.Rbp;
-  State.gregs[FEXCore::X86State::REG_RSI] = Context.Rsi;
-  State.gregs[FEXCore::X86State::REG_RDI] = Context.Rdi;
-  State.gregs[FEXCore::X86State::REG_R8] = Context.R8;
-  State.gregs[FEXCore::X86State::REG_R9] = Context.R9;
-  State.gregs[FEXCore::X86State::REG_R10] = Context.R10;
-  State.gregs[FEXCore::X86State::REG_R11] = Context.R11;
-  State.gregs[FEXCore::X86State::REG_R12] = Context.R12;
-  State.gregs[FEXCore::X86State::REG_R13] = Context.R13;
-  State.gregs[FEXCore::X86State::REG_R14] = Context.R14;
-  State.gregs[FEXCore::X86State::REG_R15] = Context.R15;
+  if (Context.ContextFlags & CONTEXT_INTEGER) {
+    // General register state
+    State.gregs[FEXCore::X86State::REG_RAX] = Context.Rax;
+    State.gregs[FEXCore::X86State::REG_RCX] = Context.Rcx;
+    State.gregs[FEXCore::X86State::REG_RDX] = Context.Rdx;
+    State.gregs[FEXCore::X86State::REG_RBX] = Context.Rbx;
 
-  State.rip = Context.Rip;
-  CTX->SetFlagsFromCompactedEFLAGS(Thread, Context.EFlags);
+    State.gregs[FEXCore::X86State::REG_RSI] = Context.Rsi;
+    State.gregs[FEXCore::X86State::REG_RDI] = Context.Rdi;
+    State.gregs[FEXCore::X86State::REG_R8] = Context.R8;
+    State.gregs[FEXCore::X86State::REG_R9] = Context.R9;
+    State.gregs[FEXCore::X86State::REG_R10] = Context.R10;
+    State.gregs[FEXCore::X86State::REG_R11] = Context.R11;
+    State.gregs[FEXCore::X86State::REG_R12] = Context.R12;
+    State.gregs[FEXCore::X86State::REG_R13] = Context.R13;
+    State.gregs[FEXCore::X86State::REG_R14] = Context.R14;
+    State.gregs[FEXCore::X86State::REG_R15] = Context.R15;
+  }
 
-  State.es_idx = Context.SegEs & 0xffff;
-  State.cs_idx = Context.SegCs & 0xffff;
-  State.ss_idx = Context.SegSs & 0xffff;
-  State.ds_idx = Context.SegDs & 0xffff;
-  State.fs_idx = Context.SegFs & 0xffff;
-  State.gs_idx = Context.SegGs & 0xffff;
+  if (Context.ContextFlags & CONTEXT_CONTROL) {
+    State.rip = Context.Rip;
+    State.gregs[FEXCore::X86State::REG_RSP] = Context.Rsp;
+    State.gregs[FEXCore::X86State::REG_RBP] = Context.Rbp;
+    CTX->SetFlagsFromCompactedEFLAGS(Thread, Context.EFlags);
+  }
 
-  // The TEB is the only populated GDT entry by default
-  const auto TEB = reinterpret_cast<uint64_t>(NtCurrentTeb());
-  State.gdt[(Context.SegGs & 0xffff) >> 3].base = TEB;
-  State.gs_cached = TEB;
-  State.fs_cached = 0;
-  State.es_cached = 0;
-  State.cs_cached = 0;
-  State.ss_cached = 0;
-  State.ds_cached = 0;
+  if (Context.ContextFlags & CONTEXT_SEGMENTS) {
+    State.es_idx = Context.SegEs & 0xffff;
+    State.cs_idx = Context.SegCs & 0xffff;
+    State.ss_idx = Context.SegSs & 0xffff;
+    State.ds_idx = Context.SegDs & 0xffff;
+    State.fs_idx = Context.SegFs & 0xffff;
+    State.gs_idx = Context.SegGs & 0xffff;
 
-  // Floating-point register state
-  CTX->SetXMMRegistersFromState(Thread, reinterpret_cast<const __uint128_t*>(Context.FltSave.XmmRegisters), nullptr);
-  memcpy(State.mm, Context.FltSave.FloatRegisters, sizeof(State.mm));
+    // The TEB is the only populated GDT entry by default
+    const auto TEB = reinterpret_cast<uint64_t>(NtCurrentTeb());
+    State.gdt[(Context.SegGs & 0xffff) >> 3].base = TEB;
+    State.gs_cached = TEB;
+    State.fs_cached = 0;
+    State.es_cached = 0;
+    State.cs_cached = 0;
+    State.ss_cached = 0;
+    State.ds_cached = 0;
+  }
 
-  State.FCW = Context.FltSave.ControlWord;
-  State.flags[FEXCore::X86State::X87FLAG_C0_LOC] = (Context.FltSave.StatusWord >> 8) & 1;
-  State.flags[FEXCore::X86State::X87FLAG_C1_LOC] = (Context.FltSave.StatusWord >> 9) & 1;
-  State.flags[FEXCore::X86State::X87FLAG_C2_LOC] = (Context.FltSave.StatusWord >> 10) & 1;
-  State.flags[FEXCore::X86State::X87FLAG_C3_LOC] = (Context.FltSave.StatusWord >> 14) & 1;
-  State.flags[FEXCore::X86State::X87FLAG_TOP_LOC] = (Context.FltSave.StatusWord >> 11) & 0b111;
-  State.AbridgedFTW = Context.FltSave.TagWord;
+  if (Context.ContextFlags & CONTEXT_FLOATING_POINT) {
+    // Floating-point register state
+    CTX->SetXMMRegistersFromState(Thread, reinterpret_cast<const __uint128_t*>(Context.FltSave.XmmRegisters), nullptr);
+    memcpy(State.mm, Context.FltSave.FloatRegisters, sizeof(State.mm));
+
+    State.FCW = Context.FltSave.ControlWord;
+    State.flags[FEXCore::X86State::X87FLAG_C0_LOC] = (Context.FltSave.StatusWord >> 8) & 1;
+    State.flags[FEXCore::X86State::X87FLAG_C1_LOC] = (Context.FltSave.StatusWord >> 9) & 1;
+    State.flags[FEXCore::X86State::X87FLAG_C2_LOC] = (Context.FltSave.StatusWord >> 10) & 1;
+    State.flags[FEXCore::X86State::X87FLAG_C3_LOC] = (Context.FltSave.StatusWord >> 14) & 1;
+    State.flags[FEXCore::X86State::X87FLAG_TOP_LOC] = (Context.FltSave.StatusWord >> 11) & 0b111;
+    State.AbridgedFTW = Context.FltSave.TagWord;
+  }
 }
 
 static void ReconstructThreadState(ARM64_NT_CONTEXT& Context) {
@@ -317,7 +326,7 @@ static ARM64_NT_CONTEXT ReconstructPackedECContext(ARM64_NT_CONTEXT& Context) {
   ReconstructThreadState(Context);
   ARM64_NT_CONTEXT ECContext {};
 
-  ECContext.ContextFlags = CONTEXT_ARM64_CONTROL | CONTEXT_ARM64_INTEGER | CONTEXT_ARM64_FLOATING_POINT;
+  ECContext.ContextFlags = CONTEXT_ARM64_FULL;
 
   auto* Thread = GetCPUArea().ThreadState();
   auto& State = Thread->CurrentFrame->State;
@@ -581,7 +590,7 @@ NTSTATUS ThreadInit() {
   uint64_t EnterECFillSRA = Thread->CurrentFrame->Pointers.Common.DispatcherLoopTopEnterECFillSRA;
   CPUArea.DispatcherLoopTopEnterECFillSRA() = EnterECFillSRA;
 
-  CPUArea.ContextAmd64() = {.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT,
+  CPUArea.ContextAmd64() = {.ContextFlags = CONTEXT_CONTROL | CONTEXT_SEGMENTS | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT,
                             .AMD64_SegCs = 0x33,
                             .AMD64_SegDs = 0x2b,
                             .AMD64_SegEs = 0x2b,

--- a/Source/Windows/ARM64EC/libarm64ecfex.def
+++ b/Source/Windows/ARM64EC/libarm64ecfex.def
@@ -3,12 +3,14 @@ LIBRARY libarm64ecfex.dll
 EXPORTS
   BTCpu64FlushInstructionCache
   BTCpu64IsProcessorFeaturePresent
+  BTCpu64NotifyMemoryDirty
+  BTCpu64NotifyReadFile
   DispatchJump DATA
   RetToEntryThunk DATA
   ExitToX64 DATA
   BeginSimulation DATA
-;  FlushInstructionCacheHeavy
-;  NotifyMapViewOfSection
+  FlushInstructionCacheHeavy
+  NotifyMapViewOfSection
   NotifyMemoryAlloc
   NotifyMemoryFree
   NotifyMemoryProtect

--- a/Source/Windows/Common/CMakeLists.txt
+++ b/Source/Windows/Common/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(CommonWindows STATIC CPUFeatures.cpp InvalidationTracker.cpp)
+add_library(CommonWindows STATIC CPUFeatures.cpp InvalidationTracker.cpp Logging.cpp)
 target_link_libraries(CommonWindows FEXCore_Base)
 
 target_include_directories(CommonWindows PRIVATE

--- a/Source/Windows/Common/CPUFeatures.cpp
+++ b/Source/Windows/Common/CPUFeatures.cpp
@@ -68,7 +68,7 @@ bool CPUFeatures::IsFeaturePresent(uint32_t Feature) {
   case PF_SSE4_2_INSTRUCTIONS_AVAILABLE: return !!(CpuInfo.ProcessorFeatureBits & CPU_FEATURE_SSE42);
   case PF_AVX_INSTRUCTIONS_AVAILABLE: return !!(CpuInfo.ProcessorFeatureBits & CPU_FEATURE_AVX);
   case PF_AVX2_INSTRUCTIONS_AVAILABLE: return !!(CpuInfo.ProcessorFeatureBits & CPU_FEATURE_AVX2);
-  default: LogMan::Msg::DFmt("Unknown CPU feature: {:X}", Feature); return false;
+  default: return false;
   }
 }
 

--- a/Source/Windows/Common/Logging.cpp
+++ b/Source/Windows/Common/Logging.cpp
@@ -2,6 +2,7 @@
 #include <FEXCore/fextl/fmt.h>
 #include <FEXCore/Utils/LogManager.h>
 
+#include <cstdio>
 #include <ntstatus.h>
 #include <windef.h>
 #include <winternl.h>
@@ -9,21 +10,34 @@
 
 namespace {
 void (*WineDbgOut)(const char* Message);
+FILE* LogFile;
 
-void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
+static void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
   const auto Output = fextl::fmt::format("[{}][{:X}] {}\n", LogMan::DebugLevelStr(Level), GetCurrentThreadId(), Message);
-  WineDbgOut(Output.c_str());
+  if (WineDbgOut) {
+    WineDbgOut(Output.c_str());
+  } else {
+    fwrite(Output.c_str(), 1, Output.size(), LogFile);
+  }
 }
 
-void AssertHandler(const char* Message) {
+static void AssertHandler(const char* Message) {
   const auto Output = fextl::fmt::format("[ASSERT] {}\n", Message);
-  WineDbgOut(Output.c_str());
+  if (WineDbgOut) {
+    WineDbgOut(Output.c_str());
+  } else {
+    fwrite(Output.c_str(), 1, Output.size(), LogFile);
+  }
 }
 } // namespace
 
 namespace FEX::Windows::Logging {
 void Init() {
   WineDbgOut = reinterpret_cast<decltype(WineDbgOut)>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "__wine_dbg_output"));
+  if (!WineDbgOut) {
+    const auto Path = fextl::fmt::format("{}\\fex-{}.log", getenv("LOCALAPPDATA"), GetCurrentProcessId());
+    LogFile = fopen(Path.c_str(), "a");
+  }
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);
 }

--- a/Source/Windows/Common/Logging.cpp
+++ b/Source/Windows/Common/Logging.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+#include <FEXCore/fextl/fmt.h>
+#include <FEXCore/Utils/LogManager.h>
+
+#include <ntstatus.h>
+#include <windef.h>
+#include <winternl.h>
+#include <winnt.h>
+
+namespace {
+void (*WineDbgOut)(const char* Message);
+
+void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
+  const auto Output = fextl::fmt::format("[{}][{:X}] {}\n", LogMan::DebugLevelStr(Level), GetCurrentThreadId(), Message);
+  WineDbgOut(Output.c_str());
+}
+
+void AssertHandler(const char* Message) {
+  const auto Output = fextl::fmt::format("[ASSERT] {}\n", Message);
+  WineDbgOut(Output.c_str());
+}
+} // namespace
+
+namespace FEX::Windows::Logging {
+void Init() {
+  WineDbgOut = reinterpret_cast<decltype(WineDbgOut)>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "__wine_dbg_output"));
+  LogMan::Throw::InstallHandler(AssertHandler);
+  LogMan::Msg::InstallHandler(MsgHandler);
+}
+} // namespace FEX::Windows::Logging

--- a/Source/Windows/Common/Logging.cpp
+++ b/Source/Windows/Common/Logging.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <FEXCore/fextl/fmt.h>
+#include <FEXCore/Config/Config.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <cstdio>
@@ -33,6 +34,11 @@ static void AssertHandler(const char* Message) {
 
 namespace FEX::Windows::Logging {
 void Init() {
+  FEX_CONFIG_OPT(SilentLog, SILENTLOG);
+  if (SilentLog()) {
+    return;
+  }
+
   WineDbgOut = reinterpret_cast<decltype(WineDbgOut)>(GetProcAddress(GetModuleHandleA("ntdll.dll"), "__wine_dbg_output"));
   if (!WineDbgOut) {
     const auto Path = fextl::fmt::format("{}\\fex-{}.log", getenv("LOCALAPPDATA"), GetCurrentProcessId());

--- a/Source/Windows/Common/Logging.h
+++ b/Source/Windows/Common/Logging.h
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+namespace FEX::Windows::Logging {
+void Init();
+} // namespace FEX::Windows::Logging

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -410,13 +410,13 @@ public:
 };
 
 void BTCpuProcessInit() {
-  FEX::Windows::Logging::Init();
   FEX::Config::InitializeConfigs();
   FEXCore::Config::Initialize();
   FEXCore::Config::AddLayer(FEX::Config::CreateGlobalMainLayer());
   FEXCore::Config::AddLayer(FEX::Config::CreateMainLayer());
   FEXCore::Config::Load();
   FEXCore::Config::ReloadMetaLayer();
+  FEX::Windows::Logging::Init();
 
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS_INTERPRETER, "0");
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, "0");

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -29,6 +29,7 @@ $end_info$
 #include "Common/TSOHandlerConfig.h"
 #include "Common/InvalidationTracker.h"
 #include "Common/CPUFeatures.h"
+#include "Common/Logging.h"
 #include "DummyHandlers.h"
 #include "BTInterface.h"
 
@@ -329,23 +330,6 @@ bool HandleSuspendInterrupt(CONTEXT* Context, uint64_t FaultAddress) {
 }
 } // namespace Context
 
-namespace Logging {
-void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
-  const auto Output = fextl::fmt::format("[{}][{:X}] {}\n", LogMan::DebugLevelStr(Level), GetCurrentThreadId(), Message);
-  __wine_dbg_output(Output.c_str());
-}
-
-void AssertHandler(const char* Message) {
-  const auto Output = fextl::fmt::format("[ASSERT] {}\n", Message);
-  __wine_dbg_output(Output.c_str());
-}
-
-void Init() {
-  LogMan::Throw::InstallHandler(AssertHandler);
-  LogMan::Msg::InstallHandler(MsgHandler);
-}
-} // namespace Logging
-
 // Calls a 2-argument function `Func` setting the parent unwind frame information to the given SP and PC
 __attribute__((naked)) extern "C" uint64_t SEHFrameTrampoline2Args(void* Arg0, void* Arg1, void* Func, uint64_t Sp, uint64_t Pc) {
   asm(".seh_proc SEHFrameTrampoline2Args;"
@@ -426,7 +410,7 @@ public:
 };
 
 void BTCpuProcessInit() {
-  Logging::Init();
+  FEX::Windows::Logging::Init();
   FEX::Config::InitializeConfigs();
   FEXCore::Config::Initialize();
   FEXCore::Config::AddLayer(FEX::Config::CreateGlobalMainLayer());


### PR DESCRIPTION
Ontop of #3913 

This updates the exposed ARM64EC API to match that of Windows and upstream wine, though it is currently usable on neither due to FEX's reliance on msvcrt.