### PR TITLE
FEXCore: Removes CoreShuttingDown from ContextImpl

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -234,8 +234,6 @@ public:
     FEX_CONFIG_OPT(StrictInProcessSplitLocks, STRICTINPROCESSSPLITLOCKS);
   } Config;
 
-  std::atomic_bool CoreShuttingDown {false};
-
   FEXCore::ForkableSharedMutex CodeInvalidationMutex;
 
   uint32_t StrictSplitLockMutex {};

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -366,8 +366,6 @@ void ContextImpl::HandleCallback(FEXCore::Core::InternalThreadState* Thread, uin
 void ContextImpl::RunUntilExit(FEXCore::Core::InternalThreadState* Thread) {
   ExecutionThread(Thread);
 
-  CoreShuttingDown.store(true);
-
   if (CustomExitHandler) {
     CustomExitHandler(Thread);
   }


### PR DESCRIPTION
This is unused now.

NFC