### PR TITLE
SignalDelegator: Refactor how thread local data is stored

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -54,7 +54,7 @@ public:
   ~SignalDelegator() override;
 
   // Called from the signal trampoline function.
-  void HandleSignal(int Signal, void* Info, void* UContext);
+  void HandleSignal(FEX::HLE::ThreadStateObject* Thread, int Signal, void* Info, void* UContext);
 
   void RegisterTLSState(FEX::HLE::ThreadStateObject* Thread);
   void UninstallTLSState(FEX::HLE::ThreadStateObject* Thread);
@@ -82,11 +82,11 @@ public:
    */
   uint64_t RegisterGuestSignalHandler(int Signal, const GuestSigAction* Action, struct GuestSigAction* OldAction);
 
-  uint64_t RegisterGuestSigAltStack(const stack_t* ss, stack_t* old_ss);
+  uint64_t RegisterGuestSigAltStack(FEX::HLE::ThreadStateObject* Thread, const stack_t* ss, stack_t* old_ss);
 
-  uint64_t GuestSigProcMask(int how, const uint64_t* set, uint64_t* oldset);
-  uint64_t GuestSigPending(uint64_t* set, size_t sigsetsize);
-  uint64_t GuestSigSuspend(uint64_t* set, size_t sigsetsize);
+  uint64_t GuestSigProcMask(FEX::HLE::ThreadStateObject* Thread, int how, const uint64_t* set, uint64_t* oldset);
+  uint64_t GuestSigPending(FEX::HLE::ThreadStateObject* Thread, uint64_t* set, size_t sigsetsize);
+  uint64_t GuestSigSuspend(FEX::HLE::ThreadStateObject* Thread, uint64_t* set, size_t sigsetsize);
   uint64_t GuestSigTimedWait(uint64_t* set, siginfo_t* info, const struct timespec* timeout, size_t sigsetsize);
   uint64_t GuestSignalFD(int fd, const uint64_t* set, size_t sigsetsize, int flags);
   /**  @} */
@@ -130,10 +130,8 @@ public:
 
   void SaveTelemetry();
 private:
-  FEX::HLE::ThreadStateObject* GetTLSThread();
-
   // Called from the thunk handler to handle the signal
-  void HandleGuestSignal(FEXCore::Core::InternalThreadState* Thread, int Signal, void* Info, void* UContext);
+  void HandleGuestSignal(FEX::HLE::ThreadStateObject* ThreadObject, int Signal, void* Info, void* UContext);
 
   /**
    * @brief Registers a signal handler for the host to handle a signal

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Signals.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Signals.cpp
@@ -25,15 +25,18 @@ struct GuestSigAction;
 namespace FEX::HLE {
 void RegisterSignals(FEX::HLE::SyscallHandler* Handler) {
   REGISTER_SYSCALL_IMPL(rt_sigprocmask, [](FEXCore::Core::CpuStateFrame* Frame, int how, const uint64_t* set, uint64_t* oldset) -> uint64_t {
-    return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigProcMask(how, set, oldset);
+    return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigProcMask(FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame),
+                                                                             how, set, oldset);
   });
 
   REGISTER_SYSCALL_IMPL(rt_sigpending, [](FEXCore::Core::CpuStateFrame* Frame, uint64_t* set, size_t sigsetsize) -> uint64_t {
-    return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigPending(set, sigsetsize);
+    return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigPending(FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame), set,
+                                                                            sigsetsize);
   });
 
   REGISTER_SYSCALL_IMPL(rt_sigsuspend, [](FEXCore::Core::CpuStateFrame* Frame, uint64_t* unewset, size_t sigsetsize) -> uint64_t {
-    return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigSuspend(unewset, sigsetsize);
+    return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigSuspend(FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame),
+                                                                            unewset, sigsetsize);
   });
 
   REGISTER_SYSCALL_IMPL(userfaultfd, [](FEXCore::Core::CpuStateFrame* Frame, int flags) -> uint64_t {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FS.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FS.cpp
@@ -40,7 +40,8 @@ void RegisterFS(FEX::HLE::SyscallHandler* Handler) {
 
   REGISTER_SYSCALL_IMPL_X32(
     sigprocmask, [](FEXCore::Core::CpuStateFrame* Frame, int how, const uint64_t* set, uint64_t* oldset, size_t sigsetsize) -> uint64_t {
-      return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigProcMask(how, set, oldset);
+      return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigProcMask(FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame),
+                                                                               how, set, oldset);
     });
 }
 } // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Thread.cpp
@@ -241,7 +241,8 @@ void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
         old64 = *old_ss;
         old64_ptr = &old64;
       }
-      uint64_t Result = FEX::HLE::_SyscallHandler->GetSignalDelegator()->RegisterGuestSigAltStack(ss64_ptr, old64_ptr);
+      uint64_t Result = FEX::HLE::_SyscallHandler->GetSignalDelegator()->RegisterGuestSigAltStack(
+        FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame), ss64_ptr, old64_ptr);
 
       if (Result == 0 && old_ss) {
         FaultSafeUserMemAccess::VerifyIsWritable(old_ss, sizeof(*old_ss));

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Thread.cpp
@@ -71,7 +71,8 @@ void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
   REGISTER_SYSCALL_IMPL_X64(sigaltstack, [](FEXCore::Core::CpuStateFrame* Frame, const stack_t* ss, stack_t* old_ss) -> uint64_t {
     FaultSafeUserMemAccess::VerifyIsReadableOrNull(ss, sizeof(*ss));
     FaultSafeUserMemAccess::VerifyIsWritableOrNull(old_ss, sizeof(*old_ss));
-    return FEX::HLE::_SyscallHandler->GetSignalDelegator()->RegisterGuestSigAltStack(ss, old_ss);
+    return FEX::HLE::_SyscallHandler->GetSignalDelegator()->RegisterGuestSigAltStack(
+      FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame), ss, old_ss);
   });
 
   // launch a new process under fex


### PR DESCRIPTION
Two primary things here:
- Remove the static `GlobalDelegator`
- Move the thread_local SignalDelegator::ThreadState information directly in to ThreadStateObject

Having the ThreadStateObject and the SignalDelegator information disjoint was confusing but was required when we didn't have any object in the frontend that could have its own independent data. Since we fixed this with the `ThreadStateObject` type we can now move this over.

The `GlobalDelegator` object is now instead stored in `ThreadStateObject` instead.

Instead of using a thread_local variable, we now just consume 8-bytes of the signal alt-stack since the kernel gives us that information about where it lives. This then converts all the thread_local usage to use either the passed in CPU state if it exists, or fetching it from the alt-stack offset.

Very minor changes in behaviour here, will help when trying to improve FEX's behaviour around signals.