### PR TITLE
FEXCore: Pass HostFeatures in to CreateNewContext directly

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -19,8 +19,8 @@ void InitializeStaticTables(OperatingMode Mode) {
   IR::InstallOpcodeHandlers(Mode);
 }
 
-fextl::unique_ptr<FEXCore::Context::Context> FEXCore::Context::Context::CreateNewContext() {
-  return fextl::make_unique<FEXCore::Context::ContextImpl>();
+fextl::unique_ptr<FEXCore::Context::Context> FEXCore::Context::Context::CreateNewContext(const FEXCore::HostFeatures& Features) {
+  return fextl::make_unique<FEXCore::Context::ContextImpl>(Features);
 }
 
 void FEXCore::Context::ContextImpl::SetExitHandler(ExitHandler handler) {
@@ -41,10 +41,6 @@ void FEXCore::Context::ContextImpl::CompileRIPCount(FEXCore::Core::InternalThrea
 
 void FEXCore::Context::ContextImpl::SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) {
   CustomCPUFactory = std::move(Factory);
-}
-
-void FEXCore::Context::ContextImpl::SetHostFeatures(const FEXCore::HostFeatures& Features) {
-  HostFeatures = Features;
 }
 
 void FEXCore::Context::ContextImpl::SetSignalDelegator(FEXCore::SignalDelegator* _SignalDelegation) {

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -96,8 +96,6 @@ public:
 
   void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) override;
 
-  void SetHostFeatures(const FEXCore::HostFeatures& Features) override;
-
   void HandleCallback(FEXCore::Core::InternalThreadState* Thread, uint64_t RIP) override;
 
   uint64_t RestoreRIPFromHostPC(FEXCore::Core::InternalThreadState* Thread, uint64_t HostPC) override;
@@ -264,7 +262,7 @@ public:
   SignalDelegator* SignalDelegation {};
   X86GeneratedCode X86CodeGen;
 
-  ContextImpl();
+  ContextImpl(const FEXCore::HostFeatures& Features);
   ~ContextImpl();
 
   static void ThreadRemoveCodeEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP);

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -74,8 +74,9 @@ $end_info$
 #include <xxhash.h>
 
 namespace FEXCore::Context {
-ContextImpl::ContextImpl()
-  : CPUID {this}
+ContextImpl::ContextImpl(const FEXCore::HostFeatures& Features)
+  : HostFeatures {Features}
+  , CPUID {this}
   , IRCaptureCache {this} {
 #ifdef BLOCKSTATS
   BlockData = std::make_unique<FEXCore::BlockSamplingData>();

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -119,7 +119,7 @@ public:
    *
    * @return a new context object
    */
-  FEX_DEFAULT_VISIBILITY static fextl::unique_ptr<FEXCore::Context::Context> CreateNewContext();
+  FEX_DEFAULT_VISIBILITY static fextl::unique_ptr<FEXCore::Context::Context> CreateNewContext(const FEXCore::HostFeatures& Features);
 
   /**
    * @brief Allows setting up in memory code and other things prior to launchign code execution
@@ -163,13 +163,6 @@ public:
    * @param Factory The factory that the context will call if the DefaultCore config ise set to CUSTOM
    */
   FEX_DEFAULT_VISIBILITY virtual void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) = 0;
-
-  /**
-   * @brief Informs the context what features the host supports.
-   *
-   * @param Features Filled out HostFeatures structure to copy
-   */
-  FEX_DEFAULT_VISIBILITY virtual void SetHostFeatures(const FEXCore::HostFeatures& Features) = 0;
 
   FEX_DEFAULT_VISIBILITY virtual void HandleCallback(FEXCore::Core::InternalThreadState* Thread, uint64_t RIP) = 0;
 

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -597,11 +597,10 @@ int main(int argc, char** argv, char** const envp) {
   FEXCore::Context::InitializeStaticTables(TestHeaderData->Bitness == 64 ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
 
   // Create FEXCore context.
-  auto CTX = FEXCore::Context::Context::CreateNewContext();
-
+  fextl::unique_ptr<FEXCore::Context::Context> CTX;
   {
     auto HostFeatures = FEX::FetchHostFeatures();
-    CTX->SetHostFeatures(HostFeatures);
+    CTX = FEXCore::Context::Context::CreateNewContext(HostFeatures);
   }
 
   auto SignalDelegation = FEX::DummyHandlers::CreateSignalDelegator();

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -453,11 +453,10 @@ int main(int argc, char** argv, char** const envp) {
   // System allocator is now system allocator or FEX
   FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
 
-  auto CTX = FEXCore::Context::Context::CreateNewContext();
-
+  fextl::unique_ptr<FEXCore::Context::Context> CTX;
   {
     auto HostFeatures = FEX::FetchHostFeatures();
-    CTX->SetHostFeatures(HostFeatures);
+    CTX = FEXCore::Context::Context::CreateNewContext(HostFeatures);
   }
 
   // Setup TSO hardware emulation immediately after initializing the context.

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -249,8 +249,7 @@ int main(int argc, char** argv, char** const envp) {
   FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
 
   auto HostFeatures = FEX::FetchHostFeatures();
-  auto CTX = FEXCore::Context::Context::CreateNewContext();
-  CTX->SetHostFeatures(HostFeatures);
+  auto CTX = FEXCore::Context::Context::CreateNewContext(HostFeatures);
 
 #ifndef _WIN32
   auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), {});

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -503,10 +503,9 @@ NTSTATUS ProcessInit() {
   SyscallHandler = fextl::make_unique<ECSyscallHandler>();
   Exception::HandlerConfig.emplace();
 
-  CTX = FEXCore::Context::Context::CreateNewContext();
   {
     auto HostFeatures = FEX::FetchHostFeatures();
-    CTX->SetHostFeatures(HostFeatures);
+    CTX = FEXCore::Context::Context::CreateNewContext(HostFeatures);
   }
 
   CTX->SetSignalDelegator(SignalDelegator.get());

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -436,10 +436,9 @@ void BTCpuProcessInit() {
   SyscallHandler = fextl::make_unique<WowSyscallHandler>();
   Context::HandlerConfig.emplace();
 
-  CTX = FEXCore::Context::Context::CreateNewContext();
   {
     auto HostFeatures = FEX::FetchHostFeatures();
-    CTX->SetHostFeatures(HostFeatures);
+    CTX = FEXCore::Context::Context::CreateNewContext(HostFeatures);
   }
 
   CTX->SetSignalDelegator(SignalDelegator.get());


### PR DESCRIPTION
The class constructor for ContextImpl::CPUID requires HostFeatures to be available at construction time. Pass the host features struct directly through during construction time instead, which cleans up the interface slightly and fixes that issue.