### PR TITLE
FEXCore: Change yield implementation to use wfe 

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64/MiscOps.cpp
@@ -262,7 +262,7 @@ DEF_OP(RDRAND) {
 }
 
 DEF_OP(Yield) {
-  yield();
+  wfe();
 }
 
 #undef DEF_OP

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -2540,6 +2540,13 @@
       "Comment": "0x90",
       "ExpectedArm64ASM": []
     },
+    "pause": {
+      "ExpectedInstructionCount": 1,
+      "Comment": "0xF3 0x90",
+      "ExpectedArm64ASM": [
+        "wfe"
+      ]
+    },
     "cbw": {
       "ExpectedInstructionCount": 2,
       "Comment": "0x98",


### PR DESCRIPTION
According to
https://github.com/rust-lang/rust/commit/c064b6560b7ce0adeb9bbf5d7dcf12b1acb0c807
turns out that the arm yield instruction is effectively a nop on all
reasonably new CPUs.
Instead switch over to wfe because it matches x86 `PAUSE` semantics more
closely.