### PR TITLE
FEXCore: Moves SignalThread/SignalEvent to Frontend

### DIFF
--- a/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -15,14 +15,6 @@ namespace FEXCore {
 namespace Core {
   struct InternalThreadState;
 
-  enum class SignalEvent {
-    Nothing, // If the guest uses our signal we need to know it was errant on our end
-    Pause,
-    Stop,
-    Return,
-    ReturnRT,
-  };
-
   enum SignalNumber {
 #ifndef _WIN32
     FAULT_SIGSEGV = SIGSEGV,
@@ -77,14 +69,6 @@ public:
   const SignalDelegatorConfig& GetConfig() const {
     return Config;
   }
-
-  /**
-   * @brief Signals a thread with a specific core event.
-   *
-   * @param Thread Which thread to signal.
-   * @param Event Which event to signal the event with.
-   */
-  virtual void SignalThread(FEXCore::Core::InternalThreadState* Thread, Core::SignalEvent Event) = 0;
 
 protected:
   SignalDelegatorConfig Config;

--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -88,7 +88,6 @@ struct InternalThreadState : public FEXCore::Allocator::FEXAllocOperators {
   } RunningEvents;
 
   FEXCore::Context::Context* CTX;
-  std::atomic<SignalEvent> SignalReason {SignalEvent::Nothing};
 
   NonMovableUniquePtr<FEXCore::Threads::Thread> ExecutionThread;
   bool StartPaused {false};

--- a/Source/Tools/CommonTools/DummyHandlers.h
+++ b/Source/Tools/CommonTools/DummyHandlers.h
@@ -25,8 +25,6 @@ public:
 
 class DummySignalDelegator final : public FEXCore::SignalDelegator, public FEXCore::Allocator::FEXAllocOperators {
 public:
-  void SignalThread(FEXCore::Core::InternalThreadState* Thread, FEXCore::Core::SignalEvent Event) override {}
-
   FEXCore::Core::InternalThreadState* GetBackingTLSThread() {
     return GetTLSThread();
   }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -124,7 +124,13 @@ public:
     FEX_UNREACHABLE;
   }
 
-  void SignalThread(FEXCore::Core::InternalThreadState* Thread, FEXCore::Core::SignalEvent Event) override;
+  /**
+   * @brief Signals a thread with a specific core event.
+   *
+   * @param Thread Which thread to signal.
+   * @param Event Which event to signal the event with.
+   */
+  void SignalThread(FEXCore::Core::InternalThreadState* Thread, SignalEvent Event);
 
   FEXCore::ArchHelpers::Arm64::UnalignedHandlerType GetUnalignedHandlerType() const {
     return UnalignedHandlerType;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -42,7 +42,7 @@ void ThreadManager::DestroyThread(FEX::HLE::ThreadStateObject* Thread, bool Need
 
 void ThreadManager::StopThread(FEX::HLE::ThreadStateObject* Thread) {
   if (Thread->Thread->RunningEvents.Running.exchange(false)) {
-    SignalDelegation->SignalThread(Thread->Thread, FEXCore::Core::SignalEvent::Stop);
+    SignalDelegation->SignalThread(Thread->Thread, SignalEvent::Stop);
   }
 }
 
@@ -74,7 +74,7 @@ void ThreadManager::NotifyPause() {
   // Tell all the threads that they should pause
   std::lock_guard lk(ThreadCreationMutex);
   for (auto& Thread : Threads) {
-    SignalDelegation->SignalThread(Thread->Thread, FEXCore::Core::SignalEvent::Pause);
+    SignalDelegation->SignalThread(Thread->Thread, SignalEvent::Pause);
   }
 }
 
@@ -87,7 +87,7 @@ void ThreadManager::Run() {
   // Spin up all the threads
   std::lock_guard lk(ThreadCreationMutex);
   for (auto& Thread : Threads) {
-    Thread->Thread->SignalReason.store(FEXCore::Core::SignalEvent::Return);
+    Thread->SignalReason.store(SignalEvent::Return);
   }
 
   for (auto& Thread : Threads) {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -22,6 +22,14 @@ namespace FEX::HLE {
 class SyscallHandler;
 class SignalDelegator;
 
+enum class SignalEvent : uint32_t {
+  Nothing, // If the guest uses our signal we need to know it was errant on our end
+  Pause,
+  Stop,
+  Return,
+  ReturnRT,
+};
+
 struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
   FEXCore::Core::InternalThreadState* Thread;
 
@@ -58,6 +66,9 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
 
   // personality emulation.
   uint32_t persona {};
+
+  // Thread signaling information
+  std::atomic<SignalEvent> SignalReason {SignalEvent::Nothing};
 };
 
 class ThreadManager final {


### PR DESCRIPTION
This is purely a Linux frontend construct now, move it.