### PR TITLE
VDSOEmulation: Support loading VDSO thunk as shared

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -950,6 +950,10 @@ void ContextImpl::InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* T
 }
 
 void ContextImpl::MarkMemoryShared(FEXCore::Core::InternalThreadState* Thread) {
+  if (!Thread) {
+    return;
+  }
+
   if (!IsMemoryShared) {
     IsMemoryShared = true;
     UpdateAtomicTSOEmulationConfig();

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
@@ -746,7 +746,7 @@ VDSOMapping LoadVDSOThunks(bool Is64Bit, FEX::HLE::SyscallHandler* const Handler
       Mapping.VDSOSize = FEXCore::AlignUp(Mapping.VDSOSize, 4096);
 
       // Map the VDSO file to memory
-      Mapping.VDSOBase = Handler->GuestMmap(nullptr, nullptr, Mapping.VDSOSize, PROT_READ, MAP_PRIVATE, VDSOFD, 0);
+      Mapping.VDSOBase = Handler->GuestMmap(nullptr, nullptr, Mapping.VDSOSize, PROT_READ, MAP_SHARED, VDSOFD, 0);
 
       // Since we found our VDSO thunk library, find our host VDSO function implementations.
       LoadHostVDSO();


### PR DESCRIPTION
Just requires a thread pointer check to be fixed in FEXCore. This doesn't need unique pages to exist for the file mapping and can be shared since it's readonly mapped.