### PR TITLE
FEXConfig: Add the ability to watch and configure global rootfs

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.cpp
+++ b/FEXCore/Source/Interface/Config/Config.cpp
@@ -43,7 +43,8 @@ namespace DefaultValues {
 } // namespace DefaultValues
 
 enum Paths {
-  PATH_DATA_DIR = 0,
+  PATH_DATA_DIR_LOCAL = 0,
+  PATH_DATA_DIR_GLOBAL,
   PATH_CONFIG_DIR_LOCAL,
   PATH_CONFIG_DIR_GLOBAL,
   PATH_CONFIG_FILE_LOCAL,
@@ -53,8 +54,8 @@ enum Paths {
 };
 static std::array<fextl::string, Paths::PATH_LAST> Paths;
 
-void SetDataDirectory(const std::string_view Path) {
-  Paths[PATH_DATA_DIR] = Path;
+void SetDataDirectory(const std::string_view Path, bool Global) {
+  Paths[PATH_DATA_DIR_LOCAL + Global] = Path;
 }
 
 void SetConfigDirectory(const std::string_view Path, bool Global) {
@@ -73,15 +74,15 @@ const fextl::string& GetTelemetryDirectory() {
       Path = TelemetryDirectory;
       Path += "/";
     } else {
-      Path = Config::GetDataDirectory() + "Telemetry/";
+      Path = Config::GetDataDirectory(false) + "Telemetry/";
     }
   }
 
   return Path;
 }
 
-const fextl::string& GetDataDirectory() {
-  return Paths[PATH_DATA_DIR];
+const fextl::string& GetDataDirectory(bool Global) {
+  return Paths[PATH_DATA_DIR_LOCAL + Global];
 }
 
 const fextl::string& GetConfigDirectory(bool Global) {
@@ -333,7 +334,7 @@ void ReloadMetaLayer() {
       FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, ExpandedString);
     } else if (!PathName->empty()) {
       // If the filesystem doesn't exist then let's see if it exists in the fex-emu folder
-      fextl::string NamedRootFS = GetDataDirectory() + "RootFS/" + *PathName;
+      fextl::string NamedRootFS = GetDataDirectory(false) + "RootFS/" + *PathName;
       if (FHU::Filesystem::Exists(NamedRootFS)) {
         FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, NamedRootFS);
       }
@@ -355,7 +356,7 @@ void ReloadMetaLayer() {
       FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_THUNKCONFIG, ExpandedString);
     } else if (!PathName->empty()) {
       // If the filesystem doesn't exist then let's see if it exists in the fex-emu folder
-      fextl::string NamedConfig = GetDataDirectory() + "ThunkConfigs/" + *PathName;
+      fextl::string NamedConfig = GetDataDirectory(false) + "ThunkConfigs/" + *PathName;
       if (FHU::Filesystem::Exists(NamedConfig)) {
         FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_THUNKCONFIG, NamedConfig);
       }

--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -128,11 +128,11 @@ namespace DefaultValues {
 #undef P
 } // namespace DefaultValues
 
-FEX_DEFAULT_VISIBILITY void SetDataDirectory(std::string_view Path);
+FEX_DEFAULT_VISIBILITY void SetDataDirectory(std::string_view Path, bool Global);
 FEX_DEFAULT_VISIBILITY void SetConfigDirectory(const std::string_view Path, bool Global);
 FEX_DEFAULT_VISIBILITY void SetConfigFileLocation(std::string_view Path, bool Global);
 
-FEX_DEFAULT_VISIBILITY const fextl::string& GetDataDirectory();
+FEX_DEFAULT_VISIBILITY const fextl::string& GetDataDirectory(bool Global = false);
 FEX_DEFAULT_VISIBILITY const fextl::string& GetConfigDirectory(bool Global);
 FEX_DEFAULT_VISIBILITY const fextl::string& GetConfigFileLocation(bool Global = false);
 FEX_DEFAULT_VISIBILITY fextl::string GetApplicationConfig(const std::string_view Program, bool Global);

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -190,9 +190,12 @@ static void ConfigInit(fextl::string ConfigFilename) {
 RootFSModel::RootFSModel() {
   INotifyFD = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
 
-  fextl::string RootFS = FEXCore::Config::GetDataDirectory() + "RootFS/";
-  FolderFD = inotify_add_watch(INotifyFD, RootFS.c_str(), IN_CREATE | IN_DELETE);
-  if (FolderFD != -1) {
+  fextl::string RootFS = FEXCore::Config::GetDataDirectory(false) + "RootFS/";
+  int LocalFolderWD = inotify_add_watch(INotifyFD, RootFS.c_str(), IN_CREATE | IN_DELETE);
+
+  RootFS = FEXCore::Config::GetDataDirectory(true) + "RootFS/";
+  int GlobalFolderWD = inotify_add_watch(INotifyFD, RootFS.c_str(), IN_CREATE | IN_DELETE);
+  if (INotifyFD != -1 && (LocalFolderWD != -1 || GlobalFolderWD != -1)) {
     Thread = std::thread {&RootFSModel::INotifyThreadFunc, this};
   } else {
     qWarning() << "Could not set up inotify. RootFS folder won't be monitored for changes.";
@@ -214,20 +217,34 @@ void RootFSModel::Reload() {
   beginResetModel();
   removeRows(0, rowCount());
 
-  fextl::string RootFS = FEXCore::Config::GetDataDirectory() + "RootFS/";
   std::vector<QString> NamedRootFS {};
-  for (auto& it : std::filesystem::directory_iterator(RootFS)) {
-    if (it.is_directory()) {
-      NamedRootFS.push_back(QString::fromStdString(it.path().filename()));
-    } else if (it.is_regular_file()) {
-      // If it is a regular file then we need to check if it is a valid archive
-      if (it.path().extension() == ".sqsh" && FEX::FormatCheck::IsSquashFS(fextl::string_from_path(it.path()))) {
-        NamedRootFS.push_back(QString::fromStdString(it.path().filename()));
-      } else if (it.path().extension() == ".ero" && FEX::FormatCheck::IsEroFS(fextl::string_from_path(it.path()))) {
-        NamedRootFS.push_back(QString::fromStdString(it.path().filename()));
+  for (auto Global : {false, true}) {
+    const fextl::string RootFS = FEXCore::Config::GetDataDirectory(Global) + "RootFS/";
+
+    std::error_code ec;
+    for (auto& it : std::filesystem::directory_iterator(RootFS, ec)) {
+      std::string Path {};
+      if (Global) {
+        // If global then keep the full path.
+        Path = it.path();
+      } else {
+        // If local then only use the filename.
+        Path = it.path().filename();
+      }
+
+      if (it.is_directory()) {
+        NamedRootFS.push_back(QString::fromStdString(Path));
+      } else if (it.is_regular_file()) {
+        // If it is a regular file then we need to check if it is a valid archive
+        if (it.path().extension() == ".sqsh" && FEX::FormatCheck::IsSquashFS(fextl::string_from_path(it.path()))) {
+          NamedRootFS.push_back(QString::fromStdString(Path));
+        } else if (it.path().extension() == ".ero" && FEX::FormatCheck::IsEroFS(fextl::string_from_path(it.path()))) {
+          NamedRootFS.push_back(QString::fromStdString(Path));
+        }
       }
     }
   }
+
   std::sort(NamedRootFS.begin(), NamedRootFS.end(), [](const QString& a, const QString& b) { return QString::localeAwareCompare(a, b) < 0; });
   for (auto& Entry : NamedRootFS) {
     appendRow(new QStandardItem(Entry));

--- a/Source/Tools/FEXConfig/Main.h
+++ b/Source/Tools/FEXConfig/Main.h
@@ -41,7 +41,6 @@ class RootFSModel : public QStandardItemModel {
   std::latch ExitRequest {1};
 
   int INotifyFD;
-  int FolderFD;
 
   void INotifyThreadFunc();
 


### PR DESCRIPTION
Global rootfs doesn't support a named rootfs (only local supports that).
So when it is a global rootfs option just give the full path to the
config path.

Just needs some special handling to ensure the full path is retained for
global paths.

A reimplementation of https://github.com/FEX-Emu/FEX/pull/4067 that doesn't hardcode paths and routes the
global data path through FEXCore.