### PR TITLE
FEX: Moves sigreturn symbols to frontend

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -328,16 +328,6 @@ public:
 
   FEXCore::JITSymbols Symbols;
 
-  void GetVDSOSigReturn(VDSOSigReturn* VDSOPointers) override {
-    if (VDSOPointers->VDSO_kernel_sigreturn == nullptr) {
-      VDSOPointers->VDSO_kernel_sigreturn = reinterpret_cast<void*>(X86CodeGen.sigreturn_32);
-    }
-
-    if (VDSOPointers->VDSO_kernel_rt_sigreturn == nullptr) {
-      VDSOPointers->VDSO_kernel_rt_sigreturn = reinterpret_cast<void*>(X86CodeGen.rt_sigreturn_32);
-    }
-  }
-
   FEXCore::Utils::PooledAllocatorVirtual OpDispatcherAllocator;
   FEXCore::Utils::PooledAllocatorVirtual FrontendAllocator;
 

--- a/FEXCore/Source/Interface/Core/X86HelperGen.h
+++ b/FEXCore/Source/Interface/Core/X86HelperGen.h
@@ -17,8 +17,6 @@ public:
   ~X86GeneratedCode();
 
   uint64_t CallbackReturn {};
-  uint64_t sigreturn_32 {};
-  uint64_t rt_sigreturn_32 {};
 
 private:
   void* CodePtr {};

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -259,8 +259,6 @@ public:
    */
   FEX_DEFAULT_VISIBILITY virtual void AppendThunkDefinitions(std::span<const FEXCore::IR::ThunkDefinition> Definitions) = 0;
 
-  FEX_DEFAULT_VISIBILITY virtual void GetVDSOSigReturn(VDSOSigReturn* VDSOPointers) = 0;
-
   /**
    * @brief Informs the context if hardware TSO is supported.
    * Once hardware TSO is enabled, then TSO emulation through atomics is disabled and relies on the hardware.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -105,10 +105,6 @@ public:
   void SetVDSOSigReturn() {
     // Get symbols from VDSO.
     VDSOPointers = FEX::VDSO::GetVDSOSymbols();
-
-    // Update VDSO to generated code.
-    // TODO: Have the frontend generate the x86 sigreturn pointers.
-    CTX->GetVDSOSigReturn(&VDSOPointers);
   }
 
   [[noreturn]]

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.h
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.h
@@ -11,7 +11,14 @@ struct VDSOSigReturn;
 
 namespace FEX::VDSO {
 using MapperFn = std::function<void*(void* addr, size_t length, int prot, int flags, int fd, off_t offset)>;
-void* LoadVDSOThunks(bool Is64Bit, FEX::HLE::SyscallHandler* const Handler);
+struct VDSOMapping {
+  void* VDSOBase {};
+  size_t VDSOSize {};
+  void* OptionalSigReturnMapping {};
+  size_t OptionalMappingSize {};
+};
+VDSOMapping LoadVDSOThunks(bool Is64Bit, FEX::HLE::SyscallHandler* const Handler);
+void UnloadVDSOMapping(const VDSOMapping& Mapping);
 
 uint64_t GetVSyscallEntry(const void* VDSOBase);
 


### PR DESCRIPTION
These are a Linux construct and should live here. Removes a weird passthrough API from FEXCore and keeps it in the frontend instead. This isn't even typically allocated in a real setup, as it's only a fallback for if VDSO isn't loaded.

The CallbackReturn function stays in FEXCore because it would have caused an API in the other direction instead.