### PR TITLE
FileManagement: Hide the FEX RootFS fd from /proc/self/fd take 2

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
@@ -161,7 +161,9 @@ private:
   FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
   uint32_t CurrentPID {};
   int RootFSFD {AT_FDCWD};
+  int ProcFD {0};
   int64_t RootFSFDInode = 0;
+  int64_t ProcFDInode = 0;
   dev_t ProcFSDev;
 };
 } // namespace FEX::HLE


### PR DESCRIPTION
Apparently Chromium/CEF can chroot or otherwise sandbox the filesystem away before forking and checking for directory FDs, making /proc inaccessible, which means we can't stat it for our inode check, breaking the hiding.

So, double down on things and do what Chromium does: open an fd to /proc ahead of time, so that continues to work. Then we use it to update the inode of our RootFS fd instead, and finally, also do the /proc fd itself to hide that one too.

We also don't need to check the st_dev of /proc more than once, since that's not expected to change anyway.

Fixes cefsimple.