### PR TITLE
CMake: Disable vixl compiling if not enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,8 +273,10 @@ if (BUILD_TESTS)
   set(COMPILE_VIXL_DISASSEMBLER TRUE)
 endif()
 
-add_subdirectory(External/vixl/)
-include_directories(SYSTEM External/vixl/src/)
+if (COMPILE_VIXL_DISASSEMBLER OR ENABLE_VIXL_SIMULATOR)
+  add_subdirectory(External/vixl/)
+  include_directories(SYSTEM External/vixl/src/)
+endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # This means we were attempted to get compiled with GCC


### PR DESCRIPTION
Like how FEXCore disabled vixl linking, make sure we aren't accidentally compiling and including it when vixl stuff is disabled. Noticed this in the build logs.