### PR TITLE
FEXCore: Move `CustomIRResult` to internal header

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -75,6 +75,23 @@ struct ExitFunctionLinkData {
   uint64_t GuestRIP;
 };
 
+struct CustomIRResult {
+  void* Creator;
+  void* Data;
+
+  explicit operator bool() const noexcept {
+    return !lock;
+  }
+
+  CustomIRResult(std::unique_lock<std::shared_mutex>&& lock, void* Creator, void* Data)
+    : Creator(Creator)
+    , Data(Data)
+    , lock(std::move(lock)) {}
+
+private:
+  std::unique_lock<std::shared_mutex> lock;
+};
+
 using BlockDelinkerFunc = void (*)(FEXCore::Core::CpuStateFrame* Frame, FEXCore::Context::ExitFunctionLinkData* Record);
 constexpr uint32_t TSC_SCALE_MAXIMUM = 1'000'000'000; ///< 1Ghz
 

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -14,8 +14,6 @@
 
 #include <istream>
 #include <ostream>
-#include <mutex>
-#include <shared_mutex>
 #include <span>
 
 namespace FEXCore {
@@ -57,23 +55,6 @@ enum ExitReason {
 enum OperatingMode {
   MODE_32BIT,
   MODE_64BIT,
-};
-
-struct CustomIRResult {
-  void* Creator;
-  void* Data;
-
-  explicit operator bool() const noexcept {
-    return !lock;
-  }
-
-  CustomIRResult(std::unique_lock<std::shared_mutex>&& lock, void* Creator, void* Data)
-    : Creator(Creator)
-    , Data(Data)
-    , lock(std::move(lock)) {}
-
-private:
-  std::unique_lock<std::shared_mutex> lock;
 };
 
 /**


### PR DESCRIPTION
This definition doesn't need to be exposed in the public API.

Stopped needing to be public once we removed our IR CI thing.