### PR TITLE
Arm64: Fixes SIGBUS handler for FEAT_LRCPC

### DIFF
--- a/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
+++ b/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
@@ -2012,6 +2012,11 @@ HandleUnalignedAccess(FEXCore::Core::InternalThreadState* Thread, UnalignedHandl
       LogMan::Msg::EFmt("Unhandled JIT SIGBUS CASAL: PC: 0x{:x} Instruction: 0x{:08x}\n", ProgramCounter, PC[0]);
       return NotHandled;
     }
+  } else if ((Instr & LDAXR_MASK) == LDAR_INST ||  // LDAR*
+             (Instr & LDAXR_MASK) == LDAPR_INST || // LDAPR*
+             (Instr & LDAXR_MASK) == STLR_INST) {  // STLR*
+    // This must fall through to the spin-lock implementation below.
+    // This mask has a partial overlap with ATOMIC_MEM_INST so we need to check this here.
   } else if ((Instr & ArchHelpers::Arm64::ATOMIC_MEM_MASK) == ArchHelpers::Arm64::ATOMIC_MEM_INST) { // Atomic memory op
     if (ArchHelpers::Arm64::HandleAtomicMemOp(Instr, GPRs)) {
       // Skip this instruction now

--- a/unittests/ASM/FEX_bugs/UnalignedLoadStoreSIGBUS.asm
+++ b/unittests/ASM/FEX_bugs/UnalignedLoadStoreSIGBUS.asm
@@ -1,0 +1,24 @@
+%ifdef CONFIG
+{
+  "Env": {
+    "FEX_TSOENABLED": "1",
+    "FEX_TSOAUTOMIGATRION": "0"
+  }
+}
+%endif
+
+; FEX-Emu had a bug where SIGBUS handling of unaligned loadstores using FEAT_LRCPC would accidentally try using the FEAT_LSE atomic memory operation
+; handlers. It wouldn't find the handler for FEAT_LRCPC instructions (because it was only supposed to handle FEAT_LSE instructions) and fault out.
+; This happens because FEAT_LRCPC and FEAT_LSE instructions partially share an instruction encoding and FEX forgot to check for FEAT_LRCPC first
+; before using the FEAT_LSE handler.
+mov r15, 0xe000_0000
+
+; Atomic unaligned load across 16-byte and 64-byte granule
+mov rax, qword [r15 + 15]
+mov rbx, qword [r15 + 63]
+
+; Atomic unaligned store across 16-byte and 64-byte granule
+mov qword [r15 + 15], rbx
+mov qword [r15 + 63], rcx
+
+hlt


### PR DESCRIPTION
When https://github.com/FEX-Emu/FEX/pull/3899 refactored some of this code, it had split an if-else chain
in to two independent if-else chains. Turns out there was a minor
dependency between them. Add back the few checks necessary to ensure
that FEAT_LRCPC falls through before hitting the FEAT_LSE checks.

This is necessary because their instructions share an encoding so the
masks between the two instruction classes overlap slightly.