### PR TITLE
Arm64Emitter: Reload STATE before SRA fill on ARM64EC

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -691,6 +691,12 @@ void Arm64Emitter::FillStaticRegs(bool FPRs, uint32_t GPRFillMask, uint32_t FPRF
   auto TmpReg = *OptionalReg;
   [[maybe_unused]] auto TmpReg2 = *OptionalReg2;
 
+#ifdef _M_ARM_64EC
+  // Load STATE in from the CPU area as x28 is not callee saved in the ARM64EC ABI.
+  ldr(TmpReg.X(), ARMEmitter::Reg::r18, TEB_CPU_AREA_OFFSET);
+  ldr(STATE, TmpReg, CPU_AREA_EMULATOR_DATA_OFFSET);
+#endif
+
 #ifndef VIXL_SIMULATOR
   if (EmitterCTX->HostFeatures.SupportsAFP) {
     // Enable AFP features when filling JIT state.


### PR DESCRIPTION
While ARM64EC code cannot use x28, it can be cleared by the kernel when performing syscalls etc so restore it from the TEB to be safe.