### PR TITLE
OpcodeDispatcher: Mark CF as being possibly set after inverting

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1730,6 +1730,7 @@ private:
       }
 
       CFInverted ^= true;
+      PossiblySetNZCVBits |= 1u << IndexNZCV(FEXCore::X86State::RFLAG_CF_RAW_LOC);
     }
 
     LOGMAN_THROW_AA_FMT(CFInverted == RequiredInvert, "post condition");

--- a/unittests/32Bit_ASM/FEX_bugs/InvertedCarrySet.asm
+++ b/unittests/32Bit_ASM/FEX_bugs/InvertedCarrySet.asm
@@ -1,0 +1,27 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "1"
+  },
+  "Mode": "32BIT"
+}
+%endif
+
+; FEX had a bug where inverting CF to match the ABI when flushing the register cache didn't mark CF as possibly being set.
+; This caused accesses relying on that flag to be set correctly to return wrong values.
+
+mov esp, 0xe0000020
+mov al, 3
+mov cl, 2
+mov ecx, 1
+mov eax, 1
+
+and al, cl ; Zeros CF, non-inverted
+push ecx ; Triggers a register cache flush
+inc eax ; Tries to preserve CF, but would encounter the bug and set it instead
+jnb succ
+mov eax, 0
+hlt
+succ:
+mov eax, 1
+hlt


### PR DESCRIPTION
Required as if for example CF is non-inverted, code zeroing it doesn't need to mark it as being possibly set, however after inverting it will now be set. To be safe, always mark it as possibly set after inversion.

Fixes crashes with MaxInst > 2 in Uplay