### PR TITLE
GdbServer: Rework sleeping

### DIFF
--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -595,9 +595,9 @@ int main(int argc, char** argv, char** const envp) {
   }
 
   auto ParentThread = SyscallHandler->TM.CreateThread(Loader.DefaultRIP(), Loader.GetStackPointer());
-  SyscallHandler->TM.TrackThread(ParentThread);
   SignalDelegation->RegisterTLSState(ParentThread);
   ThunkHandler->RegisterTLSState(ParentThread);
+  SyscallHandler->TM.TrackThread(ParentThread);
 
   // Pass in our VDSO thunks
   ThunkHandler->AppendThunkDefinitions(FEX::VDSO::GetVDSOThunkDefinitions(Loader.Is64BitMode()));

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -587,6 +587,7 @@ int main(int argc, char** argv, char** const envp) {
   fextl::unique_ptr<FEX::GdbServer> DebugServer;
   if (GdbServer) {
     DebugServer = fextl::make_unique<FEX::GdbServer>(CTX.get(), SignalDelegation.get(), SyscallHandler.get());
+    SyscallHandler->SetGdbServer(DebugServer.get());
   }
 
   if (!CTX->InitCore()) {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -601,7 +601,7 @@ GdbServer::HandledPacketType GdbServer::ThreadAction(char action, uint32_t tid) 
   switch (action) {
   case 'c': {
     {
-      std::lock_guard lk(*SyscallHandler->TM.GetThreadsCreationMutex());
+      std::lock_guard lk(SyscallHandler->TM.GetThreadsCreationMutex());
       auto Threads = SyscallHandler->TM.GetThreads();
       for (auto& Thread : *Threads) {
         Thread->ThreadSleeping.NotifyOne();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -62,13 +62,12 @@ $end_info$
 namespace FEX {
 
 #ifndef _WIN32
-void GdbServer::Break(FEXCore::Core::InternalThreadState* Thread, int signal) {
+void GdbServer::Break(FEX::HLE::ThreadStateObject* ThreadObject, int signal) {
   std::lock_guard lk(sendMutex);
   if (!CommsStream) {
     return;
   }
 
-  auto ThreadObject = FEX::HLE::ThreadManager::GetStateObjectFromFEXCoreThread(Thread);
   // Current debugging thread switches to the thread that is breaking.
   CurrentDebuggingThread = ThreadObject->ThreadInfo.TID.load();
 
@@ -119,7 +118,7 @@ GdbServer::GdbServer(FEXCore::Context::Context* ctx, FEX::HLE::SignalDelegator* 
       ThreadObject->GdbInfo->PState = ArchHelpers::Context::GetArmPState(ucontext);
 
       // Let GDB know that we have a signal
-      this->Break(Thread, Signal);
+      this->Break(ThreadObject, Signal);
 
       WaitForThreadWakeup();
       ThreadObject->GdbInfo.reset();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.h
@@ -36,7 +36,7 @@ public:
   }
 
 private:
-  void Break(FEXCore::Core::InternalThreadState* Thread, int signal);
+  void Break(FEX::HLE::ThreadStateObject* ThreadObject, int signal);
 
   void OpenListenSocket();
   void CloseListenSocket();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.h
@@ -35,6 +35,8 @@ public:
     LibraryMapChanged = true;
   }
 
+  void OnThreadCreated(FEX::HLE::ThreadStateObject* ThreadObject);
+
 private:
   void Break(FEX::HLE::ThreadStateObject* ThreadObject, int signal);
 
@@ -51,9 +53,6 @@ private:
   void SendPacket(std::ostream& stream, const fextl::string& packet);
 
   void SendACK(std::ostream& stream, bool NACK);
-
-  Event ThreadBreakEvent {};
-  void WaitForThreadWakeup();
 
   struct HandledPacketType {
     fextl::string Response {};

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -476,7 +476,7 @@ bool SignalDelegator::HandleSignalPause(FEXCore::Core::InternalThreadState* Thre
     // We need to be a little bit careful here
     // If we were already paused (due to GDB) and we are immediately stopping (due to gdb kill)
     // Then we need to ensure we don't double decrement our idle thread counter
-    if (ThreadObject->ThreadSleeping) {
+    if (ThreadObject->ThreadSleeping.HasWaiter()) {
       // If the thread was sleeping then its idle counter was decremented
       // Reincrement it here to not break logic
       FEX::HLE::_SyscallHandler->TM.IncrementIdleRefCount();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -744,7 +744,7 @@ void SyscallHandler::DefaultProgramBreak(uint64_t Base, uint64_t Size) {
 }
 
 SyscallHandler::SyscallHandler(FEXCore::Context::Context* _CTX, FEX::HLE::SignalDelegator* _SignalDelegation, FEX::HLE::ThunkHandler* ThunkHandler)
-  : TM {_CTX, _SignalDelegation}
+  : TM {_CTX, this, _SignalDelegation}
   , SeccompEmulator {this, _SignalDelegation}
   , FM {_CTX}
   , CTX {_CTX}

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -53,6 +53,7 @@ $end_info$
 
 namespace FEX {
 class CodeLoader;
+class GdbServer;
 }
 
 namespace FEXCore {
@@ -282,6 +283,14 @@ public:
 
   constexpr static uint64_t TASK_MAX_64BIT = (1ULL << 48);
 
+  void SetGdbServer(FEX::GdbServer* Server) {
+    GdbServer = Server;
+  }
+
+  FEX::GdbServer* GetGdbServer() {
+    return GdbServer;
+  }
+
 protected:
   SyscallHandler(FEXCore::Context::Context* _CTX, FEX::HLE::SignalDelegator* _SignalDelegation, FEX::HLE::ThunkHandler* ThunkHandler);
 
@@ -308,6 +317,7 @@ private:
 
   FEX::HLE::SignalDelegator* SignalDelegation;
   FEX::HLE::ThunkHandler* ThunkHandler;
+  FEX::GdbServer* GdbServer {};
 
   std::mutex FutexMutex;
   std::mutex SyscallMutex;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -54,7 +54,7 @@ $end_info$
 namespace FEX {
 class CodeLoader;
 class GdbServer;
-}
+} // namespace FEX
 
 namespace FEXCore {
 namespace Context {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -230,11 +230,11 @@ uint64_t HandleNewClone(FEX::HLE::ThreadStateObject* Thread, FEXCore::Context::C
   Thread->ThreadInfo.PID = ::getpid();
   FEX::HLE::_SyscallHandler->FM.UpdatePID(Thread->ThreadInfo.PID);
 
+  FEX::HLE::_SyscallHandler->RegisterTLSState(Thread);
+
   if (CreatedNewThreadObject) {
     FEX::HLE::_SyscallHandler->TM.TrackThread(Thread);
   }
-
-  FEX::HLE::_SyscallHandler->RegisterTLSState(Thread);
 
   // Start exuting the thread directly
   // Our host clone starts in a new stack space, so it can't return back to the JIT space

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -22,6 +22,79 @@ namespace FEX::HLE {
 class SyscallHandler;
 class SignalDelegator;
 
+// A latch that can be inspected to see if there is a waiter currently active.
+// This allows us to remove the race condition between a thread trying to go asleep and something else telling it to go to sleep or wake up.
+//
+// Only one thread can ever wait on a latch, while another thread signals it.
+class InspectableLatch final {
+public:
+  bool Wait(struct timespec* Timeout = nullptr) {
+    while (true) {
+      uint32_t Expected = HAS_NO_WAITER;
+      const uint32_t Desired = HAS_WAITER;
+
+      if (Mutex.compare_exchange_strong(Expected, Desired)) {
+        // We have latched, now futex.
+        constexpr int Op = FUTEX_WAIT | FUTEX_PRIVATE_FLAG;
+        // WAIT will keep sleeping on the futex word while it is `val`
+        int Result = ::syscall(SYS_futex, &Mutex, Op,
+                               Desired, // val
+                               Timeout, // Timeout/val2
+                               nullptr, // Addr2
+                               0);      // val3
+
+        if (Timeout && Result == -1 && errno == ETIMEDOUT) {
+          return false;
+        }
+      } else if (Expected == HAS_SIGNALED) {
+        // Reset the latch once signaled
+        Mutex.store(HAS_NO_WAITER);
+        return true;
+      }
+    }
+  }
+
+  template<class Rep, class Period>
+  bool WaitFor(const std::chrono::duration<Rep, Period>& time) {
+    struct timespec Timeout {};
+    auto SecondsDuration = std::chrono::duration_cast<std::chrono::seconds>(time);
+    Timeout.tv_sec = SecondsDuration.count();
+    Timeout.tv_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(time - SecondsDuration).count();
+    return Wait(&Timeout);
+  }
+
+  void NotifyOne() {
+    DoNotify(1);
+  }
+
+  bool HasWaiter() const {
+    return Mutex.load() == HAS_WAITER;
+  }
+
+private:
+  std::atomic<uint32_t> Mutex {};
+  constexpr static uint32_t HAS_NO_WAITER = 0;
+  constexpr static uint32_t HAS_WAITER = 1;
+  constexpr static uint32_t HAS_SIGNALED = 2;
+
+  void DoNotify(int Waiters) {
+    uint32_t Expected = HAS_WAITER;
+    const uint32_t Desired = HAS_SIGNALED;
+
+    // If the mutex is in a waiting state and we have CAS exchanged it to HAS_SIGNALED, then execute a futex syscall.
+    // otherwise just leave since nothing was waiting.
+    if (Mutex.compare_exchange_strong(Expected, Desired)) {
+      constexpr int Op = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
+
+      ::syscall(SYS_futex, &Mutex, Op,
+                Waiters, // val - Number of waiters to wake
+                0,       // val2
+                &Mutex,  // Addr2 - Mutex to do the operation on
+                0);      // val3
+    }
+  }
+};
+
 enum class SignalEvent : uint32_t {
   Nothing, // If the guest uses our signal we need to know it was errant on our end
   Pause,
@@ -81,8 +154,7 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
   std::atomic<SignalEvent> SignalReason {SignalEvent::Nothing};
 
   // Thread pause handling
-  std::atomic_bool ThreadSleeping {false};
-  FEXCore::InterruptableConditionVariable ThreadPaused;
+  InspectableLatch ThreadSleeping;
 
   // GDB signal information
   struct GdbInfoStruct {
@@ -117,10 +189,7 @@ public:
 
   FEX::HLE::ThreadStateObject* CreateThread(uint64_t InitialRIP, uint64_t StackPointer, const FEXCore::Core::CPUState* NewThreadState = nullptr,
                                             uint64_t ParentTID = 0, FEX::HLE::ThreadStateObject* InheritThread = nullptr);
-  void TrackThread(FEX::HLE::ThreadStateObject* Thread) {
-    std::lock_guard lk(ThreadCreationMutex);
-    Threads.emplace_back(Thread);
-  }
+  void TrackThread(FEX::HLE::ThreadStateObject* Thread);
 
   void DestroyThread(FEX::HLE::ThreadStateObject* Thread, bool NeedsTLSUninstall = false);
   void StopThread(FEX::HLE::ThreadStateObject* Thread);
@@ -135,7 +204,11 @@ public:
   void WaitForIdleWithTimeout();
   void WaitForThreadsToRun();
 
-  void SleepThread(FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame);
+  void SleepThread(FEXCore::Context::Context* CTX, FEX::HLE::ThreadStateObject* ThreadObject);
+  void SleepThread(FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame) {
+    auto ThreadObject = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
+    SleepThread(CTX, ThreadObject);
+  }
 
   void UnlockAfterFork(FEXCore::Core::InternalThreadState* Thread, bool Child);
 
@@ -170,8 +243,17 @@ public:
     }
   }
 
+  FEXCore::ForkableUniqueMutex* GetThreadsCreationMutex() {
+    return &ThreadCreationMutex;
+  }
+
   const fextl::vector<FEX::HLE::ThreadStateObject*>* GetThreads() const {
     return &Threads;
+  }
+
+  size_t GetThreadCount() {
+    std::lock_guard lk(ThreadCreationMutex);
+    return Threads.size();
   }
 
 private:

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -99,8 +99,9 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
 class ThreadManager final {
 public:
 
-  ThreadManager(FEXCore::Context::Context* CTX, FEX::HLE::SignalDelegator* SignalDelegation)
+  ThreadManager(FEXCore::Context::Context* CTX, FEX::HLE::SyscallHandler* SyscallHandler, FEX::HLE::SignalDelegator* SignalDelegation)
     : CTX {CTX}
+    , SyscallHandler {SyscallHandler}
     , SignalDelegation {SignalDelegation} {}
 
   ~ThreadManager();
@@ -175,6 +176,7 @@ public:
 
 private:
   FEXCore::Context::Context* CTX;
+  FEX::HLE::SyscallHandler* SyscallHandler;
   FEX::HLE::SignalDelegator* SignalDelegation;
 
   FEXCore::ForkableUniqueMutex ThreadCreationMutex;

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -323,8 +323,8 @@ int main(int argc, char** argv, char** const envp) {
       return 1;
     }
     auto ParentThread = SyscallHandler->TM.CreateThread(Loader.DefaultRIP(), Loader.GetStackPointer());
-    SyscallHandler->TM.TrackThread(ParentThread);
     SignalDelegation->RegisterTLSState(ParentThread);
+    SyscallHandler->TM.TrackThread(ParentThread);
 
     if (!ParentThread) {
       return 1;


### PR DESCRIPTION
This is enough to get GdbServer working for my simple test case again.

Some things of note:
- There is now a callback which signals to GdbServer when a thread is
  created.
- Thread sleeping is now a single uint32_t futex word for knowing when a
  thread is sleeping and if we need to signal it to wake up.
- GdbServer thread sleeping versus ThreadManager thread sleeping
  distinction has been removed. GdbServer now uses ThreadManager to put
  a thread to sleep.

This still only gets the attach at startup scheme of gdbserver working.
I haven't yet dived back in to getting arbitrary attach working.
Primarily the work necessary here is actually getting thread creation at
the start to stop and wait for gdbserver to attach. Then actually
sleeping correctly while gdbserver is communicating with gdb.