### PR TITLE
FEXCore: Disable vixl linking if vixl disasm or simulator is disabled

### DIFF
--- a/FEXCore/Source/CMakeLists.txt
+++ b/FEXCore/Source/CMakeLists.txt
@@ -182,7 +182,11 @@ endif()
 # Some defines for the softfloat library
 list(APPEND DEFINES "-DSOFTFLOAT_BUILTIN_CLZ")
 
-set (LIBS fmt::fmt vixl xxHash::xxhash FEXHeaderUtils CodeEmitter)
+set (LIBS fmt::fmt xxHash::xxhash FEXHeaderUtils CodeEmitter)
+
+if (ENABLE_VIXL_DISASSEMBLER OR ENABLE_VIXL_SIMULATOR)
+  list (APPEND LIBS vixl)
+endif()
 
 if (NOT MINGW_BUILD)
   list (APPEND LIBS dl)

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -4,11 +4,6 @@
 #include "FEXCore/Utils/EnumUtils.h"
 #include "Interface/Core/ObjectCache/Relocations.h"
 
-#include <aarch64/assembler-aarch64.h>
-#include <aarch64/constants-aarch64.h>
-#include <aarch64/cpu-aarch64.h>
-#include <aarch64/operands-aarch64.h>
-#include <platform-vixl.h>
 #ifdef VIXL_DISASSEMBLER
 #include <aarch64/disasm-aarch64.h>
 #endif

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -14,9 +14,6 @@ $end_info$
 #include "Interface/IR/IntrusiveIRList.h"
 #include "Interface/IR/RegisterAllocationData.h"
 
-#include <aarch64/assembler-aarch64.h>
-#include <aarch64/disasm-aarch64.h>
-
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/fextl/map.h>

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT MINGW_BUILD)
 endif()
 
 add_library(${NAME} STATIC ${SRCS})
-target_link_libraries(${NAME} FEXCore_Base cpp-optparse tiny-json FEXHeaderUtils)
+target_link_libraries(${NAME} FEXCore_Base cpp-optparse tiny-json FEXHeaderUtils vixl)
 target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/External/cpp-optparse/)
 target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)
 target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/External/xbyak/)

--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -2,7 +2,7 @@
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/HostFeatures.h>
 
-#include "aarch64/cpu-aarch64.h"
+#include <aarch64/cpu-aarch64.h>
 
 #ifdef _M_X86_64
 #define XBYAK64

--- a/Source/Common/HostFeatures.h
+++ b/Source/Common/HostFeatures.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 #include <FEXCore/Core/HostFeatures.h>
-#include "aarch64/cpu-aarch64.h"
+#include <aarch64/cpu-aarch64.h>
 
 namespace FEX {
 FEXCore::HostFeatures FetchHostFeatures(vixl::CPUFeatures Features, bool SupportsCacheMaintenanceOps, uint64_t CTR, uint64_t MIDR);

--- a/Source/Windows/Common/CMakeLists.txt
+++ b/Source/Windows/Common/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(CommonWindows STATIC CPUFeatures.cpp InvalidationTracker.cpp Logging.cpp)
 add_subdirectory(CRT)
 add_subdirectory(WinAPI)
-target_link_libraries(CommonWindows FEXCore_Base)
+target_link_libraries(CommonWindows FEXCore_Base vixl)
 target_compile_options(CommonWindows PRIVATE -Wno-inconsistent-dllimport)
 target_include_directories(CommonWindows PRIVATE
   "${CMAKE_SOURCE_DIR}/Source/Windows/include/"

--- a/Source/Windows/Common/CPUFeatures.cpp
+++ b/Source/Windows/Common/CPUFeatures.cpp
@@ -5,7 +5,7 @@
 #include <FEXCore/fextl/fmt.h>
 
 #include <windows.h>
-#include "aarch64/cpu-aarch64.h"
+#include <aarch64/cpu-aarch64.h>
 
 #include "CPUFeatures.h"
 


### PR DESCRIPTION
This was mostly there, just needed to remove some extraneous headers and only insert vixl in to the library list if the options were enabled.