### PR TITLE
AOTIR: Move debugdata structure to internal header

### DIFF
--- a/FEXCore/Source/Interface/IR/AOTIR.h
+++ b/FEXCore/Source/Interface/IR/AOTIR.h
@@ -17,9 +17,34 @@
 #include <shared_mutex>
 #include <FEXCore/HLE/SourcecodeResolver.h>
 
+namespace FEXCore::CPU {
+union Relocation;
+} // namespace FEXCore::CPU
+
 namespace FEXCore::Core {
-struct DebugData;
-}
+struct DebugDataSubblock {
+  uint32_t HostCodeOffset;
+  uint32_t HostCodeSize;
+};
+
+struct DebugDataGuestOpcode {
+  uint64_t GuestEntryOffset;
+  ptrdiff_t HostEntryOffset;
+};
+
+/**
+ * @brief Contains debug data for a block of code for later debugger analysis
+ *
+ * Needs to remain around for as long as the code could be executed at least
+ */
+struct DebugData : public FEXCore::Allocator::FEXAllocOperators {
+  uint64_t HostCodeSize; ///< The size of the code generated in the host JIT
+  fextl::vector<DebugDataSubblock> Subblocks;
+  fextl::vector<DebugDataGuestOpcode> GuestOpcodes;
+  fextl::vector<FEXCore::CPU::Relocation>* Relocations;
+};
+} // namespace FEXCore::Core
+
 namespace FEXCore::Context {
 class ContextImpl;
 }

--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -25,7 +25,6 @@ class Context;
 
 namespace FEXCore::CPU {
 class CPUBackend;
-union Relocation;
 } // namespace FEXCore::CPU
 
 namespace FEXCore::Frontend {
@@ -38,27 +37,6 @@ class PassManager;
 } // namespace FEXCore::IR
 
 namespace FEXCore::Core {
-struct DebugDataSubblock {
-  uint32_t HostCodeOffset;
-  uint32_t HostCodeSize;
-};
-
-struct DebugDataGuestOpcode {
-  uint64_t GuestEntryOffset;
-  ptrdiff_t HostEntryOffset;
-};
-
-/**
- * @brief Contains debug data for a block of code for later debugger analysis
- *
- * Needs to remain around for as long as the code could be executed at least
- */
-struct DebugData : public FEXCore::Allocator::FEXAllocOperators {
-  uint64_t HostCodeSize; ///< The size of the code generated in the host JIT
-  fextl::vector<DebugDataSubblock> Subblocks;
-  fextl::vector<DebugDataGuestOpcode> GuestOpcodes;
-  fextl::vector<FEXCore::CPU::Relocation>* Relocations;
-};
 
 // Special-purpose replacement for std::unique_ptr to allow InternalThreadState to be standard layout.
 // Since a NonMovableUniquePtr is neither copyable nor movable, its only function is to own and release the contained object.


### PR DESCRIPTION
This definition doesn't need to be exposed in the public API.