### PR TITLE
FEXCore: Moves InternalThreadState ExecutionThread to the frontend

### DIFF
--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -88,7 +88,6 @@ struct InternalThreadState : public FEXCore::Allocator::FEXAllocOperators {
 
   FEXCore::Context::Context* const CTX;
 
-  NonMovableUniquePtr<FEXCore::Threads::Thread> ExecutionThread;
 
   NonMovableUniquePtr<FEXCore::IR::OpDispatchBuilder> OpDispatcher;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -661,7 +661,7 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args
 
     if (flags & CLONE_VFORK) {
       // If VFORK is set then the calling process is suspended until the thread exits with execve or exit
-      NewThread->Thread->ExecutionThread->join(nullptr);
+      NewThread->ExecutionThread->join(nullptr);
 
       // Normally a thread cleans itself up on exit. But because we need to join, we are now responsible
       FEX::HLE::_SyscallHandler->TM.DestroyThread(NewThread);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -111,7 +111,7 @@ FEX::HLE::ThreadStateObject* CreateNewThread(FEXCore::Context::Context* CTX, FEX
     .CTX = CTX,
     .Thread = NewThread,
   };
-  NewThread->Thread->ExecutionThread = FEXCore::Threads::Thread::Create(ThreadHandler, &Arg);
+  NewThread->ExecutionThread = FEXCore::Threads::Thread::Create(ThreadHandler, &Arg);
 
   // Wait for the thread to have started.
   Arg.ThreadWaiting.Wait();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -47,13 +47,13 @@ void ThreadManager::StopThread(FEX::HLE::ThreadStateObject* Thread) {
 }
 
 void ThreadManager::HandleThreadDeletion(FEX::HLE::ThreadStateObject* Thread, bool NeedsTLSUninstall) {
-  if (Thread->Thread->ExecutionThread) {
-    if (Thread->Thread->ExecutionThread->joinable()) {
-      Thread->Thread->ExecutionThread->join(nullptr);
+  if (Thread->ExecutionThread) {
+    if (Thread->ExecutionThread->joinable()) {
+      Thread->ExecutionThread->join(nullptr);
     }
 
-    if (Thread->Thread->ExecutionThread->IsSelf()) {
-      Thread->Thread->ExecutionThread->detach();
+    if (Thread->ExecutionThread->IsSelf()) {
+      Thread->ExecutionThread->detach();
     }
   }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -75,6 +75,8 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
   // personality emulation.
   uint32_t persona {};
 
+  FEXCore::Core::NonMovableUniquePtr<FEXCore::Threads::Thread> ExecutionThread;
+
   // Thread signaling information
   std::atomic<SignalEvent> SignalReason {SignalEvent::Nothing};
 


### PR DESCRIPTION
Once again this is another frontend construct, so move it to ThreadStateObject