### PR TITLE
CMake: Generate test list even when testing is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,10 +412,13 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/Config.h.in
   ${CMAKE_BINARY_DIR}/generated/ConfigDefines.h)
 
+include(CTest)
 if (BUILD_TESTS)
-  include(CTest)
-  enable_testing()
   message(STATUS "Unit tests are enabled")
+  if (NOT BUILD_TESTING)
+    # CMake checks this variable before generating CTestTestfile.cmake
+    message(SEND_ERROR "Unit tests require BUILD_TESTING to be enabled")
+  endif()
 
   set (TEST_JOB_COUNT "" CACHE STRING "Override number of parallel jobs to use while running tests")
   if (TEST_JOB_COUNT)


### PR DESCRIPTION
Previously, running ctest with BUILD_TESTS=OFF would discover and execute leftover tests from a previous build. This change ensures CTestTestfile.cmake gets regenerated so that ctest will see an empty test list in that case.

NOTE: `include(CTest)` automatically calls `enable_testing` if `BUILD_TESTING=ON`, so that line has been removed. To ensure `BUILD_TESTS=OFF` produces an empty test list, the CTest module is included unconditionally.
