### PR TITLE
InstructionCountCI: explicitly enable flagm for multiinst

### DIFF
--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -1,7 +1,10 @@
 {
   "Features": {
     "Bitness": 64,
-    "EnabledHostFeatures": [],
+    "EnabledHostFeatures": [
+      "FLAGM",
+      "FLAGM2"
+    ],
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256",


### PR DESCRIPTION
Closes: https://github.com/FEX-Emu/FEX/issues/3949