### PR TITLE
SignalDelegator: Let the frontend inform AVX support

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -321,8 +321,6 @@ bool ContextImpl::InitCore() {
 
   // Set up the SignalDelegator config since core is initialized.
   FEXCore::SignalDelegator::SignalDelegatorConfig SignalConfig {
-    .SupportsAVX = HostFeatures.SupportsAVX,
-
     .DispatcherBegin = Dispatcher->Start,
     .DispatcherEnd = Dispatcher->End,
 

--- a/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -40,8 +40,6 @@ public:
   virtual ~SignalDelegator() = default;
 
   struct SignalDelegatorConfig {
-    bool SupportsAVX {};
-
     // Dispatcher information
     uint64_t DispatcherBegin;
     uint64_t DispatcherEnd;

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -498,16 +498,18 @@ int main(int argc, char** argv, char** const envp) {
   // System allocator is now system allocator or FEX
   FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);
 
+  bool SupportsAVX {};
   fextl::unique_ptr<FEXCore::Context::Context> CTX;
   {
     auto HostFeatures = FEX::FetchHostFeatures();
     CTX = FEXCore::Context::Context::CreateNewContext(HostFeatures);
+    SupportsAVX = HostFeatures.SupportsAVX;
   }
 
   // Setup TSO hardware emulation immediately after initializing the context.
   FEX::TSO::SetupTSOEmulation(CTX.get());
 
-  auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), Program.ProgramName);
+  auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), Program.ProgramName, SupportsAVX);
 
   auto SyscallHandler = Loader.Is64BitMode() ? FEX::HLE::x64::CreateHandler(CTX.get(), SignalDelegation.get()) :
                                                FEX::HLE::x32::CreateHandler(CTX.get(), SignalDelegation.get(), std::move(Allocator));

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -50,7 +50,7 @@ public:
 
   // Returns true if the host handled the signal
   // Arguments are the same as sigaction handler
-  SignalDelegator(FEXCore::Context::Context* _CTX, const std::string_view ApplicationName);
+  SignalDelegator(FEXCore::Context::Context* _CTX, const std::string_view ApplicationName, bool SupportsAVX);
   ~SignalDelegator() override;
 
   // Called from the signal trampoline function.
@@ -274,7 +274,9 @@ private:
 
   std::mutex HostDelegatorMutex;
   std::mutex GuestDelegatorMutex;
+  bool SupportsAVX;
 };
 
-fextl::unique_ptr<FEX::HLE::SignalDelegator> CreateSignalDelegator(FEXCore::Context::Context* CTX, const std::string_view ApplicationName);
+fextl::unique_ptr<FEX::HLE::SignalDelegator>
+CreateSignalDelegator(FEXCore::Context::Context* CTX, const std::string_view ApplicationName, bool SupportsAVX);
 } // namespace FEX::HLE

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -257,7 +257,7 @@ int main(int argc, char** argv, char** const envp) {
   auto CTX = FEXCore::Context::Context::CreateNewContext(HostFeatures);
 
 #ifndef _WIN32
-  auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), {});
+  auto SignalDelegation = FEX::HLE::CreateSignalDelegator(CTX.get(), {}, HostFeatures.SupportsAVX);
 #else
   // Enable exit on HLT while Wine's longjump is broken.
   //


### PR DESCRIPTION
Since the frontend has changed to informing the backend if AVX is supported, there is no reason to feed that configuration back in to SignalDelegator from the backend.

Instead inform the SignalDelegator directly in the frontend instead of this now weird round-about path.