### PR TITLE
FEXCore: Constify CTX ptr in InternalThreadState

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -394,8 +394,6 @@ void ContextImpl::InitializeCompiler(FEXCore::Core::InternalThreadState* Thread)
 
   Dispatcher->InitThreadPointers(Thread);
 
-  Thread->CTX = this;
-
   Thread->PassManager->AddDefaultPasses(this);
   Thread->PassManager->AddDefaultValidationPasses();
 
@@ -410,7 +408,9 @@ void ContextImpl::InitializeCompiler(FEXCore::Core::InternalThreadState* Thread)
 
 FEXCore::Core::InternalThreadState*
 ContextImpl::CreateThread(uint64_t InitialRIP, uint64_t StackPointer, const FEXCore::Core::CPUState* NewThreadState, uint64_t ParentTID) {
-  FEXCore::Core::InternalThreadState* Thread = new FEXCore::Core::InternalThreadState {};
+  FEXCore::Core::InternalThreadState* Thread = new FEXCore::Core::InternalThreadState {
+    .CTX = this,
+  };
 
   Thread->CurrentFrame->State.gregs[X86State::REG_RSP] = StackPointer;
   Thread->CurrentFrame->State.rip = InitialRIP;

--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -86,7 +86,7 @@ struct InternalThreadState : public FEXCore::Allocator::FEXAllocOperators {
     std::atomic_bool ThreadSleeping {false};
   } RunningEvents;
 
-  FEXCore::Context::Context* CTX;
+  FEXCore::Context::Context* const CTX;
 
   NonMovableUniquePtr<FEXCore::Threads::Thread> ExecutionThread;
   bool StartPaused {false};


### PR DESCRIPTION
The CTX pointer in the InternalThreadState object will not and must not change, since it is associated with that CTX object.

Contify it to codify it.