### PR TITLE
FEXInterpreter: Support portable installs

### DIFF
--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -217,6 +217,14 @@ def print_man_environment_tail():
     ],
     "''", True)
 
+    print_man_env_option(
+    "FEX_PORTABLE",
+    [
+    "Allows FEX to run without installation. Global locations for configuration and binfmt_misc are ignored. These files are instead read from <FEXInterpreterPath>/fex-emu/ by default.",
+    "For further customization, see FEX_APP_CONFIG_LOCATION and FEX_APP_DATA_LOCATION."
+    ],
+    "''", True)
+
 def print_man_header():
     header ='''.Dd {0}
 .Dt FEX

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -28,6 +28,12 @@ struct ApplicationNames {
   fextl::string ProgramName;
 };
 
+struct PortableInformation {
+  bool IsPortable;
+  // Path of folder containing FEXInterpreter (including / at the end)
+  fextl::string InterpreterPath;
+};
+
 /**
  * @brief Loads the FEX and application configurations for the application that is getting ready to run.
  *
@@ -40,15 +46,15 @@ struct ApplicationNames {
  * @return The application name and path structure
  */
 ApplicationNames LoadConfig(fextl::unique_ptr<FEX::ArgLoader::ArgLoader> ArgLoader, bool LoadProgramConfig, char** const envp,
-                            bool ExecFDInterp, int ProgramFDFromEnv);
+                            bool ExecFDInterp, int ProgramFDFromEnv, const PortableInformation& PortableInfo);
 
 const char* GetHomeDirectory();
 
-fextl::string GetDataDirectory();
-fextl::string GetConfigDirectory(bool Global);
-fextl::string GetConfigFileLocation(bool Global);
+fextl::string GetDataDirectory(const PortableInformation& PortableInfo);
+fextl::string GetConfigDirectory(bool Global, const PortableInformation& PortableInfo);
+fextl::string GetConfigFileLocation(bool Global, const PortableInformation& PortableInfo);
 
-void InitializeConfigs();
+void InitializeConfigs(const PortableInformation& PortableInfo);
 
 /**
  * @brief Loads the global FEX config

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -992,7 +992,7 @@ bool DrawUI() {
 } // namespace
 
 int main(int argc, char** argv) {
-  FEX::Config::InitializeConfigs();
+  FEX::Config::InitializeConfigs(FEX::Config::PortableInformation {});
 
   fextl::string ImGUIConfig = FEXCore::Config::GetConfigDirectory(false) + "FEXConfig_imgui.ini";
   auto [window, gl_context] = FEX::GUI::SetupIMGui("#FEXConfig", ImGUIConfig);

--- a/Source/Tools/FEXGetConfig/Main.cpp
+++ b/Source/Tools/FEXGetConfig/Main.cpp
@@ -107,7 +107,7 @@ TSOEmulationFacts GetTSOEmulationFacts() {
 } // namespace
 
 int main(int argc, char** argv, char** envp) {
-  FEX::Config::InitializeConfigs();
+  FEX::Config::InitializeConfigs(FEX::Config::PortableInformation {});
   FEXCore::Config::Initialize();
   FEXCore::Config::AddLayer(FEX::Config::CreateGlobalMainLayer());
   FEXCore::Config::AddLayer(FEX::Config::CreateMainLayer());

--- a/Source/Tools/FEXQonfig/Main.cpp
+++ b/Source/Tools/FEXQonfig/Main.cpp
@@ -351,7 +351,7 @@ void ConfigRuntime::onLoad(const QUrl& Filename) {
 int main(int Argc, char** Argv) {
   QApplication App(Argc, Argv);
 
-  FEX::Config::InitializeConfigs();
+  FEX::Config::InitializeConfigs(FEX::Config::PortableInformation {});
   fextl::string ConfigFilename = Argc > 1 ? Argv[1] : FEXCore::Config::GetConfigFileLocation();
   ConfigInit(ConfigFilename);
 

--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -1091,7 +1091,7 @@ bool ExtractEroFS(const fextl::string& Path, const fextl::string& RootFS, const 
 
 int main(int argc, char** argv, char** const envp) {
   auto ArgsLoader = fextl::make_unique<FEX::ArgLoader::ArgLoader>(FEX::ArgLoader::ArgLoader::LoadType::WITHOUT_FEXLOADER_PARSER, argc, argv);
-  FEX::Config::LoadConfig(std::move(ArgsLoader), false, envp, false, {});
+  FEX::Config::LoadConfig(std::move(ArgsLoader), false, envp, false, false, FEX::Config::PortableInformation {});
 
   // Reload the meta layer
   FEXCore::Config::ReloadMetaLayer();

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv, char** const envp) {
   }
 
   auto ArgsLoader = fextl::make_unique<FEX::ArgLoader::ArgLoader>(FEX::ArgLoader::ArgLoader::LoadType::WITHOUT_FEXLOADER_PARSER, argc, argv);
-  FEX::Config::LoadConfig(std::move(ArgsLoader), false, envp, false, {});
+  FEX::Config::LoadConfig(std::move(ArgsLoader), false, envp, false, false, FEX::Config::PortableInformation {});
 
   // Reload the meta layer
   FEXCore::Config::ReloadMetaLayer();

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -199,7 +199,7 @@ int main(int argc, char** argv, char** const envp) {
   LogMan::Throw::InstallHandler(AssertHandler);
   LogMan::Msg::InstallHandler(MsgHandler);
 
-  FEX::Config::InitializeConfigs();
+  FEX::Config::InitializeConfigs(FEX::Config::PortableInformation {});
   FEXCore::Config::Initialize();
   auto ArgsLoader = fextl::make_unique<FEX::ArgLoader::ArgLoader>(FEX::ArgLoader::ArgLoader::LoadType::WITH_FEXLOADER_PARSER, argc, argv);
   auto Args = ArgsLoader->Get();

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -456,7 +456,7 @@ extern "C" void SyncThreadContext(CONTEXT* Context) {
 
 NTSTATUS ProcessInit() {
   FEX::Windows::InitCRTProcess();
-  FEX::Config::InitializeConfigs();
+  FEX::Config::InitializeConfigs(FEX::Config::PortableInformation {});
   FEXCore::Config::Initialize();
   FEXCore::Config::AddLayer(FEX::Config::CreateGlobalMainLayer());
   FEXCore::Config::AddLayer(FEX::Config::CreateMainLayer());

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -424,7 +424,7 @@ public:
 
 void BTCpuProcessInit() {
   FEX::Windows::InitCRTProcess();
-  FEX::Config::InitializeConfigs();
+  FEX::Config::InitializeConfigs(FEX::Config::PortableInformation {});
   FEXCore::Config::Initialize();
   FEXCore::Config::AddLayer(FEX::Config::CreateGlobalMainLayer());
   FEXCore::Config::AddLayer(FEX::Config::CreateMainLayer());


### PR DESCRIPTION
A couple things to note here.

This expects multiple environment variables to be set
- `FEX_PORTABLE=1`
- `FEX_THUNKHOSTLIBS=<Local install path for thunks>`
- `FEX_THUNKHOSTLIBS32=<Local install path for thunks>`
- `FEX_THUNKGUESTLIBS=<Local install path for thunks>`
- `FEX_THUNKGUESTLIBS32=<Local install path for thunks>`

Some optional environment variables that can be set
- FEX_APP_CONFIG_LOCATION
   - With FEX_PORTABLE set,  this will default to a path at `<FEXInterpreter>/fex-emu/`
   - This overrides the default $HOME behaviour
   - This path is used by the `$HOME/.fex-emu/Config.json` and `$HOME/.fex-emu/AppConfig/<Files>.json`
- FEX_APP_DATA_LOCATION
  - With FEX_PORTABLE set,  this will default to a path at `<FEXInterpreter>/fex-emu/`
  - This overrides the default $HOME behaviour
  - This path is used by the `$HOME/.fex-emu/Telemetry/` and various other data bits like IR cache, code cache and probably in the future more things

This also disables FEX trying to use the binfmt_misc handler even if it is installed, so it stays disjoint from the system install.
It also disables the three global config layers since it doesn't make sense in this config.

This isn't the default and shouldn't be expected as the default use case. It also likely breaks namespaces and chroots so shouldn't be used in those cases most of the time.