### PR TITLE
FEXCore/Context: Removes unused features

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.cpp
+++ b/FEXCore/Source/Interface/Config/Config.cpp
@@ -318,24 +318,8 @@ fextl::string FindContainerPrefix() {
 void ReloadMetaLayer() {
   Meta->Load();
 
-  // Do configuration option fix ups after everything is reloaded
-  if (FEXCore::Config::Exists(FEXCore::Config::CONFIG_CORE)) {
-    // Sanitize Core option
-    FEX_CONFIG_OPT(Core, CORE);
-#if (_M_X86_64)
-    constexpr uint32_t MaxCoreNumber = 1;
-#else
-    constexpr uint32_t MaxCoreNumber = 0;
-#endif
-    if (Core > MaxCoreNumber) {
-      // Sanitize the core option by setting the core to the JIT if invalid
-      FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_CORE, fextl::fmt::format("{}", static_cast<uint32_t>(FEXCore::Config::CONFIG_IRJIT)));
-    }
-  }
-
   if (FEXCore::Config::Exists(FEXCore::Config::CONFIG_CACHEOBJECTCODECOMPILATION)) {
     FEX_CONFIG_OPT(CacheObjectCodeCompilation, CACHEOBJECTCODECOMPILATION);
-    FEX_CONFIG_OPT(Core, CORE);
   }
 
   fextl::string ContainerPrefix {FindContainerPrefix()};

--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -1,19 +1,6 @@
 {
   "Options": {
     "CPU": {
-      "Core": {
-        "Type": "uint32",
-        "Default": "FEXCore::Config::ConfigCore::CONFIG_IRJIT",
-        "TextDefault": "irjit",
-        "ShortArg": "c",
-        "Choices": [ "irjit", "host" ],
-        "ArgumentHandler": "CoreHandler",
-        "Desc": [
-          "Which CPU core to use",
-          "host only exists on x86_64",
-          "[irjit, host]"
-        ]
-      },
       "Multiblock": {
         "Type": "bool",
         "Default": "false",

--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -39,10 +39,6 @@ void FEXCore::Context::ContextImpl::CompileRIPCount(FEXCore::Core::InternalThrea
   CompileBlock(Thread->CurrentFrame, GuestRIP, MaxInst);
 }
 
-void FEXCore::Context::ContextImpl::SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) {
-  CustomCPUFactory = std::move(Factory);
-}
-
 void FEXCore::Context::ContextImpl::SetSignalDelegator(FEXCore::SignalDelegator* _SignalDelegation) {
   SignalDelegation = _SignalDelegation;
 }

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -26,14 +26,8 @@
 #include <stdint.h>
 
 #include <atomic>
-#include <condition_variable>
-#include <functional>
-#include <istream>
-#include <memory>
 #include <mutex>
 #include <shared_mutex>
-#include <stddef.h>
-#include <queue>
 
 namespace FEXCore {
 class CodeLoader;
@@ -65,11 +59,6 @@ namespace Validation {
 } // namespace FEXCore::IR
 
 namespace FEXCore::Context {
-enum CoreRunningMode {
-  MODE_RUN = 0,
-  MODE_SINGLESTEP = 1,
-};
-
 struct ExitFunctionLinkData {
   uint64_t HostBranch;
   uint64_t GuestRIP;
@@ -109,8 +98,6 @@ public:
 
   void CompileRIP(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP) override;
   void CompileRIPCount(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, uint64_t MaxInst) override;
-
-  void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) override;
 
   void HandleCallback(FEXCore::Core::InternalThreadState* Thread, uint64_t RIP) override;
 
@@ -220,7 +207,6 @@ public:
   friend class FEXCore::IR::Validation::IRValidation;
 
   struct {
-    CoreRunningMode RunningMode {CoreRunningMode::MODE_RUN};
     uint64_t VirtualMemSize {1ULL << 36};
     uint64_t TSCScale = 0;
 
@@ -240,7 +226,6 @@ public:
     FEX_CONFIG_OPT(AOTIRGenerate, AOTIRGENERATE);
     FEX_CONFIG_OPT(AOTIRLoad, AOTIRLOAD);
     FEX_CONFIG_OPT(SMCChecks, SMCCHECKS);
-    FEX_CONFIG_OPT(Core, CORE);
     FEX_CONFIG_OPT(MaxInstPerBlock, MAXINST);
     FEX_CONFIG_OPT(RootFSPath, ROOTFS);
     FEX_CONFIG_OPT(ThunkHostLibsPath, THUNKHOSTLIBS);
@@ -273,7 +258,6 @@ public:
   fextl::unique_ptr<FEXCore::ThunkHandler> ThunkHandler;
   fextl::unique_ptr<FEXCore::CPU::Dispatcher> Dispatcher;
 
-  CustomCPUFactoryType CustomCPUFactory;
   FEXCore::Context::ExitHandler CustomExitHandler;
 
 #ifdef BLOCKSTATS

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -420,14 +420,8 @@ void ContextImpl::InitializeCompiler(FEXCore::Core::InternalThreadState* Thread)
   Thread->PassManager->RegisterSyscallHandler(SyscallHandler);
 
   // Create CPU backend
-  switch (Config.Core) {
-  case FEXCore::Config::CONFIG_IRJIT:
-    Thread->PassManager->InsertRegisterAllocationPass();
-    Thread->CPUBackend = FEXCore::CPU::CreateArm64JITCore(this, Thread);
-    break;
-  case FEXCore::Config::CONFIG_CUSTOM: Thread->CPUBackend = CustomCPUFactory(this, Thread); break;
-  default: ERROR_AND_DIE_FMT("Unknown core configuration"); break;
-  }
+  Thread->PassManager->InsertRegisterAllocationPass();
+  Thread->CPUBackend = FEXCore::CPU::CreateArm64JITCore(this, Thread);
 
   Thread->PassManager->Finalize();
 }

--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -18,18 +18,6 @@
 
 namespace FEXCore::Config {
 namespace Handler {
-  static inline std::optional<fextl::string> CoreHandler(std::string_view Value) {
-    if (Value == "irjit") {
-      return "0";
-    }
-#ifdef _M_X86_64
-    else if (Value == "host") {
-      return "1";
-    }
-#endif
-    return "0";
-  }
-
   static inline std::optional<fextl::string> SMCCheckHandler(std::string_view Value) {
     if (Value == "none") {
       return "0";
@@ -59,11 +47,6 @@ enum ConfigOption {
 
 #define ENUMDEFINES
 #include <FEXCore/Config/ConfigOptions.inl>
-
-enum ConfigCore {
-  CONFIG_IRJIT,
-  CONFIG_CUSTOM,
-};
 
 enum ConfigSMCChecks {
   CONFIG_SMC_NONE,

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -68,14 +68,8 @@ public:
   virtual void Close() = 0;
 };
 
-struct VDSOSigReturn {
-  void* VDSO_kernel_sigreturn;
-  void* VDSO_kernel_rt_sigreturn;
-};
-
 using CodeRangeInvalidationFn = std::function<void(uint64_t start, uint64_t Length)>;
 
-using CustomCPUFactoryType = std::function<fextl::unique_ptr<CPU::CPUBackend>(Context*, Core::InternalThreadState* Thread)>;
 using CustomIREntrypointHandler = std::function<void(uintptr_t Entrypoint, IR::IREmitter*)>;
 
 using ExitHandler = std::function<void(Core::InternalThreadState* Thread, ExitReason)>;
@@ -129,16 +123,6 @@ public:
 
   FEX_DEFAULT_VISIBILITY virtual void CompileRIP(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP) = 0;
   FEX_DEFAULT_VISIBILITY virtual void CompileRIPCount(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, uint64_t MaxInst) = 0;
-
-  /**
-   * @brief Allows the frontend to pass in a custom CPUBackend creation factory
-   *
-   * This allows the frontend to have its own frontend. Typically for debugging
-   *
-   * @param CTX The context that we created
-   * @param Factory The factory that the context will call if the DefaultCore config ise set to CUSTOM
-   */
-  FEX_DEFAULT_VISIBILITY virtual void SetCustomCPUBackendFactory(CustomCPUFactoryType Factory) = 0;
 
   FEX_DEFAULT_VISIBILITY virtual void HandleCallback(FEXCore::Core::InternalThreadState* Thread, uint64_t RIP) = 0;
 

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -480,8 +480,6 @@ int main(int argc, char** argv, char** const envp) {
   // Setup configurations that this tool needs
   // Maximum one instruction.
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_MAXINST, "1");
-  // IRJIT. Only works on JITs.
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_CORE, fextl::fmt::format("{}", static_cast<uint64_t>(FEXCore::Config::CONFIG_IRJIT)));
   // Enable block disassembly.
   FEXCore::Config::EraseSet(
     FEXCore::Config::CONFIG_DISASSEMBLE,

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -151,7 +151,6 @@ private:
   }
 
   FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
-  FEX_CONFIG_OPT(Core, CORE);
   fextl::string const ApplicationName;
   FEXCORE_TELEMETRY_INIT(CrashMask, TYPE_CRASH_MASK);
   FEXCORE_TELEMETRY_INIT(UnhandledNonCanonical, TYPE_UNHANDLED_NONCANONICAL_ADDRESS);
@@ -198,7 +197,7 @@ private:
   bool InstallHostThunk(int Signal);
   bool UpdateHostThunk(int Signal);
 
-  FEXCore::Context::VDSOSigReturn VDSOPointers {};
+  FEX::VDSO::VDSOSigReturn VDSOPointers {};
 
   bool IsAddressInDispatcher(uint64_t Address) const {
     return Address >= Config.DispatcherBegin && Address < Config.DispatcherEnd;

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
@@ -20,7 +20,7 @@
 #include <unistd.h>
 
 namespace FEX::VDSO {
-FEXCore::Context::VDSOSigReturn VDSOPointers {};
+VDSOSigReturn VDSOPointers {};
 namespace VDSOHandlers {
   using TimeType = decltype(::time)*;
   using GetTimeOfDayType = decltype(::gettimeofday)*;
@@ -678,7 +678,7 @@ const std::span<FEXCore::IR::ThunkDefinition> GetVDSOThunkDefinitions() {
   return VDSODefinitions;
 }
 
-const FEXCore::Context::VDSOSigReturn& GetVDSOSymbols() {
+const VDSOSigReturn& GetVDSOSymbols() {
   return VDSOPointers;
 }
 } // namespace FEX::VDSO

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.h
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.h
@@ -5,10 +5,6 @@
 
 #include "LinuxSyscalls/Syscalls.h"
 
-namespace FEXCore::Context {
-struct VDSOSigReturn;
-}
-
 namespace FEX::VDSO {
 using MapperFn = std::function<void*(void* addr, size_t length, int prot, int flags, int fd, off_t offset)>;
 struct VDSOMapping {
@@ -17,11 +13,16 @@ struct VDSOMapping {
   void* OptionalSigReturnMapping {};
   size_t OptionalMappingSize {};
 };
+
+struct VDSOSigReturn {
+  void* VDSO_kernel_sigreturn;
+  void* VDSO_kernel_rt_sigreturn;
+};
 VDSOMapping LoadVDSOThunks(bool Is64Bit, FEX::HLE::SyscallHandler* const Handler);
 void UnloadVDSOMapping(const VDSOMapping& Mapping);
 
 uint64_t GetVSyscallEntry(const void* VDSOBase);
 
 const std::span<FEXCore::IR::ThunkDefinition> GetVDSOThunkDefinitions();
-const FEXCore::Context::VDSOSigReturn& GetVDSOSymbols();
+const VDSOSigReturn& GetVDSOSymbols();
 } // namespace FEX::VDSO

--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -51,9 +51,9 @@ foreach(ASM_SRC ${ASM_SOURCES})
   set(TEST_ARGS)
   if (_M_ARM_64 OR ENABLE_VIXL_SIMULATOR)
     list(APPEND TEST_ARGS
-      "--no-silent -g -c irjit -n 1   --no-multiblock"   "jit_1"     "jit"
-      "--no-silent -g -c irjit -n 500 --no-multiblock"   "jit_500"   "jit"
-      "--no-silent -g -c irjit -n 500 --multiblock"      "jit_500_m" "jit"
+      "--no-silent -g -n 1   --no-multiblock"   "jit_1"     "jit"
+      "--no-silent -g -n 500 --no-multiblock"   "jit_500"   "jit"
+      "--no-silent -g -n 500 --multiblock"      "jit_500_m" "jit"
       )
   endif()
 
@@ -61,7 +61,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
     set(CPU_CLASS Simulator)
   elseif (_M_X86_64)
     list(APPEND TEST_ARGS
-      "--no-silent -g -c host"       "host"      "host"
+      "--no-silent -g"       "host"      "host"
       )
   endif()
 

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -53,9 +53,9 @@ foreach(ASM_SRC ${ASM_SOURCES})
   set(TEST_ARGS)
   if (_M_ARM_64 OR ENABLE_VIXL_SIMULATOR)
     list(APPEND TEST_ARGS
-      "--no-silent -g -c irjit -n 1   --no-multiblock"   "jit_1"     "jit"
-      "--no-silent -g -c irjit -n 500 --no-multiblock"   "jit_500"   "jit"
-      "--no-silent -g -c irjit -n 500 --multiblock"      "jit_500_m" "jit"
+      "--no-silent -g -n 1   --no-multiblock"   "jit_1"     "jit"
+      "--no-silent -g -n 500 --no-multiblock"   "jit_500"   "jit"
+      "--no-silent -g -n 500 --multiblock"      "jit_500_m" "jit"
       )
   endif()
 
@@ -63,7 +63,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
     set(CPU_CLASS Simulator)
   elseif (_M_X86_64)
     list(APPEND TEST_ARGS
-      "--no-silent -g -c host"       "host"      "host"
+      "--no-silent -g"       "host"      "host"
       )
   endif()
 

--- a/unittests/FEXLinuxTests/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/CMakeLists.txt
@@ -65,7 +65,7 @@ function(AddTests Tests BinDirectory Bitness)
       "guest"
       "$<TARGET_FILE:FEXLoader>"
       ${THUNK_ARGS}
-      "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500" "--"
+      "-o" "stderr" "--no-silent" "-n" "500" "--"
       "${BIN_PATH}")
 
     if (_M_X86_64 AND NOT TEST_NAME STREQUAL "thunk_testlib")

--- a/unittests/POSIX/CMakeLists.txt
+++ b/unittests/POSIX/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(POSIX_TEST ${POSIX_TESTS})
     "${TEST_NAME}"
     "guest"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500" "--"
+    "-o" "stderr" "--no-silent" "-n" "500" "--"
     "${POSIX_TEST}")
   set_property(TEST "${TEST_NAME}.jit.posix" APPEND PROPERTY SKIP_RETURN_CODE 125)
 endforeach()

--- a/unittests/ThunkFunctionalTests/CMakeLists.txt
+++ b/unittests/ThunkFunctionalTests/CMakeLists.txt
@@ -4,7 +4,7 @@ function(AddThunksTest Bin ThunksFile)
   set (ARGS
     "-t" "${CMAKE_INSTALL_PREFIX}/lib/fex-emu/HostThunks"
     "-j" "${CMAKE_INSTALL_PREFIX}/share/fex-emu/GuestThunks"
-    "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500"
+    "-o" "stderr" "--no-silent" "-n" "500"
     )
   if (NOT ThunksFile)
     set (TEST_NAME ThunkFunctionalTest-NoThunks-${Bin})

--- a/unittests/gcc-target-tests-32/CMakeLists.txt
+++ b/unittests/gcc-target-tests-32/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(TEST ${TESTS})
     "${TEST_NAME}"
     "guest"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500" "--"
+    "-o" "stderr" "--no-silent" "-n" "500" "--"
     "${TEST}")
   set_property(TEST "${TEST_NAME}.jit.gcc-target-32" APPEND PROPERTY SKIP_RETURN_CODE 125)
 endforeach()

--- a/unittests/gcc-target-tests-64/CMakeLists.txt
+++ b/unittests/gcc-target-tests-64/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(TEST ${TESTS})
     "${TEST_NAME}"
     "guest"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500" "--"
+    "-o" "stderr" "--no-silent" "-n" "500" "--"
     "${TEST}")
   set_property(TEST "${TEST_NAME}.jit.gcc-target-64" APPEND PROPERTY SKIP_RETURN_CODE 125)
 endforeach()

--- a/unittests/gvisor-tests/CMakeLists.txt
+++ b/unittests/gvisor-tests/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(TEST ${TESTS})
     "${TEST_NAME}"
     "guest"
     "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "-o" "stderr" "--no-silent" "-c" "irjit" "-n" "500" "--"
+    "-o" "stderr" "--no-silent" "-n" "500" "--"
     "${TEST}")
   set_property(TEST "${TEST_NAME}.jit.gvisor" APPEND PROPERTY SKIP_RETURN_CODE 125)
 endforeach()


### PR DESCRIPTION
No functional change here.
- CoreRunningMode enum and variable wasn't used anymore.
   - Code was moved to the frontend
- CustomCPUFactory wasn't used anymore
   - All special signal handling and various features were moved to TestHarnessRunner
   - We also don't want to support actual custom CPU cores.
   - TestHarnessRunner just runs as a host runner if compiled on an x86-64 device if vixl sim isn't enabled now.
   - Removes the Core config option entirely.
- Moves VDSOPointers struct to the frontend
   - Every use of this lives in the Linux frontend instead now