### PR TITLE
External: Update fmt from 10.1.1 to 11.0.2

### DIFF
--- a/FEXCore/include/FEXCore/fextl/fmt.h
+++ b/FEXCore/include/FEXCore/fextl/fmt.h
@@ -5,6 +5,7 @@
 #include <FEXCore/Utils/File.h>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <unistd.h>
 
 namespace fextl::fmt {

--- a/Source/Windows/Common/CRT/IO.cpp
+++ b/Source/Windows/Common/CRT/IO.cpp
@@ -352,7 +352,15 @@ int getc(FILE* _File) {
   UNIMPLEMENTED();
 }
 
+void _lock_file(FILE* _File) {
+  UNIMPLEMENTED();
+}
+
 wint_t ungetwc(wint_t _Ch, FILE* _File) {
+  UNIMPLEMENTED();
+}
+
+void _unlock_file(FILE* _File) {
   UNIMPLEMENTED();
 }
 

--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -13,6 +13,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 
 #include <openssl/sha.h>
 


### PR DESCRIPTION
Required adding a new header to FEXCore/fextl/fmt.h