### PR TITLE
LinuxEmulation: Don't use clone3 for fork

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -652,7 +652,7 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args
     // CLONE_PARENT is ignored (Implied by CLONE_THREAD)
     return FEX::HLE::ForkGuest(Thread, Frame, flags, reinterpret_cast<void*>(args->args.stack), args->args.stack_size,
                                reinterpret_cast<pid_t*>(args->args.parent_tid), reinterpret_cast<pid_t*>(args->args.child_tid),
-                               reinterpret_cast<void*>(args->args.tls));
+                               reinterpret_cast<void*>(args->args.tls), args->args.exit_signal);
   } else {
     auto NewThread = FEX::HLE::CreateNewThread(Thread->CTX, Frame, args);
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.h
@@ -21,5 +21,5 @@ FEX::HLE::ThreadStateObject* CreateNewThread(FEXCore::Context::Context* CTX, FEX
 uint64_t HandleNewClone(FEX::HLE::ThreadStateObject* Thread, FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame,
                         FEX::HLE::clone3_args* GuestArgs);
 uint64_t ForkGuest(FEXCore::Core::InternalThreadState* Thread, FEXCore::Core::CpuStateFrame* Frame, uint32_t flags, void* stack,
-                   size_t StackSize, pid_t* parent_tid, pid_t* child_tid, void* tls);
+                   size_t StackSize, pid_t* parent_tid, pid_t* child_tid, void* tls, uint64_t exit_signal);
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Thread.cpp
@@ -52,8 +52,9 @@ void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
         .Type = TypeOfClone::TYPE_CLONE2,
         .args =
           {
-            .flags = flags, // CSIGNAL is contained in here
-            .pidfd = 0,     // For clone, pidfd is duplicated here
+
+            .flags = flags & ~CSIGNAL, // This no longer contains CSIGNAL
+            .pidfd = 0,                // For clone, pidfd is duplicated here
             .child_tid = reinterpret_cast<uint64_t>(child_tid),
             .parent_tid = reinterpret_cast<uint64_t>(parent_tid),
             .exit_signal = flags & CSIGNAL,


### PR DESCRIPTION
clone3 was added in Linux 5.3 but our minimum spec is 5.0. Additionally the Raspberry Pi 5 kernel seems to complain about clone3 for some reason?

Just use clone instead of clone3