### PR TITLE
OpcodeDispatcher: Unify PSHUF{L,H}W implementations

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -445,6 +445,7 @@ public:
   void PUNPCKLOp(OpcodeArgs, size_t ElementSize);
   void PUNPCKHOp(OpcodeArgs, size_t ElementSize);
   void PSHUFBOp(OpcodeArgs);
+  Ref PShufWLane(size_t Size, FEXCore::IR::IndexNamedVectorConstant IndexConstant, bool LowLane, Ref IncomingLane, uint8_t Shuffle);
   void PSHUFWOp(OpcodeArgs, bool Low);
   void PSHUFW8ByteOp(OpcodeArgs);
   void PSHUFDOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1062,8 +1062,7 @@ public:
   void AVX128_VDPP(OpcodeArgs);
   void AVX128_VPERMQ(OpcodeArgs);
 
-  template<size_t ElementSize, bool Low>
-  void AVX128_VPSHUF(OpcodeArgs);
+  void AVX128_VPSHUFW(OpcodeArgs, bool Low);
 
   template<size_t ElementSize>
   void AVX128_VSHUF(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -159,8 +159,8 @@ void OpDispatchBuilder::InstallAVX128Handlers() {
     {OPD(1, 0b10, 0x6F), 1, &OpDispatchBuilder::AVX128_VMOVAPS},
 
     {OPD(1, 0b01, 0x70), 1, &OpDispatchBuilder::AVX128_VPERMILImm<4>},
-    {OPD(1, 0b10, 0x70), 1, &OpDispatchBuilder::AVX128_VPSHUF<2, false>},
-    {OPD(1, 0b11, 0x70), 1, &OpDispatchBuilder::AVX128_VPSHUF<2, true>},
+    {OPD(1, 0b10, 0x70), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::AVX128_VPSHUFW, false>},
+    {OPD(1, 0b11, 0x70), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::AVX128_VPSHUFW, true>},
 
     {OPD(1, 0b01, 0x74), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::AVX128_VectorALU, IR::OP_VCMPEQ, 1>},
     {OPD(1, 0b01, 0x75), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::AVX128_VectorALU, IR::OP_VCMPEQ, 2>},
@@ -1871,20 +1871,14 @@ void OpDispatchBuilder::AVX128_VPERMQ(OpcodeArgs) {
   AVX128_StoreResult_WithOpSize(Op, Op->Dest, Result);
 }
 
-template<size_t ElementSize, bool Low>
-void OpDispatchBuilder::AVX128_VPSHUF(OpcodeArgs) {
+void OpDispatchBuilder::AVX128_VPSHUFW(OpcodeArgs, bool Low) {
   auto Shuffle = Op->Src[1].Literal();
 
-  AVX128_VectorUnaryImpl(Op, GetSrcSize(Op), ElementSize, [this, Shuffle](size_t _, Ref Src) {
-    Ref Result = Src;
-    const size_t BaseElement = Low ? 0 : 4;
+  AVX128_VectorUnaryImpl(Op, GetSrcSize(Op), OpSize::i16Bit, [this, Shuffle, Low](size_t _, Ref Src) {
+    const auto IndexedVectorConstant = Low ? FEXCore::IR::IndexNamedVectorConstant::INDEXED_NAMED_VECTOR_PSHUFLW :
+                                             FEXCore::IR::IndexNamedVectorConstant::INDEXED_NAMED_VECTOR_PSHUFHW;
 
-    for (size_t i = 0; i < 4; i++) {
-      const auto Index = (Shuffle >> (2 * i)) & 0b11;
-      Result = _VInsElement(OpSize::i128Bit, ElementSize, BaseElement + i, BaseElement + Index, Result, Src);
-    }
-
-    return Result;
+    return PShufWLane(OpSize::i128Bit, IndexedVectorConstant, Low, Src, Shuffle);
   });
 }
 

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -1255,299 +1255,217 @@
       ]
     },
     "vpshufhw xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.h[4], v17.h[4]",
-        "mov v2.h[5], v17.h[4]",
-        "mov v2.h[6], v17.h[4]",
-        "mov v16.16b, v2.16b",
-        "mov v16.h[7], v17.h[4]",
+        "dup v2.8h, v17.h[4]",
+        "trn1 v16.2d, v17.2d, v2.2d",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vpshufhw xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.h[4], v17.h[5]",
-        "mov v2.h[5], v17.h[4]",
-        "mov v2.h[6], v17.h[4]",
-        "mov v16.16b, v2.16b",
-        "mov v16.h[7], v17.h[4]",
+        "ldr x0, [x28, #1984]",
+        "ldr q2, [x0, #16]",
+        "tbl v16.16b, {v17.16b}, v2.16b",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vpshufhw xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.h[4], v17.h[6]",
-        "mov v2.h[5], v17.h[4]",
-        "mov v2.h[6], v17.h[4]",
-        "mov v16.16b, v2.16b",
-        "mov v16.h[7], v17.h[4]",
+        "ldr x0, [x28, #1984]",
+        "ldr q2, [x0, #32]",
+        "tbl v16.16b, {v17.16b}, v2.16b",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vpshufhw xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.h[4], v17.h[7]",
-        "mov v2.h[5], v17.h[4]",
-        "mov v2.h[6], v17.h[4]",
-        "mov v16.16b, v2.16b",
-        "mov v16.h[7], v17.h[4]",
+        "ldr x0, [x28, #1984]",
+        "ldr q2, [x0, #48]",
+        "tbl v16.16b, {v17.16b}, v2.16b",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vpshufhw ymm0, ymm1, 00b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #32]",
-        "mov v3.16b, v17.16b",
-        "mov v3.h[4], v17.h[4]",
-        "mov v3.h[5], v17.h[4]",
-        "mov v3.h[6], v17.h[4]",
-        "mov v16.16b, v3.16b",
-        "mov v16.h[7], v17.h[4]",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[4], v2.h[4]",
-        "mov v3.h[5], v2.h[4]",
-        "mov v3.h[6], v2.h[4]",
-        "mov v3.h[7], v2.h[4]",
-        "str q3, [x28, #16]"
+        "dup v3.8h, v17.h[4]",
+        "trn1 v16.2d, v17.2d, v3.2d",
+        "dup v3.8h, v2.h[4]",
+        "trn1 v2.2d, v2.2d, v3.2d",
+        "str q2, [x28, #16]"
       ]
     },
     "vpshufhw ymm0, ymm1, 01b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #32]",
-        "mov v3.16b, v17.16b",
-        "mov v3.h[4], v17.h[5]",
-        "mov v3.h[5], v17.h[4]",
-        "mov v3.h[6], v17.h[4]",
-        "mov v16.16b, v3.16b",
-        "mov v16.h[7], v17.h[4]",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[4], v2.h[5]",
-        "mov v3.h[5], v2.h[4]",
-        "mov v3.h[6], v2.h[4]",
-        "mov v3.h[7], v2.h[4]",
-        "str q3, [x28, #16]"
+        "ldr x0, [x28, #1984]",
+        "ldr q3, [x0, #16]",
+        "tbl v16.16b, {v17.16b}, v3.16b",
+        "tbl v2.16b, {v2.16b}, v3.16b",
+        "str q2, [x28, #16]"
       ]
     },
     "vpshufhw ymm0, ymm1, 10b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #32]",
-        "mov v3.16b, v17.16b",
-        "mov v3.h[4], v17.h[6]",
-        "mov v3.h[5], v17.h[4]",
-        "mov v3.h[6], v17.h[4]",
-        "mov v16.16b, v3.16b",
-        "mov v16.h[7], v17.h[4]",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[4], v2.h[6]",
-        "mov v3.h[5], v2.h[4]",
-        "mov v3.h[6], v2.h[4]",
-        "mov v3.h[7], v2.h[4]",
-        "str q3, [x28, #16]"
+        "ldr x0, [x28, #1984]",
+        "ldr q3, [x0, #32]",
+        "tbl v16.16b, {v17.16b}, v3.16b",
+        "tbl v2.16b, {v2.16b}, v3.16b",
+        "str q2, [x28, #16]"
       ]
     },
     "vpshufhw ymm0, ymm1, 11b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b10 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #32]",
-        "mov v3.16b, v17.16b",
-        "mov v3.h[4], v17.h[7]",
-        "mov v3.h[5], v17.h[4]",
-        "mov v3.h[6], v17.h[4]",
-        "mov v16.16b, v3.16b",
-        "mov v16.h[7], v17.h[4]",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[4], v2.h[7]",
-        "mov v3.h[5], v2.h[4]",
-        "mov v3.h[6], v2.h[4]",
-        "mov v3.h[7], v2.h[4]",
-        "str q3, [x28, #16]"
+        "ldr x0, [x28, #1984]",
+        "ldr q3, [x0, #48]",
+        "tbl v16.16b, {v17.16b}, v3.16b",
+        "tbl v2.16b, {v2.16b}, v3.16b",
+        "str q2, [x28, #16]"
       ]
     },
     "vpshuflw xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.h[0], v17.h[0]",
-        "mov v2.h[1], v17.h[0]",
-        "mov v2.h[2], v17.h[0]",
-        "mov v16.16b, v2.16b",
-        "mov v16.h[3], v17.h[0]",
+        "dup v2.8h, v17.h[0]",
+        "trn2 v16.2d, v2.2d, v17.2d",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vpshuflw xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.h[0], v17.h[1]",
-        "mov v2.h[1], v17.h[0]",
-        "mov v2.h[2], v17.h[0]",
-        "mov v16.16b, v2.16b",
-        "mov v16.h[3], v17.h[0]",
+        "ldr x0, [x28, #1976]",
+        "ldr q2, [x0, #16]",
+        "tbl v16.16b, {v17.16b}, v2.16b",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vpshuflw xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.h[0], v17.h[2]",
-        "mov v2.h[1], v17.h[0]",
-        "mov v2.h[2], v17.h[0]",
-        "mov v16.16b, v2.16b",
-        "mov v16.h[3], v17.h[0]",
+        "ldr x0, [x28, #1976]",
+        "ldr q2, [x0, #32]",
+        "tbl v16.16b, {v17.16b}, v2.16b",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vpshuflw xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v17.16b",
-        "mov v2.h[0], v17.h[3]",
-        "mov v2.h[1], v17.h[0]",
-        "mov v2.h[2], v17.h[0]",
-        "mov v16.16b, v2.16b",
-        "mov v16.h[3], v17.h[0]",
+        "ldr x0, [x28, #1976]",
+        "ldr q2, [x0, #48]",
+        "tbl v16.16b, {v17.16b}, v2.16b",
         "movi v2.2d, #0x0",
         "str q2, [x28, #16]"
       ]
     },
     "vpshuflw ymm0, ymm1, 00b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #32]",
-        "mov v3.16b, v17.16b",
-        "mov v3.h[0], v17.h[0]",
-        "mov v3.h[1], v17.h[0]",
-        "mov v3.h[2], v17.h[0]",
-        "mov v16.16b, v3.16b",
-        "mov v16.h[3], v17.h[0]",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[0], v2.h[0]",
-        "mov v3.h[1], v2.h[0]",
-        "mov v3.h[2], v2.h[0]",
-        "mov v3.h[3], v2.h[0]",
-        "str q3, [x28, #16]"
+        "dup v3.8h, v17.h[0]",
+        "trn2 v16.2d, v3.2d, v17.2d",
+        "dup v3.8h, v2.h[0]",
+        "trn2 v2.2d, v3.2d, v2.2d",
+        "str q2, [x28, #16]"
       ]
     },
     "vpshuflw ymm0, ymm1, 01b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #32]",
-        "mov v3.16b, v17.16b",
-        "mov v3.h[0], v17.h[1]",
-        "mov v3.h[1], v17.h[0]",
-        "mov v3.h[2], v17.h[0]",
-        "mov v16.16b, v3.16b",
-        "mov v16.h[3], v17.h[0]",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[0], v2.h[1]",
-        "mov v3.h[1], v2.h[0]",
-        "mov v3.h[2], v2.h[0]",
-        "mov v3.h[3], v2.h[0]",
-        "str q3, [x28, #16]"
+        "ldr x0, [x28, #1976]",
+        "ldr q3, [x0, #16]",
+        "tbl v16.16b, {v17.16b}, v3.16b",
+        "tbl v2.16b, {v2.16b}, v3.16b",
+        "str q2, [x28, #16]"
       ]
     },
     "vpshuflw ymm0, ymm1, 10b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #32]",
-        "mov v3.16b, v17.16b",
-        "mov v3.h[0], v17.h[2]",
-        "mov v3.h[1], v17.h[0]",
-        "mov v3.h[2], v17.h[0]",
-        "mov v16.16b, v3.16b",
-        "mov v16.h[3], v17.h[0]",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[0], v2.h[2]",
-        "mov v3.h[1], v2.h[0]",
-        "mov v3.h[2], v2.h[0]",
-        "mov v3.h[3], v2.h[0]",
-        "str q3, [x28, #16]"
+        "ldr x0, [x28, #1976]",
+        "ldr q3, [x0, #32]",
+        "tbl v16.16b, {v17.16b}, v3.16b",
+        "tbl v2.16b, {v2.16b}, v3.16b",
+        "str q2, [x28, #16]"
       ]
     },
     "vpshuflw ymm0, ymm1, 11b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b11 0x70 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #32]",
-        "mov v3.16b, v17.16b",
-        "mov v3.h[0], v17.h[3]",
-        "mov v3.h[1], v17.h[0]",
-        "mov v3.h[2], v17.h[0]",
-        "mov v16.16b, v3.16b",
-        "mov v16.h[3], v17.h[0]",
-        "mov v3.16b, v2.16b",
-        "mov v3.h[0], v2.h[3]",
-        "mov v3.h[1], v2.h[0]",
-        "mov v3.h[2], v2.h[0]",
-        "mov v3.h[3], v2.h[0]",
-        "str q3, [x28, #16]"
+        "ldr x0, [x28, #1976]",
+        "ldr q3, [x0, #48]",
+        "tbl v16.16b, {v17.16b}, v3.16b",
+        "tbl v2.16b, {v2.16b}, v3.16b",
+        "str q2, [x28, #16]"
       ]
     },
     "vpcmpeqb xmm0, xmm1, xmm2": {


### PR DESCRIPTION
MMX, SSE, and AVX were all using different implementations. Unify the three of them.
This is a nop for the MMX and SSE implementation, but this does some minor optimization for the AVX implementation since the SSE path was slightly more optimal.

Fixes #4123