### PR TITLE
FileManagement: Hide the FEX RootFS fd from /proc/self/fd

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
@@ -81,9 +81,8 @@ public:
   std::optional<std::string_view> GetSelf(const char* Pathname);
   bool IsSelfNoFollow(const char* Pathname, int flags) const;
 
-  void UpdatePID(uint32_t PID) {
-    CurrentPID = PID;
-  }
+  void UpdatePID(uint32_t PID);
+  bool IsRootFSFD(int dirfd, uint64_t inode);
 
   fextl::string GetEmulatedPath(const char* pathname, bool FollowSymlink = false);
   using FDPathTmpData = std::array<char[PATH_MAX], 2>;
@@ -162,5 +161,7 @@ private:
   FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
   uint32_t CurrentPID {};
   int RootFSFD {AT_FDCWD};
+  int64_t RootFSFDInode = 0;
+  dev_t ProcFSDev;
 };
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -120,6 +120,11 @@ uint64_t GetDentsEmulation(int fd, T* dirp, uint32_t count) {
       Outgoing->d_name[Outgoing->d_reclen - offsetof(T, d_name) - 1] = Tmp->d_type;
 
       TmpOffset += Tmp->d_reclen;
+
+      if (FEX::HLE::_SyscallHandler->FM.IsRootFSFD(fd, Outgoing->d_ino)) {
+        continue;
+      }
+
       // Outgoing is 5 bytes smaller
       Offset += NewRecLen;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
@@ -694,8 +694,6 @@ namespace x64 {
                                          SyscallPassthrough6<SYSCALL_DEF(futex)>);
     REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(io_getevents, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                          SyscallPassthrough5<SYSCALL_DEF(io_getevents)>);
-    REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(getdents64, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
-                                         SyscallPassthrough3<SYSCALL_DEF(getdents64)>);
     REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(semtimedop, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                          SyscallPassthrough4<SYSCALL_DEF(semtimedop)>);
     REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(timer_create, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
@@ -600,6 +600,11 @@ void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
       for (size_t i = 0, num = 0; i < Result; ++num) {
         linux_dirent_64* Incoming = (linux_dirent_64*)(reinterpret_cast<uint64_t>(dirp) + i);
         Incoming->d_off = num;
+        if (FEX::HLE::_SyscallHandler->FM.IsRootFSFD(fd, Incoming->d_ino)) {
+          Result -= Incoming->d_reclen;
+          memmove(Incoming, (linux_dirent_64*)(reinterpret_cast<uint64_t>(Incoming) + Incoming->d_reclen), Result - i);
+          continue;
+        }
         i += Incoming->d_reclen;
       }
     }


### PR DESCRIPTION
Chromium/CEF has code that iterates through all open FDs and bails if any are directories (apparently a sandboxing sanity check). To avoid this check, we need to hide the RootFS FD. This requires hooking all the getdents variants to skip that entry.

To keep the runtime cost low, we keep track of the inode of /proc/self/fd/<rootfs fd> (note: not the RootFS inode, the inode of the magic symlink in /proc), and first do a quick check on that. If it matches, then we stat the dirfd we are reading and check against the procfs device, to complete the inode equality check.

As an extra benefit, this also fixes code that tries to iterate and close all/extra FDs and ends up closing the RootFS fd.