### PR TITLE
Bunch of little things reported by coverity

### DIFF
--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -1070,7 +1070,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10110, rd.D(), rn.D());
   }
@@ -1082,7 +1082,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10110, rd.Q(), rn.Q());
   }
@@ -1095,7 +1095,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10111, rd.D(), rn.D());
   }
@@ -1107,7 +1107,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10111, rd.Q(), rn.Q());
   }
@@ -1123,7 +1123,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11000, rd, rn);
   }
@@ -1138,7 +1138,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11001, rd, rn);
   }
@@ -1154,7 +1154,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11010, rd, rn);
   }
@@ -1169,7 +1169,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11011, rd, rn);
   }
@@ -1184,7 +1184,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11100, rd, rn);
   }
@@ -1199,7 +1199,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11101, rd, rn);
   }
@@ -1214,7 +1214,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11110, rd, rn);
   }
@@ -1229,7 +1229,7 @@ public:
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+      ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11111, rd, rn);
   }

--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -401,7 +401,7 @@ def print_parse_argloader_options(options):
                 conversion_func = "FEXCore::Config::Handler::{0}(".format(op_vals["ArgumentHandler"])
             if (value_type == "str"):
                 NeedsString = True
-                conversion_func = "("
+                conversion_func = "std::move("
             if (value_type == "bool"):
                 # boolean values need a decimal specifier. Otherwise fmt prints strings.
                 conversion_func = "fextl::fmt::format(\"{:d}\", "

--- a/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/F80Fallbacks.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/F80Fallbacks.h
@@ -7,7 +7,7 @@
 
 namespace FEXCore::CPU {
 FEXCORE_PRESERVE_ALL_ATTR static softfloat_state SoftFloatStateFromFCW(uint16_t FCW) {
-  softfloat_state State;
+  softfloat_state State {};
   State.detectTininess = softfloat_tininess_afterRounding;
   State.exceptionFlags = 0;
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4721,6 +4721,7 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
     Reason.si_code = 0x80;
     SetRIPToNext = true;
     break;
+  default: FEX_UNREACHABLE;
   }
 
   // Calculate flags early.

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -1440,7 +1440,7 @@ void OpDispatchBuilder::AVX128_ShiftDoubleImm(OpcodeArgs, ShiftDirection Dir) {
     Result = Src;
   } else if (Shift >= Core::CPUState::XMM_SSE_REG_SIZE) {
     Result.Low = LoadZeroVector(OpSize::i128Bit);
-    Result.High = Result.High;
+    Result.High = Result.Low;
   } else {
     Ref ZeroVector = LoadZeroVector(OpSize::i128Bit);
     RefPair Zero {ZeroVector, ZeroVector};

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -177,16 +177,15 @@ void OpDispatchBuilder::FADD(OpcodeArgs, size_t Width, bool Integer, OpDispatchB
     return;
   }
 
+  LOGMAN_THROW_A_FMT(Width != 80, "No 80-bit floats from memory");
   // We have one memory argument
   Ref Arg {};
-  if (Width == 16 || Width == 32 || Width == 64) {
-    if (Integer) {
-      Arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
-      Arg = _F80CVTToInt(Arg, Width / 8);
-    } else {
-      Arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
-      Arg = _F80CVTTo(Arg, Width / 8);
-    }
+  if (Integer) {
+    Arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+    Arg = _F80CVTToInt(Arg, Width / 8);
+  } else {
+    Arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+    Arg = _F80CVTTo(Arg, Width / 8);
   }
 
   // top of stack is at offset zero
@@ -208,16 +207,15 @@ void OpDispatchBuilder::FMUL(OpcodeArgs, size_t Width, bool Integer, OpDispatchB
     return;
   }
 
+  LOGMAN_THROW_A_FMT(Width != 80, "No 80-bit floats from memory");
   // We have one memory argument
   Ref arg {};
-  if (Width == 16 || Width == 32 || Width == 64) {
-    if (Integer) {
-      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
-      arg = _F80CVTToInt(arg, Width / 8);
-    } else {
-      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
-      arg = _F80CVTTo(arg, Width / 8);
-    }
+  if (Integer) {
+    arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+    arg = _F80CVTToInt(arg, Width / 8);
+  } else {
+    arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+    arg = _F80CVTTo(arg, Width / 8);
   }
 
   // top of stack is at offset zero
@@ -246,16 +244,15 @@ void OpDispatchBuilder::FDIV(OpcodeArgs, size_t Width, bool Integer, bool Revers
     return;
   }
 
+  LOGMAN_THROW_A_FMT(Width != 80, "No 80-bit floats from memory");
   // We have one memory argument
   Ref arg {};
-  if (Width == 16 || Width == 32 || Width == 64) {
-    if (Integer) {
-      arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
-      arg = _F80CVTToInt(arg, Width / 8);
-    } else {
-      arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
-      arg = _F80CVTTo(arg, Width / 8);
-    }
+  if (Integer) {
+    arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+    arg = _F80CVTToInt(arg, Width / 8);
+  } else {
+    arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+    arg = _F80CVTTo(arg, Width / 8);
   }
 
   // top of stack is at offset zero
@@ -288,16 +285,15 @@ void OpDispatchBuilder::FSUB(OpcodeArgs, size_t Width, bool Integer, bool Revers
     return;
   }
 
+  LOGMAN_THROW_A_FMT(Width != 80, "No 80-bit floats from memory");
   // We have one memory argument
   Ref Arg {};
-  if (Width == 16 || Width == 32 || Width == 64) {
-    if (Integer) {
-      Arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
-      Arg = _F80CVTToInt(Arg, Width / 8);
-    } else {
-      Arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
-      Arg = _F80CVTTo(Arg, Width / 8);
-    }
+  if (Integer) {
+    Arg = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags);
+    Arg = _F80CVTToInt(Arg, Width / 8);
+  } else {
+    Arg = LoadSource(FPRClass, Op, Op->Src[0], Op->Flags);
+    Arg = _F80CVTTo(Arg, Width / 8);
   }
 
   // top of stack is at offset zero

--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -239,7 +239,7 @@ fextl::vector<MemoryRegion> CollectMemoryGaps(uintptr_t Begin, uintptr_t End, in
 
     // Parse mapped region in the format "fffff7cc3000-fffff7cc4000 r--p ..."
     {
-      uintptr_t RegionBegin;
+      uintptr_t RegionBegin {};
       auto result = std::from_chars(Cursor, line_end, RegionBegin, 16);
       LogMan::Throw::AFmt(result.ec == std::errc {} && *result.ptr == '-', "Unexpected line format");
       Cursor = result.ptr + 1;

--- a/Source/Tools/FEXLoader/ELFCodeLoader.h
+++ b/Source/Tools/FEXLoader/ELFCodeLoader.h
@@ -358,7 +358,7 @@ public:
   };
 
   bool MapMemory(FEX::HLE::SyscallHandler* const Handler) {
-    for (auto Header : MainElf.phdrs) {
+    for (const auto& Header : MainElf.phdrs) {
       if (Header.p_type == PT_GNU_STACK) {
         if (Header.p_flags & PF_X) {
           ExecutableStack = true;

--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -1032,60 +1032,53 @@ namespace UnSquash {
 bool UnsquashRootFS(const fextl::string& Path, const fextl::string& RootFS, const fextl::string& FolderName) {
   auto TargetFolder = Path + FolderName;
 
-  bool Extract = true;
   std::error_code ec;
   if (std::filesystem::exists(TargetFolder, ec)) {
     fextl::string Question = "Target folder \"" + FolderName + "\" already exists. Overwrite?";
     if (AskForConfirmation(Question)) {
-      if (std::filesystem::remove_all(TargetFolder, ec) != ~0ULL) {
-        Extract = true;
+      if (std::filesystem::remove_all(TargetFolder, ec) == ~0ULL) {
+        ExecWithInfo("Couldn't remove previous directory. Won't extract.");
+        return false;
       }
+    } else {
+      return false;
     }
   }
 
-  if (Extract) {
-    const std::vector<const char*> ExecveArgs = {
-      "unsquashfs", "-f", "-d", TargetFolder.c_str(), RootFS.c_str(), nullptr,
-    };
+  const std::vector<const char*> ExecveArgs = {
+    "unsquashfs", "-f", "-d", TargetFolder.c_str(), RootFS.c_str(), nullptr,
+  };
 
-    return Exec::ExecAndWaitForResponse(ExecveArgs[0], const_cast<char* const*>(ExecveArgs.data())) == 0;
-  }
-
-  return false;
+  return Exec::ExecAndWaitForResponse(ExecveArgs[0], const_cast<char* const*>(ExecveArgs.data())) == 0;
 }
 
 bool ExtractEroFS(const fextl::string& Path, const fextl::string& RootFS, const fextl::string& FolderName) {
   auto TargetFolder = Path + FolderName;
 
-  bool Extract = true;
   std::error_code ec;
   if (std::filesystem::exists(TargetFolder, ec)) {
     fextl::string Question = "Target folder \"" + FolderName + "\" already exists. Overwrite?";
     if (AskForConfirmation(Question)) {
-      if (std::filesystem::remove_all(TargetFolder, ec) != ~0ULL) {
-        Extract = true;
-      }
-      if (ec) {
+      if (std::filesystem::remove_all(TargetFolder, ec) == ~0ULL) {
         ExecWithInfo("Couldn't remove previous directory. Won't extract.");
+        return false;
       }
+    } else {
+      return false;
     }
   }
 
-  if (Extract) {
-    ExecWithInfo("Extracting Erofs. This might take a few minutes.");
+  ExecWithInfo("Extracting Erofs. This might take a few minutes.");
 
-    const auto ExtractOption = fmt::format("--extract={}", TargetFolder);
-    const std::vector<const char*> ExecveArgs = {
-      "fsck.erofs",
-      ExtractOption.c_str(),
-      RootFS.c_str(),
-      nullptr,
-    };
+  const auto ExtractOption = fmt::format("--extract={}", TargetFolder);
+  const std::vector<const char*> ExecveArgs = {
+    "fsck.erofs",
+    ExtractOption.c_str(),
+    RootFS.c_str(),
+    nullptr,
+  };
 
-    return Exec::ExecAndWaitForResponse(ExecveArgs[0], const_cast<char* const*>(ExecveArgs.data())) == 0;
-  }
-
-  return false;
+  return Exec::ExecAndWaitForResponse(ExecveArgs[0], const_cast<char* const*>(ExecveArgs.data())) == 0;
 }
 } // namespace UnSquash
 

--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -557,7 +557,7 @@ std::optional<std::vector<FileTargets>> GetRootFSLinks() {
 
   for (const json_t* RootItem = json_getChild(RootList); RootItem != nullptr; RootItem = json_getSibling(RootItem)) {
 
-    FileTargets Target;
+    FileTargets Target {};
     Target.DistroName = json_getName(RootItem);
 
     for (const json_t* DataItem = json_getChild(RootItem); DataItem != nullptr; DataItem = json_getSibling(DataItem)) {

--- a/Source/Tools/FEXRootFSFetcher/XXFileHash.cpp
+++ b/Source/Tools/FEXRootFSFetcher/XXFileHash.cpp
@@ -37,6 +37,8 @@ std::pair<bool, uint64_t> HashFile(const fextl::string& Filepath) {
   }
 
   if (XXH3_64bits_reset_withSeed(State, Seed) == XXH_ERROR) {
+    XXH3_freeState(State);
+    close(fd);
     return HadError();
   }
 
@@ -50,10 +52,14 @@ std::pair<bool, uint64_t> HashFile(const fextl::string& Filepath) {
 
     ssize_t Result = pread(fd, Data.data(), BLOCK_SIZE, CurrentOffset);
     if (Result == -1) {
+      XXH3_freeState(State);
+      close(fd);
       return HadError();
     }
 
     if (XXH3_64bits_update(State, Data.data(), Result) == XXH_ERROR) {
+      XXH3_freeState(State);
+      close(fd);
       return HadError();
     }
     auto Cur = std::chrono::high_resolution_clock::now();

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -174,7 +174,10 @@ int main(int argc, char** argv, char** const envp) {
   ::setsid();
 
   // Set process as a subreaper so subprocesses can't escape
-  ::prctl(PR_SET_CHILD_SUBREAPER, 1);
+  if (::prctl(PR_SET_CHILD_SUBREAPER, 1) == -1) [[unlikely]] {
+    // If subreaper failed then squashfuse/erofsfuse can escape, which isn't fatal.
+    LogMan::Msg::DFmt("[FEXServer] Couldn't set subreaper.");
+  }
 
   if (Options.Foreground) {
     // Only start a log thread if we are in the foreground.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -60,7 +60,11 @@ static int GenTmpFD(const char* pathname, int flags) {
 // Seal the tmpfd features by sealing them all.
 // Makes the tmpfd read-only.
 static void SealTmpFD(int fd) {
-  fcntl(fd, F_ADD_SEALS, F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_FUTURE_WRITE);
+  int ret = fcntl(fd, F_ADD_SEALS, F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_FUTURE_WRITE);
+  if (ret == -1) [[unlikely]] {
+    // This shouldn't ever happen, but also isn't fatal.
+    LogMan::Msg::EFmt("Couldn't seal tmpfd! {}", errno);
+  }
 }
 
 fextl::string GenerateCPUInfo(FEXCore::Context::Context* ctx, uint32_t CPUCores) {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
@@ -179,7 +179,7 @@ void FileManager::LoadThunkDatabase(fextl::unordered_map<fextl::string, ThunkDBO
 
 FileManager::FileManager(FEXCore::Context::Context* ctx)
   : EmuFD {ctx} {
-  auto ThunkConfigFile = ThunkConfig();
+  const auto& ThunkConfigFile = ThunkConfig();
 
   // We try to load ThunksDB from:
   // - FEX global config
@@ -367,7 +367,7 @@ fextl::string FileManager::GetEmulatedPath(const char* pathname, bool FollowSyml
     return thunkOverlay->second;
   }
 
-  auto RootFSPath = LDPath();
+  const auto& RootFSPath = LDPath();
   if (RootFSPath.empty()) { // If RootFS doesn't exist
     return {};
   }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
@@ -192,7 +192,7 @@ FileManager::FileManager(FEXCore::Context::Context* ctx)
   // - AppConfig override
   // This doesn't support the classic thunks interface.
 
-  auto AppName = AppConfigName();
+  const auto& AppName = AppConfigName();
   fextl::vector<fextl::string> ConfigPaths {
     FEXCore::Config::GetConfigFileLocation(true),
     FEXCore::Config::GetConfigFileLocation(false),

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
@@ -673,7 +673,7 @@ uint64_t FileManager::Readlink(const char* pathname, char* buf, size_t bufsiz) {
     snprintf(PidSelfPath, 50, "/proc/%i/exe", CurrentPID);
 
     if (strcmp(pathname, "/proc/self/exe") == 0 || strcmp(pathname, "/proc/thread-self/exe") == 0 || strcmp(pathname, PidSelfPath) == 0) {
-      auto App = Filename();
+      const auto& App = Filename();
       strncpy(buf, App.c_str(), bufsiz);
       return std::min(bufsiz, App.size());
     }
@@ -750,7 +750,7 @@ uint64_t FileManager::Readlinkat(int dirfd, const char* pathname, char* buf, siz
     snprintf(PidSelfPath, 50, "/proc/%i/exe", CurrentPID);
 
     if (Path == "/proc/self/exe" || Path == "/proc/thread-self/exe" || Path == PidSelfPath) {
-      auto App = Filename();
+      const auto& App = Filename();
       strncpy(buf, App.c_str(), bufsiz);
       return std::min(bufsiz, App.size());
     }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -344,7 +344,7 @@ fextl::string GdbServer::readRegs() {
   GDB.eflags = CTX->ReconstructCompactedEFLAGS(CurrentThread->Thread, false, nullptr, 0);
 
   for (size_t i = 0; i < FEXCore::Core::CPUState::NUM_MMS; ++i) {
-    memcpy(&GDB.mm[i], &state.mm[i], sizeof(GDB.mm));
+    memcpy(&GDB.mm[i], &state.mm[i], sizeof(GDB.mm[i]));
   }
 
   // Currently unsupported

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -356,7 +356,7 @@ fextl::string GdbServer::readRegs() {
   GDB.fstat |= static_cast<uint32_t>(state.flags[FEXCore::X86State::X87FLAG_C2_LOC]) << 10;
   GDB.fstat |= static_cast<uint32_t>(state.flags[FEXCore::X86State::X87FLAG_C3_LOC]) << 14;
 
-  memcpy(&GDB.xmm[0], &state.xmm.avx.data[0], sizeof(GDB.xmm));
+  memcpy(&GDB.xmm, &state.xmm.avx.data, sizeof(GDB.xmm));
 
   return encodeHex((unsigned char*)&GDB, sizeof(GDBContextDefinition));
 }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -773,7 +773,7 @@ GdbServer::HandledPacketType GdbServer::handleXfer(const fextl::string& packet) 
       }
     }
 
-    return {encode(data), HandledPacketType::TYPE_ACK};
+    return {encode(std::move(data)), HandledPacketType::TYPE_ACK};
   }
 
   return {"", HandledPacketType::TYPE_UNKNOWN};
@@ -939,7 +939,7 @@ GdbServer::HandledPacketType GdbServer::handleQuery(const fextl::string& packet)
       //  no-resumed
       //  memory-tagging
     }
-    return {SupportedFeatures, HandledPacketType::TYPE_ACK};
+    return {std::move(SupportedFeatures), HandledPacketType::TYPE_ACK};
   }
   if (match("qAttached")) {
     return {"tnotrun:0", HandledPacketType::TYPE_ACK}; // We don't currently support launching executables from gdb.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Seccomp/BPFEmitter.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Seccomp/BPFEmitter.cpp
@@ -307,16 +307,16 @@ uint64_t BPFEmitter::HandleEmission(uint32_t flags, const sock_fprog* prog) {
 
     HadError = PredFunc(Result);
 
-    if constexpr (CalculateSize) {
-      CalculatedSize += Result;
-    }
-
     if (HadError) {
       if constexpr (!CalculateSize) {
         // Had error, early return and free the memory.
         FEXCore::Allocator::munmap(GetBufferBase(), FuncSize);
       }
       return Result;
+    }
+
+    if constexpr (CalculateSize) {
+      CalculatedSize += Result;
     }
   }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Seccomp/BPFEmitter.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Seccomp/BPFEmitter.h
@@ -90,8 +90,8 @@ private:
   fextl::unordered_map<uint32_t, ARMEmitter::ForwardLabel> JumpLabels;
   fextl::unordered_map<uint32_t, ARMEmitter::ForwardLabel> ConstPool;
 
-  void* Func;
-  size_t FuncSize;
+  void* Func {};
+  size_t FuncSize {};
 };
 
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -556,7 +556,7 @@ void SignalDelegator::HandleGuestSignal(FEX::HLE::ThreadStateObject* ThreadObjec
           return;
         }
 
-        auto Top = Thread->DeferredSignalFrames.back();
+        const auto& Top = Thread->DeferredSignalFrames.back();
         Signal = Top.Signal;
         SigInfo = Top.Info;
         Thread->DeferredSignalFrames.pop_back();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -103,8 +103,8 @@ void SignalDelegator::HandleSignal(FEX::HLE::ThreadStateObject* Thread, int Sign
 }
 
 void SignalDelegator::RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
-  SetHostSignalHandler(Signal, Func, Required);
-  FrontendRegisterHostSignalHandler(Signal, Func, Required);
+  SetHostSignalHandler(Signal, std::move(Func), Required);
+  FrontendRegisterHostSignalHandler(Signal, Required);
 }
 
 void SignalDelegator::SpillSRA(FEXCore::Core::InternalThreadState* Thread, void* ucontext, uint32_t IgnoreMask) {
@@ -1002,7 +1002,7 @@ void SignalDelegator::UninstallTLSState(FEX::HLE::ThreadStateObject* Thread) {
   }
 }
 
-void SignalDelegator::FrontendRegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
+void SignalDelegator::FrontendRegisterHostSignalHandler(int Signal, bool Required) {
   // Linux signal handlers are per-process rather than per thread
   // Multiple threads could be calling in to this
   std::lock_guard lk(HostDelegatorMutex);
@@ -1010,7 +1010,7 @@ void SignalDelegator::FrontendRegisterHostSignalHandler(int Signal, HostSignalDe
   InstallHostThunk(Signal);
 }
 
-void SignalDelegator::FrontendRegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
+void SignalDelegator::FrontendRegisterFrontendHostSignalHandler(int Signal, bool Required) {
   // Linux signal handlers are per-process rather than per thread
   // Multiple threads could be calling in to this
   std::lock_guard lk(HostDelegatorMutex);
@@ -1024,8 +1024,8 @@ void SignalDelegator::RegisterHostSignalHandlerForGuest(int Signal, FEX::HLE::Ho
 }
 
 void SignalDelegator::RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
-  SetFrontendHostSignalHandler(Signal, Func, Required);
-  FrontendRegisterFrontendHostSignalHandler(Signal, Func, Required);
+  SetFrontendHostSignalHandler(Signal, std::move(Func), Required);
+  FrontendRegisterFrontendHostSignalHandler(Signal, Required);
 }
 
 uint64_t SignalDelegator::RegisterGuestSignalHandler(int Signal, const GuestSigAction* Action, GuestSigAction* OldAction) {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -140,8 +140,8 @@ private:
    *
    * It's a process level signal handler so one must be careful
    */
-  void FrontendRegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
-  void FrontendRegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required);
+  void FrontendRegisterHostSignalHandler(int Signal, bool Required);
+  void FrontendRegisterFrontendHostSignalHandler(int Signal, bool Required);
 
   void SetHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
     HostHandlers[Signal].Handlers.push_back(std::move(Func));

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -993,15 +993,10 @@ SyscallHandler::GenerateMap(const std::string_view& GuestBinaryFile, const std::
 // objdump output parsing,  index generation, index file serialization
 DoGenerate:
     LogMan::Msg::DFmt("GenerateMap: Generating index for '{}'", GuestSourceFile);
-    int StreamFD = ::open(GuestSourceFile.c_str(), O_RDONLY | O_CLOEXEC);
-
-    if (StreamFD == -1) {
-      LogMan::Msg::DFmt("GenerateMap: Failed to open '{}'", GuestSourceFile);
-      return {};
-    }
 
     fextl::string SourceData;
     if (!FEXCore::FileLoading::LoadFile(SourceData, GuestSourceFile)) {
+      LogMan::Msg::DFmt("GenerateMap: Failed to open '{}'", GuestSourceFile);
       return {};
     }
     fextl::istringstream Stream(SourceData);
@@ -1192,10 +1187,6 @@ DoGenerate:
           ::write(IndexStream, Mapping.Name.c_str(), len);
         }
       }
-    }
-
-    if (StreamFD != -1) {
-      close(StreamFD);
     }
 
     if (IndexStream != -1) {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -220,7 +220,7 @@ uint64_t ExecveHandler(FEXCore::Core::CpuStateFrame* Frame, const char* pathname
     if (pathname[0] == '/') {
       auto Path = SyscallHandler->FM.GetEmulatedPath(pathname, true);
       if (!Path.empty() && FHU::Filesystem::Exists(Path)) {
-        Filename = Path;
+        Filename = std::move(Path);
       } else {
         Filename = pathname;
       }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Ioctl/drm.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Ioctl/drm.h
@@ -197,6 +197,7 @@ namespace DRM {
       CPYT(size);
       CPYT(low_mark);
       CPYT(high_mark);
+      memcpy(&val.flags, &flags, sizeof(val.flags));
       CPYT(agp_start);
       return val;
     }
@@ -206,6 +207,7 @@ namespace DRM {
       CPYF(size);
       CPYF(low_mark);
       CPYF(high_mark);
+      memcpy(&flags, &val.flags, sizeof(val.flags));
       CPYF(agp_start);
     }
   };

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Ioctl/drm.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Ioctl/drm.h
@@ -665,7 +665,7 @@ namespace RADEON {
   };
 
   struct FEX_PACKED FEX_ANNOTATE("alias-x86_32-drm_radeon_init") FEX_ANNOTATE("fex-match") fex_drm_radeon_init_t {
-    enum {} func;
+    uint32_t func;
 
     compat_ulong_t sarea_priv_offset;
     int32_t is_pci;
@@ -691,6 +691,7 @@ namespace RADEON {
 
     operator drm_radeon_init_t() const {
       drm_radeon_init_t val {};
+      memcpy(&val.func, &func, sizeof(val.func));
       CPYT(sarea_priv_offset);
       CPYT(is_pci);
       CPYT(cp_mode);
@@ -715,6 +716,7 @@ namespace RADEON {
     }
 
     fex_drm_radeon_init_t(drm_radeon_init_t val) {
+      memcpy(&func, &val.func, sizeof(val.func));
       CPYF(sarea_priv_offset);
       CPYF(is_pci);
       CPYF(cp_mode);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Ioctl/drm.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Ioctl/drm.h
@@ -47,15 +47,15 @@ namespace DRM {
 
     operator drm_version() const {
       drm_version val {};
-      val.version_major = version_major;
-      val.version_minor = version_minor;
-      val.version_patchlevel = version_patchlevel;
-      val.name_len = name_len;
-      val.name = name;
-      val.date_len = date_len;
-      val.date = date;
-      val.desc_len = desc_len;
-      val.desc = desc;
+      CPYT(version_major);
+      CPYT(version_minor);
+      CPYT(version_patchlevel);
+      CPYT(name_len);
+      CPYT(name);
+      CPYT(date_len);
+      CPYT(date);
+      CPYT(desc_len);
+      CPYT(desc);
       return val;
     }
 
@@ -63,12 +63,12 @@ namespace DRM {
       : name {auto_compat_ptr {val.name}}
       , date {auto_compat_ptr {val.date}}
       , desc {auto_compat_ptr {val.desc}} {
-      version_major = val.version_major;
-      version_minor = val.version_minor;
-      version_patchlevel = val.version_patchlevel;
-      name_len = val.name_len;
-      date_len = val.date_len;
-      desc_len = val.desc_len;
+      CPYF(version_major);
+      CPYF(version_minor);
+      CPYF(version_patchlevel);
+      CPYF(name_len);
+      CPYF(date_len);
+      CPYF(desc_len);
     }
   };
 
@@ -80,14 +80,14 @@ namespace DRM {
 
     operator drm_unique() const {
       drm_unique val {};
-      val.unique_len = unique_len;
-      val.unique = unique;
+      CPYT(unique_len);
+      CPYT(unique);
       return val;
     }
 
     fex_drm_unique(struct drm_unique val)
       : unique {auto_compat_ptr {val.unique}} {
-      unique_len = val.unique_len;
+      CPYF(unique_len);
     }
   };
 
@@ -114,11 +114,11 @@ namespace DRM {
 
     fex_drm_map(struct drm_map val)
       : handle {auto_compat_ptr {val.handle}} {
-      CPYT(offset);
-      CPYT(size);
-      CPYT(type);
-      CPYT(flags);
-      CPYT(mtrr);
+      CPYF(offset);
+      CPYF(size);
+      CPYF(type);
+      CPYF(flags);
+      CPYF(mtrr);
     }
   };
 
@@ -558,19 +558,19 @@ namespace DRM {
 
     operator drm_mode_obj_get_properties() const {
       drm_mode_obj_get_properties val {};
-      val.props_ptr = props_ptr;
-      val.prop_values_ptr = prop_values_ptr;
-      val.count_props = count_props;
-      val.obj_id = obj_id;
-      val.obj_type = obj_type;
+      CPYT(props_ptr);
+      CPYT(prop_values_ptr);
+      CPYT(count_props);
+      CPYT(obj_id);
+      CPYT(obj_type);
       return val;
     }
 
     fex_drm_mode_obj_get_properties(struct drm_mode_obj_get_properties val) {
-      props_ptr = val.props_ptr;
-      prop_values_ptr = val.prop_values_ptr;
-      count_props = val.count_props;
-      obj_type = val.obj_type;
+      CPYF(props_ptr);
+      CPYF(prop_values_ptr);
+      CPYF(count_props);
+      CPYF(obj_type);
     }
   };
 
@@ -584,18 +584,18 @@ namespace DRM {
 
     operator drm_mode_obj_set_property() const {
       drm_mode_obj_set_property val {};
-      val.value = value;
-      val.prop_id = prop_id;
-      val.obj_id = obj_id;
-      val.obj_type = obj_type;
+      CPYT(value);
+      CPYT(prop_id);
+      CPYT(obj_id);
+      CPYT(obj_type);
       return val;
     }
 
     fex_drm_mode_obj_set_property(struct drm_mode_obj_set_property val) {
-      value = val.value;
-      prop_id = val.prop_id;
-      obj_id = val.obj_id;
-      obj_type = val.obj_type;
+      CPYF(value);
+      CPYF(prop_id);
+      CPYF(obj_id);
+      CPYF(obj_type);
     }
   };
 
@@ -615,21 +615,21 @@ namespace AMDGPU {
     fex_drm_amdgpu_gem_metadata() = delete;
     operator drm_amdgpu_gem_metadata() const {
       drm_amdgpu_gem_metadata val {};
-      val.handle = handle;
-      val.op = op;
-      val.data.flags = data.flags;
-      val.data.tiling_info = data.tiling_info;
-      val.data.data_size_bytes = data.data_size_bytes;
+      CPYT(handle);
+      CPYT(op);
+      CPYT(data.flags);
+      CPYT(data.tiling_info);
+      CPYT(data.data_size_bytes);
       memcpy(val.data.data, data.data, sizeof(data.data));
       return val;
     }
 
     fex_drm_amdgpu_gem_metadata(struct drm_amdgpu_gem_metadata val) {
-      handle = val.handle;
-      op = val.op;
-      data.flags = val.data.flags;
-      data.tiling_info = val.data.tiling_info;
-      data.data_size_bytes = val.data.data_size_bytes;
+      CPYF(handle);
+      CPYF(op);
+      CPYF(data.flags);
+      CPYF(data.tiling_info);
+      CPYF(data.data_size_bytes);
       memcpy(data.data, val.data.data, sizeof(data.data));
     }
   };
@@ -647,20 +647,20 @@ namespace RADEON {
 
     operator drm_radeon_gem_create() const {
       drm_radeon_gem_create val {};
-      val.size = size;
-      val.alignment = alignment;
-      val.handle = handle;
-      val.initial_domain = initial_domain;
-      val.flags = flags;
+      CPYT(size);
+      CPYT(alignment);
+      CPYT(handle);
+      CPYT(initial_domain);
+      CPYT(flags);
       return val;
     }
 
     fex_drm_radeon_gem_create(struct drm_radeon_gem_create val) {
-      size = val.size;
-      alignment = val.alignment;
-      handle = val.handle;
-      initial_domain = val.initial_domain;
-      flags = val.flags;
+      CPYF(size);
+      CPYF(alignment);
+      CPYF(handle);
+      CPYF(initial_domain);
+      CPYF(flags);
     }
   };
 
@@ -691,50 +691,50 @@ namespace RADEON {
 
     operator drm_radeon_init_t() const {
       drm_radeon_init_t val {};
-      val.sarea_priv_offset = sarea_priv_offset;
-      val.is_pci = is_pci;
-      val.cp_mode = cp_mode;
-      val.gart_size = gart_size;
-      val.ring_size = ring_size;
-      val.usec_timeout = usec_timeout;
-      val.fb_bpp = fb_bpp;
-      val.front_offset = front_offset;
-      val.front_pitch = front_pitch;
-      val.back_offset = back_offset;
-      val.back_pitch = back_pitch;
-      val.depth_bpp = depth_bpp;
-      val.depth_offset = depth_offset;
-      val.depth_pitch = depth_pitch;
-      val.fb_offset = fb_offset;
-      val.mmio_offset = mmio_offset;
-      val.ring_offset = ring_offset;
-      val.ring_rptr_offset = ring_rptr_offset;
-      val.buffers_offset = buffers_offset;
-      val.gart_textures_offset = gart_textures_offset;
+      CPYT(sarea_priv_offset);
+      CPYT(is_pci);
+      CPYT(cp_mode);
+      CPYT(gart_size);
+      CPYT(ring_size);
+      CPYT(usec_timeout);
+      CPYT(fb_bpp);
+      CPYT(front_offset);
+      CPYT(front_pitch);
+      CPYT(back_offset);
+      CPYT(back_pitch);
+      CPYT(depth_bpp);
+      CPYT(depth_offset);
+      CPYT(depth_pitch);
+      CPYT(fb_offset);
+      CPYT(mmio_offset);
+      CPYT(ring_offset);
+      CPYT(ring_rptr_offset);
+      CPYT(buffers_offset);
+      CPYT(gart_textures_offset);
       return val;
     }
 
     fex_drm_radeon_init_t(drm_radeon_init_t val) {
-      sarea_priv_offset = val.sarea_priv_offset;
-      is_pci = val.is_pci;
-      cp_mode = val.cp_mode;
-      gart_size = val.gart_size;
-      ring_size = val.ring_size;
-      usec_timeout = val.usec_timeout;
-      fb_bpp = val.fb_bpp;
-      front_offset = val.front_offset;
-      front_pitch = val.front_pitch;
-      back_offset = val.back_offset;
-      back_pitch = val.back_pitch;
-      depth_bpp = val.depth_bpp;
-      depth_offset = val.depth_offset;
-      depth_pitch = val.depth_pitch;
-      fb_offset = val.fb_offset;
-      mmio_offset = val.mmio_offset;
-      ring_offset = val.ring_offset;
-      ring_rptr_offset = val.ring_rptr_offset;
-      buffers_offset = val.buffers_offset;
-      gart_textures_offset = val.gart_textures_offset;
+      CPYF(sarea_priv_offset);
+      CPYF(is_pci);
+      CPYF(cp_mode);
+      CPYF(gart_size);
+      CPYF(ring_size);
+      CPYF(usec_timeout);
+      CPYF(fb_bpp);
+      CPYF(front_offset);
+      CPYF(front_pitch);
+      CPYF(back_offset);
+      CPYF(back_pitch);
+      CPYF(depth_bpp);
+      CPYF(depth_offset);
+      CPYF(depth_pitch);
+      CPYF(fb_offset);
+      CPYF(mmio_offset);
+      CPYF(ring_offset);
+      CPYF(ring_rptr_offset);
+      CPYF(buffers_offset);
+      CPYF(gart_textures_offset);
     }
   };
 
@@ -750,22 +750,22 @@ namespace RADEON {
 
     operator drm_radeon_clear_t() const {
       drm_radeon_clear_t val {};
-      val.flags = flags;
-      val.clear_color = clear_color;
-      val.clear_depth = clear_depth;
-      val.color_mask = color_mask;
-      val.depth_mask = depth_mask;
-      val.depth_boxes = depth_boxes;
+      CPYT(flags);
+      CPYT(clear_color);
+      CPYT(clear_depth);
+      CPYT(color_mask);
+      CPYT(depth_mask);
+      CPYT(depth_boxes);
       return val;
     }
 
     fex_drm_radeon_clear_t(drm_radeon_clear_t val)
       : depth_boxes {auto_compat_ptr {val.depth_boxes}} {
-      flags = val.flags;
-      clear_color = val.clear_color;
-      clear_depth = val.clear_depth;
-      color_mask = val.color_mask;
-      depth_mask = val.depth_mask;
+      CPYF(flags);
+      CPYF(clear_color);
+      CPYF(clear_depth);
+      CPYF(color_mask);
+      CPYF(depth_mask);
     }
   };
 
@@ -776,7 +776,7 @@ namespace RADEON {
 
     operator drm_radeon_stipple_t() const {
       drm_radeon_stipple_t val {};
-      val.mask = mask;
+      CPYT(mask);
       return val;
     }
 
@@ -796,22 +796,22 @@ namespace RADEON {
 
     operator drm_radeon_texture_t() const {
       drm_radeon_texture_t val {};
-      val.offset = offset;
-      val.pitch = pitch;
-      val.format = format;
-      val.width = width;
-      val.height = height;
-      val.image = image;
+      CPYT(offset);
+      CPYT(pitch);
+      CPYT(format);
+      CPYT(width);
+      CPYT(height);
+      CPYT(image);
       return val;
     }
 
     fex_drm_radeon_texture_t(drm_radeon_texture_t val)
       : image {auto_compat_ptr {val.image}} {
-      offset = val.offset;
-      pitch = val.pitch;
-      format = val.format;
-      width = val.width;
-      height = val.height;
+      CPYF(offset);
+      CPYF(pitch);
+      CPYF(format);
+      CPYF(width);
+      CPYF(height);
     }
   };
 
@@ -827,22 +827,22 @@ namespace RADEON {
 
     operator drm_radeon_vertex2_t() const {
       drm_radeon_vertex2_t val;
-      val.idx = idx;
-      val.discard = discard;
-      val.nr_states = nr_states;
-      val.state = state;
-      val.nr_prims = nr_prims;
-      val.prim = prim;
+      CPYT(idx);
+      CPYT(discard);
+      CPYT(nr_states);
+      CPYT(state);
+      CPYT(nr_prims);
+      CPYT(prim);
       return val;
     }
 
     fex_drm_radeon_vertex2_t(drm_radeon_vertex2_t val)
       : state {auto_compat_ptr {val.state}}
       , prim {auto_compat_ptr {val.prim}} {
-      idx = val.idx;
-      discard = val.discard;
-      nr_states = val.nr_states;
-      nr_prims = val.nr_prims;
+      CPYF(idx);
+      CPYF(discard);
+      CPYF(nr_states);
+      CPYF(nr_prims);
     }
   };
 
@@ -856,18 +856,18 @@ namespace RADEON {
 
     operator drm_radeon_cmd_buffer_t() const {
       drm_radeon_cmd_buffer_t val;
-      val.bufsz = bufsz;
-      val.buf = buf;
-      val.nbox = nbox;
-      val.boxes = boxes;
+      CPYT(bufsz);
+      CPYT(buf);
+      CPYT(nbox);
+      CPYT(boxes);
       return val;
     }
 
     fex_drm_radeon_cmd_buffer_t(drm_radeon_cmd_buffer_t val)
       : buf {auto_compat_ptr {val.buf}}
       , boxes {auto_compat_ptr {val.boxes}} {
-      val.bufsz = bufsz;
-      val.nbox = nbox;
+      CPYF(bufsz);
+      CPYF(nbox);
     }
   };
 
@@ -879,14 +879,14 @@ namespace RADEON {
 
     operator drm_radeon_getparam_t() const {
       drm_radeon_getparam_t val;
-      val.param = param;
-      val.value = value;
+      CPYT(param);
+      CPYT(value);
       return val;
     }
 
     fex_drm_radeon_getparam_t(drm_radeon_getparam_t val)
       : value {auto_compat_ptr {val.value}} {
-      val.param = param;
+      CPYF(param);
     }
   };
 
@@ -900,18 +900,18 @@ namespace RADEON {
 
     operator drm_radeon_mem_alloc_t() const {
       drm_radeon_mem_alloc_t val;
-      val.region = region;
-      val.alignment = alignment;
-      val.size = size;
-      val.region_offset = region_offset;
+      CPYT(region);
+      CPYT(alignment);
+      CPYT(size);
+      CPYT(region_offset);
       return val;
     }
 
     fex_drm_radeon_mem_alloc_t(drm_radeon_mem_alloc_t val)
       : region_offset {auto_compat_ptr {val.region_offset}} {
-      val.region = region;
-      val.alignment = alignment;
-      val.size = size;
+      CPYF(region);
+      CPYF(alignment);
+      CPYF(size);
     }
   };
 
@@ -922,7 +922,7 @@ namespace RADEON {
 
     operator drm_radeon_irq_emit_t() const {
       drm_radeon_irq_emit_t val;
-      val.irq_seq = irq_seq;
+      CPYT(irq_seq);
       return val;
     }
 
@@ -938,14 +938,14 @@ namespace RADEON {
 
     operator drm_radeon_setparam_t() const {
       drm_radeon_setparam_t val;
-      val.param = param;
-      val.value = value;
+      CPYT(param);
+      CPYT(value);
       return val;
     }
 
     fex_drm_radeon_setparam_t(drm_radeon_setparam_t val) {
-      param = val.param;
-      value = val.value;
+      CPYF(param);
+      CPYF(value);
     }
   };
 
@@ -958,8 +958,8 @@ namespace MSM {
 
     operator drm_msm_timespec() const {
       drm_msm_timespec val {};
-      val.tv_sec = tv_sec;
-      val.tv_nsec = tv_nsec;
+      CPYT(tv_sec);
+      CPYT(tv_nsec);
       return val;
     }
 
@@ -984,18 +984,18 @@ namespace MSM {
 
     operator drm_msm_wait_fence() const {
       drm_msm_wait_fence val {};
-      val.fence = fence;
-      val.flags = flags;
-      val.timeout = timeout;
-      val.queueid = queueid;
+      CPYT(fence);
+      CPYT(flags);
+      CPYT(timeout);
+      CPYT(queueid);
       return val;
     }
 
     fex_drm_msm_wait_fence(struct drm_msm_wait_fence val)
       : timeout {fex_drm_msm_timespec::FromHost(val.timeout)} {
-      fence = val.fence;
-      flags = val.flags;
-      queueid = val.queueid;
+      CPYF(fence);
+      CPYF(flags);
+      CPYF(queueid);
     }
   };
 
@@ -1085,9 +1085,9 @@ namespace I915 {
 
     fex_drm_i915_mem_alloc_t(drm_i915_mem_alloc_t val)
       : region_offset {auto_compat_ptr {val.region_offset}} {
-      CPYT(region);
-      CPYT(alignment);
-      CPYT(size);
+      CPYF(region);
+      CPYF(alignment);
+      CPYF(size);
     }
   };
 
@@ -1115,10 +1115,10 @@ namespace I915 {
     fex_drm_i915_cmdbuffer_t(drm_i915_cmdbuffer_t val)
       : buf {auto_compat_ptr {val.buf}}
       , cliprects {auto_compat_ptr {val.cliprects}} {
-      CPYT(sz);
-      CPYT(DR1);
-      CPYT(DR4);
-      CPYT(num_cliprects);
+      CPYF(sz);
+      CPYF(DR1);
+      CPYF(DR4);
+      CPYF(num_cliprects);
     }
   };
 
@@ -1146,13 +1146,13 @@ namespace VC4 {
 
     operator drm_vc4_perfmon_get_values() const {
       drm_vc4_perfmon_get_values val {};
-      val.id = id;
-      val.values_ptr = values_ptr;
+      CPYT(id);
+      CPYT(values_ptr);
       return val;
     }
     fex_drm_vc4_perfmon_get_values(drm_vc4_perfmon_get_values val) {
-      id = val.id;
-      values_ptr = val.values_ptr;
+      CPYF(id);
+      CPYF(values_ptr);
     }
   };
 
@@ -1207,14 +1207,14 @@ namespace V3D {
       drm_v3d_submit_csd val {};
       memcpy(val.cfg, cfg, sizeof(cfg));
       memcpy(val.coef, coef, sizeof(coef));
-      val.bo_handles = bo_handles;
-      val.bo_handle_count = bo_handle_count;
-      val.in_sync = in_sync;
-      val.out_sync = out_sync;
-      val.perfmon_id = perfmon_id;
-      val.extensions = extensions;
-      val.flags = flags;
-      val.pad = pad;
+      CPYT(bo_handles);
+      CPYT(bo_handle_count);
+      CPYT(in_sync);
+      CPYT(out_sync);
+      CPYT(perfmon_id);
+      CPYT(extensions);
+      CPYT(flags);
+      CPYT(pad);
       return val;
     }
 
@@ -1250,14 +1250,14 @@ namespace V3D {
     fex_drm_v3d_submit_csd(drm_v3d_submit_csd val) {
       memcpy(cfg, val.cfg, sizeof(cfg));
       memcpy(coef, val.coef, sizeof(coef));
-      bo_handles = val.bo_handles;
-      bo_handle_count = val.bo_handle_count;
-      in_sync = val.in_sync;
-      out_sync = val.out_sync;
-      perfmon_id = val.perfmon_id;
-      extensions = val.extensions;
-      flags = val.flags;
-      pad = val.pad;
+      CPYF(bo_handles);
+      CPYF(bo_handle_count);
+      CPYF(in_sync);
+      CPYF(out_sync);
+      CPYF(perfmon_id);
+      CPYF(extensions);
+      CPYF(flags);
+      CPYF(pad);
     }
   };
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Ioctl/drm.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Ioctl/drm.h
@@ -572,6 +572,7 @@ namespace DRM {
       CPYF(props_ptr);
       CPYF(prop_values_ptr);
       CPYF(count_props);
+      CPYF(obj_id);
       CPYF(obj_type);
     }
   };

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Time.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Time.cpp
@@ -186,6 +186,7 @@ void RegisterTime(FEX::HLE::SyscallHandler* Handler) {
   });
 
   REGISTER_SYSCALL_IMPL_X32(futimesat, [](FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, const timeval32 times[2]) -> uint64_t {
+    // TODO: This will always return ENOSYS on Arm64 since `futimesat` doesn't exist on that platform.
     uint64_t Result = 0;
     if (times) {
       FaultSafeUserMemAccess::VerifyIsReadable(times, sizeof(timeval32) * 2);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Types.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Types.h
@@ -1238,7 +1238,7 @@ struct ipc_perm_32 {
   ipc_perm_32() = delete;
 
   operator struct ipc64_perm() const {
-    struct ipc64_perm perm;
+    struct ipc64_perm perm {};
     perm.key = key;
     perm.uid = uid;
     perm.gid = gid;
@@ -1278,7 +1278,7 @@ struct ipc_perm_64 {
   ipc_perm_64() = delete;
 
   operator struct ipc64_perm() const {
-    struct ipc64_perm perm;
+    struct ipc64_perm perm {};
     perm.key = key;
     perm.uid = uid;
     perm.gid = gid;
@@ -1319,7 +1319,7 @@ struct shmid_ds_32 {
   shmid_ds_32() = delete;
 
   operator struct shmid64_ds() const {
-    struct shmid64_ds buf;
+    struct shmid64_ds buf {};
     buf.shm_perm = shm_perm;
 
     buf.shm_segsz = shm_segsz;
@@ -1365,7 +1365,7 @@ struct shmid_ds_64 {
   shmid_ds_64() = delete;
 
   operator struct shmid64_ds() const {
-    struct shmid64_ds buf;
+    struct shmid64_ds buf {};
     buf.shm_perm = shm_perm;
 
     buf.shm_segsz = shm_segsz;
@@ -1615,7 +1615,7 @@ struct FEX_ANNOTATE("fex-match") shminfo_32 {
   shminfo_32() = delete;
 
   operator struct shminfo() const {
-    struct shminfo si;
+    struct shminfo si {};
     si.shmmax = shmmax;
     si.shmmin = shmmin;
     si.shmmni = shmmni;
@@ -1650,7 +1650,7 @@ struct FEX_ANNOTATE("alias-x86_32-shminfo64") FEX_ANNOTATE("fex-match") shminfo_
   shminfo_64() = delete;
 
   operator struct shminfo() const {
-    struct shminfo si;
+    struct shminfo si {};
     si.shmmax = shmmax;
     si.shmmin = shmmin;
     si.shmmni = shmmni;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/FD.cpp
@@ -59,6 +59,7 @@ void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
 
   REGISTER_SYSCALL_IMPL_X64(
     futimesat, [](FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, const struct timeval times[2]) -> uint64_t {
+      // TODO: This will always return ENOSYS on Arm64 since `futimesat` doesn't exist on that platform.
       uint64_t Result = ::syscall(SYSCALL_DEF(futimesat), dirfd, pathname, times);
       SYSCALL_ERRNO();
     });

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Types.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Types.h
@@ -38,7 +38,7 @@ struct ipc_perm_64 {
   ipc_perm_64() = delete;
 
   operator struct ipc64_perm() const {
-    struct ipc64_perm perm;
+    struct ipc64_perm perm {};
     perm.key = key;
     perm.uid = uid;
     perm.gid = gid;

--- a/Source/Tools/pidof/pidof.cpp
+++ b/Source/Tools/pidof/pidof.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
     }
 
     // Read state
-    char State;
+    char State {};
 
     {
       std::ifstream fs(StatusPath, std::ios_base::in | std::ios_base::binary);

--- a/unittests/ASM/FEX_bugs/PSRLDQBuf.asm
+++ b/unittests/ASM/FEX_bugs/PSRLDQBuf.asm
@@ -1,0 +1,17 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0": ["0", "0", "0", "0"]
+  }
+}
+%endif
+
+; FEX-Emu had a bug with vpsrldq where if the shift was >= 16 bytes then the top half of the ymm register wasn't modified.
+; Adds a simple test to ensure this continues working.
+vmovups ymm0, [rel .data]
+vpsrldq ymm0, ymm0, 16
+hlt
+
+align 32
+.data:
+dq 0x4142434445464748, 0x5152535455565758, 0x6162636465666768, 0x7172737475767778

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -544,12 +544,13 @@
       ]
     },
     "vpsrldq ymm0, ymm1, 16": {
-      "ExpectedInstructionCount": 1,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 14 0b011 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v16.2d, #0x0"
+        "movi v16.2d, #0x0",
+        "str q16, [x28, #16]"
       ]
     },
     "vpsllq xmm0, xmm1, 0": {
@@ -677,12 +678,13 @@
       ]
     },
     "vpslldq ymm0, ymm1, 16": {
-      "ExpectedInstructionCount": 1,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 14 0b111 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v16.2d, #0x0"
+        "movi v16.2d, #0x0",
+        "str q16, [x28, #16]"
       ]
     }
   }


### PR DESCRIPTION
Mostly NFC, but it actually did find a few bugs, which is kind of unexpected.

Functional changes:
- (f51832ca6bae65c1ae692a0c0db81541106aa706) Fixes a bug in VPSRLDQ where larger than 16-byte shifts weren't zeroing the upper 16-bytes of a YMM register.
- (c559445b62a8f738fb096ed15da1c1ee5405e79c, 2d91c5441e4ef99d691fe8f1d022f241da777ef0, 9141322666eb7381b93ab3bf4605a288ad61900c, c4a0fb66092a2df82114bff9a001473777aabf99) IoctlEmulation: Fixes for a few structs that were copying the wrong direction for Host->Guest and missing a few member copies (Unlikely to affect anything as it was legacy interfaces)
- (98a91d242d77b555e78ce31263dbfa8b58295641) Fix resource leak on XXHash error
- (f6a8e595df2f82eb1dc454228beb2a1f632d4545) Add a TODO for futimesat because the syscall doesn't exist on ARM64
- (a308b9edbeb15c6b0d090e8820759ea1ac2ed7bf) Linux/Generate map: Fixes an FD leak
- (22ab16b2179d94b1b93c68dfecbdcce71c7f8d71) Fixes a "version" check in x32/ipc/msgrcv. The upper 16-bits of the call determine version and we weren't masking off the top bits correctly. Also ensures the shmat handler errors with a higher version to match Linux behaviour.
- (fa293e5e8f4a08efa2ce167f56c5b21438faa299) Fixes a buffer overrun in gdbserver when copying x87 registers