### PR TITLE
Install libraries in the correct location

### DIFF
--- a/FEXCore/Source/CMakeLists.txt
+++ b/FEXCore/Source/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(GNUInstallDirs)
 set (MAN_DIR share/man CACHE PATH "MAN_DIR")
 
 set (FEXCORE_BASE_SRCS
@@ -371,9 +372,9 @@ AddLibrary(${PROJECT_NAME}_shared SHARED)
 if (NOT MINGW_BUILD)
   install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_shared
     LIBRARY
-      DESTINATION lib
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}
       COMPONENT Libraries
     ARCHIVE
-      DESTINATION lib
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}
       COMPONENT Libraries)
 endif()


### PR DESCRIPTION
Some distributions (e.g. Fedora) use `lib64` instead of `lib` for libraries, this ensures we always install in the correct location instead of hardcoding `lib`.