### PR TITLE
FEXServer: Listen on both abstract & named sockets

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -96,14 +96,21 @@ fextl::string GetServerRootFSLockFile() {
 }
 
 fextl::string GetTempFolder() {
-  auto XDGRuntimeEnv = getenv("XDG_RUNTIME_DIR");
-  if (XDGRuntimeEnv) {
-    // If the XDG runtime directory works then use that.
-    return XDGRuntimeEnv;
+  const std::array<const char*, 5> Vars = {
+    "XDG_RUNTIME_DIR", "TMPDIR", "TMP", "TEMP", "TEMPDIR",
+  };
+
+  for (auto& Var : Vars) {
+    auto Path = getenv(Var);
+    if (Path) {
+      // If one of the env variable-driven paths works then use that.
+      return Path;
+    }
   }
-  // Fallback to `/tmp/` if XDG_RUNTIME_DIR doesn't exist.
+
+  // Fallback to `/tmp/` if no env vars are set.
   // Might not be ideal but we don't have much of a choice.
-  return fextl::string {std::filesystem::temp_directory_path().string()};
+  return fextl::string {"/tmp"};
 }
 
 fextl::string GetServerMountFolder() {

--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -160,7 +160,7 @@ int ConnectToServer(ConnectionOption ConnectionOption) {
   // Create the initial unix socket
   int SocketFD = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (SocketFD == -1) {
-    LogMan::Msg::EFmt("Couldn't open AF_UNIX socket {} {}", errno, strerror(errno));
+    LogMan::Msg::EFmt("Couldn't open AF_UNIX socket {}", errno);
     return -1;
   }
 
@@ -177,7 +177,7 @@ int ConnectToServer(ConnectionOption ConnectionOption) {
 
   if (connect(SocketFD, reinterpret_cast<struct sockaddr*>(&addr), SizeOfAddr) == -1) {
     if (ConnectionOption == ConnectionOption::Default || errno != ECONNREFUSED) {
-      LogMan::Msg::EFmt("Couldn't connect to FEXServer socket {} {} {}", ServerSocketName, errno, strerror(errno));
+      LogMan::Msg::EFmt("Couldn't connect to FEXServer socket {} {}", ServerSocketName, errno);
     }
     close(SocketFD);
     return -1;

--- a/Source/Common/FEXServerClient.h
+++ b/Source/Common/FEXServerClient.h
@@ -53,6 +53,7 @@ fextl::string GetServerRootFSLockFile();
 fextl::string GetTempFolder();
 fextl::string GetServerMountFolder();
 fextl::string GetServerSocketName();
+fextl::string GetServerSocketPath();
 int GetServerFD();
 
 bool SetupClient(char* InterpreterPath);

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -163,7 +163,13 @@ int main(int argc, char** argv, char** const envp) {
     return -1;
   }
 
-  if (!ProcessPipe::InitializeServerSocket()) {
+  if (!ProcessPipe::InitializeServerSocket(true)) {
+    // Couldn't create server socket for some reason
+    PipeScanner::ClosePipes();
+    return -1;
+  }
+
+  if (!ProcessPipe::InitializeServerSocket(false)) {
     // Couldn't create server socket for some reason
     PipeScanner::ClosePipes();
     return -1;

--- a/Source/Tools/FEXServer/ProcessPipe.h
+++ b/Source/Tools/FEXServer/ProcessPipe.h
@@ -4,7 +4,7 @@
 
 namespace ProcessPipe {
 bool InitializeServerPipe();
-bool InitializeServerSocket();
+bool InitializeServerSocket(bool abstract);
 void WaitForRequests();
 void SetConfiguration(bool Foreground, uint32_t PersistentTimeout);
 void Shutdown();

--- a/docs/ProgrammingConcerns.md
+++ b/docs/ProgrammingConcerns.md
@@ -79,6 +79,9 @@ Use `FHU::Filesystem::GetFilename` instead.
 #### std::filesystem::copy_file
 Use `FHU::Filesystem::CopyFile` instead.
 
+#### std::filesystem::temp_directory_path
+See `GetTempFolder()` in `FEXServerClient.cpp` (split/move to `FHU::Filesystem` if needed by other users).
+
 ### `std::fstream`
 This API always allocates memory and should be avoided.
 Use a combination of open and fextl::string APIs instead of fstream.


### PR DESCRIPTION
Abstract sockets have one limitation: they are bound to a network namespace. Chromium/CEF sandboxes using a new netns, which breaks connecting to the FEXServer.

To work around this, use and try *both* abstract and named sockets. As long as either the filesystem or the network is unsandboxed, things will work. If both are sandboxed, there isn't much we can do... but at that point we shouldn't be reinitializing the FEXServer connection anyway since the FS should be available on FEXInterpreter startup.