### PR TITLE
LinuxSyscalls: With poll syscall, ensure fds is writable only if nfds is not zero

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
@@ -253,12 +253,6 @@ auto selectHandler = [](FEXCore::Core::CpuStateFrame* Frame, int nfds, fd_set32*
 };
 
 void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_IMPL_X32(poll, [](FEXCore::Core::CpuStateFrame* Frame, struct pollfd* fds, nfds_t nfds, int timeout) -> uint64_t {
-    FaultSafeUserMemAccess::VerifyIsReadableOrNull(fds, sizeof(struct pollfd) * nfds);
-    uint64_t Result = ::poll(fds, nfds, timeout);
-    SYSCALL_ERRNO();
-  });
-
   REGISTER_SYSCALL_IMPL_X32(ppoll,
                             [](FEXCore::Core::CpuStateFrame* Frame, struct pollfd* fds, nfds_t nfds, timespec32* timeout_ts,
                                const uint64_t* sigmask, size_t sigsetsize) -> uint64_t {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/FD.cpp
@@ -29,12 +29,6 @@ $end_info$
 
 namespace FEX::HLE::x64 {
 void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_IMPL_X64(poll, [](FEXCore::Core::CpuStateFrame* Frame, struct pollfd* fds, nfds_t nfds, int timeout) -> uint64_t {
-    FaultSafeUserMemAccess::VerifyIsWritable(fds, sizeof(struct pollfd) * nfds);
-    uint64_t Result = ::poll(fds, nfds, timeout);
-    SYSCALL_ERRNO();
-  });
-
   REGISTER_SYSCALL_IMPL_X64(
     select, [](FEXCore::Core::CpuStateFrame* Frame, int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, struct timeval* timeout) -> uint64_t {
       ///< All FD arrays need to be writable


### PR DESCRIPTION
The pointer is allowed to be null or garbage if the number of nfds passed in is zero.
Unify the x86 and x86-64 implementations to ensure consistency.

Fixes Warhammer 40k: Relics of War