### PR TITLE
Add some more tests as unsupported by vixl

### DIFF
--- a/unittests/32Bit_ASM/Disabled_Tests_Simulator
+++ b/unittests/32Bit_ASM/Disabled_Tests_Simulator
@@ -1,3 +1,2 @@
-# Simulator can't handle all rounding modes
-Test_X87/RoundingPos.asm
-Test_X87/RoundingNeg.asm
+# Simulator can't handle `mrs x0, nzcv`
+Test_32Bit_SecondaryModRM/Reg_7_1.asm

--- a/unittests/ASM/Disabled_Tests_Simulator
+++ b/unittests/ASM/Disabled_Tests_Simulator
@@ -26,6 +26,12 @@ Test_SelfModifyingCode/Delinking.asm
 Test_SelfModifyingCode/DifferentBlock.asm
 Test_SelfModifyingCode/SameBlock.asm
 
+# Simulator can't do wfe
+Test_Primary/Pause.asm
+
+# Simulator can't handle `mrs x0, nzcv`
+Test_SecondaryModRM/Reg_7_1.asm
+
 # Simulator can't handle unaligned accesses
 Test_Primary/Primary_01_Atomic16.asm
 Test_Primary/Primary_01_Atomic32.asm

--- a/unittests/ASM/Disabled_Tests_Simulator
+++ b/unittests/ASM/Disabled_Tests_Simulator
@@ -114,7 +114,6 @@ Test_VEX/vcvtps2ph_rtne_mxcsr.asm
 Test_VEX/vcvtps2ph_rd_mxcsr.asm
 Test_VEX/vcvtps2ph_ru_mxcsr.asm
 Test_VEX/vcvtps2ph_trunc_mxcsr.asm
-Test_X87/Rounding.asm
 Test_X87_F64/Rounding_F64.asm
 
 # Simulator doesn't support cycle counter reading


### PR DESCRIPTION
It seems a form of `mrs` is unsupported as well as the hint `wfe` used for `pause`.

Remove skipping Rounding(Neg|Pos).asm as they are passing.
