### PR TITLE
ARM64EC: Improvements to exception flag handling

### DIFF
--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -558,6 +558,8 @@ NTSTATUS ResetToConsistentState(EXCEPTION_RECORD* Exception, CONTEXT* GuestConte
     NtContinueNative(NativeContext, false);
   }
 
+  GetCPUArea().Area->InSimulation = false;
+  GetCPUArea().Area->InSyscallCallback = false;
   return STATUS_SUCCESS;
 }
 

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -318,6 +318,10 @@ static void ReconstructThreadState(ARM64_NT_CONTEXT& Context) {
   for (size_t i = 0; i < Config.SRAFPRCount; i++) {
     memcpy(State.xmm.sse.data[i], &Context.V[Config.SRAFPRMapping[i]], sizeof(__uint128_t));
   }
+
+  // Spill EFlags
+  uint32_t EFlags = CTX->ReconstructCompactedEFLAGS(Thread, true, Context.X, Context.Cpsr);
+  CTX->SetFlagsFromCompactedEFLAGS(Thread, EFlags);
 }
 
 // Reconstructs an x64 context from the input context within the JIT, packed into a regular ARM64 context following the ARM64EC register mapping

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -374,9 +374,14 @@ static ARM64_NT_CONTEXT ReconstructPackedECContext(ARM64_NT_CONTEXT& Context) {
   ECContext.X24 = 0;
   ECContext.X28 = 0;
 
-  // NZCV will be converted into EFlags by ntdll, the rest are lost during exception handling.
+  // NZCV+SS will be converted into EFlags by ntdll, the rest are lost during exception handling.
   // See HandleGuestException
   ECContext.Cpsr = Context.Cpsr;
+  uint32_t EFlags = CTX->ReconstructCompactedEFLAGS(Thread, false, nullptr, 0);
+  if (EFlags & (1U << FEXCore::X86State::RFLAG_TF_LOC)) {
+    ECContext.Cpsr |= 1 << 21; // PSTATE.SS
+  }
+
   ECContext.Fpcr = Context.Fpcr;
   ECContext.Fpsr = Context.Fpsr;
 

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -181,7 +181,10 @@ static EXCEPTION_RECORD HandleGuestException(const EXCEPTION_RECORD& Src, ARM64_
   case FEXCore::Core::FAULT_SIGILL: Dst.ExceptionCode = EXCEPTION_ILLEGAL_INSTRUCTION; return Dst;
   case FEXCore::Core::FAULT_SIGTRAP:
     switch (Fault.TrapNo) {
-    case FEXCore::X86State::X86_TRAPNO_DB: Dst.ExceptionCode = EXCEPTION_SINGLE_STEP; return Dst;
+    case FEXCore::X86State::X86_TRAPNO_DB:
+      Context.Cpsr &= ~(1 << 21); // PSTATE.SS
+      Dst.ExceptionCode = EXCEPTION_SINGLE_STEP;
+      return Dst;
     case FEXCore::X86State::X86_TRAPNO_BP:
       Context.Pc -= 1;
       Dst.ExceptionAddress = reinterpret_cast<void*>(Context.Pc);


### PR DESCRIPTION
Better matches the windows behaviour here to avoid losing flags after a thread suspends  and resumes.