### PR TITLE
IR/Passes: Adds missing comment that clang-format keeps complaining about locally

### DIFF
--- a/FEXCore/Source/Interface/IR/Passes.h
+++ b/FEXCore/Source/Interface/IR/Passes.h
@@ -6,7 +6,7 @@
 namespace FEXCore {
 class CPUIDEmu;
 struct HostFeatures;
-}
+} // namespace FEXCore
 
 namespace FEXCore::Utils {
 class IntrusivePooledAllocator;


### PR DESCRIPTION
NFC