### PR TITLE
Fix IR operation usage to use OpSize when possible

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -270,7 +270,7 @@ Ref OpDispatchBuilder::CalculateFlags_ADC(uint8_t SrcSize, Ref Src1, Ref Src2) {
 
   CalculateAF(Src1, Src2);
 
-  if (SrcSize >= 4) {
+  if (SrcSize >= OpSize::i32Bit) {
     RectifyCarryInvert(false);
     HandleNZCV_RMW();
     Res = _AdcWithFlags(OpSize, Src1, Src2);
@@ -307,7 +307,7 @@ Ref OpDispatchBuilder::CalculateFlags_SBB(uint8_t SrcSize, Ref Src1, Ref Src2) {
   CalculateAF(Src1, Src2);
 
   Ref Res;
-  if (SrcSize >= 4) {
+  if (SrcSize >= OpSize::i32Bit) {
     // Arm's subtraction has inverted CF from x86, so rectify the input and
     // invert the output.
     RectifyCarryInvert(true);
@@ -344,7 +344,7 @@ Ref OpDispatchBuilder::CalculateFlags_SUB(uint8_t SrcSize, Ref Src1, Ref Src2, b
   CalculateAF(Src1, Src2);
 
   Ref Res;
-  if (SrcSize >= 4) {
+  if (SrcSize >= OpSize::i32Bit) {
     Res = _SubWithFlags(IR::SizeToOpSize(SrcSize), Src1, Src2);
   } else {
     _SubNZCV(IR::SizeToOpSize(SrcSize), Src1, Src2);
@@ -374,7 +374,7 @@ Ref OpDispatchBuilder::CalculateFlags_ADD(uint8_t SrcSize, Ref Src1, Ref Src2, b
   CalculateAF(Src1, Src2);
 
   Ref Res;
-  if (SrcSize >= 4) {
+  if (SrcSize >= OpSize::i32Bit) {
     Res = _AddWithFlags(IR::SizeToOpSize(SrcSize), Src1, Src2);
   } else {
     _AddNZCV(IR::SizeToOpSize(SrcSize), Src1, Src2);


### PR DESCRIPTION
No functional change.

This is a continued stride towards using OpSize enums instead of constant numbers to reduce confusion and misunderstandings.

It gets very confusing at times when an argument to an IR operation is a size versus an index, or scale or another constant. We had already cleaned up a decent amount of this early this year, late last year but this hits all the OpcodeDispatcher files in the folder. Once this is merged we can start enforcing OpSize passing to IR operations without implicit conversions. Likely will require a bit more mopping up on the edges, but should make it easier.

Just a little cleanup while I'm distracted.