### PR TITLE
Windows: Switch supported MinGW CRT to UCRT

### DIFF
--- a/Source/Windows/ARM64EC/CMakeLists.txt
+++ b/Source/Windows/ARM64EC/CMakeLists.txt
@@ -3,7 +3,6 @@ include(GNUInstallDirs)
 add_library(arm64ecfex SHARED
   Module.cpp
   Module.S
-  ARM64ECSymbols.S
   libarm64ecfex.def
   $<TARGET_OBJECTS:FEXCore_object>
 )

--- a/Source/Windows/Common/CMakeLists.txt
+++ b/Source/Windows/Common/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(CommonWindows STATIC CPUFeatures.cpp InvalidationTracker.cpp Logging.cpp)
+add_library(CommonWindows STATIC CPUFeatures.cpp InvalidationTracker.cpp Logging.cpp LoadConfig.S)
 add_subdirectory(CRT)
 add_subdirectory(WinAPI)
 target_link_libraries(CommonWindows FEXCore_Base)

--- a/Source/Windows/Common/CRT/IO.cpp
+++ b/Source/Windows/Common/CRT/IO.cpp
@@ -278,31 +278,23 @@ int fclose(FILE* File) {
   return 0;
 }
 
-int fseeko64(FILE* File, _off64_t Offset, int Origin) {
+DLLEXPORT_FUNC(int, _fseeki64, (FILE * File, _off64_t Offset, int Origin)) {
   SetFilePointerEx(File->Handle, LARGE_INTEGER {.QuadPart = Offset}, nullptr, OriginToMoveMethod(Origin));
   return 0;
 }
 
-int fseeko(FILE* File, _off_t Offset, int Origin) {
-  return fseeko64(File, Offset, Origin);
-}
-
 int fseek(FILE* File, long Offset, int Origin) {
-  return fseeko64(File, Offset, Origin);
+  return _fseeki64(File, Offset, Origin);
 }
 
-_off64_t ftello64(FILE* File) {
+DLLEXPORT_FUNC(_off64_t, _ftelli64, (FILE * File)) {
   LARGE_INTEGER Res;
   SetFilePointerEx(File->Handle, LARGE_INTEGER {}, &Res, FILE_CURRENT);
   return Res.QuadPart;
 }
 
-_off_t ftello(FILE* File) {
-  return static_cast<_off_t>(ftello64(File));
-}
-
 long ftell(FILE* File) {
-  return static_cast<long>(ftello64(File));
+  return static_cast<long>(_ftelli64(File));
 }
 
 size_t fread(void* __restrict__ DstBuf, size_t ElementSize, size_t Count, FILE* __restrict__ File) {
@@ -328,7 +320,11 @@ int fflush(FILE* _File) {
   UNIMPLEMENTED();
 }
 
-int __mingw_vfprintf(FILE* __restrict__, const char* __restrict__, va_list) {
+int fprintf(FILE* __restrict__, const char* __restrict__, ...) {
+  UNIMPLEMENTED();
+}
+
+int vfprintf(FILE* __restrict__, const char* __restrict__, va_list) {
   UNIMPLEMENTED();
 }
 
@@ -345,6 +341,10 @@ wint_t fputwc(wchar_t _Ch, FILE* _File) {
 }
 
 int fputc(int _Ch, FILE* _File) {
+  UNIMPLEMENTED();
+}
+
+int fputs(const char* __restrict__ _Str, FILE* __restrict__ _File) {
   UNIMPLEMENTED();
 }
 

--- a/Source/Windows/Common/CRT/String.cpp
+++ b/Source/Windows/Common/CRT/String.cpp
@@ -32,11 +32,11 @@ char* strdup(const char* Src) {
   return _strdup(Src);
 }
 
-float __mingw_strtof(const char* __restrict__, char** __restrict__) {
+float strtof(const char* __restrict__, char** __restrict__) {
   UNIMPLEMENTED();
 }
 
-double __mingw_strtod(const char* __restrict__, char** __restrict__) {
+double strtod(const char* __restrict__, char** __restrict__) {
   UNIMPLEMENTED();
 }
 
@@ -60,7 +60,7 @@ long double strtold(const char* __restrict__, char** __restrict__) {
   UNIMPLEMENTED();
 }
 
-double __mingw_wcstod(const wchar_t* __restrict__ _Str, wchar_t** __restrict__ _EndPtr) {
+double wcstod(const wchar_t* __restrict__ _Str, wchar_t** __restrict__ _EndPtr) {
   UNIMPLEMENTED();
 }
 
@@ -68,7 +68,7 @@ long double wcstold(const wchar_t* __restrict__, wchar_t** __restrict__) {
   UNIMPLEMENTED();
 }
 
-float __mingw_wcstof(const wchar_t* __restrict__ nptr, wchar_t** __restrict__ endptr) {
+float wcstof(const wchar_t* __restrict__ nptr, wchar_t** __restrict__ endptr) {
   UNIMPLEMENTED();
 }
 
@@ -80,8 +80,12 @@ DLLEXPORT_FUNC(unsigned __int64, _strtoui64_l, (const char* _String, char** _End
   UNIMPLEMENTED();
 }
 
-int __mingw_vsscanf(const char* __restrict__ _Str, const char* __restrict__ Format, va_list argp) {
+int __stdio_common_vsscanf(unsigned __int64 options, const char* input, size_t length, const char* format, _locale_t locale, va_list valist) {
   UNIMPLEMENTED();
+}
+
+int __stdio_common_vswprintf(unsigned __int64 options, wchar_t* str, size_t len, const wchar_t* format, _locale_t locale, va_list valist) {
+  return _vsnwprintf(str, len, format, valist);
 }
 
 int __mingw_vsnwprintf(wchar_t* __restrict__ Dest, size_t Count, const wchar_t* __restrict__ Format, va_list Args) {
@@ -94,16 +98,25 @@ int __mingw_vsprintf(char* __restrict__ Dest, const char* __restrict__ Format, v
   return ret;
 }
 
-size_t strftime(char* __restrict__ _Buf, size_t _SizeInBytes, const char* __restrict__ _Format, const struct tm* __restrict__ _Tm) {
+DLLEXPORT_FUNC(size_t, _strftime_l,
+               (char* __restrict__ Buf, size_t Max_size, const char* __restrict__ Format, const struct tm* __restrict__ Tm, _locale_t Locale)) {
   UNIMPLEMENTED();
 }
 
-int __mingw_vsnprintf(char* __restrict__ Dest, size_t Count, const char* __restrict__ Format, va_list Args) {
+int vsnprintf(char* __restrict__ Dest, size_t Count, const char* __restrict__ Format, va_list Args) {
   int ret = _vsnprintf(Dest, Count, Format, Args);
   if (ret == -1) {
     Dest[Count - 1] = '\0';
     return _vsnprintf(nullptr, 0, Format, Args);
   }
+  return ret;
+}
+
+int snprintf(char* stream, size_t n, const char* format, ...) {
+  __builtin_va_list args;
+  __builtin_va_start(args, format);
+  int ret = vsnprintf(stream, n, format, args);
+  __builtin_va_end(args);
   return ret;
 }
 
@@ -163,10 +176,6 @@ int wctob(wint_t _WCh) {
 }
 
 DLLEXPORT_FUNC(errno_t, strerror_s, (char* _Buf, size_t _SizeInBytes, int _ErrNum)) {
-  UNIMPLEMENTED();
-}
-
-DLLEXPORT_FUNC(int, _sscanf_l, (const char* buffer, const char* format, _locale_t locale, ...)) {
   UNIMPLEMENTED();
 }
 

--- a/Source/Windows/Common/LoadConfig.S
+++ b/Source/Windows/Common/LoadConfig.S
@@ -9,35 +9,41 @@
 #define EXPORT_SYM(x) .globl x; x:
 #define SYM(x) x
 
+.text
+.balign ALIGN
+#ifdef __arm64ec__
 /*
 Calls to this are synthesized by the linker when calling into import libraries,
 this is referred to as an 'Adjustor Thunk' in ARM64EC documentation.
 */
-.text
-.balign ALIGN
 EXPORT_SYM(__icall_helper_arm64ec)
 .seh_proc "__icall_helper_arm64ec"
-  stp    fp,   lr, [sp, #-16]!
+  stp  fp,   lr, [sp, #-16]!
 .seh_save_fplr_x 16
-  mov    fp,   sp
+  mov  fp,   sp
 .seh_set_fp
 .seh_endprologue
-  adrp    x16, __os_arm64x_check_icall
-  ldr       x16, [x16, #:lo12:__os_arm64x_check_icall]
-  blr    x16
+  adrp x16, __os_arm64x_check_icall
+  ldr  x16, [x16, #:lo12:__os_arm64x_check_icall]
+  blr  x16
 .seh_startepilogue
-  ldp    fp,  lr,  [sp], #16
+  ldp  fp,  lr,  [sp], #16
 .seh_save_fplr_x 16
 .seh_endepilogue
-  br    x11
+  br   x11
 .seh_endproc
+#endif
 
+SYM(__guard_check_icall_dummy):
+  ret
+
+.section  .00cfg, "dr"
+.balign ALIGN
+#ifdef __arm64ec__
 /*
 These symbols are updated at runtime by the dynamic linker to point to emulator
 helper routines.
 */
-.section  .00cfg, "dr"
-.balign ALIGN
 EXPORT_SYM(__os_arm64x_dispatch_call_no_redirect)
   PTR 0
 EXPORT_SYM(__os_arm64x_dispatch_ret)
@@ -78,7 +84,11 @@ EXPORT_SYM(__os_arm64x_helper7)
   PTR 0
 EXPORT_SYM(__os_arm64x_helper8)
   PTR 0
+#endif
+EXPORT_SYM(__guard_check_icall_fptr)
+  PTR SYM(__guard_check_icall_dummy)
 
+#ifdef __arm64ec__
 /*
 This structure is read at runtime by the dynamic linker on ARM64EC to configure
 metadata necessary for EC code to interface with x86_64 code.
@@ -116,6 +126,7 @@ EXPORT_SYM(__chpe_metadata)
   .4byte __os_arm64x_helper6@IMGREL
   .4byte __os_arm64x_helper7@IMGREL
   .4byte __os_arm64x_helper8@IMGREL
+#endif
 
 .section  .rdata,"dr"
 .globl  SYM(_load_config_used)
@@ -141,21 +152,23 @@ SYM(_load_config_used):
   PTR  0 /* SecurityCookie */
   PTR  0 /* SEHandlerTable */
   PTR  0 /* SEHandlerCount */
-  PTR  0 /* GuardCFCheckFunction */
+  PTR  SYM(__guard_check_icall_fptr) /* GuardCFCheckFunction */
   PTR  0 /* GuardCFCheckDispatch */
-  PTR  0 /* GuardCFFunctionTable */
-  PTR  0 /* GuardCFFunctionCount */
-  .4byte  0 /* GuardFlags */
+  PTR  SYM(__guard_fids_table) /* GuardCFFunctionTable */
+  PTR  SYM(__guard_fids_count) /* GuardCFFunctionCount */
+  .4byte  SYM(__guard_flags) /* GuardFlags */
   .2byte  0 /* CodeIntegrity_Flags */
   .2byte  0 /* CodeIntegrity_Catalog */
   .4byte  0 /* CodeIntegrity_CatalogOffset */
   .4byte  0 /* CodeIntegrity_Reserved */
-  PTR  0 /* GuardAddressTakenIatEntryTable */
-  PTR  0 /* GuardAddressTakenIatEntryCount */
-  PTR  0 /* GuardLongJumpTargetTable */
-  PTR  0 /* GuardLongJumpTargetCount */
+  PTR  SYM(__guard_iat_table) /* GuardAddressTakenIatEntryTable */
+  PTR  SYM(__guard_iat_count) /* GuardAddressTakenIatEntryCount */
+  PTR  SYM(__guard_longjmp_table) /* GuardLongJumpTargetTable */
+  PTR  SYM(__guard_longjmp_count) /* GuardLongJumpTargetCount */
   PTR  0 /* DynamicValueRelocTable */
+#ifdef __arm64ec__
   PTR  SYM(__chpe_metadata) /* CHPEMetadataPointer */
+#endif
   PTR  0 /* GuardRFFailureRoutine */
   PTR  0 /* GuardRFFailureRoutineFunctionPointer */
   .4byte  0 /* DynamicValueRelocTableOffset */
@@ -166,8 +179,8 @@ SYM(_load_config_used):
   .4byte  0 /* Reserved3 */
   PTR  0 /* EnclaveConfigurationPointer */
   PTR  0 /* VolatileMetadataPointer */
-  PTR  0 /* GuardEHContinuationTable */
-  PTR  0 /* GuardEHContinuationCount */
+  PTR SYM(__guard_eh_cont_table) /* GuardEHContinuationTable */
+  PTR SYM(__guard_eh_cont_count) /* GuardEHContinuationCount */
   PTR  0 /* GuardXFGCheckFunctionPointer */
   PTR  0 /* GuardXFGDispatchFunctionPointer */
   PTR  0 /* GuardXFGTableDispatchFunctionPointer */


### PR DESCRIPTION
MSVCRT is deprecated and the reasons FEX used it no longer apply, so support UCRT and UCRT only.

Draft as not tested particularly well and this needs new CI binaries 
cc: @AndreRH 