### PR TITLE
InstCountCI: include x86 instruction count 

### DIFF
--- a/Scripts/UpdateInstructionCountJson.py
+++ b/Scripts/UpdateInstructionCountJson.py
@@ -5,6 +5,11 @@ import sys
 logger = logging.getLogger()
 logger.setLevel(logging.ERROR)
 
+def insert_before(d, key, item):
+    items = list(d.items())
+    items.insert(list(d.keys()).index(key), item)
+    return dict(items)
+
 def update_performance_numbers(performance_json_path, performance_json, new_json_numbers):
     for key, items in new_json_numbers.items():
         if len(key) == 0:
@@ -18,6 +23,12 @@ def update_performance_numbers(performance_json_path, performance_json, new_json
             performance_json["Instructions"][key]["ExpectedInstructionCount"] = items["ExpectedInstructionCount"]
         if "ExpectedArm64ASM" in items:
             performance_json["Instructions"][key]["ExpectedArm64ASM"] = items["ExpectedArm64ASM"]
+        if "x86Insts" in performance_json["Instructions"][key]:
+            d = performance_json["Instructions"][key]
+            d.pop('x86InstructionCount', None)
+            d = insert_before(d, "ExpectedInstructionCount",
+                              ("x86InstructionCount", len(d["x86Insts"])))
+            performance_json["Instructions"][key] = d
 
     # Output to the original file.
     with open(performance_json_path, "w") as json_file:

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -1045,6 +1045,7 @@
         "mov rax, gs:0x100",
         "mov rbx, gs:0x14"
       ],
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 4,
       "ExpectedArm64ASM": [
         "ldr x20, [x28, #960]",

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -317,6 +317,7 @@
         "mov eax, gs:0x100",
         "mov ebx, gs:0x14"
       ],
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 4,
       "ExpectedArm64ASM": [
         "ldr w20, [x28, #960]",

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -17,6 +17,7 @@
   ],
   "Instructions": {
     "push ax, bx": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 2,
       "Comment": [
         "Mergable 16-bit pushes. May or may not be an optimization."
@@ -31,6 +32,7 @@
       ]
     },
     "push rax, rbx": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 2,
       "Comment": [
         "Mergable 64-bit pushes"
@@ -45,6 +47,7 @@
       ]
     },
     "adds xmm0, xmm1, xmm2": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 4,
       "Comment": [
         "Redundant scalar adds that can get eliminated without AFP."
@@ -61,6 +64,7 @@
       ]
     },
     "positive movsb": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 6,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -80,6 +84,7 @@
       ]
     },
     "positive movsw": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 6,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -99,6 +104,7 @@
       ]
     },
     "positive movsd": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 6,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -118,6 +124,7 @@
       ]
     },
     "positive movsq": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 6,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -137,6 +144,7 @@
       ]
     },
     "negative movsb": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 6,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -156,6 +164,7 @@
       ]
     },
     "negative movsw": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 6,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -175,6 +184,7 @@
       ]
     },
     "negative movsd": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 6,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -194,6 +204,7 @@
       ]
     },
     "negative movsq": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 6,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -213,6 +224,7 @@
       ]
     },
     "positive rep movsb": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 44,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -270,6 +282,7 @@
       ]
     },
     "positive rep movsw": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 44,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -327,6 +340,7 @@
       ]
     },
     "positive rep movsd": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 44,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -384,6 +398,7 @@
       ]
     },
     "positive rep movsq": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 44,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -441,6 +456,7 @@
       ]
     },
     "negative rep movsb": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 47,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -501,6 +517,7 @@
       ]
     },
     "negative rep movsw": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 47,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -561,6 +578,7 @@
       ]
     },
     "negative rep movsd": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 47,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -621,6 +639,7 @@
       ]
     },
     "negative rep movsq": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 47,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -681,6 +700,7 @@
       ]
     },
     "positive rep stosb": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 30,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -724,6 +744,7 @@
       ]
     },
     "positive rep stosw": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 30,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -767,6 +788,7 @@
       ]
     },
     "positive rep stosd": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 30,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -810,6 +832,7 @@
       ]
     },
     "positive rep stosq": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 29,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -852,6 +875,7 @@
       ]
     },
     "negative rep stosb": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 31,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -896,6 +920,7 @@
       ]
     },
     "negative rep stosw": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 31,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -940,6 +965,7 @@
       ]
     },
     "negative rep stosd": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 31,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -984,6 +1010,7 @@
       ]
     },
     "negative rep stosq": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 30,
       "Comment": [
         "When direction flag is a compile time constant we can optimize",
@@ -1027,6 +1054,7 @@
       ]
     },
     "Sekiro spill block": {
+      "x86InstructionCount": 119,
       "ExpectedInstructionCount": 126,
       "Comment": [
         "This block of code came from the settings screen when it loaded",

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -15,6 +15,7 @@
   ],
   "Instructions": {
     "adds xmm0, xmm1, xmm2": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 2,
       "Comment": [
         "Redundant scalar operations should get eliminated with AFP"

--- a/unittests/InstructionCountCI/FEXOpt/libnss.json
+++ b/unittests/InstructionCountCI/FEXOpt/libnss.json
@@ -16,6 +16,7 @@
   "Comment": [],
   "Instructions": {
     "libnss3 sha": {
+      "x86InstructionCount": 168,
       "ExpectedInstructionCount": 2366,
       "Comment": [
         "This block of code comes from libnss3 which causes panic spilling in FEX's RA.",

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -12,6 +12,7 @@
   },
   "Instructions": {
     "Chained add": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 5,
       "x86Insts": [
         "add rax, rbx",
@@ -26,6 +27,7 @@
       ]
     },
     "Chained sub": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 4,
       "x86Insts": [
         "sub rax, rbx",
@@ -39,6 +41,7 @@
       ]
     },
     "Inverted add": {
+      "x86InstructionCount": 3,
       "ExpectedInstructionCount": 4,
       "x86Insts": [
         "add rax, rbx",
@@ -53,6 +56,7 @@
       ]
     },
     "Inverted sub": {
+      "x86InstructionCount": 3,
       "ExpectedInstructionCount": 5,
       "x86Insts": [
         "sub rax, rbx",
@@ -68,6 +72,7 @@
       ]
     },
     "ADC dead": {
+      "x86InstructionCount": 3,
       "ExpectedInstructionCount": 3,
       "x86Insts": [
         "add rax, rbx",
@@ -81,6 +86,7 @@
       ]
     },
     "INC consumed": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 6,
       "x86Insts": [
         "add rax, rbx",
@@ -96,6 +102,7 @@
       ]
     },
     "INC dead": {
+      "x86InstructionCount": 3,
       "ExpectedInstructionCount": 4,
       "x86Insts": [
         "add rax, rbx",
@@ -110,6 +117,7 @@
       ]
     },
     "DEC consumed": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 6,
       "x86Insts": [
         "sub rax, rbx",
@@ -125,6 +133,7 @@
       ]
     },
     "DEC dead": {
+      "x86InstructionCount": 3,
       "ExpectedInstructionCount": 4,
       "x86Insts": [
         "sub rax, rbx",
@@ -139,6 +148,7 @@
       ]
     },
     "8-bit DEC consumed": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 11,
       "x86Insts": [
         "sub al, ah",
@@ -159,6 +169,7 @@
       ]
     },
     "8-bit DEC dead": {
+      "x86InstructionCount": 3,
       "ExpectedInstructionCount": 9,
       "x86Insts": [
         "sub al, ah",
@@ -178,6 +189,7 @@
       ]
     },
     "Variable shift dead": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 3,
       "x86Insts": [
         "sar rax, cl",
@@ -190,6 +202,7 @@
       ]
     },
     "Variable rotate-through-carry dead": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 17,
       "x86Insts": [
         "rcr rax, cl",
@@ -216,6 +229,7 @@
       ]
     },
     "Partial NZCV select (cmp)": {
+      "x86InstructionCount": 3,
       "ExpectedInstructionCount": 6,
       "x86Insts": [
         "cmp rax, rbx",
@@ -232,6 +246,7 @@
       ]
     },
     "Partial NZCV select (add)": {
+      "x86InstructionCount": 3,
       "ExpectedInstructionCount": 6,
       "x86Insts": [
         "add rax, rbx",
@@ -248,6 +263,7 @@
       ]
     },
     "AND use only ZF": {
+      "x86InstructionCount": 3,
       "ExpectedInstructionCount": 6,
       "x86Insts": [
         "and eax, ebx",
@@ -264,6 +280,7 @@
       ]
     },
     "AND use only PF": {
+      "x86InstructionCount": 3,
       "ExpectedInstructionCount": 10,
       "x86Insts": [
         "and eax, ebx",
@@ -284,6 +301,7 @@
       ]
     },
     "Dead cmpxchg flags": {
+      "x86InstructionCount": 2,
       "ExpectedInstructionCount": 10,
       "x86Insts": [
         "cmpxchg8b [rbp]",

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -13,6 +13,7 @@
   },
   "Instructions": {
     "The Witcher 3": {
+      "x86InstructionCount": 7,
       "ExpectedInstructionCount": 10,
       "x86Insts": [
         "mov eax, 0x1",
@@ -37,6 +38,7 @@
       ]
     },
     "FMOD scalar loop": {
+      "x86InstructionCount": 38,
       "ExpectedInstructionCount": 64,
       "x86Insts": [
         "mov     esi, ecx",
@@ -146,6 +148,7 @@
       ]
     },
     "Scalar vector add loop": {
+      "x86InstructionCount": 5,
       "ExpectedInstructionCount": 6,
       "Comment": [
         "Saw this in bytemark"
@@ -167,6 +170,7 @@
       ]
     },
     "bytemark data xor loop": {
+      "x86InstructionCount": 9,
       "ExpectedInstructionCount": 12,
       "Comment": [
         "Saw this in bytemark"
@@ -198,6 +202,7 @@
       ]
     },
     "bytemark num sort": {
+      "x86InstructionCount": 4,
       "ExpectedInstructionCount": 6,
       "Comment": [
         "Saw this in bytemark"
@@ -218,6 +223,7 @@
       ]
     },
     "bytemark fpemu": {
+      "x86InstructionCount": 8,
       "ExpectedInstructionCount": 10,
       "Comment": [
         "Saw this in bytemark"
@@ -246,6 +252,7 @@
       ]
     },
     "bytemark DivideInternalFPF": {
+      "x86InstructionCount": 13,
       "ExpectedInstructionCount": 15,
       "Comment": [
         "Saw this in bytemark"
@@ -284,6 +291,7 @@
       ]
     },
     "bytemark huffman 1": {
+      "x86InstructionCount": 18,
       "ExpectedInstructionCount": 24,
       "x86Insts": [
         "mov    r9,rdx",
@@ -333,6 +341,7 @@
       ]
     },
     "bytemark huffman 2": {
+      "x86InstructionCount": 10,
       "ExpectedInstructionCount": 17,
       "x86Insts": [
         "movsxd r9,r8d",
@@ -367,6 +376,7 @@
       ]
     },
     "bytemark huffman 3": {
+      "x86InstructionCount": 19,
       "ExpectedInstructionCount": 36,
       "x86Insts": [
         "mov    ecx,eax",
@@ -429,6 +439,7 @@
       ]
     },
     "glibc AVX memcpy block 1": {
+      "x86InstructionCount": 20,
       "ExpectedInstructionCount": 26,
       "x86Insts": [
         "vmovdqu ymm5,yword [rsi+0x20]",
@@ -482,6 +493,7 @@
       ]
     },
     "glibc AVX memcpy block 2": {
+      "x86InstructionCount": 22,
       "ExpectedInstructionCount": 31,
       "x86Insts": [
         "vmovdqu ymm5,yword [rsi+rdx*1-0x20]",
@@ -542,6 +554,7 @@
       ]
     },
     "bytemark strsift": {
+      "x86InstructionCount": 15,
       "ExpectedInstructionCount": 20,
       "x86Insts": [
         "mov    rsi,rdx",

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -13,6 +13,7 @@
   },
   "Instructions": {
     "Sonic Mania movie player": {
+      "x86InstructionCount": 10,
       "ExpectedInstructionCount": 15,
       "Comment": "Used to be hottest block in Sonic Mania",
       "x86Insts": [
@@ -46,6 +47,7 @@
       ]
     },
     "wine mscrt.dll memmove": {
+      "x86InstructionCount": 12,
       "ExpectedInstructionCount": 13,
       "Comment": "Hot in Sonic Mania",
       "x86Insts": [
@@ -79,6 +81,7 @@
       ]
     },
     "dxvk hotblock from MGRR": {
+      "x86InstructionCount": 14,
       "ExpectedInstructionCount": 27,
       "Comment": [
         "Hottest block in Metal Gear Rising: Revengeance render thread"
@@ -130,6 +133,7 @@
       ]
     },
     "Psychonauts matrix swizzle": {
+      "x86InstructionCount": 103,
       "ExpectedInstructionCount": 144,
       "Comment": [
         "Hottest block in Windows Psychonauts",

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
@@ -13,6 +13,7 @@
   },
   "Instructions": {
     "FMOD scalar loop": {
+      "x86InstructionCount": 38,
       "ExpectedInstructionCount": 48,
       "x86Insts": [
         "mov     esi, ecx",

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -13,6 +13,7 @@
   },
   "Instructions": {
     "Block1": {
+      "x86InstructionCount": 70,
       "ExpectedInstructionCount": 1369,
       "x86Insts": [
         "sub esp,0x2c",
@@ -1459,6 +1460,7 @@
       ]
     },
     "Block2": {
+      "x86InstructionCount": 37,
       "ExpectedInstructionCount": 552,
       "x86Insts": [
         "sub esp,0x1c",
@@ -2055,6 +2057,7 @@
       ]
     },
     "Block3": {
+      "x86InstructionCount": 32,
       "ExpectedInstructionCount": 807,
       "x86Insts": [
         "fld dword [ecx]",
@@ -2901,6 +2904,7 @@
       ]
     },
     "Block4": {
+      "x86InstructionCount": 54,
       "ExpectedInstructionCount": 205,
       "x86Insts": [
         "push ebp",
@@ -3167,6 +3171,7 @@
       ]
     },
     "Block5": {
+      "x86InstructionCount": 49,
       "ExpectedInstructionCount": 970,
       "x86Insts": [
         "fld dword [esp + 0x80]",
@@ -4193,6 +4198,7 @@
       ]
     },
     "Block6": {
+      "x86InstructionCount": 39,
       "ExpectedInstructionCount": 925,
       "x86Insts": [
         "push ebp",
@@ -5164,6 +5170,7 @@
       ]
     },
     "Block7": {
+      "x86InstructionCount": 25,
       "ExpectedInstructionCount": 851,
       "x86Insts": [
         "fld dword [ebx + 0x4]",
@@ -6047,6 +6054,7 @@
       ]
     },
     "Block8": {
+      "x86InstructionCount": 25,
       "ExpectedInstructionCount": 254,
       "x86Insts": [
         "fstp st0",
@@ -6333,6 +6341,7 @@
       ]
     },
     "Block9": {
+      "x86InstructionCount": 25,
       "ExpectedInstructionCount": 254,
       "x86Insts": [
         "fstp st0",
@@ -6619,6 +6628,7 @@
       ]
     },
     "Block10": {
+      "x86InstructionCount": 125,
       "ExpectedInstructionCount": 26,
       "x86Insts": [
         "push esi",

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -13,6 +13,7 @@
   },
   "Instructions": {
     "Block1": {
+      "x86InstructionCount": 911,
       "ExpectedInstructionCount": 25781,
       "x86Insts": [
         "sub esp,0x118",
@@ -26712,6 +26713,7 @@
       ]
     },
     "Block2": {
+      "x86InstructionCount": 630,
       "ExpectedInstructionCount": 16635,
       "x86Insts": [
         "mov eax,dword [ebp + 0x8]",
@@ -43984,6 +43986,7 @@
       ]
     },
     "Block3": {
+      "x86InstructionCount": 649,
       "ExpectedInstructionCount": 11537,
       "x86Insts": [
         "fld dword [esi + 0x64]",
@@ -56177,6 +56180,7 @@
       ]
     },
     "Block4": {
+      "x86InstructionCount": 2050,
       "ExpectedInstructionCount": 63,
       "x86Insts": [
         "fldz",
@@ -58297,6 +58301,7 @@
       ]
     },
     "Block5": {
+      "x86InstructionCount": 368,
       "ExpectedInstructionCount": 283,
       "x86Insts": [
         "mov ebx,dword [eax + 0x68]",
@@ -58955,6 +58960,7 @@
       ]
     },
     "Block6": {
+      "x86InstructionCount": 315,
       "ExpectedInstructionCount": 58,
       "x86Insts": [
         "mov eax,dword [esp + 0x110]",
@@ -59335,6 +59341,7 @@
       ]
     },
     "Block7": {
+      "x86InstructionCount": 214,
       "ExpectedInstructionCount": 7388,
       "x86Insts": [
         "fld dword [ecx + 0xc]",
@@ -66944,6 +66951,7 @@
       ]
     },
     "Block8": {
+      "x86InstructionCount": 229,
       "ExpectedInstructionCount": 6571,
       "x86Insts": [
         "movzx eax,word [esi + edx*0x8]",
@@ -73751,6 +73759,7 @@
       ]
     },
     "Block9": {
+      "x86InstructionCount": 260,
       "ExpectedInstructionCount": 251,
       "x86Insts": [
         "fld dword [edi]",
@@ -74269,6 +74278,7 @@
       ]
     },
     "Block10": {
+      "x86InstructionCount": 206,
       "ExpectedInstructionCount": 450,
       "x86Insts": [
         "fld dword [0x00b42a74]",

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -13,6 +13,7 @@
   },
   "Instructions": {
     "Block1": {
+      "x86InstructionCount": 520,
       "ExpectedInstructionCount": 16358,
       "x86Insts": [
         "sub esp,0x88",
@@ -16898,6 +16899,7 @@
       ]
     },
     "Block2": {
+      "x86InstructionCount": 434,
       "ExpectedInstructionCount": 14022,
       "x86Insts": [
         "sub esp,0x90",
@@ -31361,6 +31363,7 @@
       ]
     },
     "Block3": {
+      "x86InstructionCount": 702,
       "ExpectedInstructionCount": 108,
       "x86Insts": [
         "mov eax,dword [ebp + 0xffffff44]",
@@ -32178,6 +32181,7 @@
       ]
     },
     "Block4": {
+      "x86InstructionCount": 351,
       "ExpectedInstructionCount": 12310,
       "x86Insts": [
         "mov ebp,dword [esp + 0x64]",
@@ -44846,6 +44850,7 @@
       ]
     },
     "Block5": {
+      "x86InstructionCount": 346,
       "ExpectedInstructionCount": 12245,
       "x86Insts": [
         "mov ebp,dword [esp + 0x64]",
@@ -57444,6 +57449,7 @@
       ]
     },
     "Block6": {
+      "x86InstructionCount": 409,
       "ExpectedInstructionCount": 7565,
       "x86Insts": [
         "mov eax,dword [ebp + 0x10]",
@@ -65425,6 +65431,7 @@
       ]
     },
     "Block7": {
+      "x86InstructionCount": 418,
       "ExpectedInstructionCount": 7572,
       "x86Insts": [
         "push ebp",
@@ -73422,6 +73429,7 @@
       ]
     },
     "Block8": {
+      "x86InstructionCount": 231,
       "ExpectedInstructionCount": 8481,
       "x86Insts": [
         "fadd dword [esp + 0x40]",
@@ -82141,6 +82149,7 @@
       ]
     },
     "Block9": {
+      "x86InstructionCount": 222,
       "ExpectedInstructionCount": 8400,
       "x86Insts": [
         "fadd dword [esp + 0x40]",
@@ -90770,6 +90779,7 @@
       ]
     },
     "Block10": {
+      "x86InstructionCount": 420,
       "ExpectedInstructionCount": 6381,
       "x86Insts": [
         "push ebp",

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -11717,6 +11717,7 @@
       ]
     },
     "fld and fnstsw": {
+      "x86InstructionCount": 5,
       "ExpectedInstructionCount": 160,
       "x86Insts": [
         "fld dword [rax]",
@@ -17892,6 +17893,7 @@
       ]
     },
     "memcpy4_32": {
+      "x86InstructionCount": 8,
       "ExpectedInstructionCount": 19,
       "x86Insts": [
         "fld dword [rax]",
@@ -17926,6 +17928,7 @@
       ]
     },
     "memcpy4_64": {
+      "x86InstructionCount": 8,
       "ExpectedInstructionCount": 19,
       "x86Insts": [
         "fld qword [rax]",

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -10082,6 +10082,7 @@
       ]
     },
     "memcpy4_32": {
+      "x86InstructionCount": 8,
       "ExpectedInstructionCount": 19,
       "x86Insts": [
         "fld dword [rax]",
@@ -10116,6 +10117,7 @@
       ]
     },
     "memcpy4_64": {
+      "x86InstructionCount": 8,
       "ExpectedInstructionCount": 19,
       "x86Insts": [
         "fld qword [rax]",

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -17751,6 +17751,7 @@
       ]
     },
     "memcpy4_32": {
+      "x86InstructionCount": 8,
       "ExpectedInstructionCount": 19,
       "x86Insts": [
         "fld dword [rax]",
@@ -17785,6 +17786,7 @@
       ]
     },
     "memcpy4_64": {
+      "x86InstructionCount": 8,
       "ExpectedInstructionCount": 19,
       "x86Insts": [
         "fld qword [rax]",

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -10348,6 +10348,7 @@
       ]
     },
     "memcpy4_32": {
+      "x86InstructionCount": 8,
       "ExpectedInstructionCount": 19,
       "x86Insts": [
         "fld dword [rax]",
@@ -10382,6 +10383,7 @@
       ]
     },
     "memcpy4_64": {
+      "x86InstructionCount": 8,
       "ExpectedInstructionCount": 19,
       "x86Insts": [
         "fld qword [rax]",


### PR DESCRIPTION
    useful for checking blow up ratios. I keep calculating this by hand so let's
    just add it to the json