### PR TITLE
FEXCore: Override x87 precision control when necessary 

### DIFF
--- a/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/F80Fallbacks.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/F80Fallbacks.h
@@ -6,17 +6,20 @@
 #include "Interface/IR/IR.h"
 
 namespace FEXCore::CPU {
-FEXCORE_PRESERVE_ALL_ATTR static softfloat_state SoftFloatStateFromFCW(uint16_t FCW) {
+FEXCORE_PRESERVE_ALL_ATTR static softfloat_state SoftFloatStateFromFCW(uint16_t FCW, bool Force80BitPrecision = false) {
   softfloat_state State {};
   State.detectTininess = softfloat_tininess_afterRounding;
   State.exceptionFlags = 0;
+  State.roundingPrecision = 80;
 
-  auto PC = (FCW >> 8) & 3;
-  switch (PC) {
-  case 0: State.roundingPrecision = 32; break;
-  case 2: State.roundingPrecision = 64; break;
-  case 3: State.roundingPrecision = 80; break;
-  case 1: LOGMAN_MSG_A_FMT("Invalid x87 precision mode, {}", PC);
+  if (!Force80BitPrecision) {
+    auto PC = (FCW >> 8) & 3;
+    switch (PC) {
+    case 0: State.roundingPrecision = 32; break;
+    case 2: State.roundingPrecision = 64; break;
+    case 3: State.roundingPrecision = 80; break;
+    case 1: LOGMAN_MSG_A_FMT("Invalid x87 precision mode, {}", PC);
+    }
   }
 
   auto RC = (FCW >> 10) & 3;
@@ -132,7 +135,7 @@ struct OpHandlers<IR::OP_F80CVTTOINT> {
 template<>
 struct OpHandlers<IR::OP_F80ROUND> {
   FEXCORE_PRESERVE_ALL_ATTR static X80SoftFloat handle(uint16_t FCW, X80SoftFloat Src1) {
-    softfloat_state State = SoftFloatStateFromFCW(FCW);
+    softfloat_state State = SoftFloatStateFromFCW(FCW, true);
     return X80SoftFloat::FRNDINT(&State, Src1);
   }
 };
@@ -140,7 +143,7 @@ struct OpHandlers<IR::OP_F80ROUND> {
 template<>
 struct OpHandlers<IR::OP_F80F2XM1> {
   FEXCORE_PRESERVE_ALL_ATTR static X80SoftFloat handle(uint16_t FCW, X80SoftFloat Src1) {
-    softfloat_state State = SoftFloatStateFromFCW(FCW);
+    softfloat_state State = SoftFloatStateFromFCW(FCW, true);
     return X80SoftFloat::F2XM1(&State, Src1);
   }
 };
@@ -148,7 +151,7 @@ struct OpHandlers<IR::OP_F80F2XM1> {
 template<>
 struct OpHandlers<IR::OP_F80TAN> {
   FEXCORE_PRESERVE_ALL_ATTR static X80SoftFloat handle(uint16_t FCW, X80SoftFloat Src1) {
-    softfloat_state State = SoftFloatStateFromFCW(FCW);
+    softfloat_state State = SoftFloatStateFromFCW(FCW, true);
     return X80SoftFloat::FTAN(&State, Src1);
   }
 };
@@ -164,7 +167,7 @@ struct OpHandlers<IR::OP_F80SQRT> {
 template<>
 struct OpHandlers<IR::OP_F80SIN> {
   FEXCORE_PRESERVE_ALL_ATTR static X80SoftFloat handle(uint16_t FCW, X80SoftFloat Src1) {
-    softfloat_state State = SoftFloatStateFromFCW(FCW);
+    softfloat_state State = SoftFloatStateFromFCW(FCW, true);
     return X80SoftFloat::FSIN(&State, Src1);
   }
 };
@@ -172,7 +175,7 @@ struct OpHandlers<IR::OP_F80SIN> {
 template<>
 struct OpHandlers<IR::OP_F80COS> {
   FEXCORE_PRESERVE_ALL_ATTR static X80SoftFloat handle(uint16_t FCW, X80SoftFloat Src1) {
-    softfloat_state State = SoftFloatStateFromFCW(FCW);
+    softfloat_state State = SoftFloatStateFromFCW(FCW, true);
     return X80SoftFloat::FCOS(&State, Src1);
   }
 };
@@ -226,7 +229,7 @@ struct OpHandlers<IR::OP_F80DIV> {
 template<>
 struct OpHandlers<IR::OP_F80FYL2X> {
   FEXCORE_PRESERVE_ALL_ATTR static X80SoftFloat handle(uint16_t FCW, X80SoftFloat Src1, X80SoftFloat Src2) {
-    softfloat_state State = SoftFloatStateFromFCW(FCW);
+    softfloat_state State = SoftFloatStateFromFCW(FCW, true);
     return X80SoftFloat::FYL2X(&State, Src1, Src2);
   }
 };
@@ -234,7 +237,7 @@ struct OpHandlers<IR::OP_F80FYL2X> {
 template<>
 struct OpHandlers<IR::OP_F80ATAN> {
   FEXCORE_PRESERVE_ALL_ATTR static X80SoftFloat handle(uint16_t FCW, X80SoftFloat Src1, X80SoftFloat Src2) {
-    softfloat_state State = SoftFloatStateFromFCW(FCW);
+    softfloat_state State = SoftFloatStateFromFCW(FCW, true);
     return X80SoftFloat::FATAN(&State, Src1, Src2);
   }
 };
@@ -242,7 +245,7 @@ struct OpHandlers<IR::OP_F80ATAN> {
 template<>
 struct OpHandlers<IR::OP_F80FPREM1> {
   FEXCORE_PRESERVE_ALL_ATTR static X80SoftFloat handle(uint16_t FCW, X80SoftFloat Src1, X80SoftFloat Src2) {
-    softfloat_state State = SoftFloatStateFromFCW(FCW);
+    softfloat_state State = SoftFloatStateFromFCW(FCW, true);
     return X80SoftFloat::FREM1(&State, Src1, Src2);
   }
 };
@@ -250,7 +253,7 @@ struct OpHandlers<IR::OP_F80FPREM1> {
 template<>
 struct OpHandlers<IR::OP_F80FPREM> {
   FEXCORE_PRESERVE_ALL_ATTR static X80SoftFloat handle(uint16_t FCW, X80SoftFloat Src1, X80SoftFloat Src2) {
-    softfloat_state State = SoftFloatStateFromFCW(FCW);
+    softfloat_state State = SoftFloatStateFromFCW(FCW, true);
     return X80SoftFloat::FREM(&State, Src1, Src2);
   }
 };
@@ -258,7 +261,7 @@ struct OpHandlers<IR::OP_F80FPREM> {
 template<>
 struct OpHandlers<IR::OP_F80SCALE> {
   FEXCORE_PRESERVE_ALL_ATTR static X80SoftFloat handle(uint16_t FCW, X80SoftFloat Src1, X80SoftFloat Src2) {
-    softfloat_state State = SoftFloatStateFromFCW(FCW);
+    softfloat_state State = SoftFloatStateFromFCW(FCW, true);
     return X80SoftFloat::FSCALE(&State, Src1, Src2);
   }
 };

--- a/unittests/ASM/Disabled_Tests_Simulator
+++ b/unittests/ASM/Disabled_Tests_Simulator
@@ -1,3 +1,15 @@
+# Simulator on x86 doesn't pass these tests due to not using float128
+Test_X87/precision_test_fcos.asm
+Test_X87/precision_test_fsin.asm
+Test_X87/precision_test_ftan.asm
+Test_X87/precision_test_fatan.asm
+Test_X87/precision_test_fyl2xp1.asm
+Test_X87/precision_test_neg_fcos.asm
+Test_X87/precision_test_neg_fsin.asm
+Test_X87/precision_test_neg_ftan.asm
+Test_X87/precision_test_neg_fatan.asm
+Test_X87/precision_test_neg_fyl2xp1.asm
+
 # AES unsupported in simulator
 Test_H0F38/66_DB.asm
 Test_H0F38/66_DC.asm

--- a/unittests/ASM/Includes/x87cw.mac
+++ b/unittests/ASM/Includes/x87cw.mac
@@ -1,0 +1,34 @@
+%ifndef X87_CW_INC
+%define X87_CW_INC
+
+; Sets x87 precision and rounding modes
+; Uses the stack and clobbers rax
+; Args: precision constant, rounding constant
+%macro set_cw_precision_rounding 2
+  sub rsp, 2
+  fnstcw [rsp]
+  movzx ax, [rsp]
+
+  ; Precision
+  and eax, ~(3 << 8)
+  or eax, %1 << 8
+
+  ; Rounding
+  and eax, ~(3 << 10)
+  or eax, %2 << 10
+
+  mov [rsp], ax
+  fldcw [rsp]
+  add rsp, 2
+%endmacro
+
+x87_prec_32 equ 00b
+x87_prec_64 equ 10b
+x87_prec_80 equ 11b
+
+x87_round_nearest equ 00b
+x87_round_down equ 01b
+x87_round_up equ 10b
+x87_round_towards_zero equ 11b
+
+%endif

--- a/unittests/ASM/X87/precision_test_fabs.asm
+++ b/unittests/ASM/X87/precision_test_fabs.asm
@@ -1,0 +1,165 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0x3fff"],
+    "XMM1":  ["0x8111111111111111", "0x3fff"],
+    "XMM2":  ["0x8111111111111111", "0x3fff"],
+    "XMM3":  ["0x8111111111111111", "0x3fff"],
+    "XMM4":  ["0x8111111111111111", "0x3fff"],
+    "XMM5":  ["0x8111111111111111", "0x3fff"],
+    "XMM6":  ["0x8111111111111111", "0x3fff"],
+    "XMM7":  ["0x8111111111111111", "0x3fff"],
+    "XMM8":  ["0x8111111111111111", "0x3fff"],
+    "XMM9":  ["0x8111111111111111", "0x3fff"],
+    "XMM10":  ["0x8111111111111111", "0x3fff"],
+    "XMM11":  ["0x8111111111111111", "0x3fff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0x3fff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fadd.asm
+++ b/unittests/ASM/X87/precision_test_fadd.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0x3fff"],
+    "XMM1":  ["0x8111111111111000", "0x3fff"],
+    "XMM2":  ["0x8111110000000000", "0x3fff"],
+    "XMM3":  ["0x8111111111111111", "0x3fff"],
+    "XMM4":  ["0x8111111111111000", "0x3fff"],
+    "XMM5":  ["0x8111110000000000", "0x3fff"],
+    "XMM6":  ["0x8111111111111111", "0x3fff"],
+    "XMM7":  ["0x8111111111111800", "0x3fff"],
+    "XMM8":  ["0x8111120000000000", "0x3fff"],
+    "XMM9":  ["0x8111111111111111", "0x3fff"],
+    "XMM10":  ["0x8111111111111000", "0x3fff"],
+    "XMM11":  ["0x8111110000000000", "0x3fff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0x3fff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fcos.asm
+++ b/unittests/ASM/X87/precision_test_fcos.asm
@@ -1,0 +1,165 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM1":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM2":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM3":  ["0x86b5441382debef4", "0x3ffe"],
+    "XMM4":  ["0x86b5441382debef4", "0x3ffe"],
+    "XMM5":  ["0x86b5441382debef4", "0x3ffe"],
+    "XMM6":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM7":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM8":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM9":  ["0x86b5441382debef4", "0x3ffe"],
+    "XMM10":  ["0x86b5441382debef4", "0x3ffe"],
+    "XMM11":  ["0x86b5441382debef4", "0x3ffe"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0x3fff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fdiv.asm
+++ b/unittests/ASM/X87/precision_test_fdiv.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0x3fff"],
+    "XMM1":  ["0x8111111111111000", "0x3fff"],
+    "XMM2":  ["0x8111110000000000", "0x3fff"],
+    "XMM3":  ["0x8111111111111111", "0x3fff"],
+    "XMM4":  ["0x8111111111111000", "0x3fff"],
+    "XMM5":  ["0x8111110000000000", "0x3fff"],
+    "XMM6":  ["0x8111111111111111", "0x3fff"],
+    "XMM7":  ["0x8111111111111800", "0x3fff"],
+    "XMM8":  ["0x8111120000000000", "0x3fff"],
+    "XMM9":  ["0x8111111111111111", "0x3fff"],
+    "XMM10":  ["0x8111111111111000", "0x3fff"],
+    "XMM11":  ["0x8111110000000000", "0x3fff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0x3fff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fdivr.asm
+++ b/unittests/ASM/X87/precision_test_fdivr.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0x3fff"],
+    "XMM1":  ["0x8111111111111000", "0x3fff"],
+    "XMM2":  ["0x8111110000000000", "0x3fff"],
+    "XMM3":  ["0x8111111111111111", "0x3fff"],
+    "XMM4":  ["0x8111111111111000", "0x3fff"],
+    "XMM5":  ["0x8111110000000000", "0x3fff"],
+    "XMM6":  ["0x8111111111111111", "0x3fff"],
+    "XMM7":  ["0x8111111111111800", "0x3fff"],
+    "XMM8":  ["0x8111120000000000", "0x3fff"],
+    "XMM9":  ["0x8111111111111111", "0x3fff"],
+    "XMM10":  ["0x8111111111111000", "0x3fff"],
+    "XMM11":  ["0x8111110000000000", "0x3fff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0x3fff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fmul.asm
+++ b/unittests/ASM/X87/precision_test_fmul.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0x3fff"],
+    "XMM1":  ["0x8111111111111000", "0x3fff"],
+    "XMM2":  ["0x8111110000000000", "0x3fff"],
+    "XMM3":  ["0x8111111111111111", "0x3fff"],
+    "XMM4":  ["0x8111111111111000", "0x3fff"],
+    "XMM5":  ["0x8111110000000000", "0x3fff"],
+    "XMM6":  ["0x8111111111111111", "0x3fff"],
+    "XMM7":  ["0x8111111111111800", "0x3fff"],
+    "XMM8":  ["0x8111120000000000", "0x3fff"],
+    "XMM9":  ["0x8111111111111111", "0x3fff"],
+    "XMM10":  ["0x8111111111111000", "0x3fff"],
+    "XMM11":  ["0x8111110000000000", "0x3fff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0x3fff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fprem.asm
+++ b/unittests/ASM/X87/precision_test_fprem.asm
@@ -1,0 +1,205 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8888888888888880", "0x3ff9"],
+    "XMM1":  ["0x8888888888888880", "0x3ff9"],
+    "XMM2":  ["0x8888888888888880", "0x3ff9"],
+    "XMM3":  ["0x8888888888888880", "0x3ff9"],
+    "XMM4":  ["0x8888888888888880", "0x3ff9"],
+    "XMM5":  ["0x8888888888888880", "0x3ff9"],
+    "XMM6":  ["0x8888888888888880", "0x3ff9"],
+    "XMM7":  ["0x8888888888888880", "0x3ff9"],
+    "XMM8":  ["0x8888888888888880", "0x3ff9"],
+    "XMM9":  ["0x8888888888888880", "0x3ff9"],
+    "XMM10":  ["0x8888888888888880", "0x3ff9"],
+    "XMM11":  ["0x8888888888888880", "0x3ff9"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0x3fff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fprem1.asm
+++ b/unittests/ASM/X87/precision_test_fprem1.asm
@@ -1,0 +1,205 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8888888888888880", "0x3ff9"],
+    "XMM1":  ["0x8888888888888880", "0x3ff9"],
+    "XMM2":  ["0x8888888888888880", "0x3ff9"],
+    "XMM3":  ["0x8888888888888880", "0x3ff9"],
+    "XMM4":  ["0x8888888888888880", "0x3ff9"],
+    "XMM5":  ["0x8888888888888880", "0x3ff9"],
+    "XMM6":  ["0x8888888888888880", "0x3ff9"],
+    "XMM7":  ["0x8888888888888880", "0x3ff9"],
+    "XMM8":  ["0x8888888888888880", "0x3ff9"],
+    "XMM9":  ["0x8888888888888880", "0x3ff9"],
+    "XMM10":  ["0x8888888888888880", "0x3ff9"],
+    "XMM11":  ["0x8888888888888880", "0x3ff9"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0x3fff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fscale.asm
+++ b/unittests/ASM/X87/precision_test_fscale.asm
@@ -1,0 +1,205 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8222222222222222", "0x4000"],
+    "XMM1":  ["0x8222222222222222", "0x4000"],
+    "XMM2":  ["0x8222222222222222", "0x4000"],
+    "XMM3":  ["0x8222222222222222", "0x4000"],
+    "XMM4":  ["0x8222222222222222", "0x4000"],
+    "XMM5":  ["0x8222222222222222", "0x4000"],
+    "XMM6":  ["0x8222222222222222", "0x4000"],
+    "XMM7":  ["0x8222222222222222", "0x4000"],
+    "XMM8":  ["0x8222222222222222", "0x4000"],
+    "XMM9":  ["0x8222222222222222", "0x4000"],
+    "XMM10":  ["0x8222222222222222", "0x4000"],
+    "XMM11":  ["0x8222222222222222", "0x4000"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0x3fff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fsin.asm
+++ b/unittests/ASM/X87/precision_test_fsin.asm
@@ -1,0 +1,165 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0xd9b11c39ec002fd9", "0x3ffe"],
+    "XMM1":  ["0xd9b11c39ec002fd9", "0x3ffe"],
+    "XMM2":  ["0xd9b11c39ec002fd9", "0x3ffe"],
+    "XMM3":  ["0xd9b11c39ec002fd8", "0x3ffe"],
+    "XMM4":  ["0xd9b11c39ec002fd8", "0x3ffe"],
+    "XMM5":  ["0xd9b11c39ec002fd8", "0x3ffe"],
+    "XMM6":  ["0xd9b11c39ec002fd9", "0x3ffe"],
+    "XMM7":  ["0xd9b11c39ec002fd9", "0x3ffe"],
+    "XMM8":  ["0xd9b11c39ec002fd9", "0x3ffe"],
+    "XMM9":  ["0xd9b11c39ec002fd8", "0x3ffe"],
+    "XMM10":  ["0xd9b11c39ec002fd8", "0x3ffe"],
+    "XMM11":  ["0xd9b11c39ec002fd8", "0x3ffe"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0x3fff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fsqrt.asm
+++ b/unittests/ASM/X87/precision_test_fsqrt.asm
@@ -1,0 +1,173 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8000000000000001", "0x3fff"],
+    "XMM1":  ["0x8000000000000800", "0x3fff"],
+    "XMM2":  ["0x8000010000000000", "0x3fff"],
+    "XMM3":  ["0x8000000000000000", "0x3fff"],
+    "XMM4":  ["0x8000000000000000", "0x3fff"],
+    "XMM5":  ["0x8000000000000000", "0x3fff"],
+    "XMM6":  ["0x8000000000000001", "0x3fff"],
+    "XMM7":  ["0x8000000000000800", "0x3fff"],
+    "XMM8":  ["0x8000010000000000", "0x3fff"],
+    "XMM9":  ["0x8000000000000000", "0x3fff"],
+    "XMM10":  ["0x8000000000000000", "0x3fff"],
+    "XMM11":  ["0x8000000000000000", "0x3fff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_80bit]
+fsqrt
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_64bit]
+fsqrt
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_32bit]
+fsqrt
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_80bit]
+fsqrt
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_64bit]
+fsqrt
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_32bit]
+fsqrt
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_80bit]
+fsqrt
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_64bit]
+fsqrt
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_32bit]
+fsqrt
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_80bit]
+fsqrt
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_64bit]
+fsqrt
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_32bit]
+fsqrt
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_80bit:
+dq 0x8000_0000_0000_0002
+dw 0x3fff
+
+.source_64bit:
+dq 0x8000_0000_0000_1000
+dw 0x3fff
+
+.source_32bit:
+dq 0x8000_0200_0000_0000
+dw 0x3fff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fsub.asm
+++ b/unittests/ASM/X87/precision_test_fsub.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0x3fff"],
+    "XMM1":  ["0x8111111111111000", "0x3fff"],
+    "XMM2":  ["0x8111110000000000", "0x3fff"],
+    "XMM3":  ["0x8111111111111111", "0x3fff"],
+    "XMM4":  ["0x8111111111111000", "0x3fff"],
+    "XMM5":  ["0x8111110000000000", "0x3fff"],
+    "XMM6":  ["0x8111111111111111", "0x3fff"],
+    "XMM7":  ["0x8111111111111800", "0x3fff"],
+    "XMM8":  ["0x8111120000000000", "0x3fff"],
+    "XMM9":  ["0x8111111111111111", "0x3fff"],
+    "XMM10":  ["0x8111111111111000", "0x3fff"],
+    "XMM11":  ["0x8111110000000000", "0x3fff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0x3fff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fsubr.asm
+++ b/unittests/ASM/X87/precision_test_fsubr.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0xbfff"],
+    "XMM1":  ["0x8111111111111000", "0xbfff"],
+    "XMM2":  ["0x8111110000000000", "0xbfff"],
+    "XMM3":  ["0x8111111111111111", "0xbfff"],
+    "XMM4":  ["0x8111111111111800", "0xbfff"],
+    "XMM5":  ["0x8111120000000000", "0xbfff"],
+    "XMM6":  ["0x8111111111111111", "0xbfff"],
+    "XMM7":  ["0x8111111111111000", "0xbfff"],
+    "XMM8":  ["0x8111110000000000", "0xbfff"],
+    "XMM9":  ["0x8111111111111111", "0xbfff"],
+    "XMM10":  ["0x8111111111111000", "0xbfff"],
+    "XMM11":  ["0x8111110000000000", "0xbfff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0x3fff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_ftan.asm
+++ b/unittests/ASM/X87/precision_test_ftan.asm
@@ -1,0 +1,177 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0xced9f672ba44b549", "0x3fff"],
+    "XMM1":  ["0xced9f672ba44b549", "0x3fff"],
+    "XMM2":  ["0xced9f672ba44b549", "0x3fff"],
+    "XMM3":  ["0xced9f672ba44b549", "0x3fff"],
+    "XMM4":  ["0xced9f672ba44b549", "0x3fff"],
+    "XMM5":  ["0xced9f672ba44b549", "0x3fff"],
+    "XMM6":  ["0xced9f672ba44b54a", "0x3fff"],
+    "XMM7":  ["0xced9f672ba44b54a", "0x3fff"],
+    "XMM8":  ["0xced9f672ba44b54a", "0x3fff"],
+    "XMM9":  ["0xced9f672ba44b549", "0x3fff"],
+    "XMM10":  ["0xced9f672ba44b549", "0x3fff"],
+    "XMM11":  ["0xced9f672ba44b549", "0x3fff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0x3fff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fyl2x.asm
+++ b/unittests/ASM/X87/precision_test_fyl2x.asm
@@ -1,0 +1,180 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0xc333333333333333", "0x4001"],
+    "XMM1":  ["0xc333333333333333", "0x4001"],
+    "XMM2":  ["0xc333333333333333", "0x4001"],
+    "XMM3":  ["0xc333333333333333", "0x4001"],
+    "XMM4":  ["0xc333333333333333", "0x4001"],
+    "XMM5":  ["0xc333333333333333", "0x4001"],
+    "XMM6":  ["0xc333333333333333", "0x4001"],
+    "XMM7":  ["0xc333333333333333", "0x4001"],
+    "XMM8":  ["0xc333333333333333", "0x4001"],
+    "XMM9":  ["0xc333333333333333", "0x4001"],
+    "XMM10":  ["0xc333333333333333", "0x4001"],
+    "XMM11":  ["0xc333333333333333", "0x4001"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+.source_1:
+dq 64
+
+; Positive
+.source_2:
+dq 0x8222_2222_2222_2222
+dw 0x3fff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_fyl2xp1.asm
+++ b/unittests/ASM/X87/precision_test_fyl2xp1.asm
@@ -1,0 +1,180 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0xc3ed7db72edb35da", "0x4001"],
+    "XMM1":  ["0xc3ed7db72edb35da", "0x4001"],
+    "XMM2":  ["0xc3ed7db72edb35da", "0x4001"],
+    "XMM3":  ["0xc3ed7db72edb35da", "0x4001"],
+    "XMM4":  ["0xc3ed7db72edb35da", "0x4001"],
+    "XMM5":  ["0xc3ed7db72edb35da", "0x4001"],
+    "XMM6":  ["0xc3ed7db72edb35db", "0x4001"],
+    "XMM7":  ["0xc3ed7db72edb35db", "0x4001"],
+    "XMM8":  ["0xc3ed7db72edb35db", "0x4001"],
+    "XMM9":  ["0xc3ed7db72edb35da", "0x4001"],
+    "XMM10":  ["0xc3ed7db72edb35da", "0x4001"],
+    "XMM11":  ["0xc3ed7db72edb35da", "0x4001"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+.source_1:
+dq 64
+
+; Positive
+.source_2:
+dq 0x8222_2222_2222_2222
+dw 0x3fff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fabs.asm
+++ b/unittests/ASM/X87/precision_test_neg_fabs.asm
@@ -1,0 +1,165 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0x3fff"],
+    "XMM1":  ["0x8111111111111111", "0x3fff"],
+    "XMM2":  ["0x8111111111111111", "0x3fff"],
+    "XMM3":  ["0x8111111111111111", "0x3fff"],
+    "XMM4":  ["0x8111111111111111", "0x3fff"],
+    "XMM5":  ["0x8111111111111111", "0x3fff"],
+    "XMM6":  ["0x8111111111111111", "0x3fff"],
+    "XMM7":  ["0x8111111111111111", "0x3fff"],
+    "XMM8":  ["0x8111111111111111", "0x3fff"],
+    "XMM9":  ["0x8111111111111111", "0x3fff"],
+    "XMM10":  ["0x8111111111111111", "0x3fff"],
+    "XMM11":  ["0x8111111111111111", "0x3fff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fabs
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0xbfff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fadd.asm
+++ b/unittests/ASM/X87/precision_test_neg_fadd.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0xbfff"],
+    "XMM1":  ["0x8111111111111000", "0xbfff"],
+    "XMM2":  ["0x8111110000000000", "0xbfff"],
+    "XMM3":  ["0x8111111111111111", "0xbfff"],
+    "XMM4":  ["0x8111111111111800", "0xbfff"],
+    "XMM5":  ["0x8111120000000000", "0xbfff"],
+    "XMM6":  ["0x8111111111111111", "0xbfff"],
+    "XMM7":  ["0x8111111111111000", "0xbfff"],
+    "XMM8":  ["0x8111110000000000", "0xbfff"],
+    "XMM9":  ["0x8111111111111111", "0xbfff"],
+    "XMM10":  ["0x8111111111111000", "0xbfff"],
+    "XMM11":  ["0x8111110000000000", "0xbfff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+faddp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Negative
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0xbfff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fcos.asm
+++ b/unittests/ASM/X87/precision_test_neg_fcos.asm
@@ -1,0 +1,165 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM1":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM2":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM3":  ["0x86b5441382debef4", "0x3ffe"],
+    "XMM4":  ["0x86b5441382debef4", "0x3ffe"],
+    "XMM5":  ["0x86b5441382debef4", "0x3ffe"],
+    "XMM6":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM7":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM8":  ["0x86b5441382debef5", "0x3ffe"],
+    "XMM9":  ["0x86b5441382debef4", "0x3ffe"],
+    "XMM10":  ["0x86b5441382debef4", "0x3ffe"],
+    "XMM11":  ["0x86b5441382debef4", "0x3ffe"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fcos
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0xbfff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fdiv.asm
+++ b/unittests/ASM/X87/precision_test_neg_fdiv.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0xbfff"],
+    "XMM1":  ["0x8111111111111000", "0xbfff"],
+    "XMM2":  ["0x8111110000000000", "0xbfff"],
+    "XMM3":  ["0x8111111111111111", "0xbfff"],
+    "XMM4":  ["0x8111111111111800", "0xbfff"],
+    "XMM5":  ["0x8111120000000000", "0xbfff"],
+    "XMM6":  ["0x8111111111111111", "0xbfff"],
+    "XMM7":  ["0x8111111111111000", "0xbfff"],
+    "XMM8":  ["0x8111110000000000", "0xbfff"],
+    "XMM9":  ["0x8111111111111111", "0xbfff"],
+    "XMM10":  ["0x8111111111111000", "0xbfff"],
+    "XMM11":  ["0x8111110000000000", "0xbfff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fdivp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Negative
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0xbfff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fdivr.asm
+++ b/unittests/ASM/X87/precision_test_neg_fdivr.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0xbfff"],
+    "XMM1":  ["0x8111111111111000", "0xbfff"],
+    "XMM2":  ["0x8111110000000000", "0xbfff"],
+    "XMM3":  ["0x8111111111111111", "0xbfff"],
+    "XMM4":  ["0x8111111111111800", "0xbfff"],
+    "XMM5":  ["0x8111120000000000", "0xbfff"],
+    "XMM6":  ["0x8111111111111111", "0xbfff"],
+    "XMM7":  ["0x8111111111111000", "0xbfff"],
+    "XMM8":  ["0x8111110000000000", "0xbfff"],
+    "XMM9":  ["0x8111111111111111", "0xbfff"],
+    "XMM10":  ["0x8111111111111000", "0xbfff"],
+    "XMM11":  ["0x8111110000000000", "0xbfff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fdivrp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Negative
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0xbfff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fmul.asm
+++ b/unittests/ASM/X87/precision_test_neg_fmul.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0xbfff"],
+    "XMM1":  ["0x8111111111111000", "0xbfff"],
+    "XMM2":  ["0x8111110000000000", "0xbfff"],
+    "XMM3":  ["0x8111111111111111", "0xbfff"],
+    "XMM4":  ["0x8111111111111800", "0xbfff"],
+    "XMM5":  ["0x8111120000000000", "0xbfff"],
+    "XMM6":  ["0x8111111111111111", "0xbfff"],
+    "XMM7":  ["0x8111111111111000", "0xbfff"],
+    "XMM8":  ["0x8111110000000000", "0xbfff"],
+    "XMM9":  ["0x8111111111111111", "0xbfff"],
+    "XMM10":  ["0x8111111111111000", "0xbfff"],
+    "XMM11":  ["0x8111110000000000", "0xbfff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fld1
+fmulp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Negative
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0xbfff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fprem.asm
+++ b/unittests/ASM/X87/precision_test_neg_fprem.asm
@@ -1,0 +1,205 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8888888888888880", "0xbff9"],
+    "XMM1":  ["0x8888888888888880", "0xbff9"],
+    "XMM2":  ["0x8888888888888880", "0xbff9"],
+    "XMM3":  ["0x8888888888888880", "0xbff9"],
+    "XMM4":  ["0x8888888888888880", "0xbff9"],
+    "XMM5":  ["0x8888888888888880", "0xbff9"],
+    "XMM6":  ["0x8888888888888880", "0xbff9"],
+    "XMM7":  ["0x8888888888888880", "0xbff9"],
+    "XMM8":  ["0x8888888888888880", "0xbff9"],
+    "XMM9":  ["0x8888888888888880", "0xbff9"],
+    "XMM10":  ["0x8888888888888880", "0xbff9"],
+    "XMM11":  ["0x8888888888888880", "0xbff9"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem
+fxch
+fstp st0
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0xbfff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fprem1.asm
+++ b/unittests/ASM/X87/precision_test_neg_fprem1.asm
@@ -1,0 +1,205 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8888888888888880", "0xbff9"],
+    "XMM1":  ["0x8888888888888880", "0xbff9"],
+    "XMM2":  ["0x8888888888888880", "0xbff9"],
+    "XMM3":  ["0x8888888888888880", "0xbff9"],
+    "XMM4":  ["0x8888888888888880", "0xbff9"],
+    "XMM5":  ["0x8888888888888880", "0xbff9"],
+    "XMM6":  ["0x8888888888888880", "0xbff9"],
+    "XMM7":  ["0x8888888888888880", "0xbff9"],
+    "XMM8":  ["0x8888888888888880", "0xbff9"],
+    "XMM9":  ["0x8888888888888880", "0xbff9"],
+    "XMM10":  ["0x8888888888888880", "0xbff9"],
+    "XMM11":  ["0x8888888888888880", "0xbff9"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fprem1
+fxch
+fstp st0
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0xbfff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fscale.asm
+++ b/unittests/ASM/X87/precision_test_neg_fscale.asm
@@ -1,0 +1,205 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8222222222222222", "0xc000"],
+    "XMM1":  ["0x8222222222222222", "0xc000"],
+    "XMM2":  ["0x8222222222222222", "0xc000"],
+    "XMM3":  ["0x8222222222222222", "0xc000"],
+    "XMM4":  ["0x8222222222222222", "0xc000"],
+    "XMM5":  ["0x8222222222222222", "0xc000"],
+    "XMM6":  ["0x8222222222222222", "0xc000"],
+    "XMM7":  ["0x8222222222222222", "0xc000"],
+    "XMM8":  ["0x8222222222222222", "0xc000"],
+    "XMM9":  ["0x8222222222222222", "0xc000"],
+    "XMM10":  ["0x8222222222222222", "0xc000"],
+    "XMM11":  ["0x8222222222222222", "0xc000"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld1
+fld tword [rel .source_1]
+fscale
+fxch
+fstp st0
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Negative
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0xbfff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fsin.asm
+++ b/unittests/ASM/X87/precision_test_neg_fsin.asm
@@ -1,0 +1,165 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0xd9b11c39ec002fd9", "0xbffe"],
+    "XMM1":  ["0xd9b11c39ec002fd9", "0xbffe"],
+    "XMM2":  ["0xd9b11c39ec002fd9", "0xbffe"],
+    "XMM3":  ["0xd9b11c39ec002fd9", "0xbffe"],
+    "XMM4":  ["0xd9b11c39ec002fd9", "0xbffe"],
+    "XMM5":  ["0xd9b11c39ec002fd9", "0xbffe"],
+    "XMM6":  ["0xd9b11c39ec002fd8", "0xbffe"],
+    "XMM7":  ["0xd9b11c39ec002fd8", "0xbffe"],
+    "XMM8":  ["0xd9b11c39ec002fd8", "0xbffe"],
+    "XMM9":  ["0xd9b11c39ec002fd8", "0xbffe"],
+    "XMM10":  ["0xd9b11c39ec002fd8", "0xbffe"],
+    "XMM11":  ["0xd9b11c39ec002fd8", "0xbffe"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fsin
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0xbfff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fsub.asm
+++ b/unittests/ASM/X87/precision_test_neg_fsub.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0xbfff"],
+    "XMM1":  ["0x8111111111111000", "0xbfff"],
+    "XMM2":  ["0x8111110000000000", "0xbfff"],
+    "XMM3":  ["0x8111111111111111", "0xbfff"],
+    "XMM4":  ["0x8111111111111800", "0xbfff"],
+    "XMM5":  ["0x8111120000000000", "0xbfff"],
+    "XMM6":  ["0x8111111111111111", "0xbfff"],
+    "XMM7":  ["0x8111111111111000", "0xbfff"],
+    "XMM8":  ["0x8111110000000000", "0xbfff"],
+    "XMM9":  ["0x8111111111111111", "0xbfff"],
+    "XMM10":  ["0x8111111111111000", "0xbfff"],
+    "XMM11":  ["0x8111110000000000", "0xbfff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Negative
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0xbfff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fsubr.asm
+++ b/unittests/ASM/X87/precision_test_neg_fsubr.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0x8111111111111111", "0x3fff"],
+    "XMM1":  ["0x8111111111111000", "0x3fff"],
+    "XMM2":  ["0x8111110000000000", "0x3fff"],
+    "XMM3":  ["0x8111111111111111", "0x3fff"],
+    "XMM4":  ["0x8111111111111000", "0x3fff"],
+    "XMM5":  ["0x8111110000000000", "0x3fff"],
+    "XMM6":  ["0x8111111111111111", "0x3fff"],
+    "XMM7":  ["0x8111111111111800", "0x3fff"],
+    "XMM8":  ["0x8111120000000000", "0x3fff"],
+    "XMM9":  ["0x8111111111111111", "0x3fff"],
+    "XMM10":  ["0x8111111111111000", "0x3fff"],
+    "XMM11":  ["0x8111110000000000", "0x3fff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fld tword [rel .source_zero]
+fsubrp
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Negative
+.source_1:
+dq 0x8111_1111_1111_1111
+dw 0xbfff
+
+.source_zero:
+dq 0x0
+dq 0x0
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_ftan.asm
+++ b/unittests/ASM/X87/precision_test_neg_ftan.asm
@@ -1,0 +1,177 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0xced9f672ba44b549", "0xbfff"],
+    "XMM1":  ["0xced9f672ba44b549", "0xbfff"],
+    "XMM2":  ["0xced9f672ba44b549", "0xbfff"],
+    "XMM3":  ["0xced9f672ba44b54a", "0xbfff"],
+    "XMM4":  ["0xced9f672ba44b54a", "0xbfff"],
+    "XMM5":  ["0xced9f672ba44b54a", "0xbfff"],
+    "XMM6":  ["0xced9f672ba44b549", "0xbfff"],
+    "XMM7":  ["0xced9f672ba44b549", "0xbfff"],
+    "XMM8":  ["0xced9f672ba44b549", "0xbfff"],
+    "XMM9":  ["0xced9f672ba44b549", "0xbfff"],
+    "XMM10":  ["0xced9f672ba44b549", "0xbfff"],
+    "XMM11":  ["0xced9f672ba44b549", "0xbfff"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_1]
+fptan
+fstp st0
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+; Positive
+.source_1:
+dq 0x8222_2222_2222_2222
+dw 0xbfff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0

--- a/unittests/ASM/X87/precision_test_neg_fyl2x.asm
+++ b/unittests/ASM/X87/precision_test_neg_fyl2x.asm
@@ -1,0 +1,181 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0xc333333333333333", "0xc001"],
+    "XMM1":  ["0xc333333333333333", "0xc001"],
+    "XMM2":  ["0xc333333333333333", "0xc001"],
+    "XMM3":  ["0xc333333333333333", "0xc001"],
+    "XMM4":  ["0xc333333333333333", "0xc001"],
+    "XMM5":  ["0xc333333333333333", "0xc001"],
+    "XMM6":  ["0xc333333333333333", "0xc001"],
+    "XMM7":  ["0xc333333333333333", "0xc001"],
+    "XMM8":  ["0xc333333333333333", "0xc001"],
+    "XMM9":  ["0xc333333333333333", "0xc001"],
+    "XMM10":  ["0xc333333333333333", "0xc001"],
+    "XMM11":  ["0xc333333333333333", "0xc001"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2x
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+.source_1:
+dq 64
+
+; Negative
+.source_2:
+dq 0x8222_2222_2222_2222
+dw 0xbfff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0
+

--- a/unittests/ASM/X87/precision_test_neg_fyl2xp1.asm
+++ b/unittests/ASM/X87/precision_test_neg_fyl2xp1.asm
@@ -1,0 +1,180 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0":  ["0xc3ed7db72edb35da", "0xc001"],
+    "XMM1":  ["0xc3ed7db72edb35da", "0xc001"],
+    "XMM2":  ["0xc3ed7db72edb35da", "0xc001"],
+    "XMM3":  ["0xc3ed7db72edb35db", "0xc001"],
+    "XMM4":  ["0xc3ed7db72edb35db", "0xc001"],
+    "XMM5":  ["0xc3ed7db72edb35db", "0xc001"],
+    "XMM6":  ["0xc3ed7db72edb35da", "0xc001"],
+    "XMM7":  ["0xc3ed7db72edb35da", "0xc001"],
+    "XMM8":  ["0xc3ed7db72edb35da", "0xc001"],
+    "XMM9":  ["0xc3ed7db72edb35da", "0xc001"],
+    "XMM10":  ["0xc3ed7db72edb35da", "0xc001"],
+    "XMM11":  ["0xc3ed7db72edb35da", "0xc001"]
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+finit ; enters x87 state
+
+; 80-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_1]
+
+; 64-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_64, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_2]
+
+; 32-bit mode, round-nearest
+set_cw_precision_rounding x87_prec_32, x87_round_nearest
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_3]
+
+; 80-bit mode, round-down
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_4]
+
+; 64-bit mode, round-down
+set_cw_precision_rounding x87_prec_64, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_5]
+
+; 32-bit mode, round-down
+set_cw_precision_rounding x87_prec_32, x87_round_down
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_6]
+
+; 80-bit mode, round-up
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_7]
+
+; 64-bit mode, round-up
+set_cw_precision_rounding x87_prec_64, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_8]
+
+; 32-bit mode, round-up
+set_cw_precision_rounding x87_prec_32, x87_round_up
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_9]
+
+; 80-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_10]
+
+; 64-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_64, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_11]
+
+; 32-bit mode, round-towards_zero
+set_cw_precision_rounding x87_prec_32, x87_round_towards_zero
+fld tword [rel .source_2]
+fild qword [rel .source_1]
+fyl2xp1
+fstp tword [rel .result_12]
+
+; Fetch results
+movups xmm0, [rel .result_1]
+movups xmm1, [rel .result_2]
+movups xmm2, [rel .result_3]
+movups xmm3, [rel .result_4]
+movups xmm4, [rel .result_5]
+movups xmm5, [rel .result_6]
+movups xmm6, [rel .result_7]
+movups xmm7, [rel .result_8]
+movups xmm8, [rel .result_9]
+movups xmm9, [rel .result_10]
+movups xmm10, [rel .result_11]
+movups xmm11, [rel .result_12]
+
+hlt
+
+.source_1:
+dq 64
+
+; Negative
+.source_2:
+dq 0x8222_2222_2222_2222
+dw 0xbfff
+
+.result_1:
+dq 0
+dq 0
+
+.result_2:
+dq 0
+dq 0
+
+.result_3:
+dq 0
+dq 0
+
+.result_4:
+dq 0
+dq 0
+
+.result_5:
+dq 0
+dq 0
+
+.result_6:
+dq 0
+dq 0
+
+.result_7:
+dq 0
+dq 0
+
+.result_8:
+dq 0
+dq 0
+
+.result_9:
+dq 0
+dq 0
+
+.result_10:
+dq 0
+dq 0
+
+.result_11:
+dq 0
+dq 0
+
+.result_12:
+dq 0
+dq 0


### PR DESCRIPTION
According to the documentation for x87 FCW precision control, this only
affects fadd*, fsub*, fmul*, fdiv*, and fsqrt. FEX was incorrectly
reducing precision for all x87 operations.

Precision is ignored for the following x87 ALU operations:
- fabs
- fscale
- fprem{1,}
- fcos
- fsin
- ftan
- fyl2x
- fyl2xp1
- fpatan
- fsincos
- Plus any operations just doing data movement and conversions

Next commit adds unittests to ensure this is correct for each
instruction.

Only missing unittests are fpatan and fsincos.