### PR TITLE
FEXCore: Moves DeferredSignalFrames to the frontend

### DIFF
--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -110,17 +110,6 @@ struct InternalThreadState : public FEXCore::Allocator::FEXAllocOperators {
 
   std::shared_mutex ObjectCacheRefCounter {};
 
-  struct DeferredSignalState {
-#ifndef _WIN32
-    siginfo_t Info;
-#endif
-    int Signal;
-  };
-
-  // Queue of thread local signal frames that have been deferred.
-  // Async signals aren't guaranteed to be delivered in any particular order, but FEX treats them as FILO.
-  fextl::vector<DeferredSignalState> DeferredSignalFrames;
-
   ///< Data pointer for exclusive use by the frontend
   void* FrontendPtr;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -23,6 +23,11 @@ class SyscallHandler;
 class SignalDelegator;
 
 struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
+  struct DeferredSignalState {
+    siginfo_t Info;
+    int Signal;
+  };
+
   FEXCore::Core::InternalThreadState* Thread;
 
   struct {
@@ -50,6 +55,9 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
 
     uint64_t PendingSignals {};
 
+    // Queue of thread local signal frames that have been deferred.
+    // Async signals aren't guaranteed to be delivered in any particular order, but FEX treats them as FILO.
+    fextl::vector<DeferredSignalState> DeferredSignalFrames;
   } SignalInfo {};
 
   // Seccomp thread specific data.


### PR DESCRIPTION
Deferred signal frames are a frontend construct. Move it there.