### PR TITLE
FEXQConfig: Add strict split-lock option

### DIFF
--- a/Source/Tools/FEXQonfig/main.qml
+++ b/Source/Tools/FEXQonfig/main.qml
@@ -618,6 +618,11 @@ ApplicationWindow {
                             onToggled: tsoButtonGroup.onClickedButton(2)
                         }
                     }
+
+                    ConfigCheckBox {
+                        text: qsTr("Enable non-tearing split-lock atomics")
+                        config: "StrictInProcessSplitLocks"
+                    }
                 }
             }
 


### PR DESCRIPTION
This was missed in the initial FEXQConfig implementation since it was implemented at the same time.