### PR TITLE
VDSO: Implements v6.11 vdso getrandom

### DIFF
--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -566,7 +566,7 @@ int main(int argc, char** argv, char** const envp) {
   ThunkHandler->RegisterTLSState(ParentThread);
 
   // Pass in our VDSO thunks
-  ThunkHandler->AppendThunkDefinitions(FEX::VDSO::GetVDSOThunkDefinitions());
+  ThunkHandler->AppendThunkDefinitions(FEX::VDSO::GetVDSOThunkDefinitions(Loader.Is64BitMode()));
   SignalDelegation->SetVDSOSigReturn();
 
   SyscallHandler->DeserializeSeccompFD(ParentThread, FEXSeccompFD);

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.h
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.h
@@ -23,6 +23,6 @@ void UnloadVDSOMapping(const VDSOMapping& Mapping);
 
 uint64_t GetVSyscallEntry(const void* VDSOBase);
 
-const std::span<FEXCore::IR::ThunkDefinition> GetVDSOThunkDefinitions();
+const std::span<FEXCore::IR::ThunkDefinition> GetVDSOThunkDefinitions(bool Is64Bit);
 const VDSOSigReturn& GetVDSOSymbols();
 } // namespace FEX::VDSO

--- a/ThunkLibs/libVDSO/libVDSO_Guest.cpp
+++ b/ThunkLibs/libVDSO/libVDSO_Guest.cpp
@@ -58,6 +58,7 @@ __attribute__((naked)) void __kernel_rt_sigreturn() {
   )" ::
                  : "memory");
 }
-
+#else
+ssize_t __vdso_getrandom(void*, size_t, uint32_t, void*, size_t) __attribute__((alias("fexfn_pack_getrandom")));
 #endif
 }

--- a/ThunkLibs/libVDSO/libVDSO_Guest.lds
+++ b/ThunkLibs/libVDSO/libVDSO_Guest.lds
@@ -47,6 +47,8 @@ VERSION {
     clock_getres;
     __vdso_getcpu;
     getcpu;
+    __vdso_getrandom;
+    getrandom;
   local: *;
   };
 }

--- a/ThunkLibs/libVDSO/libVDSO_interface.cpp
+++ b/ThunkLibs/libVDSO/libVDSO_interface.cpp
@@ -2,6 +2,7 @@
 
 #include <sched.h>
 #include <sys/time.h>
+#include <sys/types.h>
 #include <time.h>
 
 #include "Types.h"
@@ -24,4 +25,8 @@ struct fex_gen_config<getcpu> {};
 extern int clock_gettime64(clockid_t __clock_id, struct timespec64* __tp) __THROW;
 template<>
 struct fex_gen_config<clock_gettime64> {};
+#else
+extern ssize_t getrandom(void* buffer, size_t len, uint32_t flags, void* opaque_state, size_t opaque_len);
+template<>
+struct fex_gen_config<getrandom> {};
 #endif


### PR DESCRIPTION
This is an interesting vdso implementation because it only exists in
x86-64 with kernel v6.11. For Arm64 the implementation is likely to land
in a couple kernel versions from now.

Some differences with vdso_getrandom versus the regular getrandom
syscall
- Has two additional arguments, opaque_state and opaque_len
- Expects the userspace to mmap/munmap this opaque state structure
- Lets userspace query information about this structure upfront
- If the opaque data structure isn't provided then it falls back to
  regular SYS_getrandom

With the "glibc" implementation, we can tell the interface to allocate a
single page that gets unused (otherwise glibc ends up not using the
interface), and fallback to the regular SYS_getrandom.

In the case of the vdso interface, currently the arguments just get
passed through.

~~Keeping this as a WIP until the ARM64 kernel patches land and I can
actually test the things. Running the "glibc" path works today with the
selftest, but the vdso path is currently completely untested.~~