### PR TITLE
Stop installing binfmt_misc on x86

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,7 +433,7 @@ add_subdirectory(FEXHeaderUtils/)
 add_subdirectory(CodeEmitter/)
 add_subdirectory(FEXCore/)
 
-if (NOT MINGW_BUILD)
+if (_M_ARM_64 AND NOT MINGW_BUILD)
   # Binfmt_misc files must be installed prior to Source/ installs
   add_subdirectory(Data/binfmts/)
 endif()

--- a/Source/Tools/FEXLoader/CMakeLists.txt
+++ b/Source/Tools/FEXLoader/CMakeLists.txt
@@ -50,7 +50,7 @@ endfunction()
 GenerateInterpreter(FEXLoader 0)
 GenerateInterpreter(FEXInterpreter 1)
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+if (_M_ARM_64)
   if (NOT USE_LEGACY_BINFMTMISC)
     # Just restart the systemd service
     add_custom_target(binfmt_misc


### PR DESCRIPTION
With the new systemd support, we had forgotten to wrap this check in an arm64 check. I had done an install and broke my x86 machine.

Add the check back so we stop breaking x86 machines...again. Took me only about three hours to find the issue this time.