### PR TITLE
LinuxEmulation: Personality handling

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Info.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Info.cpp
@@ -62,8 +62,13 @@ void RegisterInfo(FEX::HLE::SyscallHandler* Handler) {
       const char version[] = "#" GIT_DESCRIBE_STRING " SMP " __DATE__ " " __TIME__;
       strcpy(buf->version, version);
       static_assert(sizeof(version) <= sizeof(buf->version), "uname version define became too large!");
-      // Tell the guest that we are a 64bit kernel
-      strcpy(buf->machine, "x86_64");
+      if (Thread->persona & PER_LINUX32) {
+        // Tell the guest that we are a 32bit kernel
+        strcpy(buf->machine, "i686");
+      } else {
+        // Tell the guest that we are a 64bit kernel
+        strcpy(buf->machine, "x86_64");
+      }
       return 0;
     });
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
@@ -330,8 +330,6 @@ void RegisterCommon(FEX::HLE::SyscallHandler* Handler) {
                                    SyscallPassthrough2<SYSCALL_DEF(capget)>);
   REGISTER_SYSCALL_IMPL_PASS_FLAGS(capset, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                    SyscallPassthrough2<SYSCALL_DEF(capset)>);
-  REGISTER_SYSCALL_IMPL_PASS_FLAGS(personality, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
-                                   SyscallPassthrough1<SYSCALL_DEF(personality)>);
   REGISTER_SYSCALL_IMPL_PASS_FLAGS(getpriority, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                    SyscallPassthrough2<SYSCALL_DEF(getpriority)>);
   REGISTER_SYSCALL_IMPL_PASS_FLAGS(setpriority, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -22,6 +22,7 @@ FEX::HLE::ThreadStateObject* ThreadManager::CreateThread(uint64_t InitialRIP, ui
 
   if (InheritThread) {
     FEX::HLE::_SyscallHandler->SeccompEmulator.InheritSeccompFilters(InheritThread, ThreadStateObject);
+    ThreadStateObject->persona = InheritThread->persona;
   }
 
   ++IdleWaitRefCount;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -55,6 +55,9 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
   // Seccomp thread specific data.
   uint32_t SeccompMode {SECCOMP_MODE_DISABLED};
   fextl::vector<FEX::HLE::SeccompEmulator::FilterInformation*> Filters {};
+
+  // personality emulation.
+  uint32_t persona {};
 };
 
 class ThreadManager final {

--- a/unittests/FEXLinuxTests/tests/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(FEXLinuxTests)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 unset(CMAKE_C_FLAGS)
 unset(CMAKE_CXX_FLAGS)

--- a/unittests/FEXLinuxTests/tests/syscalls/personality.cpp
+++ b/unittests/FEXLinuxTests/tests/syscalls/personality.cpp
@@ -1,0 +1,45 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <sys/personality.h>
+#include <sys/utsname.h>
+#include <string_view>
+
+constexpr uint32_t QUERY_PERSONA = ~0U;
+TEST_CASE("default - query") {
+  REQUIRE(::personality(0) != -1);
+
+  auto persona = ::personality(QUERY_PERSONA);
+  CHECK(persona == 0);
+}
+
+TEST_CASE("default - set all") {
+  REQUIRE(::personality(-2U) != -1);
+  auto persona = ::personality(QUERY_PERSONA);
+  CHECK(persona == -2U);
+}
+
+TEST_CASE("default - check linux32") {
+  REQUIRE(::personality(0) != -1);
+
+  struct utsname name {};
+  uname(&name);
+  CHECK(std::string_view(name.machine) == "x86_64");
+
+  CHECK(::personality(PER_LINUX32) != -1);
+  auto persona = ::personality(QUERY_PERSONA);
+  CHECK(persona == PER_LINUX32);
+
+  uname(&name);
+  CHECK(std::string_view(name.machine) == "i686");
+}
+
+TEST_CASE("default - check uname26") {
+  REQUIRE(::personality(UNAME26) != -1);
+  auto persona = ::personality(QUERY_PERSONA);
+  CHECK(persona == UNAME26);
+
+  struct utsname name {};
+  uname(&name);
+  CHECK(std::string_view(name.release).starts_with("2.6."));
+}


### PR DESCRIPTION
Comes from #1119 

Previously we were just passing the personality to the host kernel, which worked for most cases but not all.
- Adds per-thread tracking of personality
- Handles PER_LINUX32 which AArch64-only hardware would have returned error on
- Supports the uname changes that PER_LINUX32 and UNAME26 changes

Flags still not supported after this PR:
- ADDR_COMPAT_LAYOUT
- READ_IMPLIES_EXEC
- ADDR_LIMIT_3GB

Adds a unit test to ensure personality is set and returned as expected.