### PR TITLE
TestHarnessRunner: Fixes FS/GS usage in tests

### DIFF
--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.cpp
@@ -51,6 +51,10 @@ public:
     push(r13);
     push(r14);
     push(r15);
+    rdfsbase(rbx);
+    push(rbx);
+    rdgsbase(rbx);
+    push(rbx);
     sub(rsp, 8);
 
     // Save this stack pointer so we can cleanly shutdown the emulation with a long jump
@@ -105,6 +109,10 @@ public:
 
     add(rsp, 8);
 
+    pop(rbx);
+    wrgsbase(rbx);
+    pop(rbx);
+    wrfsbase(rbx);
     pop(r15);
     pop(r14);
     pop(r13);


### PR DESCRIPTION
When writing `FEX_bugs/tls_vector_element.asm` I had to switch to using
GS segment instead of FS segment because the unittests didn't correctly
restore FS after running. This is because GS is unused on Linux
applications, but FS would become broken and break glibc cleanup on
shutdown.

Now that xbyak has been updated to v7.09, it now supports
{rd,wr}{fs,gs}base which allows us to save and restore the segments
correctly. This lets us drop in TLS tests in to unittests more easily
now.

Ensured this works by modifying the test temporarily to use fs instead
of gs again, seeing it crash before HostRunner changes, and work after
HostRunner changes.

Fixes https://github.com/FEX-Emu/FEX/issues/4104