### PR TITLE
FEXCore: Removes EarlyExit running event

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -899,17 +899,15 @@ void ContextImpl::ExecutionThread(FEXCore::Core::InternalThreadState* Thread) {
     Thread->StartRunning.Wait();
   }
 
-  if (!Thread->RunningEvents.EarlyExit.load()) {
-    Thread->RunningEvents.WaitingToStart = false;
+  Thread->RunningEvents.WaitingToStart = false;
 
-    Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_NONE;
+  Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_NONE;
 
-    Thread->RunningEvents.Running = true;
+  Thread->RunningEvents.Running = true;
 
-    static_cast<ContextImpl*>(Thread->CTX)->Dispatcher->ExecuteDispatch(Thread->CurrentFrame);
+  static_cast<ContextImpl*>(Thread->CTX)->Dispatcher->ExecuteDispatch(Thread->CurrentFrame);
 
-    Thread->RunningEvents.Running = false;
-  }
+  Thread->RunningEvents.Running = false;
 
   {
     // Ensure the Code Object Serialization service has fully serialized this thread's data before clearing the cache

--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -83,7 +83,6 @@ struct InternalThreadState : public FEXCore::Allocator::FEXAllocOperators {
   struct {
     std::atomic_bool Running {false};
     std::atomic_bool WaitingToStart {true};
-    std::atomic_bool EarlyExit {false};
     std::atomic_bool ThreadSleeping {false};
   } RunningEvents;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -166,7 +166,6 @@ void ThreadManager::Stop(bool IgnoreCurrentThread) {
       // If the thread is waiting to start but immediately killed then there can be a hang
       // This occurs in the case of gdb attach with immediate kill
       if (Thread->Thread->RunningEvents.WaitingToStart.load()) {
-        Thread->Thread->RunningEvents.EarlyExit = true;
         Thread->Thread->StartRunning.NotifyAll();
       }
     }


### PR DESCRIPTION
This was working around an edge case in the GdbServer where a thread was getting created while the process was shutting down. This edge case is getting removed so get rid of it.