### PR TITLE
Remove file since FXAM_Simple is not a Linux test

### DIFF
--- a/unittests/FEXLinuxTests/Known_Failures_Host
+++ b/unittests/FEXLinuxTests/Known_Failures_Host
@@ -1,2 +1,0 @@
-## Unable to support zero flag
-FXAM_Simple.asm


### PR DESCRIPTION
Already properly skipped in the right place.
File added accidentally.