### PR TITLE
unittests: Be more strict with -- separator

### DIFF
--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -92,7 +92,9 @@ foreach(ASM_SRC ${ASM_SOURCES})
       "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Disabled_Tests_${CPU_CLASS}"
       "Test_32Bit_${REL_TEST_ASM}"
       ${LAUNCH_PROGRAM}
-      ${ARGS_LIST} "${OUTPUT_NAME}" "${OUTPUT_CONFIG_NAME}")
+      ${ARGS_LIST}
+      "--"
+      "${OUTPUT_NAME}" "${OUTPUT_CONFIG_NAME}")
     # This will cause the ASM tests to fail if it can't find the TestHarness or ASMN files
     # Prety crap way to work around the fact that tests can't have a build dependency in a different directory
     # Just make sure to independently run `make all` then `make test`

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -99,7 +99,9 @@ foreach(ASM_SRC ${ASM_SOURCES})
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests_${CPU_CLASS}"
       "Test_${REL_TEST_ASM}"
       ${LAUNCH_PROGRAM}
-      ${ARGS_LIST} "${OUTPUT_NAME}" "${OUTPUT_CONFIG_NAME}")
+      ${ARGS_LIST}
+      "--"
+      "${OUTPUT_NAME}" "${OUTPUT_CONFIG_NAME}")
     # This will cause the ASM tests to fail if it can't find the TestHarness or ASMN files
     # Prety crap way to work around the fact that tests can't have a build dependency in a different directory
     # Just make sure to independently run `make all` then `make test`


### PR DESCRIPTION
> We had a bug in our arguments getting passed to unittests for years (https://github.com/FEX-Emu/FEX/pull/4071) and it was undiscovered. Due to a quirk with cpp-optparse where any unsupported arguments were gathered and passed to the guest application. This didn't necessarily break anything in our unittests, just made them run silently, and for all the harness things the additional argument was ignored anyway.

cherry-picked from #4070 with the review comments resolved.

Only the ASM and 32-bit ASM tests were missing this.

Breaking it out in to an independent PR since it can be freestanding.