### PR TITLE
FEXServer/PipeScanner: Stop writing null to incoming pipes

### DIFF
--- a/Source/Tools/FEXServer/PipeScanner.cpp
+++ b/Source/Tools/FEXServer/PipeScanner.cpp
@@ -41,8 +41,6 @@ void ScanForPipes() {
 
 void ClosePipes() {
   for (auto pipe : IncomingPipes) {
-    int Null {0};
-    write(pipe, &Null, sizeof(Null));
     close(pipe);
   }
   IncomingPipes.clear();


### PR DESCRIPTION
This was causing problems in a typical use case of piping stdout/stderr to another application. So if FEXInterpreter was started, with stdout piped to another application, and FEXServer wasn't running so a new instance needed to be started. FEXServer would write a null to every pipe then close it. This includes the stdout that is being piped to the new application!

This writing was legacy behaviour before FEX was properly listening to POLLHUP and is no longer necessary. Just remove the writing completely to fix this issue.

Easiest test case was just `./Bin/FEXInterpreter /usr/bin/ls / | xxd | head -n 3`

Returned:
```
$ ./Bin/FEXInterpreter `which ls` / | xxd | head -n 3
00000000: 0000 0000 6269 6e0a 6269 6e2e 7573 722d  ....bin.bin.usr-
00000010: 6973 2d6d 6572 6765 640a 626f 6f74 0a64  is-merged.boot.d
00000020: 6576 0a65 7463 0a68 6f6d 650a 6c69 620a  ev.etc.home.lib.
```

That first null shouldn't be there.