### PR TITLE
FEXCore: Moves TLS initialization for Alloc::OSAllocator

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -124,7 +124,6 @@ public:
    *    - ExecutionThread(Thread); // Starts executing without creating another host thread
    *  Thunk callback executing guest code from native host thread
    *    - Thread = CreateThread(0, 0, NewState, PPID);
-   *    - InitializeThreadTLSData(Thread);
    *    - HandleCallback(Thread, RIP);
    */
 
@@ -139,7 +138,7 @@ public:
    *
    * @param Thread The internal FEX thread state object
    */
-  void DestroyThread(FEXCore::Core::InternalThreadState* Thread, bool NeedsTLSUninstall) override;
+  void DestroyThread(FEXCore::Core::InternalThreadState* Thread) override;
 
 #ifndef _WIN32
   void LockBeforeFork(FEXCore::Core::InternalThreadState* Thread) override;
@@ -303,13 +302,6 @@ public:
   uintptr_t CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_t GuestRIP, uint64_t MaxInst = 0);
 
   // Used for thread creation from syscalls
-  /**
-   * @brief Initializes TID, PID and TLS data for a thread
-   *
-   * @param Thread The internal FEX thread state object
-   */
-  void InitializeThreadTLSData(FEXCore::Core::InternalThreadState* Thread);
-
   void CopyMemoryMapping(FEXCore::Core::InternalThreadState* ParentThread, FEXCore::Core::InternalThreadState* ChildThread);
 
   uint8_t GetGPRSize() const {

--- a/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -32,14 +32,6 @@ namespace Alloc::OSAllocator {
 
 thread_local FEXCore::Core::InternalThreadState* TLSThread {};
 
-void RegisterTLSData(FEXCore::Core::InternalThreadState* Thread) {
-  TLSThread = Thread;
-}
-
-void UninstallTLSData(FEXCore::Core::InternalThreadState* Thread) {
-  TLSThread = nullptr;
-}
-
 class OSAllocator_64Bit final : public Alloc::HostAllocator {
 public:
   OSAllocator_64Bit();
@@ -585,3 +577,13 @@ fextl::unique_ptr<Alloc::HostAllocator> Create64BitAllocator() {
   return fextl::make_unique<OSAllocator_64Bit>();
 }
 } // namespace Alloc::OSAllocator
+
+namespace FEXCore::Allocator {
+void RegisterTLSData(FEXCore::Core::InternalThreadState* Thread) {
+  Alloc::OSAllocator::TLSThread = Thread;
+}
+
+void UninstallTLSData(FEXCore::Core::InternalThreadState* Thread) {
+  Alloc::OSAllocator::TLSThread = nullptr;
+}
+} // namespace FEXCore::Allocator

--- a/FEXCore/Source/Utils/Allocator/HostAllocator.h
+++ b/FEXCore/Source/Utils/Allocator/HostAllocator.h
@@ -48,7 +48,5 @@ public:
 } // namespace Alloc
 
 namespace Alloc::OSAllocator {
-void RegisterTLSData(FEXCore::Core::InternalThreadState* Thread);
-void UninstallTLSData(FEXCore::Core::InternalThreadState* Thread);
 fextl::unique_ptr<Alloc::HostAllocator> Create64BitAllocator();
 } // namespace Alloc::OSAllocator

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -169,7 +169,7 @@ public:
     uint64_t InitialRIP, uint64_t StackPointer, const FEXCore::Core::CPUState* NewThreadState = nullptr, uint64_t ParentTID = 0) = 0;
 
   FEX_DEFAULT_VISIBILITY virtual void ExecutionThread(FEXCore::Core::InternalThreadState* Thread) = 0;
-  FEX_DEFAULT_VISIBILITY virtual void DestroyThread(FEXCore::Core::InternalThreadState* Thread, bool NeedsTLSUninstall = false) = 0;
+  FEX_DEFAULT_VISIBILITY virtual void DestroyThread(FEXCore::Core::InternalThreadState* Thread) = 0;
 #ifndef _WIN32
   FEX_DEFAULT_VISIBILITY virtual void LockBeforeFork(FEXCore::Core::InternalThreadState* Thread) {}
   FEX_DEFAULT_VISIBILITY virtual void UnlockAfterFork(FEXCore::Core::InternalThreadState* Thread, bool Child) {}

--- a/FEXCore/include/FEXCore/Utils/Allocator.h
+++ b/FEXCore/include/FEXCore/Utils/Allocator.h
@@ -9,6 +9,10 @@
 #include <optional>
 #include <sys/types.h>
 
+namespace FEXCore::Core {
+struct InternalThreadState;
+}
+
 namespace FEXCore::Allocator {
 FEX_DEFAULT_VISIBILITY void SetupHooks();
 FEX_DEFAULT_VISIBILITY void ClearHooks();
@@ -83,4 +87,9 @@ FEX_DEFAULT_VISIBILITY void ReclaimMemoryRegion(const fextl::vector<MemoryRegion
 // Use this to reserve the top 128TB of VA so the guest never see it
 // Returns nullptr on host VA < 48bits
 FEX_DEFAULT_VISIBILITY fextl::vector<MemoryRegion> Steal48BitVA();
+
+#ifndef _WIN32
+FEX_DEFAULT_VISIBILITY void RegisterTLSData(FEXCore::Core::InternalThreadState* Thread);
+FEX_DEFAULT_VISIBILITY void UninstallTLSData(FEXCore::Core::InternalThreadState* Thread);
+#endif
 } // namespace FEXCore::Allocator

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -956,6 +956,8 @@ SignalDelegator::~SignalDelegator() {
 }
 
 void SignalDelegator::RegisterTLSState(FEX::HLE::ThreadStateObject* Thread) {
+  FEXCore::Allocator::RegisterTLSData(Thread->Thread);
+
   Thread->SignalInfo.Delegator = this;
 
   // Set up our signal alternative stack
@@ -999,6 +1001,8 @@ void SignalDelegator::UninstallTLSState(FEX::HLE::ThreadStateObject* Thread) {
   if (Result == -1) {
     LogMan::Msg::EFmt("Failed to uninstall alternative signal stack {}", strerror(errno));
   }
+
+  FEXCore::Allocator::UninstallTLSData(Thread->Thread);
 }
 
 void SignalDelegator::FrontendRegisterHostSignalHandler(int Signal, bool Required) {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -62,7 +62,11 @@ void ThreadManager::HandleThreadDeletion(FEX::HLE::ThreadStateObject* Thread, bo
     }
   }
 
-  CTX->DestroyThread(Thread->Thread, NeedsTLSUninstall);
+  if (NeedsTLSUninstall) {
+    FEXCore::Allocator::UninstallTLSData(Thread->Thread);
+  }
+
+  CTX->DestroyThread(Thread->Thread);
   FEX::HLE::_SyscallHandler->SeccompEmulator.FreeSeccompFilters(Thread);
 
   delete Thread;


### PR DESCRIPTION
Alloc::OSAllocator uses a TLS variable of the thread object so it can use a forkable mutex plus a deferring signal section. This was setup when the FEXCore "ExecutionThread" function is called, which is a bit awkward and is an artifact from when the thread creation was mixed between the frontend and the backend.

Instead let the frontend inform the backend when to install the TLS variable.

This is one step required to make GdbServer work correctly again since the thread initialization and pausing is awkward today.