### PR TITLE
LinuxSyscalls: Some minor cleanups

### DIFF
--- a/Source/Common/HostFeatures.h
+++ b/Source/Common/HostFeatures.h
@@ -6,4 +6,4 @@
 namespace FEX {
 FEXCore::HostFeatures FetchHostFeatures(vixl::CPUFeatures Features, bool SupportsCacheMaintenanceOps, uint64_t CTR, uint64_t MIDR);
 FEXCore::HostFeatures FetchHostFeatures();
-}
+} // namespace FEX

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -40,6 +40,7 @@ $end_info$
 #endif
 
 #include "LinuxSyscalls/x64/SyscallsEnum.h"
+#include "LinuxSyscalls/x32/SyscallsEnum.h"
 
 #define CONCAT_(a, b) a##b
 #define CONCAT(a, b) CONCAT_(a, b)
@@ -255,7 +256,11 @@ public:
 protected:
   SyscallHandler(FEXCore::Context::Context* _CTX, FEX::HLE::SignalDelegator* _SignalDelegation);
 
-  fextl::vector<SyscallFunctionDefinition> Definitions {};
+  fextl::vector<SyscallFunctionDefinition> Definitions {std::max<std::size_t>(FEX::HLE::x64::SYSCALL_x64_MAX, FEX::HLE::x32::SYSCALL_x86_MAX),
+                                                        {
+                                                          .NumArgs = 255,
+                                                          .Ptr = reinterpret_cast<void*>(&UnimplementedSyscall),
+                                                        }};
   std::mutex MMapMutex;
 
   // BRK management

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.cpp
@@ -51,20 +51,6 @@ x32SyscallHandler::x32SyscallHandler(FEXCore::Context::Context* ctx, FEX::HLE::S
 }
 
 void x32SyscallHandler::RegisterSyscallHandlers() {
-  auto cvt = [](auto in) {
-    union {
-      decltype(in) val;
-      void* raw;
-    } raw;
-    raw.val = in;
-    return raw.raw;
-  };
-
-  Definitions.resize(FEX::HLE::x32::SYSCALL_x86_MAX, SyscallFunctionDefinition {
-                                                       .NumArgs = 255,
-                                                       .Ptr = cvt(&UnimplementedSyscall),
-                                                     });
-
   FEX::HLE::RegisterEpoll(this);
   FEX::HLE::RegisterFD(this);
   FEX::HLE::RegisterFS(this);
@@ -98,7 +84,7 @@ void x32SyscallHandler::RegisterSyscallHandlers() {
 
 #if PRINT_MISSING_SYSCALLS
   for (auto& Syscall : SyscallNames) {
-    if (Definitions[Syscall.first].Ptr == cvt(&UnimplementedSyscall)) {
+    if (Definitions[Syscall.first].Ptr == reinterpret_cast<void*>(&UnimplementedSyscall)) {
       LogMan::Msg::DFmt("Unimplemented syscall: {}: {}", Syscall.first, Syscall.second);
     }
   }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
@@ -31,7 +31,6 @@ class SignalDelegator;
 }
 
 namespace FEX::HLE::x32 {
-#include "SyscallsEnum.h"
 
 class x32SyscallHandler final : public FEX::HLE::SyscallHandler {
 public:
@@ -50,15 +49,7 @@ public:
                           void* SyscallHandler, int ArgumentCount) override {
     auto& Def = Definitions.at(SyscallNumber);
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-    auto cvt = [](auto in) {
-      union {
-        decltype(in) val;
-        void* raw;
-      } raw;
-      raw.val = in;
-      return raw.raw;
-    };
-    LOGMAN_THROW_A_FMT(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, {}", SyscallNumber);
+    LOGMAN_THROW_A_FMT(Def.Ptr == reinterpret_cast<void*>(&UnimplementedSyscall), "Oops overwriting sysall problem, {}", SyscallNumber);
 #endif
     Def.Ptr = SyscallHandler;
     Def.NumArgs = ArgumentCount;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/SyscallsEnum.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/SyscallsEnum.h
@@ -6,6 +6,7 @@ $end_info$
 */
 #pragma once
 
+namespace FEX::HLE::x32 {
 ///< Enum containing all 32bit x86 linux syscalls for the guest kernel version
 enum Syscalls_x86 {
   SYSCALL_x86_restart_syscall = 0,
@@ -481,3 +482,4 @@ enum Syscalls_x86 {
   SYSCALL_x86_mseal = 462,
   SYSCALL_x86_MAX = 512,
 };
+} // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
@@ -45,15 +45,7 @@ public:
                           void* SyscallHandler, int ArgumentCount) override {
     auto& Def = Definitions.at(SyscallNumber);
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-    auto cvt = [](auto in) {
-      union {
-        decltype(in) val;
-        void* raw;
-      } raw;
-      raw.val = in;
-      return raw.raw;
-    };
-    LOGMAN_THROW_A_FMT(Def.Ptr == cvt(&UnimplementedSyscall), "Oops overwriting sysall problem, {}", SyscallNumber);
+    LOGMAN_THROW_A_FMT(Def.Ptr == reinterpret_cast<void*>(&UnimplementedSyscall), "Oops overwriting sysall problem, {}", SyscallNumber);
 #endif
     Def.Ptr = SyscallHandler;
     Def.NumArgs = ArgumentCount;


### PR DESCRIPTION
- We can have the SyscallFunctionDefinitions be the correct size out of the gate. Both tables are always 512 entries in size.
- In the RegisterSyscall_{32,64} handlers, just get the reference using operator[]. We always know we will be under the size of the array, add a an assert to check. Removes a bit of vector range checking overhead.
- Namespace 32-bit syscalls like 64-bit syscalls and include in the regular header like 64-bit. This was just an oversight
- Use std::fill for the syscall gap for the invalid syscall, just a minor cleanup.

No functional change.