### PR TITLE
add Ubuntu 24.10 and remove unsupported releases

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ FEX is very much work in progress, so expect things to change.
 
 
 ## Quick start guide
-### For Ubuntu 20.04, 21.04, 21.10, 22.04
+### For Ubuntu 22.04, 24.04 and 24.10
 Execute the following command in the terminal to install FEX through a PPA.
 
 `curl --silent https://raw.githubusercontent.com/FEX-Emu/FEX/main/Scripts/InstallFEX.py --output /tmp/InstallFEX.py && python3 /tmp/InstallFEX.py && rm /tmp/InstallFEX.py`

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,12 @@ Please see [Building FEX](#building-fex).
 ## Getting Started
 FEX has been tested to build and run on ARMv8.0+ hardware.
 ARMv7 hardware will not work.
-Expected operating system usage is Linux. FEX has been tested with Ubuntu 20.04, 20.10, and 21.04. Also Arch Linux.
+Expected operating system usage is Linux. FEX has been tested with the following Linux OSes:
+
+- Ubuntu 22.04
+- Ubuntu 24.04
+- Ubuntu 24.10
+- Arch Linux
 
 On AArch64 hosts the user **MUST** have an x86-64 RootFS [Creating a RootFS](#RootFS-Generation).
 

--- a/Scripts/InstallFEX.py
+++ b/Scripts/InstallFEX.py
@@ -83,9 +83,8 @@ def IsSupportedDistro():
     if Distro[0] == "ubuntu":
         # We only support what is available in ppa:fex-emu/fex
         return Distro[1] == "22.04" or \
-            Distro[1] == "23.04" or \
-            Distro[1] == "23.10" or \
-            Distro[1] == "24.04"
+            Distro[1] == "24.04" or \
+            Distro[1] == "24.10"
 
     return False
 


### PR DESCRIPTION
This adds that release since it is built in the PPA:

https://launchpad.net/~fex-emu/+archive/ubuntu/fex?field.series_filter=oracular

It may be recommended to remove non-LTS releases or at least ones that are no longer supported by Ubuntu perhaps. 