### PR TITLE
WOW64: Set the software CPU area flag

### DIFF
--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -449,6 +449,9 @@ static void RethrowGuestException(const EXCEPTION_RECORD& Rec, ARM64_NT_CONTEXT&
   Args->Rec = FEX::Windows::HandleGuestException(Fault, Rec, Args->Context.Pc, Args->Context.X8);
   if (Args->Rec.ExceptionCode == EXCEPTION_SINGLE_STEP) {
     Args->Context.Cpsr &= ~(1 << 21); // PSTATE.SS
+  } else if (Args->Rec.ExceptionCode == EXCEPTION_BREAKPOINT) {
+    // INT3 will set RIP to the instruction following it, undo this (any edge cases with multibyte instructions that trigger breakpoints are bugs present in Windows also)
+    Args->Context.Pc -= 1;
   }
 
   Context.Sp = reinterpret_cast<uint64_t>(Args);

--- a/Source/Windows/Common/Exception.h
+++ b/Source/Windows/Common/Exception.h
@@ -29,8 +29,7 @@ HandleGuestException(FEXCore::Core::CpuStateFrame::SynchronousFaultDataStruct& F
     switch (Fault.TrapNo) {
     case FEXCore::X86State::X86_TRAPNO_DB: Dst.ExceptionCode = EXCEPTION_SINGLE_STEP; return Dst;
     case FEXCore::X86State::X86_TRAPNO_BP:
-      Rip -= 1;
-      Dst.ExceptionAddress = reinterpret_cast<void*>(Rip);
+      Dst.ExceptionAddress = reinterpret_cast<void*>(Rip - 1);
       Dst.ExceptionCode = EXCEPTION_BREAKPOINT;
       Dst.NumberParameters = 1;
       Dst.ExceptionInformation[0] = 0;
@@ -44,9 +43,9 @@ HandleGuestException(FEXCore::Core::CpuStateFrame::SynchronousFaultDataStruct& F
       if ((Fault.err_code & 0b111) == 0b010) {
         switch (Fault.err_code >> 3) {
         case 0x2d:
-          Rip += 2;
+          Rip += 3;
           Dst.ExceptionCode = EXCEPTION_BREAKPOINT;
-          Dst.ExceptionAddress = reinterpret_cast<void*>(Rip + 1);
+          Dst.ExceptionAddress = reinterpret_cast<void*>(Rip);
           Dst.NumberParameters = 1;
           Dst.ExceptionInformation[0] = Rax; // RAX
           // Note that ExceptionAddress doesn't equal the reported context RIP here, this discrepancy expected and not having it can trigger anti-debug logic.

--- a/Source/Windows/include/winternl.h
+++ b/Source/Windows/include/winternl.h
@@ -13,7 +13,10 @@ extern "C" {
 #define NtCurrentProcess() ((HANDLE) ~(ULONG_PTR)0)
 #define NtCurrentThread() ((HANDLE) ~(ULONG_PTR)1)
 
+#define WOW64_TLS_WOW64INFO 10
 #define WOW64_TLS_MAX_NUMBER 19
+
+#define WOW64_CPUFLAGS_SOFTWARE 0x02
 
 #define STATUS_EMULATION_SYSCALL ((NTSTATUS)0x40000039)
 
@@ -342,6 +345,16 @@ typedef struct __TEB {                          /* win32/win64 */
   GUID EffectiveContainerId;      /* ff0/1828 */
 } __TEB, *__PTEB;
 
+typedef struct _WOW64INFO {
+  ULONG NativeSystemPageSize;
+  ULONG CpuFlags;
+  ULONG Wow64ExecuteFlags;
+  ULONG unknown;
+  ULONGLONG SectionHandle;
+  ULONGLONG CrossProcessWorkList;
+  USHORT NativeMachineType;
+  USHORT EmulatedMachineType;
+} WOW64INFO;
 
 typedef struct _THREAD_BASIC_INFORMATION {
   NTSTATUS ExitStatus;


### PR DESCRIPTION
This is required for wow64.dll to setup the cross-process queue that is used to pass through e.g. memory unmap events.