### PR TITLE
Frontend: short-circuit code generation on invalid instructions with multiblock

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -598,6 +598,11 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
 
       uint64_t InstsInBlock = Block.NumInstructions;
 
+      if (InstsInBlock == 0) {
+        // Special case for an empty instruction block.
+        Thread->OpDispatcher->ExitFunction(Thread->OpDispatcher->_EntrypointOffset(IR::SizeToOpSize(GPRSize), Block.Entry - GuestRIP));
+      }
+
       for (size_t i = 0; i < InstsInBlock; ++i) {
         const FEXCore::X86Tables::X86InstInfo* TableInfo {nullptr};
         const FEXCore::X86Tables::DecodedInst* DecodedInfo {nullptr};

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -104,6 +104,7 @@ private:
   uint64_t SectionMaxAddress {~0ULL};
 
   DecodedBlockInformation BlockInfo;
+  fextl::set<uint64_t> CurrentBlockTargets;
   fextl::set<uint64_t> BlocksToDecode;
   fextl::set<uint64_t> HasBlocks;
   fextl::set<uint64_t>* ExternalBranches {nullptr};


### PR DESCRIPTION
A source of overhead with multiblock is hitting instructions through a conditional branch that can never be executed. Usually AVX512 instructions in glibc. This causes us to emit partial blocks for a ton of targets that will never get executed.

Instead, when we have multiblock enabled, if a block hits an instruction encoding we don't support, then remove all the decoded instructions from the block and early terminate it if it isn't the entry block. This resolves the issue of emitting a bunch of IR and code for blocks never executed.

If the block of code has an invalid instruction in the entry block for decoding then it'll still emit code up to the invalid instruction and raise a SIGILL. This has the potential for generating some additional blocks of code if a game is abusing SIGILL, but since that's unlikely it's a good trade-off.

Also removes a few log instructions that don't really provide anything anymore and just show up as confusing messages when multiblock is enabled.