### PR TITLE
Check if a candidate home directory exists before using it

### DIFF
--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -439,17 +439,17 @@ const char* GetHomeDirectory() {
   const char* HomeDir = getenv("HOME");
 
   // Try to get home directory from uid
-  if (!HomeDir) {
+  if (!HomeDir || !FHU::Filesystem::Exists(HomeDir)) {
     HomeDir = FindUserHomeThroughUID();
   }
 
   // try the PWD
-  if (!HomeDir) {
+  if (!HomeDir || !FHU::Filesystem::Exists(HomeDir)) {
     HomeDir = getenv("PWD");
   }
 
   // Still doesn't exit? You get local
-  if (!HomeDir) {
+  if (!HomeDir || !FHU::Filesystem::Exists(HomeDir)) {
     HomeDir = ".";
   }
 


### PR DESCRIPTION
This allows FEX to be used in situations where `HOME` is set to something invalid, e.g. inside Nix builds.