### PR TITLE
OpcodeDispatcher: Allow x86 code to read CNTVCT on ARM64EC

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4665,6 +4665,15 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
       return;
     }
 
+#ifdef _M_ARM_64EC
+    // This is used when QueryPerformanceCounter is called on recent Windows versions, it causes CNTVCT to be written into RAX.
+    constexpr uint8_t GET_CNTVCT_LITERAL = 0x81;
+    if (Literal == GET_CNTVCT_LITERAL) {
+      StoreGPRRegister(X86State::REG_RAX, _CycleCounter());
+      return;
+    }
+#endif
+
     Reason.ErrorRegister = Literal << 3 | (0b010);
     Reason.Signal = Core::FAULT_SIGSEGV;
     // GP is raised when task-gate isn't setup to be valid


### PR DESCRIPTION
Required by newer insider preview versions, I noticed many crashes with this exception number and QueryPeformanceCounter in the backtrace, testing with XTA found it to not be passed through and instead write the host CNTVCT (unscaled) into RAX. No other registers seem to be affected.