### PR TITLE
Common: Remove dependency on cpp-optparse (Only for FEXLoader)

### DIFF
--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -379,7 +379,7 @@ def print_argloader_options_map(options):
                 short = op_vals["ShortArg"]
 
             if short != None:
-                output_argloader.write("{{\"-{}\", FEXCore::Config::ConfigOption::CONFIG_{}, {}}},\n".format(short, op_key.upper(), ParserType))
+                output_argloader.write("{{\"{}\", FEXCore::Config::ConfigOption::CONFIG_{}, {}}},\n".format(short, op_key.upper(), ParserType))
 
             output_argloader.write("{{\"--{}\", FEXCore::Config::ConfigOption::CONFIG_{}, {}}},\n".format(op_key.lower(), op_key.upper(), ParserType))
 

--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -82,13 +82,16 @@ def print_unnamed_options(options):
 
         output_file.write("\n")
 
-def print_man_option(short, long, desc, default):
+def print_man_option(short, long, desc, value_type, default):
     if (short != None):
         output_man.write(".It Fl {0} , ".format(short))
     else:
         output_man.write(".It ")
 
-    output_man.write("Fl Fl {0}=".format(long))
+    if value_type == "bool":
+        output_man.write("Fl Fl {0}, Fl Fl no-{0}".format(long))
+    else:
+        output_man.write("Fl Fl {0}=".format(long))
 
     output_man.write("\n");
 
@@ -143,6 +146,7 @@ def print_man_options(options):
                 short,
                 long,
                 op_vals["Desc"],
+                value_type,
                 default
             )
             if (value_type == "strenum"):
@@ -351,81 +355,72 @@ def print_config_option(type, group_name, json_name, default_value, short, choic
 
     output_argloader.write("\n");
 
-def print_argloader_options(options):
-    output_argloader.write("#ifdef BEFORE_PARSE\n")
-    output_argloader.write("#undef BEFORE_PARSE\n")
+def print_argloader_options_map(options):
+    output_argloader.write("#ifdef ARG_TO_CONFIG\n")
+    output_argloader.write("#undef ARG_TO_CONFIG\n")
     for op_group, group_vals in options.items():
         for op_key, op_vals in group_vals.items():
-            default = op_vals["Default"]
-
-            if (op_vals["Type"] == "str" or op_vals["Type"] == "strarray" or op_vals["Type"] == "strenum"):
-                # Wrap the string argument in quotes
-                default = "\"" + default + "\""
-
-            # Textual default rather than enum based
-            if ("TextDefault" in op_vals):
-                default = "\"" + op_vals["TextDefault"] + "\""
-
-            short = None
-            choices = None
-
-            if ("ShortArg" in op_vals):
-                short = op_vals["ShortArg"]
-            if ("Choices" in op_vals):
-                choices = op_vals["Choices"]
-
-            print_config_option(
-                op_vals["Type"],
-                op_group,
-                op_key,
-                default,
-                short,
-                choices,
-                op_vals["Desc"])
-
-        output_argloader.write("\n")
-    output_argloader.write("#endif\n")
-
-def print_parse_argloader_options(options):
-    output_argloader.write("#ifdef AFTER_PARSE\n")
-    output_argloader.write("#undef AFTER_PARSE\n")
-    for op_group, group_vals in options.items():
-        for op_key, op_vals in group_vals.items():
-            output_argloader.write("if (Options.is_set_by_user(\"{0}\")) {{\n".format(op_key))
 
             value_type = op_vals["Type"]
-            NeedsString = False
-            conversion_func = "fextl::fmt::format(\"{}\", "
-            if ("ArgumentHandler" in op_vals):
-                NeedsString = True
-                conversion_func = "FEXCore::Config::Handler::{0}(".format(op_vals["ArgumentHandler"])
-            if (value_type == "str"):
-                NeedsString = True
-                conversion_func = "std::move("
-            if (value_type == "bool"):
-                # boolean values need a decimal specifier. Otherwise fmt prints strings.
-                conversion_func = "fextl::fmt::format(\"{:d}\", "
 
-            if (value_type == "strenum"):
-                output_argloader.write("\tfextl::string UserValue = Options[\"{0}\"];\n".format(op_key))
-                output_argloader.write("\tSet(FEXCore::Config::ConfigOption::CONFIG_{}, FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, UserValue));\n".format(op_key.upper(), op_key, op_key, op_key))
-            elif (value_type == "strarray"):
-                # these need a bit more help
-                output_argloader.write("\tauto Array = Options.all(\"{0}\");\n".format(op_key))
-                output_argloader.write("\tfor (auto iter = Array.begin(); iter != Array.end(); ++iter) {\n")
-                output_argloader.write("\t\tSet(FEXCore::Config::ConfigOption::CONFIG_{0}, *iter);\n".format(op_key.upper()))
-                output_argloader.write("\t}\n")
-            else:
-                if (NeedsString):
-                    output_argloader.write("\tfextl::string UserValue = Options[\"{0}\"];\n".format(op_key))
-                else:
-                    output_argloader.write("\t{0} UserValue = Options.get(\"{1}\");\n".format(value_type, op_key))
+            ParserType = "ValueType::String"
 
-                output_argloader.write("\tSet(FEXCore::Config::ConfigOption::CONFIG_{0}, {1}UserValue));\n".format(op_key.upper(), conversion_func))
+            if value_type == "bool":
+                ParserType = "ValueType::BoolTrue"
+
+            if value_type == "strenum":
+                ParserType = "ValueType::StringEnum"
+
+            if value_type == "strarray":
+                ParserType = "ValueType::StringArray"
+
+            short = None
+            if ("ShortArg" in op_vals):
+                short = op_vals["ShortArg"]
+
+            if short != None:
+                output_argloader.write("{{\"-{}\", FEXCore::Config::ConfigOption::CONFIG_{}, {}}},\n".format(short, op_key.upper(), ParserType))
+
+            output_argloader.write("{{\"--{}\", FEXCore::Config::ConfigOption::CONFIG_{}, {}}},\n".format(op_key.lower(), op_key.upper(), ParserType))
+
+            if value_type == "bool":
+                output_argloader.write("{{\"--no-{}\", FEXCore::Config::ConfigOption::CONFIG_{}, ValueType::BoolFalse}},\n".format(op_key.lower(), op_key.upper()))
+    output_argloader.write("#endif\n")
+
+def print_parse_argloader_strconversion(options):
+    output_argloader.write("#ifdef STR_CONVERT_PARSE\n")
+    output_argloader.write("#undef STR_CONVERT_PARSE\n")
+    for op_group, group_vals in options.items():
+        for op_key, op_vals in group_vals.items():
+            value_type = op_vals["Type"]
+            if not "ArgumentHandler" in op_vals:
+                continue
+
+            output_argloader.write("case FEXCore::Config::ConfigOption::CONFIG_{}: {{\n".format(op_key.upper()))
+            output_argloader.write("\tauto Converted = FEXCore::Config::Handler::{0}(SecondArg);\n".format(op_vals["ArgumentHandler"]))
+            output_argloader.write("\tLoader->SetArg(FEXCore::Config::ConfigOption::CONFIG_{}, Converted);\n".format(op_key.upper()))
+            output_argloader.write("break;\n".format(op_key.upper()))
             output_argloader.write("}\n")
 
     output_argloader.write("#endif\n")
 
+def print_parse_argloader_enumparser(options):
+    output_argloader.write("#ifdef STR_ENUM_PARSE\n")
+    output_argloader.write("#undef STR_ENUM_PARSE\n")
+    for op_group, group_vals in options.items():
+        for op_key, op_vals in group_vals.items():
+            value_type = op_vals["Type"]
+
+            if (value_type == "strenum"):
+                output_argloader.write("case FEXCore::Config::ConfigOption::CONFIG_{}: {{\n".format(op_key.upper()))
+                output_argloader.write("\tauto Converted = FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, SecondArg);\n".format(op_key, op_key, op_key))
+                output_argloader.write("\tif (Converted) { SecondArg = *Converted; }\n")
+                output_argloader.write("\tLoader->SetArg(FEXCore::Config::ConfigOption::CONFIG_{}, SecondArg);\n".format(op_key.upper()))
+                output_argloader.write("break;\n".format(op_key.upper()))
+                output_argloader.write("}\n")
+
+
+    output_argloader.write("#endif\n")
 
 def print_parse_envloader_options(options):
     output_argloader.write("#ifdef ENVLOADER\n")
@@ -574,8 +569,9 @@ output_man.close()
 
 # Generate argument loader code
 output_argloader = open(output_argumentloader_filename, "w")
-print_argloader_options(options);
-print_parse_argloader_options(options);
+print_argloader_options_map(options);
+print_parse_argloader_strconversion(options);
+print_parse_argloader_enumparser(options);
 
 # Generate environment loader code
 print_parse_envloader_options(options);

--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -18,7 +18,7 @@
 
 namespace FEXCore::Config {
 namespace Handler {
-  static inline std::optional<fextl::string> SMCCheckHandler(std::string_view Value) {
+  static inline fextl::string SMCCheckHandler(std::string_view Value) {
     if (Value == "none") {
       return "0";
     } else if (Value == "mtrack") {
@@ -28,7 +28,7 @@ namespace Handler {
     }
     return "0";
   }
-  static inline std::optional<fextl::string> CacheObjectCodeHandler(std::string_view Value) {
+  static inline fextl::string CacheObjectCodeHandler(std::string_view Value) {
     if (Value == "none") {
       return "0";
     } else if (Value == "read") {

--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -5,47 +5,242 @@
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/vector.h>
 
-#include "cpp-optparse/OptionParser.h"
 #include "git_version.h"
 
-#include <stdint.h>
-
 namespace FEX::ArgLoader {
+enum class ValueType : uint32_t {
+  String,
+  BoolTrue,
+  BoolFalse,
+  StringEnum,
+  StringArray,
+  Max,
+};
+
+struct OptionDetails {
+  std::string_view Arg;
+  FEXCore::Config::ConfigOption Option;
+  ValueType ParseType;
+};
+
+constexpr static OptionDetails ArgToOption[] = {
+#define ARG_TO_CONFIG
+#include <FEXCore/Config/ConfigOptions.inl>
+};
+
+const OptionDetails* FindOption(std::string_view Argument) {
+  for (auto& Arg : ArgToOption) {
+    if (Arg.Arg == Argument) {
+      return &Arg;
+    }
+  }
+
+  return nullptr;
+}
+
+void PrintHelp() {
+  const char* Arguments[3] {};
+  Arguments[0] = "man";
+  Arguments[1] = "FEX";
+  Arguments[2] = nullptr;
+
+  execvp("man", (char* const*)Arguments);
+}
+
+void ExitWithError(std::string_view Error) {
+  fextl::fmt::print("Error: {}\n", Error);
+  _exit(1);
+}
+
+class ArgParser final {
+public:
+  ArgParser(FEX::ArgLoader::ArgLoader* Loader)
+    : Loader {Loader} {}
+
+  std::pair<fextl::vector<fextl::string>, fextl::vector<const char*>> Parse(int argc, char** argv);
+  void Version(std::string_view version) {
+    _Version = version;
+  }
+
+private:
+  FEX::ArgLoader::ArgLoader* Loader;
+  std::string_view _Version {};
+  using ParseArgHandler = void (ArgParser::*)(std::string_view Arg, std::string_view SecondArg, const OptionDetails* Details);
+
+  void ParseArgument_String(std::string_view Arg, std::string_view SecondArg, const OptionDetails* Details) {
+    switch (Details->Option) {
+#define STR_CONVERT_PARSE
+#include <FEXCore/Config/ConfigOptions.inl>
+    [[likely]] default:
+      Loader->SetArg(Details->Option, SecondArg);
+      break;
+    }
+  }
+
+  void ParseArgument_BoolTrue(std::string_view Arg, std::string_view SecondArg, const OptionDetails* Details) {
+    Loader->SetArg(Details->Option, "1");
+  }
+
+  void ParseArgument_BoolFalse(std::string_view Arg, std::string_view SecondArg, const OptionDetails* Details) {
+    Loader->SetArg(Details->Option, "0");
+  }
+
+  void ParseArgument_StringEnum(std::string_view Arg, std::string_view SecondArg, const OptionDetails* Details) {
+    switch (Details->Option) {
+#define STR_ENUM_PARSE
+#include <FEXCore/Config/ConfigOptions.inl>
+    [[unlikely]] default:
+      ExitWithError(fextl::fmt::format("Unknown strenum argument: {}", Arg));
+      break;
+    }
+  }
+
+  constexpr static std::array<ParseArgHandler, FEXCore::ToUnderlying(ValueType::Max)> Parser = {
+    &ArgParser::ParseArgument_String,
+    &ArgParser::ParseArgument_BoolTrue,
+    &ArgParser::ParseArgument_BoolFalse,
+    &ArgParser::ParseArgument_StringEnum,
+    // Behaves the same as string but appends multiple.
+    &ArgParser::ParseArgument_String,
+  };
+
+  void ParseArgument(std::string_view Arg, std::string_view SecondArg, const OptionDetails* Details) {
+    (this->*Parser[FEXCore::ToUnderlying(Details->ParseType)])(Arg, SecondArg, Details);
+  }
+};
+
+static bool NeedsArg(const OptionDetails* Details) {
+  return Details->ParseType == ValueType::String || Details->ParseType == ValueType::StringEnum || Details->ParseType == ValueType::StringArray;
+}
+
+std::pair<fextl::vector<fextl::string>, fextl::vector<const char*>> ArgParser::Parse(int argc, char** argv) {
+  fextl::vector<fextl::string> RemainingArgs {};
+  fextl::vector<const char*> ProgramArguments {};
+
+  // Skip argv[0]
+  int ArgParsed = 1;
+  for (; ArgParsed < argc; ++ArgParsed) {
+    std::string_view Arg = argv[ArgParsed];
+
+    // Special case version and help
+    if (Arg == "--version") [[unlikely]] {
+      fextl::fmt::print("{}\n", _Version);
+      std::exit(0);
+    }
+
+    if (Arg == "-h" || Arg == "--help") [[unlikely]] {
+      PrintHelp();
+      std::exit(0);
+    }
+
+    if (Arg == "--") {
+      // Special case break. Remaining arguments get passed to guest.
+      ++ArgParsed;
+      break;
+    }
+
+    const bool IsShort = Arg.find("--", 0, 2) == Arg.npos && Arg.find("-", 0, 1) == 0;
+    const bool IsLong = Arg.find("--", 0, 2) == 0;
+
+    std::string_view ArgFirst {};
+    std::string_view ArgSecond {};
+
+    const OptionDetails* OptionDetails {};
+
+    if (IsShort) {
+      ArgFirst = Arg;
+
+      OptionDetails = FindOption(ArgFirst);
+
+      if (OptionDetails == nullptr) [[unlikely]] {
+        ExitWithError(fextl::fmt::format("Unsupported argument: {}\nUse --help for more information.", Arg));
+      }
+
+      if (NeedsArg(OptionDetails)) {
+        ++ArgParsed;
+        ArgSecond = argv[ArgParsed];
+      }
+    } else if (IsLong) {
+      const auto Split = Arg.find_first_of('=');
+      bool NeedsSplitArg {};
+      if (Split == Arg.npos) {
+        ArgFirst = Arg;
+        OptionDetails = FindOption(Arg);
+
+        if (OptionDetails == nullptr) [[unlikely]] {
+          ExitWithError(fextl::fmt::format("Unsupported argument: {}\nUse --help for more information.", Arg));
+        }
+
+        NeedsSplitArg = NeedsArg(OptionDetails);
+      } else {
+        ArgFirst = Arg.substr(0, Split);
+        OptionDetails = FindOption(ArgFirst);
+
+        if (OptionDetails == nullptr) [[unlikely]] {
+          ExitWithError(fextl::fmt::format("Unsupported argument: {}\nUse --help for more information.", Arg));
+        }
+
+        NeedsSplitArg = NeedsArg(OptionDetails);
+      }
+
+      if (NeedsSplitArg && Split == Arg.npos) [[unlikely]] {
+        ExitWithError(fextl::fmt::format("{} needs argument", Arg));
+      }
+
+      if (!NeedsSplitArg && Split != Arg.npos) [[unlikely]] {
+        ExitWithError(fextl::fmt::format("{} can't have argument", Arg));
+      }
+
+      if (NeedsSplitArg) {
+        ArgSecond = Arg.substr(Split + 1, Arg.size());
+
+        if (ArgSecond.empty()) [[unlikely]] {
+          ExitWithError(fextl::fmt::format("{} needs argument", Arg));
+        }
+      }
+    }
+
+    if (ProgramArguments.empty() && OptionDetails == nullptr) {
+      // In the special case that we hit a parse error and we haven't parsed any arguments, pass everything.
+      // This handles the typical case eg: `FEXLoader /usr/bin/ls /`.
+      // Some would claim that `--` should be used to split FEX arguments from sub-application arguments.
+      break;
+    }
+
+    // Unsupported FEX argument. Error.
+    if (ProgramArguments.empty() && OptionDetails == nullptr) [[unlikely]] {
+      ExitWithError(fextl::fmt::format("Unsupported argument: {}\nUse --help for more information.", Arg));
+    }
+
+    // Save the FEX argument.
+    ProgramArguments.emplace_back(argv[ArgParsed]);
+
+    // Now parse the argument.
+    ParseArgument(Arg, ArgSecond, OptionDetails);
+  }
+
+  // Pass any remaining arguments to guest application
+  for (; ArgParsed < argc; ++ArgParsed) {
+    RemainingArgs.emplace_back(argv[ArgParsed]);
+  }
+
+  return std::make_pair(std::move(RemainingArgs), std::move(ProgramArguments));
+}
+
 void FEX::ArgLoader::ArgLoader::Load() {
-  RemainingArgs.clear();
-  ProgramArguments.clear();
   if (Type == LoadType::WITHOUT_FEXLOADER_PARSER) {
-    LoadWithoutArguments();
     return;
   }
 
-  optparse::OptionParser Parser {};
-  Parser.version("FEX-Emu (" GIT_DESCRIBE_STRING ") ");
-  optparse::OptionGroup CPUGroup(Parser, "CPU Core options");
-  optparse::OptionGroup EmulationGroup(Parser, "Emulation options");
-  optparse::OptionGroup DebugGroup(Parser, "Debug options");
-  optparse::OptionGroup HacksGroup(Parser, "Hacks options");
-  optparse::OptionGroup MiscGroup(Parser, "Miscellaneous options");
-  optparse::OptionGroup LoggingGroup(Parser, "Logging options");
+  RemainingArgs.clear();
+  ProgramArguments.clear();
+  ArgParser Parser(this);
+  Parser.Version("FEX-Emu (" GIT_DESCRIBE_STRING ") ");
+  std::tie(RemainingArgs, ProgramArguments) = Parser.Parse(argc, argv);
+}
 
-#define BEFORE_PARSE
-#include <FEXCore/Config/ConfigOptions.inl>
-
-  Parser.add_option_group(CPUGroup);
-  Parser.add_option_group(EmulationGroup);
-  Parser.add_option_group(DebugGroup);
-  Parser.add_option_group(HacksGroup);
-  Parser.add_option_group(MiscGroup);
-  Parser.add_option_group(LoggingGroup);
-
-  optparse::Values Options = Parser.parse_args(argc, argv);
-
-  using int32 = int32_t;
-  using uint32 = uint32_t;
-#define AFTER_PARSE
-#include <FEXCore/Config/ConfigOptions.inl>
-  RemainingArgs = Parser.args();
-  ProgramArguments = Parser.parsed_args();
+void FEX::ArgLoader::ArgLoader::SetArg(FEXCore::Config::ConfigOption Option, std::string_view Arg) {
+  Set(Option, Arg);
 }
 
 void FEX::ArgLoader::ArgLoader::LoadWithoutArguments() {

--- a/Source/Common/ArgumentLoader.h
+++ b/Source/Common/ArgumentLoader.h
@@ -18,7 +18,12 @@ public:
     , Type {Type}
     , argc {argc}
     , argv {argv} {
-    Load();
+
+    if (Type == LoadType::WITHOUT_FEXLOADER_PARSER) {
+      LoadWithoutArguments();
+    } else {
+      Load();
+    }
   }
 
   void Load() override;
@@ -26,7 +31,8 @@ public:
   fextl::vector<fextl::string> Get() {
     return RemainingArgs;
   }
-  fextl::vector<fextl::string> GetParsedArgs() {
+
+  fextl::vector<const char*> GetParsedArgs() {
     return ProgramArguments;
   }
 
@@ -34,13 +40,15 @@ public:
     return Type;
   }
 
+  void SetArg(FEXCore::Config::ConfigOption Option, std::string_view Arg);
+
 private:
   LoadType Type;
   int argc {};
   char** argv {};
 
   fextl::vector<fextl::string> RemainingArgs {};
-  fextl::vector<fextl::string> ProgramArguments {};
+  fextl::vector<const char*> ProgramArguments {};
 };
 
 } // namespace FEX::ArgLoader

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -16,7 +16,6 @@ if (NOT MINGW_BUILD)
 endif()
 
 add_library(${NAME} STATIC ${SRCS})
-target_link_libraries(${NAME} FEXCore_Base cpp-optparse tiny-json FEXHeaderUtils)
-target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/External/cpp-optparse/)
+target_link_libraries(${NAME} FEXCore_Base tiny-json FEXHeaderUtils)
 target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)
 target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/External/xbyak/)

--- a/Source/Tools/FEXGetConfig/CMakeLists.txt
+++ b/Source/Tools/FEXGetConfig/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SRCS Main.cpp)
 
 add_executable(${NAME} ${SRCS})
 
-list(APPEND LIBS Common)
+list(APPEND LIBS Common cpp-optparse)
 
 if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
   target_link_options(${NAME}

--- a/Source/Tools/FEXLoader/ELFCodeLoader.h
+++ b/Source/Tools/FEXLoader/ELFCodeLoader.h
@@ -232,7 +232,7 @@ public:
   fextl::vector<LoadedSection> Sections;
 
   ELFCodeLoader(const fextl::string& Filename, int ProgramFDFromEnv, const fextl::string& RootFS,
-                [[maybe_unused]] const fextl::vector<fextl::string>& args, const fextl::vector<fextl::string>& ParsedArgs,
+                [[maybe_unused]] const fextl::vector<fextl::string>& args, const fextl::vector<const char*>& ParsedArgs,
                 char** const envp = nullptr, FEXCore::Config::Value<fextl::string>* AdditionalEnvp = nullptr)
     : Args {args} {
 
@@ -328,9 +328,7 @@ public:
       EnvironmentBackingSize += EnvironmentVariables[i].size() + 1;
     }
 
-    for (auto& Arg : ParsedArgs) {
-      LoaderArgs.emplace_back(Arg.c_str());
-    }
+    std::move(ParsedArgs.begin(), ParsedArgs.end(), std::back_inserter(LoaderArgs));
   }
 
   void FreeSections() {

--- a/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
+++ b/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SRCS Main.cpp
   XXFileHash.cpp)
 
 add_executable(${NAME} ${SRCS})
-list(APPEND LIBS FEXCore Common xxHash::xxhash)
+list(APPEND LIBS FEXCore Common xxHash::xxhash cpp-optparse)
 
 target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/Source/)
 

--- a/Source/Tools/FEXServer/CMakeLists.txt
+++ b/Source/Tools/FEXServer/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(${NAME} PRIVATE
   ${CMAKE_BINARY_DIR}/generated
   ${CMAKE_SOURCE_DIR}/Source/)
 
-target_link_libraries(${NAME} PRIVATE FEXCore Common ${PTHREAD_LIB})
+target_link_libraries(${NAME} PRIVATE FEXCore Common cpp-optparse ${PTHREAD_LIB})
 
 if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
   target_link_options(${NAME}


### PR DESCRIPTION
Doesn't remove it from the full project since three tools still use it.

FEXLoader argument loader is fairly special since we have a generator tied to it. This generator lets us have some niceties where everything ends up being a string literal without any sort of dynamic requirements.

cpp-optparse has a systemic issue where it makes deep copies of /everything/ all the time. This means it has huge runtime costs and huge stack usage (4992 bytes). The new implementation uses 608 bytes of stack space (plus 640 if it actually parses a strenum).

When profiling cpp-optparse with FEXLoader's argument it takes ~2,039,307 ns to parse the arguments! As a direct comparison this new implementation takes ~56,885 ns. Both sides not getting passed /any/ arguments, really shows how spicy this library is.