### PR TITLE
LinuxSyscalls: Update max reported kernel version to 6.11

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -780,8 +780,8 @@ uint32_t SyscallHandler::CalculateHostKernelVersion() {
 }
 
 uint32_t SyscallHandler::CalculateGuestKernelVersion() {
-  // We currently only emulate a kernel between the ranges of Kernel 5.0.0 and 6.8.0
-  return std::max(KernelVersion(5, 0), std::min(KernelVersion(6, 8), GetHostKernelVersion()));
+  // We currently only emulate a kernel between the ranges of Kernel 5.0.0 and 6.11.0
+  return std::max(KernelVersion(5, 0), std::min(KernelVersion(6, 11), GetHostKernelVersion()));
 }
 
 uint64_t SyscallHandler::HandleSyscall(FEXCore::Core::CpuStateFrame* Frame, FEXCore::HLE::SyscallArguments* Args) {


### PR DESCRIPTION
Investigated the uapi differences and nothing terrifying leapt out that we haven't already implemented.