### PR TITLE
FEXLoader: don't install FEXUpdateAOTIRCache

### DIFF
--- a/Source/Tools/FEXLoader/CMakeLists.txt
+++ b/Source/Tools/FEXLoader/CMakeLists.txt
@@ -50,8 +50,6 @@ endfunction()
 GenerateInterpreter(FEXLoader 0)
 GenerateInterpreter(FEXInterpreter 1)
 
-install(PROGRAMS "${PROJECT_SOURCE_DIR}/Scripts/FEXUpdateAOTIRCache.sh" DESTINATION bin RENAME FEXUpdateAOTIRCache)
-
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
   # Check for conflicting binfmt before installing
   set (CONFLICTING_BINFMTS_32


### PR DESCRIPTION
not used. we'll probably rip the whole thing out at some point but for now, no reason to pollute user systems with this.