### PR TITLE
GdbServer: Fixes encoding of hex

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -158,7 +158,7 @@ static fextl::string hexstring(fextl::istringstream& ss, int delm) {
 }
 
 static fextl::string appendHex(const char* data, size_t length) {
-  return fextl::fmt::format("{:#02x}", fmt::join(data, data + length, ""));
+  return fextl::fmt::format("{:02x}", fmt::join(data, data + length, ""));
 }
 
 static fextl::string encodeHex(const unsigned char* data, size_t length) {


### PR DESCRIPTION
Just a typo accidentally prefixing 0x on the hex when it shouldn't.