### PR TITLE
FEXCore: Moves ThreadWaiting to the frontend 

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -873,9 +873,6 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
 void ContextImpl::ExecutionThread(FEXCore::Core::InternalThreadState* Thread) {
   Thread->ExitReason = FEXCore::Context::ExitReason::EXIT_WAITING;
 
-  // Now notify the thread that we are initialized
-  Thread->ThreadWaiting.NotifyAll();
-
   if (Thread->StartPaused) {
     // Parent thread doesn't need to wait to run
     Thread->StartRunning.Wait();

--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -91,7 +91,6 @@ struct InternalThreadState : public FEXCore::Allocator::FEXAllocOperators {
   NonMovableUniquePtr<FEXCore::Threads::Thread> ExecutionThread;
   bool StartPaused {false};
   InterruptableConditionVariable StartRunning;
-  Event ThreadWaiting;
 
   NonMovableUniquePtr<FEXCore::IR::OpDispatchBuilder> OpDispatcher;
 


### PR DESCRIPTION
Only in one location does the frontend actually care about this, the
backend doesn't care at all.