### PR TITLE
FEXQonfig: Fix minor saving/loading quirks

### DIFF
--- a/Source/Tools/FEXQonfig/Main.cpp
+++ b/Source/Tools/FEXQonfig/Main.cpp
@@ -169,7 +169,8 @@ static void ConfigInit(fextl::string ConfigFilename) {
 
   // Ensure config and RootFS directories exist
   std::error_code ec {};
-  fextl::string Dirs[] = {FHU::Filesystem::ParentPath(ConfigFilename), FEXCore::Config::GetDataDirectory() + "RootFS/"};
+  std::filesystem::path Dirs[] = {std::filesystem::absolute(ConfigFilename).parent_path(),
+                                  std::filesystem::absolute(FEXCore::Config::GetDataDirectory()) / "RootFS/"};
   for (auto& Dir : Dirs) {
     bool created = std::filesystem::create_directories(Dir, ec);
     if (created) {

--- a/Source/Tools/FEXQonfig/Main.cpp
+++ b/Source/Tools/FEXQonfig/Main.cpp
@@ -316,7 +316,9 @@ ConfigRuntime::ConfigRuntime(const QString& ConfigFilename) {
   if (!ConfigFilename.isEmpty()) {
     Window->setProperty("configFilename", QUrl::fromLocalFile(ConfigFilename));
   } else {
+    Window->setProperty("configFilename", QUrl::fromLocalFile(FEXCore::Config::GetConfigFileLocation().c_str()));
     Window->setProperty("configDirty", true);
+    Window->setProperty("loadedDefaults", true);
   }
 
   ConfigRuntime::connect(Window, SIGNAL(selectedConfigFile(const QUrl&)), this, SLOT(onLoad(const QUrl&)));

--- a/Source/Tools/FEXQonfig/main.qml
+++ b/Source/Tools/FEXQonfig/main.qml
@@ -72,7 +72,9 @@ ApplicationWindow {
         }
 
         onAccepted: {
-            root.selectedConfigFile(selectedFile)
+            if (!isSaving) {
+                root.selectedConfigFile(selectedFile)
+            }
             configFilename = selectedFile
             if (onNextAccept) {
                 onNextAccept()

--- a/Source/Tools/FEXQonfig/main.qml
+++ b/Source/Tools/FEXQonfig/main.qml
@@ -76,6 +76,7 @@ ApplicationWindow {
                 root.selectedConfigFile(selectedFile)
             }
             configFilename = selectedFile
+            configDirty = false
             if (onNextAccept) {
                 onNextAccept()
                 onNextAccept = null

--- a/Source/Tools/FEXQonfig/main.qml
+++ b/Source/Tools/FEXQonfig/main.qml
@@ -46,22 +46,26 @@ ApplicationWindow {
 
     FileDialog {
         id: openFileDialog
-        title: qsTr("Open FEX configuration")
+        property bool isSaving: false
+
+        title: isSaving ? qsTr("Save FEX configuration") : qsTr("Open FEX configuration")
         nameFilters: [ qsTr("Config files(*.json)"), qsTr("All files(*)") ]
+
+        selectExisting: !isSaving
 
         property var onNextAccept: null
 
         // Prompts the user for an existing file and calls the callback on completion
-        function openAndThen(callback) {
-            this.selectExisting = true
+        function loadAndThen(callback) {
+            isSaving = false
             console.assert(!onNextAccept, "Tried to open dialog multiple times")
             onNextAccept = callback
             open()
         }
 
         // Prompts the user for a new or existing file and calls the callback on completion
-        function openNewAndThen(callback) {
-            this.selectExisting = false
+        function saveAndThen(callback) {
+            isSaving = true
             console.assert(!onNextAccept, "Tried to open dialog multiple times")
             onNextAccept = callback
             open()
@@ -90,7 +94,7 @@ ApplicationWindow {
             case buttonSave:
                 if (configFilename.toString() === "") {
                     // Filename not yet set => trigger "Save As" dialog
-                    openFileDialog.openNewAndThen(() => {
+                    openFileDialog.saveAndThen(() => {
                         save(configFilename)
                         root.close()
                     });
@@ -122,7 +126,7 @@ ApplicationWindow {
 
         if (filename.toString() === "") {
             // Filename not yet set => trigger "Save As" dialog
-            openFileDialog.openNewAndThen(() => {
+            openFileDialog.saveAndThen(() => {
                 save(configFilename)
             });
             return
@@ -139,7 +143,7 @@ ApplicationWindow {
                 text: qsTr("&Open...")
                 shortcut: StandardKey.Open
                 // TODO: Ask to discard pending changes first
-                onTriggered: openFileDialog.openAndThen(() => {})
+                onTriggered: openFileDialog.loadAndThen(() => {})
             }
             Action {
                 text: qsTr("&Save")
@@ -150,7 +154,7 @@ ApplicationWindow {
                 text: qsTr("Save &as...")
                 shortcut: StandardKey.SaveAs
                 onTriggered: {
-                    openFileDialog.openNewAndThen(() => {
+                    openFileDialog.saveAndThen(() => {
                         root.save(configFilename)
                     });
                 }

--- a/Source/Tools/FEXQonfig/main.qml
+++ b/Source/Tools/FEXQonfig/main.qml
@@ -23,6 +23,7 @@ ApplicationWindow {
     property url configFilename
 
     property bool configDirty: false
+    property bool loadedDefaults: false
     property bool closeConfirmed: false
 
     signal selectedConfigFile(name: url)
@@ -30,6 +31,13 @@ ApplicationWindow {
 
     // Property used to force reloading any elements that read ConfigModel
     property bool refreshCache: false
+
+    onConfigDirtyChanged: {
+        if (!configDirty) {
+            // We either just saved or loaded a file
+            loadedDefaults = false
+        }
+    }
 
     function refreshUI() {
         refreshCache = !refreshCache
@@ -905,7 +913,7 @@ ApplicationWindow {
             Label {
                 Layout.alignment: Qt.AlignHCenter
                 enabled: false
-                text: configFilename.toString() === ""
+                text: loadedDefaults
                         ? qsTr("Config.json not found — loaded defaults")
                         : qsTr("Editing %1").arg(urlToLocalFile(configFilename))
             }

--- a/Source/Tools/FEXQonfig/main.qml
+++ b/Source/Tools/FEXQonfig/main.qml
@@ -48,6 +48,9 @@ ApplicationWindow {
         if (str.startsWith("file://")) {
             return decodeURIComponent(str.substring(7))
         }
+        if (str.startsWith("file:")) {
+            return decodeURIComponent(str.substring(5))
+        }
 
         return str;
     }


### PR DESCRIPTION
* FEXConfig was displaying an error when saving to a new file even though the operation succeeded.
* `~/.fex-emu/Config.json` (as returned by `FEXCore::Config::GetConfigFileLocation()`) is automatically set as the config filename on first load now
* Various minor UI quirks have been fixed