### PR TITLE
Windows: Install libraries to CMAKE_INSTALL_LIBDIR

### DIFF
--- a/Source/Windows/ARM64EC/CMakeLists.txt
+++ b/Source/Windows/ARM64EC/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 add_library(arm64ecfex SHARED
   Module.cpp
   Module.S
@@ -25,5 +27,5 @@ target_link_libraries(arm64ecfex
 target_link_options(arm64ecfex PRIVATE -static -nostdlib -nostartfiles -nodefaultlibs -lc++ -lc++abi -lunwind -lclang_rt.builtins-arm64ec)
 install(TARGETS arm64ecfex
   RUNTIME
-  DESTINATION lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
   COMPONENT runtime)

--- a/Source/Windows/WOW64/CMakeLists.txt
+++ b/Source/Windows/WOW64/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 add_library(wow64fex SHARED
   Module.cpp
   libwow64fex.def
@@ -24,5 +26,5 @@ target_link_libraries(wow64fex
 target_link_options(wow64fex PRIVATE -static -nostdlib -nostartfiles -nodefaultlibs -lc++ -lc++abi -lunwind -lclang_rt.builtins-aarch64)
 install(TARGETS wow64fex
   RUNTIME
-  DESTINATION lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
   COMPONENT runtime)


### PR DESCRIPTION
Windows is jumping on the bandwagon too! this allows FEX to install itself directly into the system wine install:
` -DCMAKE_INSTALL_LIBDIR=$(LIBDIRA64)/wine/aarch64-windows`