### PR TITLE
Thunks/Vulkan: Updates thunks to v1.3.296

### DIFF
--- a/ThunkLibs/libvulkan/libvulkan_interface.cpp
+++ b/ThunkLibs/libvulkan/libvulkan_interface.cpp
@@ -76,6 +76,10 @@ template<>
 struct fex_gen_type<VkDeviceOrHostAddressConstKHR> : fexgen::assume_compatible_data_layout {};
 template<>
 struct fex_gen_type<VkPerformanceValueDataINTEL> : fexgen::assume_compatible_data_layout {};
+template<>
+struct fex_gen_type<VkIndirectExecutionSetInfoEXT> : fexgen::assume_compatible_data_layout {};
+template<>
+struct fex_gen_type<VkIndirectCommandsTokenDataEXT> : fexgen::assume_compatible_data_layout {};
 #endif
 
 // Explicitly register types that are only ever referenced through nested pointers
@@ -829,6 +833,16 @@ struct fex_gen_config<vkGetDeviceImageSubresourceLayoutKHR> {};
 template<>
 struct fex_gen_config<vkGetImageSubresourceLayout2KHR> {};
 template<>
+struct fex_gen_config<vkCreatePipelineBinariesKHR> {};
+template<>
+struct fex_gen_config<vkDestroyPipelineBinaryKHR> {};
+template<>
+struct fex_gen_config<vkGetPipelineKeyKHR> {};
+template<>
+struct fex_gen_config<vkGetPipelineBinaryDataKHR> {};
+template<>
+struct fex_gen_config<vkReleaseCapturedPipelineDataKHR> {};
+template<>
 struct fex_gen_config<vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR> {};
 template<>
 struct fex_gen_config<vkCmdSetLineStippleKHR> {};
@@ -1329,6 +1343,8 @@ struct fex_gen_config<vkBindOpticalFlowSessionImageNV> {};
 template<>
 struct fex_gen_config<vkCmdOpticalFlowExecuteNV> {};
 template<>
+struct fex_gen_config<vkAntiLagUpdateAMD> {};
+template<>
 struct fex_gen_config<vkCreateShadersEXT> {};
 template<>
 struct fex_gen_config<vkDestroyShaderEXT> {};
@@ -1336,6 +1352,8 @@ template<>
 struct fex_gen_config<vkGetShaderBinaryDataEXT> {};
 template<>
 struct fex_gen_config<vkCmdBindShadersEXT> {};
+template<>
+struct fex_gen_config<vkCmdSetDepthClampRangeEXT> {};
 template<>
 struct fex_gen_config<vkGetFramebufferTilePropertiesQCOM> {};
 template<>
@@ -1352,6 +1370,24 @@ template<>
 struct fex_gen_config<vkQueueNotifyOutOfBandNV> {};
 template<>
 struct fex_gen_config<vkCmdSetAttachmentFeedbackLoopEnableEXT> {};
+template<>
+struct fex_gen_config<vkGetGeneratedCommandsMemoryRequirementsEXT> {};
+template<>
+struct fex_gen_config<vkCmdPreprocessGeneratedCommandsEXT> {};
+template<>
+struct fex_gen_config<vkCmdExecuteGeneratedCommandsEXT> {};
+template<>
+struct fex_gen_config<vkCreateIndirectCommandsLayoutEXT> {};
+template<>
+struct fex_gen_config<vkDestroyIndirectCommandsLayoutEXT> {};
+template<>
+struct fex_gen_config<vkCreateIndirectExecutionSetEXT> {};
+template<>
+struct fex_gen_config<vkDestroyIndirectExecutionSetEXT> {};
+template<>
+struct fex_gen_config<vkUpdateIndirectExecutionSetPipelineEXT> {};
+template<>
+struct fex_gen_config<vkUpdateIndirectExecutionSetShaderEXT> {};
 template<>
 struct fex_gen_config<vkCreateAccelerationStructureKHR> {};
 template<>


### PR DESCRIPTION
Between this version and our previous version v1.3.278 this adds a few
extensions.
- VK_EXT_device_generated_commands
- VK_EXT_depth_clamp_control
- VK_AMD_anti_lag
- VK_KHR_pipeline_binary

These extensions are almost immediately getting picked up by mesa and
the D3D layers, so we want to support them as soon as possible.

Once again updated as described in https://github.com/FEX-Emu/FEX/pull/2076. This is starting to take more
time as more features and extensions get added to Vulkan. We probably
want to update the `DefinitionExtract.py` script at some point to
contain all the tertiary data in some json so everything gets generated
automatically. Not doing that today but something to think about.

Fixes https://github.com/FEX-Emu/FEX/issues/4083