### PR TITLE
Optimize `adc x, 0`

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/ALUOps.cpp
@@ -115,6 +115,21 @@ DEF_OP(AdcWithFlags) {
   adcs(ConvertSize48(IROp), GetReg(Node), GetZeroableReg(Op->Src1), GetReg(Op->Src2.ID()));
 }
 
+DEF_OP(AdcZeroWithFlags) {
+  auto Op = IROp->C<IR::IROp_AdcZeroWithFlags>();
+  auto Size = ConvertSize48(IROp);
+
+  cset(Size, TMP1, ARMEmitter::Condition::CC_CC);
+  adds(Size, GetReg(Node), GetReg(Op->Src1.ID()), TMP1);
+}
+
+DEF_OP(AdcZero) {
+  auto Op = IROp->C<IR::IROp_AdcZero>();
+  auto Size = ConvertSize48(IROp);
+
+  cinc(Size, GetReg(Node), GetReg(Op->Src1.ID()), ARMEmitter::Condition::CC_CC);
+}
+
 DEF_OP(Adc) {
   auto Op = IROp->C<IR::IROp_Adc>();
 

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1171,6 +1171,21 @@
           "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
+      "GPR = AdcZero OpSize:#Size, GPR:$Src1": {
+        "Desc": ["Adds GPR with inverted carry-in"],
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
+      },
+      "GPR = AdcZeroWithFlags OpSize:#Size, GPR:$Src1": {
+        "Desc": ["Adds and set NZCV for the sum of GPR and inverted carry-in given as NZCV"],
+        "HasSideEffects": true,
+        "DestSize": "Size",
+        "EmitValidation": [
+          "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
+        ]
+      },
       "GPR = SbbWithFlags OpSize:#Size, GPR:$Src1, GPR:$Src2": {
         "Desc": ["Subtracts and set NZCV for the difference of two GPRs and carry-in given as NZCV"],
         "HasSideEffects": true,

--- a/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
@@ -144,6 +144,14 @@ FlagInfo DeadFlagCalculationEliminination::Classify(IROp_Header* IROp) {
       .ReplacementNoWrite = OP_ADCNZCV,
     };
 
+  case OP_ADCZEROWITHFLAGS:
+    return {
+      .Read = FLAG_C,
+      .Write = FLAG_NZCV,
+      .CanReplace = true,
+      .Replacement = OP_ADCZERO,
+    };
+
   case OP_SBBWITHFLAGS:
     return {
       .Read = FLAG_C,

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -598,7 +598,7 @@
     },
     "bytemark idea 1": {
       "x86InstructionCount": 8,
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "x86Insts": [
         "movzx  eax,ax",
         "imul   r8d,eax",
@@ -612,14 +612,13 @@
       "ExpectedArm64ASM": [
         "uxth w4, w4",
         "mul w12, w12, w4",
-        "mov w20, #0x0",
         "mov w4, w12",
         "lsr w4, w4, #16",
         "uxth w13, w12",
         "sub w12, w12, w4",
         "cmp w13, w4",
-        "cfinv",
-        "adcs w26, w12, w20",
+        "cset w0, lo",
+        "adds w26, w12, w0",
         "cfinv",
         "mov x27, x12",
         "mov x12, x26"
@@ -627,7 +626,7 @@
     },
     "bytemark idea 2": {
       "x86InstructionCount": 12,
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 16,
       "x86Insts": [
         "movzx  eax,ax",
         "imul   r10d,eax",
@@ -645,14 +644,12 @@
       "ExpectedArm64ASM": [
         "uxth w4, w4",
         "mul w14, w14, w4",
-        "mov w20, #0x0",
         "mov w4, w14",
         "lsr w4, w4, #16",
         "uxth w10, w14",
         "sub w14, w14, w4",
         "cmp w10, w4",
-        "cfinv",
-        "adc w14, w14, w20",
+        "cinc w14, w14, lo",
         "mov w4, w14",
         "mov w10, w13",
         "eor w26, w10, w11",
@@ -665,7 +662,7 @@
     },
     "bytemark idea 3": {
       "x86InstructionCount": 11,
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 14,
       "x86Insts": [
         "movzx  eax,si",
         "imul   r8d,eax",
@@ -682,14 +679,12 @@
       "ExpectedArm64ASM": [
         "uxth w4, w10",
         "mul w12, w12, w4",
-        "mov w20, #0x0",
         "mov w4, w12",
         "lsr w4, w4, #16",
         "uxth w10, w12",
         "sub w12, w12, w4",
         "cmp w10, w4",
-        "cfinv",
-        "adc w12, w12, w20",
+        "cinc w12, w12, lo",
         "mov w10, w12",
         "add x20, x8, x11",
         "ldrh w12, [x20, #102]",

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -596,6 +596,108 @@
         "subs x26, x10, x12"
       ]
     },
+    "bytemark idea 1": {
+      "x86InstructionCount": 8,
+      "ExpectedInstructionCount": 13,
+      "x86Insts": [
+        "movzx  eax,ax",
+        "imul   r8d,eax",
+        "mov    eax,r8d",
+        "shr    eax,0x10",
+        "movzx  r9d,r8w",
+        "sub    r8d,eax",
+        "cmp    r9d,eax",
+        "adc    r8d,0x0"
+      ],
+      "ExpectedArm64ASM": [
+        "uxth w4, w4",
+        "mul w12, w12, w4",
+        "mov w20, #0x0",
+        "mov w4, w12",
+        "lsr w4, w4, #16",
+        "uxth w13, w12",
+        "sub w12, w12, w4",
+        "cmp w13, w4",
+        "cfinv",
+        "adcs w26, w12, w20",
+        "cfinv",
+        "mov x27, x12",
+        "mov x12, x26"
+      ]
+    },
+    "bytemark idea 2": {
+      "x86InstructionCount": 12,
+      "ExpectedInstructionCount": 18,
+      "x86Insts": [
+        "movzx  eax,ax",
+        "imul   r10d,eax",
+        "mov    eax,r10d",
+        "shr    eax,0x10",
+        "movzx  esi,r10w",
+        "sub    r10d,eax",
+        "cmp    esi,eax",
+        "adc    r10d,0x0",
+        "mov    eax,r10d",
+        "mov    esi,r9d",
+        "xor    si,di",
+        "movzx  r10d,word [rsp+r8*1+0x158]"
+      ],
+      "ExpectedArm64ASM": [
+        "uxth w4, w4",
+        "mul w14, w14, w4",
+        "mov w20, #0x0",
+        "mov w4, w14",
+        "lsr w4, w4, #16",
+        "uxth w10, w14",
+        "sub w14, w14, w4",
+        "cmp w10, w4",
+        "cfinv",
+        "adc w14, w14, w20",
+        "mov w4, w14",
+        "mov w10, w13",
+        "eor w26, w10, w11",
+        "cmn wzr, w26, lsl #16",
+        "bfxil x10, x26, #0, #16",
+        "add x20, x8, x12",
+        "ldrh w14, [x20, #344]",
+        "cfinv"
+      ]
+    },
+    "bytemark idea 3": {
+      "x86InstructionCount": 11,
+      "ExpectedInstructionCount": 16,
+      "x86Insts": [
+        "movzx  eax,si",
+        "imul   r8d,eax",
+        "mov    eax,r8d",
+        "shr    eax,0x10",
+        "movzx  esi,r8w",
+        "sub    r8d,eax",
+        "cmp    esi,eax",
+        "adc    r8d,0x0",
+        "mov    esi,r8d",
+        "movzx  r8d,word [rsp+rdi*1+0x66]",
+        "test   dx,dx"
+      ],
+      "ExpectedArm64ASM": [
+        "uxth w4, w10",
+        "mul w12, w12, w4",
+        "mov w20, #0x0",
+        "mov w4, w12",
+        "lsr w4, w4, #16",
+        "uxth w10, w12",
+        "sub w12, w12, w4",
+        "cmp w10, w4",
+        "cfinv",
+        "adc w12, w12, w20",
+        "mov w10, w12",
+        "add x20, x8, x11",
+        "ldrh w12, [x20, #102]",
+        "cmn wzr, w5, lsl #16",
+        "cfinv",
+        "mov x26, x5"
+      ]
+    },
     "pcmpistri xmm0, xmm1, 0_0_00_11_01b": {
       "ExpectedInstructionCount": 41,
       "Comment": [


### PR DESCRIPTION
When flags are not needed, we can translate to an equivalent arm64 idiom.

When flags *are* needed, we can still rearrange a bit to save a move, though that's less interesting.

Since we don't know whether we need flags in the dispatcher, we add a specialized pair of IR ops so we can optimize things appropriately.