### PR TITLE
FEXCore: Removes remaining RunningEvents from InternalThreadState 

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -868,14 +868,7 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
 }
 
 void ContextImpl::ExecutionThread(FEXCore::Core::InternalThreadState* Thread) {
-
-  Thread->RunningEvents.WaitingToStart = false;
-
-  Thread->RunningEvents.Running = true;
-
   static_cast<ContextImpl*>(Thread->CTX)->Dispatcher->ExecuteDispatch(Thread->CurrentFrame);
-
-  Thread->RunningEvents.Running = false;
 
   {
     // Ensure the Code Object Serialization service has fully serialized this thread's data before clearing the cache

--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -80,14 +80,7 @@ static_assert(!std::is_move_assignable_v<NonMovableUniquePtr<int>>);
 struct InternalThreadState : public FEXCore::Allocator::FEXAllocOperators {
   FEXCore::Core::CpuStateFrame* const CurrentFrame = &BaseFrameState;
 
-  struct {
-    std::atomic_bool Running {false};
-    std::atomic_bool WaitingToStart {true};
-    std::atomic_bool ThreadSleeping {false};
-  } RunningEvents;
-
   FEXCore::Context::Context* const CTX;
-
 
   NonMovableUniquePtr<FEXCore::IR::OpDispatchBuilder> OpDispatcher;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -475,7 +475,7 @@ bool SignalDelegator::HandleSignalPause(FEXCore::Core::InternalThreadState* Thre
     // We need to be a little bit careful here
     // If we were already paused (due to GDB) and we are immediately stopping (due to gdb kill)
     // Then we need to ensure we don't double decrement our idle thread counter
-    if (Thread->RunningEvents.ThreadSleeping) {
+    if (ThreadObject->ThreadSleeping) {
       // If the thread was sleeping then its idle counter was decremented
       // Reincrement it here to not break logic
       FEX::HLE::_SyscallHandler->TM.IncrementIdleRefCount();
@@ -500,10 +500,6 @@ bool SignalDelegator::HandleSignalPause(FEXCore::Core::InternalThreadState* Thre
 
 void SignalDelegator::SignalThread(FEXCore::Core::InternalThreadState* Thread, SignalEvent Event) {
   auto ThreadObject = FEX::HLE::ThreadManager::GetStateObjectFromFEXCoreThread(Thread);
-  if (Event == SignalEvent::Pause && Thread->RunningEvents.Running.load() == false) {
-    // Skip signaling a thread if it is already paused.
-    return;
-  }
   ThreadObject->SignalReason.store(Event);
   FHU::Syscalls::tgkill(ThreadObject->ThreadInfo.PID, ThreadObject->ThreadInfo.TID, SignalDelegator::SIGNAL_FOR_PAUSE);
 }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -81,6 +81,7 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
   std::atomic<SignalEvent> SignalReason {SignalEvent::Nothing};
 
   // Thread pause handling
+  std::atomic_bool ThreadSleeping {false};
   FEXCore::InterruptableConditionVariable ThreadPaused;
 
   int StatusCode {};


### PR DESCRIPTION
These are all frontend constructs with mostly deprecated constraints.
WaitingToStart isn't used anymore, Running is effectively always true
(and behaviour has changed that if a thread is alive, it's running).

The only one that remains is `ThreadSleeping` which is only handled in
the frontend, and there was some conflation between ThreadSleeping and
Running which was hard to gauge. So delete `Running` and
`WaitingToStart`, but move `ThreadSleeping` to the frontend.