### PR TITLE
Config: Fixes stack usage in EnvLoader

### DIFF
--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -243,7 +243,7 @@ void EnvLoader::Load() {
   // Walk all the environment options and corresponding config option.
 #define OPT_BASE(type, group, enum, json, default) \
   Value = GetVar(EnvMap, "FEX_" #enum);            \
-  if (Value.has_value()) Set(FEXCore::Config::ConfigOption::CONFIG_##enum, fextl::string(*Value));
+  if (Value.has_value()) Set(FEXCore::Config::ConfigOption::CONFIG_##enum, *Value);
 #include <FEXCore/Config/ConfigValues.inl>
 }
 


### PR DESCRIPTION
EnvLoader::Load was generating strings on the stack and then copying them to the FEXCore::Config state. FEXCore::Config::Set supports string_views directly which will emplace in to the map directly.

This improves this functions stack usage from ~4464 bytes to ~288 bytes.

I believe this was missed when we were converting from std::string to fextl::string.