### PR TITLE
Arm64: Implement support for strict in-process split-locks

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -422,6 +422,14 @@
           "Can be dangerous due to aligned loadstores through the same code now become non-atomic."
         ]
       },
+      "StrictInProcessSplitLocks": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Strict global lock when handling an unaligned atomic that crosses a 16-byte or cacheline granularity",
+          "This is required to ensure a split-lock doesn't tear inside the process"
+        ]
+      },
       "TSOAutoMigration": {
         "Type": "bool",
         "Default": "true",

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -239,12 +239,14 @@ public:
     FEX_CONFIG_OPT(DisableTelemetry, DISABLETELEMETRY);
     FEX_CONFIG_OPT(DisableVixlIndirectCalls, DISABLE_VIXL_INDIRECT_RUNTIME_CALLS);
     FEX_CONFIG_OPT(SmallTSCScale, SMALLTSCSCALE);
+    FEX_CONFIG_OPT(StrictInProcessSplitLocks, STRICTINPROCESSSPLITLOCKS);
   } Config;
-
 
   std::atomic_bool CoreShuttingDown {false};
 
   FEXCore::ForkableSharedMutex CodeInvalidationMutex;
+
+  uint32_t StrictSplitLockMutex {};
 
   FEXCore::HostFeatures HostFeatures;
   // CPUID depends on HostFeatures so needs to be initialized after that.

--- a/FEXCore/Source/Utils/SpinWaitLock.h
+++ b/FEXCore/Source/Utils/SpinWaitLock.h
@@ -272,6 +272,12 @@ static inline void unlock(T* Futex) {
 template<typename T>
 class UniqueSpinMutex final {
 public:
+  // Move-only type
+  UniqueSpinMutex(const UniqueSpinMutex&) = delete;
+  UniqueSpinMutex& operator=(const UniqueSpinMutex&) = delete;
+  UniqueSpinMutex(UniqueSpinMutex&& rhs) = default;
+  UniqueSpinMutex& operator=(UniqueSpinMutex&&) = default;
+
   UniqueSpinMutex(T* Futex)
     : Futex {Futex} {
     FEXCore::Utils::SpinWaitLock::lock(Futex);

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -556,11 +556,13 @@ void FillHackConfig() {
     auto Value = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED);
     auto VectorTSO = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_VECTORTSOENABLED);
     auto MemcpyTSO = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_MEMCPYSETTSOENABLED);
+    auto StrictSplitLockAtomics = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_STRICTINPROCESSSPLITLOCKS);
     auto HalfBarrierTSO = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_HALFBARRIERTSOENABLED);
 
     bool TSOEnabled = Value.has_value() && **Value == "1";
     bool VectorTSOEnabled = VectorTSO.has_value() && **VectorTSO == "1";
     bool MemcpyTSOEnabled = MemcpyTSO.has_value() && **MemcpyTSO == "1";
+    bool StrictSplitLockAtomicsEnabled = StrictSplitLockAtomics.has_value() && **StrictSplitLockAtomics == "1";
     bool HalfBarrierTSOEnabled = HalfBarrierTSO.has_value() && **HalfBarrierTSO == "1";
 
     if (ImGui::Checkbox("TSO Emulation Enabled", &TSOEnabled)) {
@@ -587,6 +589,16 @@ void FillHackConfig() {
         if (ImGui::IsItemHovered()) {
           ImGui::BeginTooltip();
           ImGui::Text("Disables TSO emulation on memcpy/memset instructions");
+          ImGui::EndTooltip();
+        }
+
+        if (ImGui::Checkbox("Strict in-process split-lock atomics Enabled", &StrictSplitLockAtomicsEnabled)) {
+          LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_STRICTINPROCESSSPLITLOCKS, StrictSplitLockAtomicsEnabled ? "1" : "0");
+          ConfigChanged = true;
+        }
+        if (ImGui::IsItemHovered()) {
+          ImGui::BeginTooltip();
+          ImGui::Text("Disables strict in-process split-lock atomics using a mutex");
           ImGui::EndTooltip();
         }
 

--- a/Source/Tools/FEXGetConfig/Main.cpp
+++ b/Source/Tools/FEXGetConfig/Main.cpp
@@ -107,12 +107,12 @@ TSOEmulationFacts GetTSOEmulationFacts() {
 } // namespace
 
 int main(int argc, char** argv, char** envp) {
+  FEX::Config::InitializeConfigs();
   FEXCore::Config::Initialize();
   FEXCore::Config::AddLayer(FEX::Config::CreateGlobalMainLayer());
   FEXCore::Config::AddLayer(FEX::Config::CreateMainLayer());
   // No FEX arguments passed through command line
   FEXCore::Config::AddLayer(FEX::Config::CreateEnvironmentLayer(envp));
-  FEXCore::Config::Load();
 
   // Load the arguments
   optparse::OptionParser Parser = optparse::OptionParser().description("Simple application to get a couple of FEX options");
@@ -144,6 +144,8 @@ int main(int argc, char** argv, char** envp) {
       FEXCore::Config::AddLayer(FEX::Config::CreateAppLayer(SteamAppName, FEXCore::Config::LayerType::LAYER_LOCAL_STEAM_APP));
     }
   }
+
+  FEXCore::Config::Load();
 
   // Reload the meta layer
   FEXCore::Config::ReloadMetaLayer();
@@ -212,8 +214,9 @@ int main(int argc, char** argv, char** envp) {
     fprintf(stdout, "\tMemory atomics emulation method:      %s\n", TSOFacts.LSE ? "\e[32mLSE\e[0m" : "\e[31mLL/SC\e[0m");
     fprintf(stdout, "\tUnaligned atomic memory granularity:  %s\n", TSOFacts.LSE2 ? "\e[32m16-byte\e[0m" : "\e[31mNatural alignment\e[0m");
     ///< TODO: Once TME is supported by hardware this can change.
-    fprintf(stdout, "\tUnaligned memory atomic emulation:    %s\n", TSOFacts.LSE ? "\e[31mTearing CAS loops\e[0m" : "\e[31mTearing LL/SC loops\e[0m");
     fprintf(stdout, "\tUnaligned memory loadstore emulation: %s\n", UnalignedMemoryLoadStoreTSOEmulation);
+    fprintf(stdout, "\t16-Byte split-lock atomic emulation:  %s\n", TSOFacts.LSE ? "\e[31mTearing CAS loops\e[0m" : "\e[31mTearing LL/SC loops\e[0m");
+    fprintf(stdout, "\t64-Byte split-lock atomic emulation:  %s\n", TSOFacts.LSE ? "\e[31mTearing CAS loops\e[0m" : "\e[31mTearing LL/SC loops\e[0m");
     fprintf(stdout, "\tGPR memory model emulation:           %s\n", GPRMemoryTSOEmulation);
     fprintf(stdout, "\tMemcpy memory model emulation:        %s\n", MemcpyMemoryTSOEmulation);
     fprintf(stdout, "\tVector memory model emulation:        %s\n", VectorMemoryTSOEmulation);
@@ -222,12 +225,16 @@ int main(int argc, char** argv, char** envp) {
     FEX_CONFIG_OPT(MemcpySetTSOEnabled, MEMCPYSETTSOENABLED);
     FEX_CONFIG_OPT(VectorTSOEnabled, VECTORTSOENABLED);
     FEX_CONFIG_OPT(HalfBarrierTSOEnabled, HALFBARRIERTSOENABLED);
+    FEX_CONFIG_OPT(StrictInProcessSplitLocks, STRICTINPROCESSSPLITLOCKS);
+    fprintf(stderr, "Strict: %d\n", StrictInProcessSplitLocks());
 
     fprintf(stdout, "\nConfiguration:\n");
     fprintf(stdout, "\tTSO Emulation:                        %s\n", TSOEnabled() ? "Enabled" : "Disabled");
     fprintf(stdout, "\tMemcpy TSO Emulation:                 %s\n", TSOEnabled() && MemcpySetTSOEnabled() ? "Enabled" : "Disabled");
     fprintf(stdout, "\tVector TSO Emulation:                 %s\n", TSOEnabled() && VectorTSOEnabled() ? "Enabled" : "Disabled");
     fprintf(stdout, "\tHalf-barrier unaligned TSO emulation: %s\n", TSOEnabled() && HalfBarrierTSOEnabled() ? "Enabled" : "Disabled");
+    fprintf(stdout, "\t16-Byte strict split-lock emulation:  %s\n", StrictInProcessSplitLocks() ? "In-process mutex" : "Tearing");
+    fprintf(stdout, "\t64-Byte strict split-lock emulation:  %s\n", StrictInProcessSplitLocks() ? "In-process mutex" : "Tearing");
   }
 
   return 0;


### PR DESCRIPTION
For atomics that cross the 16-byte or 64-byte granularity, we need to
lock a mutex to ensure strict emulation of split-locks.

I took another look at these when I found out that Zen3 actually
implements split-locks. Not sure which architecture actually added
support for from them, but I wanted to ensure we have the ability to
handle this.

One thing that we can't handle in user-space is cross-process
split-locks through shared memory. This requires a kernel SIGBUS handler
to ensure a crashing/SIGKILL'd process doesn't lock all FEX processes in
the system.

This fixes a little split-lock abusing test that I have locally. It's a
bit flakey so it isn't viable to run in CI. Considering it is explicitly
testing a race problem.