### PR TITLE
LinuxEmulation: Update syscalls for v6.11

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Arm64/SyscallsEnum.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Arm64/SyscallsEnum.h
@@ -5,7 +5,6 @@ tags: LinuxSyscalls|syscalls-arm64
 $end_info$
 */
 #pragma once
-#include <cstdint>
 
 namespace FEX::HLE::Arm64 {
 ///< Enum containing all Arm64 linux syscalls for the host kernel
@@ -476,5 +475,6 @@ enum Syscalls_Arm64 {
   SYSCALL_Arm64_epoll_ctl_old = ~0,
   SYSCALL_Arm64_epoll_wait_old = ~0,
   SYSCALL_Arm64_newfstatat = ~0,
+  SYSCALL_Arm64_uretprobe = ~0,
 };
 } // namespace FEX::HLE::Arm64

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/NotImplemented.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/NotImplemented.cpp
@@ -22,6 +22,10 @@ namespace FEX::HLE::x64 {
     LogMan::Msg::DFmt("Using deprecated/removed syscall: " #name);                      \
     return -ENOSYS;                                                                     \
   });
+
+#define REGISTER_SYSCALL_NOT_IMPL_SAFE_X64(name) \
+  REGISTER_SYSCALL_IMPL_X64(name, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { return -ENOSYS; });
+
 #define REGISTER_SYSCALL_NO_PERM_X64(name) \
   REGISTER_SYSCALL_IMPL_X64(name, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { return -EPERM; });
 
@@ -34,5 +38,6 @@ void RegisterNotImplemented(FEX::HLE::SyscallHandler* Handler) {
   REGISTER_SYSCALL_NOT_IMPL_X64(epoll_ctl_old);
   REGISTER_SYSCALL_NOT_IMPL_X64(epoll_wait_old);
   REGISTER_SYSCALL_NO_PERM_X64(kexec_file_load);
+  REGISTER_SYSCALL_NOT_IMPL_SAFE_X64(uretprobe);
 }
 } // namespace FEX::HLE::x64

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/SyscallsEnum.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/SyscallsEnum.h
@@ -360,6 +360,7 @@ enum Syscalls_x64 {
   SYSCALL_x64_statx = 332,
   SYSCALL_x64_io_pgetevents = 333,
   SYSCALL_x64_rseq = 334,
+  SYSCALL_x64_uretprobe = 335,
   SYSCALL_x64_pidfd_send_signal = 424,
   SYSCALL_x64_io_uring_setup = 425,
   SYSCALL_x64_io_uring_enter = 426,


### PR DESCRIPTION
Only thing added was uretprobe on x86-64. We can't support this so just return ENOSYS.