### PR TITLE
FEXCore: Moves StatusCode to the frontend

### DIFF
--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -102,7 +102,6 @@ struct InternalThreadState : public FEXCore::Allocator::FEXAllocOperators {
   NonMovableUniquePtr<FEXCore::IR::PassManager> PassManager;
   NonMovableUniquePtr<JITSymbolBuffer> SymbolBuffer;
 
-  int StatusCode {};
   FEXCore::Context::ExitReason ExitReason {FEXCore::Context::ExitReason::EXIT_WAITING};
   std::shared_ptr<FEXCore::CompileService> CompileService;
 

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -674,7 +674,7 @@ int main(int argc, char** argv, char** const envp) {
     }
   }
 
-  auto ProgramStatus = ParentThread->Thread->StatusCode;
+  auto ProgramStatus = ParentThread->StatusCode;
 
   SignalDelegation->UninstallTLSState(ParentThread);
   SyscallHandler->TM.DestroyThread(ParentThread);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -226,7 +226,7 @@ uint64_t HandleNewClone(FEX::HLE::ThreadStateObject* Thread, FEXCore::Context::C
   FEX::HLE::_SyscallHandler->UninstallTLSState(Thread);
 
   // The rest of the context remains as is and the thread will continue executing
-  return Thread->Thread->StatusCode;
+  return Thread->StatusCode;
 }
 
 static int Clone3Fork(uint32_t flags) {
@@ -390,8 +390,6 @@ void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
 
   REGISTER_SYSCALL_IMPL_FLAGS(exit, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY | SyscallFlags::NORETURN,
                               [](FEXCore::Core::CpuStateFrame* Frame, int status) -> uint64_t {
-                                auto Thread = Frame->Thread;
-
                                 // TLS/DTV teardown is something FEX can't control. Disable glibc checking when we leave a pthread.
                                 // Since this thread is hard stopping, we can't track the TLS/DTV teardown in FEX's thread handling.
                                 FEXCore::Allocator::YesIKnowImNotSupposedToUseTheGlibcAllocator::HardDisable();
@@ -403,7 +401,7 @@ void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
                                   syscall(SYSCALL_DEF(futex), ThreadObject->ThreadInfo.clear_child_tid, FUTEX_WAKE, ~0ULL, 0, 0, 0);
                                 }
 
-                                Thread->StatusCode = status;
+                                ThreadObject->StatusCode = status;
                                 FEX::HLE::_SyscallHandler->TM.StopThread(ThreadObject);
 
                                 return 0;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -77,6 +77,8 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
 
   // Thread signaling information
   std::atomic<SignalEvent> SignalReason {SignalEvent::Nothing};
+
+  int StatusCode {};
 };
 
 class ThreadManager final {


### PR DESCRIPTION
This is a Linux construct, move it to the frontend.

This is going to need some changes in the future since exit_group and exit syscalls are supposed to behave differently than how FEX implements it. For now just move it to the frontend.