### PR TITLE
OpcodeDispatcher: Remove old bad assumption in INC/DEC

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3055,12 +3055,6 @@ void OpDispatchBuilder::RDTSCOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::INCOp(OpcodeArgs) {
-  if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX) {
-    LogMan::Msg::EFmt("Can't handle REP on this");
-    DecodeFailure = true;
-    return;
-  }
-
   Ref Dest;
   Ref Result;
   const auto Size = GetSrcBitSize(Op);
@@ -3102,12 +3096,6 @@ void OpDispatchBuilder::INCOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::DECOp(OpcodeArgs) {
-  if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX) {
-    LogMan::Msg::EFmt("Can't handle REP on this");
-    DecodeFailure = true;
-    return;
-  }
-
   Ref Dest;
   Ref Result;
   const auto Size = GetSrcBitSize(Op);

--- a/unittests/ASM/FEX_bugs/repeat_on_incdec.asm
+++ b/unittests/ASM/FEX_bugs/repeat_on_incdec.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0",
+    "RCX": "8",
+    "RDX": "0",
+    "RSP": "0"
+  }
+}
+%endif
+
+; FEX-Emu had a bug where it thought repeat worked on increment and decrement instructions.
+; While the prefix can be encoded on the instructions, it is ignored by the hardware implementation.
+; This checks to ensure that inc/dec ignore the repeat prefix, and that rcx isn't ever changed from it.
+
+mov rsp, 0
+mov rcx, 8
+lea rax, [rel .test]
+
+rep inc rsp
+rep inc byte [rax]
+
+rep dec rsp
+rep dec byte [rax]
+
+mov rbx, [rel .test]
+mov rdx, [rel .test + 8]
+
+hlt
+
+.test:
+db 0, 0, 0, 0, 0, 0, 0, 0
+db 0, 0, 0, 0, 0, 0, 0, 0


### PR DESCRIPTION
Somewhere there was an assumption made that INC and DEC supported the repeat prefix. This isn't actually the case, while the prefix can be encoded, it is a nop and should only expect to be used for padding.

Adds a unittest to ensure that behaviour is as expected.