### PR TITLE
Arm64: Allow directly correlating an ARM register back to an x86 register

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -373,6 +373,20 @@ Arm64Emitter::Arm64Emitter(FEXCore::Context::ContextImpl* ctx, void* EmissionPtr
   }
 }
 
+FEXCore::X86State::X86Reg Arm64Emitter::GetX86RegRelationToARMReg(ARMEmitter::Register Reg) {
+  for (size_t i = 0; i < StaticRegisters.size(); ++i) {
+    const auto& RegI = StaticRegisters[i];
+    if (RegI == Reg) {
+      // X86 Registers are mapped linerally from the StaticRegisters span.
+      // Directly correlating Enum index to span index.
+      return static_cast<FEXCore::X86State::X86Reg>(FEXCore::ToUnderlying(FEXCore::X86State::X86Reg::REG_RAX) + i);
+    }
+  }
+
+  // Unmapped register.
+  return FEXCore::X86State::X86Reg::REG_INVALID;
+}
+
 void Arm64Emitter::LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, uint64_t Constant, bool NOPPad) {
   bool Is64Bit = s == ARMEmitter::Size::i64Bit;
   int Segments = Is64Bit ? 4 : 2;

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -12,6 +12,7 @@
 #include <aarch64/simulator-constants-aarch64.h>
 #endif
 
+#include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/fextl/vector.h>
 #include <CodeEmitter/Emitter.h>
@@ -100,6 +101,10 @@ protected:
   void LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, uint64_t Constant, bool NOPPad = false);
 
   void FillSpecialRegs(ARMEmitter::Register TmpReg, ARMEmitter::Register TmpReg2, bool SetFIZ, bool SetPredRegs);
+
+  // Correlate an ARM register back to an x86 register index.
+  // Returning REG_INVALID if there was no mapping.
+  FEXCore::X86State::X86Reg GetX86RegRelationToARMReg(ARMEmitter::Register Reg);
 
   // NOTE: These functions WILL clobber the register TMP4 if AVX support is enabled
   //       and FPRs are being spilled or filled. If only GPRs are spilled/filled, then


### PR DESCRIPTION
Fixes a bug that is getting introduced in to #3955 when it rearranged register allocation.