### PR TITLE
GdbServer: Implement support for `$vKill`

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -1118,7 +1118,10 @@ GdbServer::HandledPacketType GdbServer::CommandMultiLetterV(const fextl::string&
     return HandlevFile(packet);
   }
 
-  // TODO: vKill
+  if (packet.starts_with("vKill")) {
+    tgkill(::getpid(), ::getpid(), SIGKILL);
+  }
+
   // TODO: vRun
   // TODO: vStopped
 


### PR DESCRIPTION
This is the command used when the `k` argument is passed to gdb. There is nothing to do once this is received other than "kill" as quickly as possible. The absolute way to ensure this is using SIGKILL.

No way to do a `r` command after `k` yet, but might be possible.