### PR TITLE
FEXLoader: Align stack base

### DIFF
--- a/Source/Tools/FEXLoader/ELFCodeLoader.h
+++ b/Source/Tools/FEXLoader/ELFCodeLoader.h
@@ -725,6 +725,9 @@ public:
     uint64_t ExecFNLocation = TotalArgumentMemSize;
     TotalArgumentMemSize += Args[0].size() + 1;
 
+    // Align the argument block to 16 bytes to keep the stack aligned
+    TotalArgumentMemSize = FEXCore::AlignUp(TotalArgumentMemSize, 16);
+
     // Offset the stack by how much memory we need
     StackPointer -= TotalArgumentMemSize;
 


### PR DESCRIPTION
This ensures that __libc_stack_end is aligned, the same way it is on native.