### PR TITLE
WIP Linux: Add support for using set_robust_list2

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Arm64/SyscallsEnum.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Arm64/SyscallsEnum.h
@@ -348,6 +348,7 @@ enum Syscalls_Arm64 {
   SYSCALL_Arm64_lsm_set_self_attr = 460,
   SYSCALL_Arm64_lsm_list_modules = 461,
   SYSCALL_Arm64_mseal = 462,
+  SYSCALL_Arm64_set_robust_list2 = 468, // Subject to change
   SYSCALL_Arm64_MAX = 512,
 
   // Unsupported syscalls on this host

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -62,6 +62,10 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE {
+int set_robust_list2(struct robust_list_head* head, int index, uint32_t flags) {
+  return ::syscall(SYSCALL_DEF(set_robust_list2), head, index, flags);
+}
+
 class SignalDelegator;
 SyscallHandler* _SyscallHandler {};
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -65,6 +65,15 @@ namespace Core {
 
 namespace FEX::HLE {
 
+enum robust_list_type {
+  ROBUST_LIST_32BIT = 0,
+  ROBUST_LIST_64BIT = 1,
+};
+
+// TODO: Switch to a kernel version check where used.
+constexpr bool ENABLE_ROBUST_LIST2 = true;
+int set_robust_list2(struct robust_list_head* head, int index, uint32_t flags);
+
 class SyscallHandler;
 class SignalDelegator;
 class ThunkHandler;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
@@ -624,6 +624,14 @@ void RegisterCommon(FEX::HLE::SyscallHandler* Handler) {
   } else {
     REGISTER_SYSCALL_IMPL(mseal, UnimplementedSyscallSafe);
   }
+
+  // Kernel version subject to change
+  if (Handler->IsHostKernelVersionAtLeast(6, 11, 0)) {
+    REGISTER_SYSCALL_IMPL_PASS_FLAGS(set_robust_list2, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+                                     SyscallPassthrough3<SYSCALL_DEF(set_robust_list2)>);
+  } else {
+    REGISTER_SYSCALL_IMPL(set_robust_list2, UnimplementedSyscallSafe);
+  }
 }
 
 namespace x64 {
@@ -730,10 +738,13 @@ namespace x64 {
                                          SyscallPassthrough6<SYSCALL_DEF(pselect6)>);
     REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(ppoll, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                          SyscallPassthrough5<SYSCALL_DEF(ppoll)>);
-    REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(set_robust_list, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
-                                         SyscallPassthrough2<SYSCALL_DEF(set_robust_list)>);
-    REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(get_robust_list, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
-                                         SyscallPassthrough3<SYSCALL_DEF(get_robust_list)>);
+    if (!ENABLE_ROBUST_LIST2) {
+      // Gets handled in x64/Thread.cpp
+      REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(set_robust_list, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+                                           SyscallPassthrough2<SYSCALL_DEF(set_robust_list)>);
+      REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(get_robust_list, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+                                           SyscallPassthrough3<SYSCALL_DEF(get_robust_list)>);
+    }
     REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(sync_file_range, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                          SyscallPassthrough4<SYSCALL_DEF(sync_file_range)>);
     REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(vmsplice, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -31,7 +31,15 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
     std::atomic<uint32_t> TID;
     int32_t* set_child_tid {0};
     int32_t* clear_child_tid {0};
-    uint64_t robust_list_head {0};
+
+    uint64_t robust_list_head_x64 {0};
+    uint64_t robust_list_head_x32 {0};
+
+    // Robust list index mappings.
+    // Start off as -1 to allow dynamic slot allocation from the kernel.
+    int robust_list_index_x64 {-1};
+    int robust_list_index_x32 {-1};
+
   } ThreadInfo {};
 
   struct {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/SyscallsEnum.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/SyscallsEnum.h
@@ -480,6 +480,7 @@ enum Syscalls_x86 {
   SYSCALL_x86_lsm_set_self_attr = 460,
   SYSCALL_x86_lsm_list_modules = 461,
   SYSCALL_x86_mseal = 462,
+  SYSCALL_x86_set_robust_list2 = 468, // Subject to change
   SYSCALL_x86_MAX = 512,
 };
 } // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/SyscallsEnum.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/SyscallsEnum.h
@@ -400,6 +400,7 @@ enum Syscalls_x64 {
   SYSCALL_x64_lsm_set_self_attr = 460,
   SYSCALL_x64_lsm_list_modules = 461,
   SYSCALL_x64_mseal = 462,
+  SYSCALL_x64_set_robust_list2 = 468, // Subject to change
   SYSCALL_x64_MAX = 512,
 
   // Unsupported syscalls on this host


### PR DESCRIPTION
Let FEX use this for both 32-bit and 64-bit robust futex lists, also wire it up so guest applications can use it.

Currently no kernel version check wired up, and syscall number is subject to change.