### PR TITLE
FEXCore: Splits up atomic enablement checks

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -608,8 +608,8 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_07h(uint32_t Leaf) const {
     // Disable Enhanced REP MOVS when TSO is enabled.
     // vcruntime140 memmove will use `rep movsb` in this case which completely destroys perf in Hades(appId 1145360)
     // This is due to LRCPC performance on Cortex being abysmal.
-    // Only enable EnhancedREPMOVS if SoftwareTSO isn't required OR if MemcpySetTSO is not enabled.
-    const uint32_t SupportsEnhancedREPMOVS = CTX->SoftwareTSORequired() == false || MemcpySetTSOEnabled() == false;
+    // Only enable EnhancedREPMOVS if atomic memcpy tso emulation isn't enabled.
+    const uint32_t SupportsEnhancedREPMOVS = CTX->IsMemcpyAtomicTSOEnabled() == false;
     const uint32_t SupportsVPCLMULQDQ = CTX->HostFeatures.SupportsPMULL_128Bit && SupportsAVX();
 
     // Number of subfunctions

--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -119,7 +119,6 @@ private:
   uint32_t Cores {};
   FEX_CONFIG_OPT(HideHypervisorBit, HIDEHYPERVISORBIT);
   FEX_CONFIG_OPT(SmallTSCScale, SMALLTSCSCALE);
-  FEX_CONFIG_OPT(MemcpySetTSOEnabled, MEMCPYSETTSOENABLED);
 
   // XFEATURE_ENABLED_MASK
   // Mask that configures what features are enabled on the CPU.

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/JITClass.h
@@ -64,8 +64,6 @@ public:
 
 private:
   FEX_CONFIG_OPT(ParanoidTSO, PARANOIDTSO);
-  FEX_CONFIG_OPT(VectorTSOEnabled, VECTORTSOENABLED);
-  FEX_CONFIG_OPT(MemcpySetTSOEnabled, MEMCPYSETTSOENABLED);
 
   const bool HostSupportsSVE128 {};
   const bool HostSupportsSVE256 {};

--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MemoryOps.cpp
@@ -676,7 +676,7 @@ DEF_OP(LoadMemTSO) {
     }
     default: LOGMAN_MSG_A_FMT("Unhandled LoadMemTSO size: {}", OpSize); break;
     }
-    if (VectorTSOEnabled()) {
+    if (CTX->IsVectorAtomicTSOEnabled()) {
       // Half-barrier.
       dmb(ARMEmitter::BarrierScope::ISHLD);
     }
@@ -1191,7 +1191,7 @@ DEF_OP(VLoadVectorElement) {
   }
 
   // Emit a half-barrier if TSO is enabled.
-  if (CTX->IsAtomicTSOEnabled() && VectorTSOEnabled()) {
+  if (CTX->IsVectorAtomicTSOEnabled()) {
     dmb(ARMEmitter::BarrierScope::ISHLD);
   }
 }
@@ -1210,7 +1210,7 @@ DEF_OP(VStoreVectorElement) {
                                                                                                                          "size");
 
   // Emit a half-barrier if TSO is enabled.
-  if (CTX->IsAtomicTSOEnabled() && VectorTSOEnabled()) {
+  if (CTX->IsVectorAtomicTSOEnabled()) {
     dmb(ARMEmitter::BarrierScope::ISH);
   }
 
@@ -1272,7 +1272,7 @@ DEF_OP(VBroadcastFromMem) {
   }
 
   // Emit a half-barrier if TSO is enabled.
-  if (CTX->IsAtomicTSOEnabled() && VectorTSOEnabled()) {
+  if (CTX->IsVectorAtomicTSOEnabled()) {
     dmb(ARMEmitter::BarrierScope::ISHLD);
   }
 }
@@ -1492,7 +1492,7 @@ DEF_OP(StoreMemTSO) {
       }
     }
   } else {
-    if (VectorTSOEnabled()) {
+    if (CTX->IsVectorAtomicTSOEnabled()) {
       // Half-Barrier.
       dmb(ARMEmitter::BarrierScope::ISH);
     }
@@ -1524,7 +1524,7 @@ DEF_OP(MemSet) {
   // that the value is zero, we can optimize any operation larger than 8-bit down to 8-bit to use the MOPS implementation.
   const auto Op = IROp->C<IR::IROp_MemSet>();
 
-  const bool IsAtomic = Op->IsAtomic && MemcpySetTSOEnabled();
+  const bool IsAtomic = CTX->IsMemcpyAtomicTSOEnabled();
   const int32_t Size = Op->Size;
   const auto MemReg = GetReg(Op->Addr.ID());
   const auto Value = GetReg(Op->Value.ID());
@@ -1714,7 +1714,7 @@ DEF_OP(MemCpy) {
   // Assuming non-atomicity and non-faulting behaviour, this can accelerate this implementation.
   const auto Op = IROp->C<IR::IROp_MemCpy>();
 
-  const bool IsAtomic = Op->IsAtomic && MemcpySetTSOEnabled();
+  const bool IsAtomic = CTX->IsMemcpyAtomicTSOEnabled();
   const int32_t Size = Op->Size;
   const auto MemRegDest = GetReg(Op->Dest.ID());
   const auto MemRegSrc = GetReg(Op->Src.ID());


### PR DESCRIPTION
PR #3980 is adding a feature to merge loadstores in to paired loadstores, but it was using the incorrect atomic check to determine if it can safely merge them or not. It was using the GPR atomic check instead of the vector atomic check. While this would improve performance on Apple Silicon with its hardware TSO implementation, it would have had zero impact on Cortex and Oryon.

Instead split out the three config options to live as a boolean check in the ContextImpl similar to how we disable "AtomicTSOEmulation". Removing the various configs in the JIT and CPUID so that it queries from the same context. This makes it clearer that if you are wanting the current active configuration for memcpy, vector, or general atomic TSO emulation, you should query one of those three getters.

This also fixes a weird edge case bug in the arm64 JIT where you could have TSO emulation disable, but still have vector TSO enabled partially. Just because half a config wasn't checked in {Load,Store}MemTSO for vectors. If the global "TSOEnabled" option is disabled then TSO should always be disabled.

Alyssa will be able to pull this in to #3980 once merged and get the performance uplift on Cortex and Oryon, since our default configuration is to have vector and memcpy TSO emulation disabled.