### PR TITLE
HostFeatures: Moves MIDR querying to the frontend

### DIFF
--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
+
+#include <FEXCore/fextl/vector.h>
 #include <cstdint>
 
 namespace FEXCore {
@@ -37,5 +39,9 @@ struct HostFeatures {
   // Float exception behaviour
   bool SupportsAFP {};
   bool SupportsFloatExceptions {};
+
+  // MIDR information
+  // Also used for determining number of CPU cores for CPUID
+  fextl::vector<uint32_t> CPUMIDRs;
 };
 } // namespace FEXCore

--- a/Source/Common/HostFeatures.h
+++ b/Source/Common/HostFeatures.h
@@ -623,6 +623,8 @@ protected:
   }
 };
 
+void FillMIDRInformationViaLinux(FEXCore::HostFeatures* Features);
+
 FEXCore::HostFeatures FetchHostFeatures(FEX::CPUFeatures& Features, bool SupportsCacheMaintenanceOps, uint64_t CTR, uint64_t MIDR);
 FEXCore::HostFeatures FetchHostFeatures();
 } // namespace FEX


### PR DESCRIPTION
The MIDR querying is inherently OS specific and needs a bit of special casing. Instead let the frontend inform FEXCore how many CPU cores there are and their MIDRs instead.

This lets us keep the Linux specific code in the frontend.