### PR TITLE
FEXCore: Move `JITSymbolBuffer` to internal header

### DIFF
--- a/FEXCore/Source/Common/JitSymbols.cpp
+++ b/FEXCore/Source/Common/JitSymbols.cpp
@@ -55,7 +55,7 @@ void JITSymbols::RegisterJITSpace(const void* HostAddr, uint32_t CodeSize) {
 }
 
 // Buffered JIT symbols.
-void JITSymbols::Register(Core::JITSymbolBuffer* Buffer, const void* HostAddr, uint64_t GuestAddr, uint32_t CodeSize) {
+void JITSymbols::Register(FEXCore::JITSymbolBuffer* Buffer, const void* HostAddr, uint64_t GuestAddr, uint32_t CodeSize) {
   if (fd == -1) {
     return;
   }
@@ -79,7 +79,7 @@ void JITSymbols::Register(Core::JITSymbolBuffer* Buffer, const void* HostAddr, u
   WriteBuffer(Buffer);
 }
 
-void JITSymbols::Register(Core::JITSymbolBuffer* Buffer, const void* HostAddr, uint32_t CodeSize, std::string_view Name, uintptr_t Offset) {
+void JITSymbols::Register(FEXCore::JITSymbolBuffer* Buffer, const void* HostAddr, uint32_t CodeSize, std::string_view Name, uintptr_t Offset) {
   if (fd == -1) {
     return;
   }
@@ -104,7 +104,7 @@ void JITSymbols::Register(Core::JITSymbolBuffer* Buffer, const void* HostAddr, u
   WriteBuffer(Buffer);
 }
 
-void JITSymbols::RegisterNamedRegion(Core::JITSymbolBuffer* Buffer, const void* HostAddr, uint32_t CodeSize, std::string_view Name) {
+void JITSymbols::RegisterNamedRegion(FEXCore::JITSymbolBuffer* Buffer, const void* HostAddr, uint32_t CodeSize, std::string_view Name) {
   if (fd == -1) {
     return;
   }
@@ -128,7 +128,7 @@ void JITSymbols::RegisterNamedRegion(Core::JITSymbolBuffer* Buffer, const void* 
   WriteBuffer(Buffer);
 }
 
-void JITSymbols::WriteBuffer(Core::JITSymbolBuffer* Buffer, bool ForceWrite) {
+void JITSymbols::WriteBuffer(FEXCore::JITSymbolBuffer* Buffer, bool ForceWrite) {
   auto Now = std::chrono::steady_clock::now();
   if (!ForceWrite) {
     if (((Buffer->LastWrite - Now) < Buffer->MAXIMUM_THRESHOLD) && Buffer->Offset < Buffer->NEEDS_WRITE_DISTANCE) {

--- a/FEXCore/Source/Common/JitSymbols.h
+++ b/FEXCore/Source/Common/JitSymbols.h
@@ -11,6 +11,26 @@
 #include <string_view>
 
 namespace FEXCore {
+// Buffered JIT symbol tracking.
+struct JITSymbolBuffer {
+  // Maximum buffer size to ensure we are a page in size.
+  constexpr static size_t BUFFER_SIZE = 4096 - (8 * 2);
+  // Maximum distance until the end of the buffer to do a write.
+  constexpr static size_t NEEDS_WRITE_DISTANCE = BUFFER_SIZE - 64;
+  // Maximum time threshhold to wait before a buffer write occurs.
+  constexpr static std::chrono::milliseconds MAXIMUM_THRESHOLD {100};
+
+  JITSymbolBuffer()
+    : LastWrite {std::chrono::steady_clock::now()} {}
+  // stead_clock to ensure a monotonic increasing clock.
+  // In highly stressed situations this can still cause >2% CPU time in vdso_clock_gettime.
+  // If we need lower CPU time when JIT symbols are enabled then FEX can read the cycle counter directly.
+  std::chrono::steady_clock::time_point LastWrite {};
+  size_t Offset {};
+  char Buffer[BUFFER_SIZE] {};
+};
+static_assert(sizeof(JITSymbolBuffer) == 4096, "Ensure this is one page in size");
+
 class JITSymbols final {
 public:
   JITSymbols();
@@ -21,16 +41,16 @@ public:
   void RegisterJITSpace(const void* HostAddr, uint32_t CodeSize);
 
   // Allocate JIT buffer.
-  static fextl::unique_ptr<Core::JITSymbolBuffer> AllocateBuffer() {
-    return fextl::make_unique<Core::JITSymbolBuffer>();
+  static fextl::unique_ptr<FEXCore::JITSymbolBuffer> AllocateBuffer() {
+    return fextl::make_unique<FEXCore::JITSymbolBuffer>();
   }
 
-  void Register(Core::JITSymbolBuffer* Buffer, const void* HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
-  void Register(Core::JITSymbolBuffer* Buffer, const void* HostAddr, uint32_t CodeSize, std::string_view Name, uintptr_t Offset);
-  void RegisterNamedRegion(Core::JITSymbolBuffer* Buffer, const void* HostAddr, uint32_t CodeSize, std::string_view Name);
+  void Register(FEXCore::JITSymbolBuffer* Buffer, const void* HostAddr, uint64_t GuestAddr, uint32_t CodeSize);
+  void Register(FEXCore::JITSymbolBuffer* Buffer, const void* HostAddr, uint32_t CodeSize, std::string_view Name, uintptr_t Offset);
+  void RegisterNamedRegion(FEXCore::JITSymbolBuffer* Buffer, const void* HostAddr, uint32_t CodeSize, std::string_view Name);
 
 private:
   int fd {-1};
-  void WriteBuffer(Core::JITSymbolBuffer* Buffer, bool ForceWrite = false);
+  void WriteBuffer(FEXCore::JITSymbolBuffer* Buffer, bool ForceWrite = false);
 };
 } // namespace FEXCore


### PR DESCRIPTION
This definition doesn't need to be exposed in the public API.