### PR TITLE
AVX128: Fixes incorrect size usage in AVX128_Vector_CVT_Int_To_Float

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -1676,27 +1676,27 @@ void OpDispatchBuilder::AVX128_Vector_CVT_Int_To_Float(OpcodeArgs) {
     }
   }();
 
-  auto Convert = [this](size_t Size, Ref Src, IROps Op) -> Ref {
+  auto Convert = [this](Ref Src, IROps Op) -> Ref {
     size_t ElementSize = SrcElementSize;
     if (Widen) {
-      DeriveOp(Extended, Op, _VSXTL(Size, ElementSize, Src));
+      DeriveOp(Extended, Op, _VSXTL(OpSize::i128Bit, ElementSize, Src));
       Src = Extended;
       ElementSize <<= 1;
     }
 
-    return _Vector_SToF(Size, ElementSize, Src);
+    return _Vector_SToF(OpSize::i128Bit, ElementSize, Src);
   };
 
   RefPair Result {};
-  Result.Low = Convert(Size, Src.Low, IROps::OP_VSXTL);
+  Result.Low = Convert(Src.Low, IROps::OP_VSXTL);
 
   if (Is128Bit) {
     Result = AVX128_Zext(Result.Low);
   } else {
     if (Widen) {
-      Result.High = Convert(Size, Src.Low, IROps::OP_VSXTL2);
+      Result.High = Convert(Src.Low, IROps::OP_VSXTL2);
     } else {
-      Result.High = Convert(Size, Src.High, IROps::OP_VSXTL);
+      Result.High = Convert(Src.High, IROps::OP_VSXTL);
     }
   }
 

--- a/unittests/ASM/FEX_bugs/vcvtdq2ps_incorrect_size.asm
+++ b/unittests/ASM/FEX_bugs/vcvtdq2ps_incorrect_size.asm
@@ -1,0 +1,32 @@
+%ifdef CONFIG
+{
+}
+%endif
+
+; FEX-Emu had a bug in the vcvtdq2ps and vcvtdq2pd instruction where it was incorrectly generating a 256-bit IR operation.
+; Due to a quirk of the IR operation handling, this instruction was actually handled "correctly" as a 128-bit operation.
+; The problem occured once there was enough live registers to cause spilling, and the register spiller tries to spill the full result.
+; The full result in this case was described as a 256-bit operation when it was supposed to be only a 128-bit operation.
+; This was found in `Aperture Desk Job` in `libphonon.so` in function `own_ipps_sLn_L9LAynn`.
+jmp .test
+
+.test:
+vmovups ymm4,  [rel data_7ffde364df00]
+vmovups ymm5,  [rel data_7ffde364df00]
+vmovups ymm6,  [rel data_7ffde364df00]
+vmovups ymm7,  [rel data_7ffde364df00]
+vmovups ymm8,  [rel data_7ffde364df00]
+vmovups ymm9,  [rel data_7ffde364df00]
+vmovups ymm10,  [rel data_7ffde364df00]
+vmovups ymm11,  [rel data_7ffde364df00]
+
+vpsubd  ymm12, ymm0, ymm4
+vpsubd  ymm13, ymm1, ymm4
+vcvtdq2ps ymm2, ymm2
+vcvtdq2ps ymm14, ymm14
+vmovmskps ecx, ymm15
+hlt
+
+align 32
+data_7ffde364df00:
+dq 0, 0, 0, 0


### PR DESCRIPTION
This handler was incorrectly using 256-bit IR operation sizes. Due to a
quirk with our IR handling, this would "safely" fall back to a 128-bit
operation and work "correctly".

The problem encountered is that since the IR operation is claiming to be
256-bit, when the value got spilled due to register pressure then a
true 256-bit store and load operation would be generated. This would
then emit an SVE load and store, with the expectation of 256-bit SVE
loadstores. This caused a SIGILL on Oryon since it doesn't support SVE,
but even would generate an invalid predicated loadstore on SVE 128-bit
hardware.

Fixes Aperture Desk Job in FEX.