### PR TITLE
Avoid warning on assertionless builds

### DIFF
--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -641,8 +641,7 @@ def print_ir_allocator_helpers():
     output_file.write("\t}\n\n")
 
     output_file.write("\tuint8_t GetOpElements(const OrderedNode *Op) const {\n")
-    output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n")
-    output_file.write("\t\tLOGMAN_THROW_A_FMT(OpHasDest(Op), \"Op {} has no dest\\n\", GetName(HeaderOp->Op));\n")
+    output_file.write("\t\tLOGMAN_THROW_A_FMT(OpHasDest(Op), \"Op {} has no dest\\n\", GetOpName(Op));\n")
     output_file.write("\t\treturn IR::OpSizeToSize(GetOpSize(Op)) / IR::OpSizeToSize(GetOpElementSize(Op));\n")
     output_file.write("\t}\n\n")
 


### PR DESCRIPTION
This was causing unused variable warning due
to the variable only being used in an assertion.