### PR TITLE
FEXLoader: Fixes newer wine versions and Fedora

### DIFF
--- a/FEXHeaderUtils/FEXHeaderUtils/StringArgumentParser.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/StringArgumentParser.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <FEXCore/fextl/vector.h>
+#include <FEXCore/fextl/fmt.h>
+
+#include <algorithm>
+#include <string_view>
+
+namespace FHU {
+
+/**
+ * @brief Parses a string of arguments, returning a vector of string_views.
+ *
+ * @param ArgumentString The string of arguments to parse
+ *
+ * @return The array of parsed arguments
+ */
+static inline fextl::vector<std::string_view> ParseArgumentsFromString(const std::string_view ArgumentString) {
+  fextl::vector<std::string_view> Arguments;
+
+  auto Begin = ArgumentString.begin();
+  auto ArgEnd = Begin;
+  const auto End = ArgumentString.end();
+  while (ArgEnd != End && Begin != End) {
+    // The end of an argument ends with a space or the end of the interpreter line.
+    ArgEnd = std::find(Begin, End, ' ');
+
+    if (Begin != ArgEnd) {
+      const auto View = std::string_view(Begin, ArgEnd - Begin);
+      if (!View.empty()) {
+        Arguments.emplace_back(View);
+      }
+    }
+
+    Begin = ArgEnd + 1;
+  }
+
+  return Arguments;
+}
+} // namespace FHU

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -337,7 +337,7 @@ fextl::string RecoverGuestProgramFilename(fextl::string Program, bool ExecFDInte
   return Program;
 }
 
-ApplicationNames GetApplicationNames(fextl::vector<fextl::string> Args, bool ExecFDInterp, int ProgramFDFromEnv) {
+ApplicationNames GetApplicationNames(const fextl::vector<fextl::string>& Args, bool ExecFDInterp, int ProgramFDFromEnv) {
   if (Args.empty()) {
     // Early exit if we weren't passed an argument
     return {};
@@ -346,8 +346,7 @@ ApplicationNames GetApplicationNames(fextl::vector<fextl::string> Args, bool Exe
   fextl::string Program {};
   fextl::string ProgramName {};
 
-  Args[0] = RecoverGuestProgramFilename(std::move(Args[0]), ExecFDInterp, ProgramFDFromEnv);
-  Program = Args[0];
+  Program = RecoverGuestProgramFilename(Args[0], ExecFDInterp, ProgramFDFromEnv);
 
   bool Wine = false;
   for (size_t CurrentProgramNameIndex = 0; CurrentProgramNameIndex < Args.size(); ++CurrentProgramNameIndex) {

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -40,7 +40,7 @@ struct PortableInformation {
  *
  * @return The application name and path structure
  */
-ApplicationNames GetApplicationNames(fextl::vector<fextl::string> Args, bool ExecFDInterp, int ProgramFDFromEnv);
+ApplicationNames GetApplicationNames(const fextl::vector<fextl::string>& Args, bool ExecFDInterp, int ProgramFDFromEnv);
 
 /**
  * @brief Loads the FEX and application configurations for the application that is getting ready to run.

--- a/unittests/APITests/ArgumentParser.cpp
+++ b/unittests/APITests/ArgumentParser.cpp
@@ -1,0 +1,75 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <FEXHeaderUtils/StringArgumentParser.h>
+
+TEST_CASE("Basic") {
+  const auto ArgString = "Test a b c";
+  auto Args = FHU::ParseArgumentsFromString(ArgString);
+  REQUIRE(Args.size() == 4);
+  CHECK(Args.at(0) == "Test");
+  CHECK(Args.at(1) == "a");
+  CHECK(Args.at(2) == "b");
+  CHECK(Args.at(3) == "c");
+}
+
+TEST_CASE("Basic - Empty") {
+  const auto ArgString = "";
+  auto Args = FHU::ParseArgumentsFromString(ArgString);
+  REQUIRE(Args.size() == 0);
+}
+
+TEST_CASE("Basic - Empty spaces") {
+  const auto ArgString = "                       ";
+  auto Args = FHU::ParseArgumentsFromString(ArgString);
+  REQUIRE(Args.size() == 0);
+}
+
+TEST_CASE("Basic - Space at start") {
+  const auto ArgString = "      Test a b c";
+  auto Args = FHU::ParseArgumentsFromString(ArgString);
+  REQUIRE(Args.size() == 4);
+  CHECK(Args.at(0) == "Test");
+  CHECK(Args.at(1) == "a");
+  CHECK(Args.at(2) == "b");
+  CHECK(Args.at(3) == "c");
+}
+
+TEST_CASE("Basic - Bonus spaces between args") {
+  const auto ArgString = "Test       a      b      c";
+  auto Args = FHU::ParseArgumentsFromString(ArgString);
+  REQUIRE(Args.size() == 4);
+  CHECK(Args.at(0) == "Test");
+  CHECK(Args.at(1) == "a");
+  CHECK(Args.at(2) == "b");
+  CHECK(Args.at(3) == "c");
+}
+
+TEST_CASE("Basic - non printable") {
+  const auto ArgString = "Test a b \x01c";
+  auto Args = FHU::ParseArgumentsFromString(ArgString);
+  REQUIRE(Args.size() == 4);
+  CHECK(Args.at(0) == "Test");
+  CHECK(Args.at(1) == "a");
+  CHECK(Args.at(2) == "b");
+  CHECK(Args.at(3) == "\x01c");
+}
+
+TEST_CASE("Basic - Emoji") {
+  const auto ArgString = "Test a b 🐸";
+  auto Args = FHU::ParseArgumentsFromString(ArgString);
+  REQUIRE(Args.size() == 4);
+  CHECK(Args.at(0) == "Test");
+  CHECK(Args.at(1) == "a");
+  CHECK(Args.at(2) == "b");
+  CHECK(Args.at(3) == "🐸");
+}
+
+TEST_CASE("Basic - space at the end") {
+  const auto ArgString = "Test a b 🐸        ";
+  auto Args = FHU::ParseArgumentsFromString(ArgString);
+  REQUIRE(Args.size() == 4);
+  CHECK(Args.at(0) == "Test");
+  CHECK(Args.at(1) == "a");
+  CHECK(Args.at(2) == "b");
+  CHECK(Args.at(3) == "🐸");
+}

--- a/unittests/APITests/CMakeLists.txt
+++ b/unittests/APITests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (TESTS
   Allocator
+  ArgumentParser
   InterruptableConditionVariable
   Filesystem
   )


### PR DESCRIPTION
This was brought up by #3831 but I finally got the courage to look at the hard problem.

Although I'm only tackling half of the problem with this PR, which is that FEXLoader needs to strip the rootfs path from the executed path if it begins with the rootfs, plus some changes to the surrounding code.

The primary concern here is that when an application has been executed under FEX, specifically through binfmt_misc, then FEX needs to prepend the full rootfs path otherwise Linux can't find the program. Additionally execveat with an FD will resolve a full path to the rootfs.

So past FEX's initial setup, we need to strip off the rootfs path to provide an "absolute" path that is visible to the guest application later. Which is kind of funny since we have a `RootFSRedirect` function which did the exact opposite. This was due to legacy problems in the original ELFLoader that couldn't handle symlinks correctly, which has since been resolved, so that no longer needs to exist.

There was also some weirdness in `GetApplicationNames` where the passed in argument list was modifying Args[0] and then saving the Program as well. Which I just got rid of. Also stopped passing in the arguments by value because....why did I write it like that?

In InterpreterHandler we now need to check if we can open the path inside the rootfs or fallback without it. Plus I had to change the shebang handling so it stopped prefixing the rootfs AGAIN. Took the time to change the shebang handling there so it stops creating string copies and instead just generates views.

Overall this fixes a fairly major flaw with how we were representing `/proc/self` to the application, which was breaking wine since it would prefix the rootfs multiple times, which was weird.

It doesn't address the remaining problem in #3831, which is that applications can still see some of the leaky abstractions with symlinks through the rootfs, but I want to get at least this step in.