### PR TITLE
Linux/FaultSafeUserMemAccess: Break out fault safe handler

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -12,6 +12,7 @@ $end_info$
 #include "LinuxSyscalls/LinuxAllocator.h"
 #include "LinuxSyscalls/ThreadManager.h"
 #include "LinuxSyscalls/Seccomp/SeccompEmulator.h"
+#include "ArchHelpers/MContext.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/Thunks.h>
@@ -674,6 +675,18 @@ namespace FaultSafeUserMemAccess {
   }
 #endif
   bool IsFaultLocation(uint64_t PC);
+
+  static inline bool TryHandleSafeFault(int Signal, const siginfo_t& SigInfo, void* UContext) {
+    if (Signal == SIGSEGV && (SigInfo.si_code == SEGV_MAPERR || SigInfo.si_code == SEGV_ACCERR) &&
+        FaultSafeUserMemAccess::IsFaultLocation(ArchHelpers::Context::GetPc(UContext))) {
+      // Return from the subroutine, returning EFAULT.
+      ArchHelpers::Context::SetArmReg(UContext, 0, EFAULT);
+      ArchHelpers::Context::SetPc(UContext, ArchHelpers::Context::GetArmReg(UContext, 30));
+      return true;
+    }
+
+    return false;
+  }
 } // namespace FaultSafeUserMemAccess
 
 } // namespace FEX::HLE


### PR DESCRIPTION
This is going to get used by gdbserver soon for ensuring memory accesses are fault safe, because it tries to read outside of correct memory bounds at times.