### PR TITLE
Library Forwarding: Follow up from #3964

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -142,7 +142,7 @@
       },
       "ThunkHostLibs": {
         "Type": "str",
-        "Default": "@CMAKE_INSTALL_PREFIX@/lib/fex-emu/HostThunks/",
+        "Default": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/fex-emu/HostThunks/",
         "ShortArg": "t",
         "Desc": [
           "Folder to find the host-side thunking libraries."
@@ -158,7 +158,7 @@
       },
       "ThunkHostLibs32": {
         "Type": "str",
-        "Default": "@CMAKE_INSTALL_PREFIX@/lib/fex-emu/HostThunks_32/",
+        "Default": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/fex-emu/HostThunks_32/",
         "Desc": [
           "Folder to find the 32-bit host-side thunking libraries."
         ]

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.14)
 project(host-thunks)
 include(${FEX_PROJECT_SOURCE_DIR}/CMakeFiles/version_to_variables.cmake)
+include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 20)
-set (HOSTLIBS_DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/fex-emu" CACHE PATH "global data directory")
+set (HOSTLIBS_DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/fex-emu" CACHE PATH "global data directory")
 option(ENABLE_CLANG_THUNKS "Enable building thunks with clang" FALSE)
 
 if (ENABLE_CLANG_THUNKS)


### PR DESCRIPTION
Thunk host libraries were still hardcoded to lib/, use the same mechanism as #3964 for installing to the correct location.