### PR TITLE
Config: Little assume non-null check

### DIFF
--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -187,6 +187,7 @@ public:
   }
 
   void Set(ConfigOption Option, const char* Data) {
+    LOGMAN_THROW_AA_FMT(Data != nullptr, "Data can't be null");
     OptionMap[Option].emplace_back(fextl::string(Data));
   }
 


### PR DESCRIPTION
Removes a simple runtime nullcheck in Config::Layer::Set. Since we never pass a nullptr to this.