### PR TITLE
FEXCore: Removes stale function definition

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -301,9 +301,6 @@ public:
   CompileCodeResult CompileCode(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, uint64_t MaxInst = 0);
   uintptr_t CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_t GuestRIP, uint64_t MaxInst = 0);
 
-  // Used for thread creation from syscalls
-  void CopyMemoryMapping(FEXCore::Core::InternalThreadState* ParentThread, FEXCore::Core::InternalThreadState* ChildThread);
-
   uint8_t GetGPRSize() const {
     return Config.Is64BitMode ? 8 : 4;
   }


### PR DESCRIPTION
`CopyMemoryMapping` was removed a long time ago, the definition happened to remain. Remove the definition.