### PR TITLE
FEX: Moves HostFeatures querying to the frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,39 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "^arm64ec")
   set(ENABLE_JEMALLOC TRUE)
 endif()
 
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_FLAGS "-std=c++11 -Wattributes -Werror=attributes")
+check_cxx_source_compiles(
+  "
+  __attribute__((preserve_all))
+  int Testy(int a, int b, int c, int d, int e, int f) {
+  return a + b + c + d + e + f;
+  }
+  int main() {
+  return Testy(0, 1, 2, 3, 4, 5);
+  }"
+  HAS_CLANG_PRESERVE_ALL)
+unset(CMAKE_REQUIRED_FLAGS)
+if (HAS_CLANG_PRESERVE_ALL)
+  if (MINGW_BUILD)
+    message(STATUS "Ignoring broken clang::preserve_all support")
+    set(HAS_CLANG_PRESERVE_ALL FALSE)
+  else()
+    message(STATUS "Has clang::preserve_all")
+  endif()
+endif ()
+
+if (_M_ARM_64 AND HAS_CLANG_PRESERVE_ALL)
+  add_definitions("-DFEX_PRESERVE_ALL_ATTR=__attribute__((preserve_all))" "-DFEX_HAS_PRESERVE_ALL_ATTR=1")
+else()
+  add_definitions("-DFEX_PRESERVE_ALL_ATTR=" "-DFEX_HAS_PRESERVE_ALL_ATTR=0")
+endif()
+
+if (ENABLE_VIXL_SIMULATOR)
+  # We can run the simulator on both x86-64 or AArch64 hosts
+  add_definitions(-DVIXL_SIMULATOR=1 -DVIXL_INCLUDE_SIMULATOR_AARCH64=1)
+endif()
+
 if (ENABLE_CCACHE)
   find_program(CCACHE_PROGRAM ccache)
   if(CCACHE_PROGRAM)
@@ -281,8 +314,6 @@ include_directories(External/json-maker/)
 
 add_subdirectory(External/tiny-json/)
 include_directories(External/tiny-json/)
-
-include_directories(External/xbyak/)
 
 include_directories(Source/)
 include_directories("${CMAKE_BINARY_DIR}/Source/")

--- a/FEXCore/CMakeLists.txt
+++ b/FEXCore/CMakeLists.txt
@@ -24,27 +24,6 @@ include(CheckCXXCompilerFlag)
 include(CheckIncludeFileCXX)
 include(CheckCXXSourceCompiles)
 
-set(CMAKE_REQUIRED_FLAGS "-std=c++11 -Wattributes -Werror=attributes")
-check_cxx_source_compiles(
-  "
-  __attribute__((preserve_all))
-  int Testy(int a, int b, int c, int d, int e, int f) {
-  return a + b + c + d + e + f;
-  }
-  int main() {
-  return Testy(0, 1, 2, 3, 4, 5);
-  }"
-  HAS_CLANG_PRESERVE_ALL)
-unset(CMAKE_REQUIRED_FLAGS)
-if (HAS_CLANG_PRESERVE_ALL)
-  if (MINGW_BUILD)
-    message(STATUS "Ignoring broken clang::preserve_all support")
-    set(HAS_CLANG_PRESERVE_ALL FALSE)
-  else()
-    message(STATUS "Has clang::preserve_all")
-  endif()
-endif ()
-
 if (EXISTS ${CMAKE_CURRENT_DIR}/External/vixl/)
     # Useful to have for freestanding libFEXCore
     add_subdirectory(External/vixl/)

--- a/FEXCore/Source/CMakeLists.txt
+++ b/FEXCore/Source/CMakeLists.txt
@@ -90,7 +90,6 @@ set (SRCS
   Interface/Core/CPUBackend.cpp
   Interface/Core/CPUID.cpp
   Interface/Core/Frontend.cpp
-  Interface/Core/HostFeatures.cpp
   Interface/Core/ObjectCache/JobHandling.cpp
   Interface/Core/ObjectCache/NamedRegionObjectHandler.cpp
   Interface/Core/ObjectCache/ObjectCacheService.cpp
@@ -167,11 +166,6 @@ endif()
 
 if (_M_ARM_64)
   list(APPEND DEFINES -D_M_ARM_64=1)
-endif()
-
-if (ENABLE_VIXL_SIMULATOR)
-  # We can run the simulator on both x86-64 or AArch64 hosts
-  list(APPEND DEFINES -DVIXL_SIMULATOR=1 -DVIXL_INCLUDE_SIMULATOR_AARCH64=1)
 endif()
 
 if (ENABLE_VIXL_DISASSEMBLER)

--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -6,6 +6,7 @@
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CPUID.h>
+#include <FEXCore/Core/HostFeatures.h>
 #include <FEXCore/Core/SignalDelegator.h>
 #include "FEXCore/Debug/InternalThreadState.h"
 
@@ -42,8 +43,8 @@ void FEXCore::Context::ContextImpl::SetCustomCPUBackendFactory(CustomCPUFactoryT
   CustomCPUFactory = std::move(Factory);
 }
 
-HostFeatures FEXCore::Context::ContextImpl::GetHostFeatures() const {
-  return HostFeatures;
+void FEXCore::Context::ContextImpl::SetHostFeatures(const FEXCore::HostFeatures& Features) {
+  HostFeatures = Features;
 }
 
 void FEXCore::Context::ContextImpl::SetSignalDelegator(FEXCore::SignalDelegator* _SignalDelegation) {

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -96,7 +96,7 @@ public:
 
   void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) override;
 
-  HostFeatures GetHostFeatures() const override;
+  void SetHostFeatures(const FEXCore::HostFeatures& Features) override;
 
   void HandleCallback(FEXCore::Core::InternalThreadState* Thread, uint64_t RIP) override;
 

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -20,7 +20,7 @@
 
 namespace FEXCore {
 class CodeLoader;
-class HostFeatures;
+struct HostFeatures;
 class ForkableSharedMutex;
 } // namespace FEXCore
 
@@ -165,12 +165,11 @@ public:
   FEX_DEFAULT_VISIBILITY virtual void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) = 0;
 
   /**
-   * @brief Retrieves a feature struct indicating certain supported aspects from
-   *        the hose.
+   * @brief Informs the context what features the host supports.
    *
-   * @param CTX A valid non-null context instance.
+   * @param Features Filled out HostFeatures structure to copy
    */
-  FEX_DEFAULT_VISIBILITY virtual HostFeatures GetHostFeatures() const = 0;
+  FEX_DEFAULT_VISIBILITY virtual void SetHostFeatures(const FEXCore::HostFeatures& Features) = 0;
 
   FEX_DEFAULT_VISIBILITY virtual void HandleCallback(FEXCore::Core::InternalThreadState* Thread, uint64_t RIP) = 0;
 

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -3,10 +3,7 @@
 #include <cstdint>
 
 namespace FEXCore {
-class HostFeatures final {
-public:
-  HostFeatures();
-
+struct HostFeatures {
   /**
    * @brief Backend features that change how codegen is generated from IR
    *

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRCS
   Config.cpp
   ArgumentLoader.cpp
   EnvironmentLoader.cpp
+  HostFeatures.cpp
   JSONPool.cpp
   StringUtil.cpp)
 
@@ -18,3 +19,4 @@ add_library(${NAME} STATIC ${SRCS})
 target_link_libraries(${NAME} FEXCore_Base cpp-optparse tiny-json json-maker FEXHeaderUtils)
 target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/External/cpp-optparse/)
 target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)
+target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/External/xbyak/)

--- a/Source/Common/HostFeatures.h
+++ b/Source/Common/HostFeatures.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include <FEXCore/Core/HostFeatures.h>
+
+namespace FEX {
+FEXCore::HostFeatures FetchHostFeatures();
+}

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include "DummyHandlers.h"
+#include "Common/HostFeatures.h"
 #include "FEXCore/Core/Context.h"
 #include "FEXCore/Debug/InternalThreadState.h"
 #include <FEXCore/Config/Config.h>
@@ -597,6 +598,11 @@ int main(int argc, char** argv, char** const envp) {
 
   // Create FEXCore context.
   auto CTX = FEXCore::Context::Context::CreateNewContext();
+
+  {
+    auto HostFeatures = FEX::FetchHostFeatures();
+    CTX->SetHostFeatures(HostFeatures);
+  }
 
   auto SignalDelegation = FEX::DummyHandlers::CreateSignalDelegator();
   auto SyscallHandler = FEX::DummyHandlers::CreateSyscallHandler();

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -10,6 +10,7 @@ $end_info$
 #include "Common/ArgumentLoader.h"
 #include "Common/FEXServerClient.h"
 #include "Common/Config.h"
+#include "Common/HostFeatures.h"
 #include "ELFCodeLoader.h"
 #include "VDSO_Emulation.h"
 #include "LinuxSyscalls/GdbServer.h"
@@ -453,6 +454,11 @@ int main(int argc, char** argv, char** const envp) {
   FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
 
   auto CTX = FEXCore::Context::Context::CreateNewContext();
+
+  {
+    auto HostFeatures = FEX::FetchHostFeatures();
+    CTX->SetHostFeatures(HostFeatures);
+  }
 
   // Setup TSO hardware emulation immediately after initializing the context.
   FEX::TSO::SetupTSOEmulation(CTX.get());

--- a/Source/Tools/TestHarnessRunner/CMakeLists.txt
+++ b/Source/Tools/TestHarnessRunner/CMakeLists.txt
@@ -22,3 +22,4 @@ target_link_libraries(TestHarnessRunner
     ${LIBS}
     ${PTHREAD_LIB}
 )
+target_include_directories(TestHarnessRunner PRIVATE ${CMAKE_SOURCE_DIR}/External/xbyak/)

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -18,6 +18,7 @@ $end_info$
 #endif
 
 #include "Common/ArgumentLoader.h"
+#include "Common/HostFeatures.h"
 #include "HarnessHelpers.h"
 #include "TestHarnessRunner/HostRunner.h"
 
@@ -247,7 +248,9 @@ int main(int argc, char** argv, char** const envp) {
 
   FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
 
+  auto HostFeatures = FEX::FetchHostFeatures();
   auto CTX = FEXCore::Context::Context::CreateNewContext();
+  CTX->SetHostFeatures(HostFeatures);
 
 #ifndef _WIN32
   auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), {});
@@ -260,7 +263,6 @@ int main(int argc, char** argv, char** const envp) {
 #endif
 
   // Skip any tests that the host doesn't support features for
-  auto HostFeatures = CTX->GetHostFeatures();
   SupportsAVX = HostFeatures.SupportsAVX;
 
   bool TestUnsupported = (!HostFeatures.Supports3DNow && Loader.Requires3DNow()) || (!HostFeatures.SupportsSSE4A && Loader.RequiresSSE4A()) ||

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -25,6 +25,7 @@ $end_info$
 #include <FEXCore/Utils/TypeDefines.h>
 
 #include "Common/Config.h"
+#include "Common/HostFeatures.h"
 #include "Common/InvalidationTracker.h"
 #include "Common/TSOHandlerConfig.h"
 #include "Common/CPUFeatures.h"
@@ -468,6 +469,11 @@ NTSTATUS ProcessInit() {
   Exception::HandlerConfig.emplace();
 
   CTX = FEXCore::Context::Context::CreateNewContext();
+  {
+    auto HostFeatures = FEX::FetchHostFeatures();
+    CTX->SetHostFeatures(HostFeatures);
+  }
+
   CTX->SetSignalDelegator(SignalDelegator.get());
   CTX->SetSyscallHandler(SyscallHandler.get());
   CTX->InitCore();

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -26,6 +26,7 @@ $end_info$
 #include <FEXCore/Utils/TypeDefines.h>
 
 #include "Common/Config.h"
+#include "Common/HostFeatures.h"
 #include "Common/TSOHandlerConfig.h"
 #include "Common/InvalidationTracker.h"
 #include "Common/CPUFeatures.h"
@@ -434,6 +435,11 @@ void BTCpuProcessInit() {
   Context::HandlerConfig.emplace();
 
   CTX = FEXCore::Context::Context::CreateNewContext();
+  {
+    auto HostFeatures = FEX::FetchHostFeatures();
+    CTX->SetHostFeatures(HostFeatures);
+  }
+
   CTX->SetSignalDelegator(SignalDelegator.get());
   CTX->SetSyscallHandler(SyscallHandler.get());
   CTX->InitCore();


### PR DESCRIPTION
This moves the CPU feature querying to the frontend. The primary purpose here is for the wow64 frontend to not require linux-isms for querying these features. This is required since non-Linux environments don't have the "CPUID" feature for reading EL1 MSRs in EL0.

Wiring up the remaining wow64 registry querying is left for a future exercise.

This also technically removes an xbyak requirement from FEXCore for when building the x86 Test harness runner, but that doesn't really matter for regular use cases.