### PR TITLE
FEXQonfig: Allow system-provided RootFS images

### DIFF
--- a/Source/Tools/FEXQonfig/Main.h
+++ b/Source/Tools/FEXQonfig/Main.h
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+#include <FEXCore/fextl/string.h>
+
 #include <QStandardItemModel>
 #include <QQmlApplicationEngine>
 
@@ -41,9 +43,11 @@ class RootFSModel : public QStandardItemModel {
   std::latch ExitRequest {1};
 
   int INotifyFD;
-  int FolderFD;
+  int FolderFDUser;
+  int FolderFDSystem;
 
   void INotifyThreadFunc();
+  void ProcessRootfsDir(const fextl::string& Dir, std::vector<QString>& FsList);
 
 public:
   RootFSModel();
@@ -55,6 +59,7 @@ public slots:
   bool hasItem(const QString&) const;
 
   QUrl getBaseUrl() const;
+  QList<QString> getStandardPrefixes() const;
 };
 
 class ConfigRuntime : public QObject {

--- a/Source/Tools/FEXQonfig/main.qml
+++ b/Source/Tools/FEXQonfig/main.qml
@@ -369,7 +369,14 @@ ApplicationWindow {
                             component RootFSRadioDelegate: RadioButton {
                                 property var name
 
-                                text: name
+                                text: (() => {
+                                    for (const base of RootFSModel.getStandardPrefixes()) {
+                                        if (name.startsWith(base)) {
+                                            return name.substring(base.length)
+                                        }
+                                    }
+                                    return name
+                                })()
                                 checked: rootfsList.selectedItem === name
 
                                 onToggled: {


### PR DESCRIPTION
Add a secondary RootFS directory that can be managed by the system package manager.