### PR TITLE
Windows: Implement CreateDirectoryW CRT function

### DIFF
--- a/Source/Windows/Common/Priv.h
+++ b/Source/Windows/Common/Priv.h
@@ -35,6 +35,8 @@ class ScopedUnicodeString {
 private:
   UNICODE_STRING Str {};
 public:
+  ScopedUnicodeString() = default;
+
   ScopedUnicodeString(const char* AStr) {
     RtlCreateUnicodeStringFromAsciiz(&Str, AStr);
   }
@@ -42,6 +44,7 @@ public:
   ~ScopedUnicodeString() {
     RtlFreeUnicodeString(&Str);
   }
+
   UNICODE_STRING* operator->() {
     return &Str;
   }


### PR DESCRIPTION
Used when the .fex-emu config dir doesn't exist. Also fixes up CreateFile to not leak memory.