### PR TITLE
Thunks: Removes global static initializer

### DIFF
--- a/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
+++ b/FEXCore/Source/Interface/HLE/Thunks/Thunks.cpp
@@ -97,7 +97,6 @@ struct TrampolineInstanceInfo {
 // Opaque type pointing to an instance of HostToGuestTrampolineTemplate and its
 // embedded TrampolineInstanceInfo
 struct HostToGuestTrampolinePtr;
-const auto HostToGuestTrampolineSize = __stop_HostToGuestTrampolineTemplate - __start_HostToGuestTrampolineTemplate;
 
 static TrampolineInstanceInfo& GetInstanceInfo(HostToGuestTrampolinePtr* Trampoline) {
   const auto Length = __stop_HostToGuestTrampolineTemplate - __start_HostToGuestTrampolineTemplate;
@@ -437,6 +436,8 @@ MakeHostTrampolineForGuestFunction(void* HostPacker, uintptr_t GuestTarget, uint
   }
 
   LogMan::Msg::DFmt("Thunks: Adding host trampoline for guest function {:#x} via unpacker {:#x}", GuestTarget, GuestUnpacker);
+
+  const auto HostToGuestTrampolineSize = __stop_HostToGuestTrampolineTemplate - __start_HostToGuestTrampolineTemplate;
 
   if (ThunkHandler->HostTrampolineInstanceDataAvailable < HostToGuestTrampolineSize) {
     const auto allocation_step = 16 * 1024;


### PR DESCRIPTION
This variable can't be constexpr initialized since it requires linker fix-ups, which changes it in to a global static initializer instead.

While this benign as it doesn't allocate any memory, just move it next to its single use. Removes the static initializer that was there for no reason.