### PR TITLE
HostFeatures: Removes feature flags always supported by FEX

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -638,7 +638,7 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_07h(uint32_t Leaf) const {
               (0 << 21) |                              // Reserved
               (0 << 22) |                              // Reserved
               (1 << 23) |                              // CLFLUSHOPT instruction
-              (CTX->HostFeatures.SupportsCLWB << 24) | // CLWB instruction
+              (1 << 24) |                              // CLWB instruction
               (0 << 25) |                              // Intel processor trace
               (0 << 26) |                              // Reserved
               (0 << 27) |                              // Reserved

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -19,15 +19,10 @@ struct HostFeatures {
   bool SupportsRCPC {};
   bool SupportsTSOImm9 {};
   bool SupportsRAND {};
-  bool Supports3DNow {};
-  bool SupportsSSE4A {};
   bool SupportsAVX {};
   bool SupportsSVE128 {};
   bool SupportsSVE256 {};
   bool SupportsSHA {};
-  bool SupportsBMI1 {};
-  bool SupportsBMI2 {};
-  bool SupportsCLWB {};
   bool SupportsPMULL_128Bit {};
   bool SupportsCSSC {};
   bool SupportsFCMA {};

--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -62,6 +62,7 @@ static uint32_t GetDCZID() {
   return DCZID_DZP_MASK;
 }
 
+[[maybe_unused]]
 static int ReadSVEVectorLengthInBits() {
   // Return unsupported
   return 0;
@@ -166,9 +167,6 @@ FEXCore::HostFeatures FetchHostFeatures() {
   HostFeatures.SupportsRPRES = Features.Has(vixl::CPUFeatures::Feature::kRPRES);
   HostFeatures.SupportsSVEBitPerm = Features.Has(vixl::CPUFeatures::Feature::kSVEBitPerm);
 
-  HostFeatures.Supports3DNow = true;
-  HostFeatures.SupportsSSE4A = true;
-
 #ifdef VIXL_SIMULATOR
   // Hardcode enable SVE with 256-bit wide registers.
   HostFeatures.SupportsSVE128 = ForceSVEWidth() ? ForceSVEWidth() >= 128 : true;
@@ -180,10 +178,6 @@ FEXCore::HostFeatures FetchHostFeatures() {
   HostFeatures.SupportsAVX = true;
 
   HostFeatures.SupportsAES256 = HostFeatures.SupportsAVX && HostFeatures.SupportsAES;
-
-  HostFeatures.SupportsBMI1 = true;
-  HostFeatures.SupportsBMI2 = true;
-  HostFeatures.SupportsCLWB = true;
 
   if (!HostFeatures.SupportsAtomics) {
     WARN_ONCE_FMT("Host CPU doesn't support atomics. Expect bad performance");
@@ -265,13 +259,8 @@ FEXCore::HostFeatures FetchHostFeatures() {
   HostFeatures.SupportsRAND = X86Features.has(Xbyak::util::Cpu::tRDRAND) && X86Features.has(Xbyak::util::Cpu::tRDSEED);
   HostFeatures.SupportsRCPC = true;
   HostFeatures.SupportsTSOImm9 = true;
-  HostFeatures.Supports3DNow = X86Features.has(Xbyak::util::Cpu::t3DN) && X86Features.has(Xbyak::util::Cpu::tE3DN);
-  HostFeatures.SupportsSSE4A = X86Features.has(Xbyak::util::Cpu::tSSE4a);
   HostFeatures.SupportsAVX = true;
   HostFeatures.SupportsSHA = X86Features.has(Xbyak::util::Cpu::tSHA);
-  HostFeatures.SupportsBMI1 = X86Features.has(Xbyak::util::Cpu::tBMI1);
-  HostFeatures.SupportsBMI2 = X86Features.has(Xbyak::util::Cpu::tBMI2);
-  HostFeatures.SupportsCLWB = X86Features.has(Xbyak::util::Cpu::tCLWB);
   HostFeatures.SupportsPMULL_128Bit = X86Features.has(Xbyak::util::Cpu::tPCLMULQDQ);
   HostFeatures.SupportsAES256 = HostFeatures.SupportsAES && X86Features.has(Xbyak::util::Cpu::tVAES);
 


### PR DESCRIPTION
These are only missing if using the hostrunner and the CI machine doesn't support that particular feature. FEX otherwise always supports these feature flags so they don't need to exist as options.

Just check the feature bit directly in the HostRunner frontend for these bits.