### PR TITLE
Install GDBSymbol integration in the correct location

### DIFF
--- a/Source/Tools/FEXGDBReader/CMakeLists.txt
+++ b/Source/Tools/FEXGDBReader/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(GNUInstallDirs)
 set(NAME FEXGDBReader)
 set(SRCS FEXGDBReader.cpp)
 
@@ -5,7 +6,7 @@ add_library(${NAME} SHARED ${SRCS})
 
 install(TARGETS ${NAME}
   RUNTIME
-  LIBRARY DESTINATION lib/gdb
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/gdb
   COMPONENT LIBRARY)
 
 target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)


### PR DESCRIPTION
Similarly to #3964 install this in the correct location instead of hardcoding.