### PR TITLE
Support a merged RootFS (and a bunch of related fixes)

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h
@@ -23,7 +23,7 @@ class EmulatedFDManager {
 public:
   EmulatedFDManager(FEXCore::Context::Context* ctx);
   ~EmulatedFDManager();
-  int32_t OpenAt(int dirfs, const char* pathname, int flags, uint32_t mode);
+  int32_t Open(const char* pathname, int flags, uint32_t mode);
 
 private:
   FEXCore::Context::Context* CTX;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
@@ -333,6 +333,8 @@ FileManager::FileManager(FEXCore::Context::Context* ctx)
     ProcFSDev = Buffer.st_dev;
   }
 
+  uint32_t KernelVersion = FEX::HLE::SyscallHandler::CalculateHostKernelVersion();
+  HasOpenat2 = KernelVersion >= FEX::HLE::SyscallHandler::KernelVersion(5, 8, 0);
   UpdatePID(::getpid());
 }
 
@@ -646,15 +648,17 @@ uint64_t FileManager::Open(const char* pathname, int flags, uint32_t mode) {
 
   if (!ShouldSkipOpenInEmu(flags)) {
     FDPathTmpData TmpFilename;
-    auto Path = GetEmulatedFDPath(AT_FDCWD, SelfPath, false, TmpFilename);
+    auto Path = GetEmulatedFDPath(AT_FDCWD, SelfPath, !HasOpenat2, TmpFilename);
     if (Path.first != -1) {
       FEX::HLE::open_how how = {
         .flags = (uint64_t)flags,
         .mode = (flags & (O_CREAT | O_TMPFILE)) ? mode & 07777 : 0, // openat2() is stricter about this
         .resolve = (Path.first == AT_FDCWD) ? 0u : RESOLVE_IN_ROOT, // AT_FDCWD means it's a thunk and not via RootFS
       };
-      fd = ::syscall(SYSCALL_DEF(openat2), Path.first, Path.second, &how, sizeof(how));
-      if (fd == -1 && errno == EXDEV) {
+      if (HasOpenat2) {
+        fd = ::syscall(SYSCALL_DEF(openat2), Path.first, Path.second, &how, sizeof(how));
+      }
+      if (fd == -1 && (!HasOpenat2 || errno == EXDEV)) {
         // This means a magic symlink (/proc/foo) was involved. In this case we
         // just punt and do the access without RESOLVE_IN_ROOT.
         fd = ::syscall(SYSCALL_DEF(openat), Path.first, Path.second, flags, mode);
@@ -899,15 +903,17 @@ uint64_t FileManager::Openat([[maybe_unused]] int dirfs, const char* pathname, i
 
   if (!ShouldSkipOpenInEmu(flags)) {
     FDPathTmpData TmpFilename;
-    auto Path = GetEmulatedFDPath(dirfs, SelfPath, false, TmpFilename);
+    auto Path = GetEmulatedFDPath(dirfs, SelfPath, !HasOpenat2, TmpFilename);
     if (Path.first != -1) {
       FEX::HLE::open_how how = {
         .flags = (uint64_t)flags,
         .mode = (flags & (O_CREAT | O_TMPFILE)) ? mode & 07777 : 0, // openat2() is stricter about this,
         .resolve = (Path.first == AT_FDCWD) ? 0u : RESOLVE_IN_ROOT, // AT_FDCWD means it's a thunk and not via RootFS
       };
-      fd = ::syscall(SYSCALL_DEF(openat2), Path.first, Path.second, &how, sizeof(how));
-      if (fd == -1 && errno == EXDEV) {
+      if (HasOpenat2) {
+        fd = ::syscall(SYSCALL_DEF(openat2), Path.first, Path.second, &how, sizeof(how));
+      }
+      if (fd == -1 && (!HasOpenat2 || errno == EXDEV)) {
         // This means a magic symlink (/proc/foo) was involved. In this case we
         // just punt and do the access without RESOLVE_IN_ROOT.
         fd = ::syscall(SYSCALL_DEF(openat), Path.first, Path.second, flags, mode);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
@@ -787,7 +787,7 @@ uint64_t FileManager::Readlink(const char* pathname, char* buf, size_t bufsiz) {
     if (Result == -1 && errno == EINVAL) {
       // This means that the file wasn't a symlink
       // This is expected behaviour
-      return -errno;
+      return -1;
     }
   }
   if (Result == -1) {
@@ -865,7 +865,7 @@ uint64_t FileManager::Readlinkat(int dirfd, const char* pathname, char* buf, siz
     if (Result == -1 && errno == EINVAL) {
       // This means that the file wasn't a symlink
       // This is expected behaviour
-      return -errno;
+      return -1;
     }
   }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
@@ -517,8 +517,8 @@ std::pair<int, const char*> FileManager::GetEmulatedFDPath(int dirfd, const char
         // Get the symlink of RootFS FD + stripped subpath.
         auto SymlinkSize = FEX::HLE::GetSymlink(RootFSFD, &SubPath[1], CurrentTmp, PATH_MAX - 1);
 
-        if (SymlinkSize > 0 && CurrentTmp[0] == '/') {
-          // If the symlink is absolute:
+        if (SymlinkSize > 1 && CurrentTmp[0] == '/') {
+          // If the symlink is absolute and not the root:
           // 1) Zero terminate it.
           // 2) Set the path as our current subpath.
           // 3) Switch to the next temporary index. (We don't want to overwrite the current one on the next loop iteration).

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
@@ -418,6 +418,21 @@ ssize_t FileManager::StripRootFSPrefix(char* pathname, ssize_t len, bool leaky) 
   return len - Prefix;
 }
 
+fextl::string FileManager::GetHostPath(fextl::string& Path, bool AliasedOnly) {
+  auto Prefix = GetRootFSPrefixLen(Path.c_str(), Path.length(), AliasedOnly);
+
+  if (Prefix == 0) {
+    return {};
+  }
+
+  auto ret = Path.substr(Prefix);
+  if (ret.empty()) { // Getting the root
+    ret = "/";
+  }
+
+  return ret;
+}
+
 fextl::string FileManager::GetEmulatedPath(const char* pathname, bool FollowSymlink) {
   if (!pathname ||                  // If no pathname
       pathname[0] != '/' ||         // If relative

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
@@ -517,6 +517,9 @@ std::pair<int, const char*> FileManager::GetEmulatedFDPath(int dirfd, const char
         // Get the symlink of RootFS FD + stripped subpath.
         auto SymlinkSize = FEX::HLE::GetSymlink(RootFSFD, &SubPath[1], CurrentTmp, PATH_MAX - 1);
 
+        // This might be a /proc symlink into the RootFS, so strip it in that case.
+        SymlinkSize = StripRootFSPrefix(CurrentTmp, SymlinkSize, false);
+
         if (SymlinkSize > 1 && CurrentTmp[0] == '/') {
           // If the symlink is absolute and not the root:
           // 1) Zero terminate it.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
@@ -170,5 +170,6 @@ private:
   int64_t RootFSFDInode = 0;
   int64_t ProcFDInode = 0;
   dev_t ProcFSDev;
+  bool HasOpenat2;
 };
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
@@ -88,6 +88,8 @@ public:
   using FDPathTmpData = std::array<char[PATH_MAX], 2>;
   std::pair<int, const char*> GetEmulatedFDPath(int dirfd, const char* pathname, bool FollowSymlink, FDPathTmpData& TmpFilename);
 
+  bool ReplaceEmuFd(int fd, int flags, uint32_t mode);
+
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
   void TrackFEXFD(int FD) noexcept {
     std::lock_guard lk(FEXTrackingFDMutex);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
@@ -85,6 +85,7 @@ public:
   bool IsRootFSFD(int dirfd, uint64_t inode);
 
   fextl::string GetEmulatedPath(const char* pathname, bool FollowSymlink = false);
+  fextl::string GetHostPath(fextl::string& Path, bool AliasedOnly);
   using FDPathTmpData = std::array<char[PATH_MAX], 2>;
   std::pair<int, const char*> GetEmulatedFDPath(int dirfd, const char* pathname, bool FollowSymlink, FDPathTmpData& TmpFilename);
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h
@@ -142,6 +142,8 @@ private:
 #endif
 
   bool RootFSPathExists(const char* Filepath);
+  size_t GetRootFSPrefixLen(const char* pathname, size_t len, bool AliasedOnly);
+  ssize_t StripRootFSPrefix(char* pathname, ssize_t len, bool leaky);
 
   struct ThunkDBObject {
     fextl::string LibraryName;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -9,6 +9,7 @@ $end_info$
 
 #include "CodeLoader.h"
 
+#include "FEXHeaderUtils/StringArgumentParser.h"
 #include "Linux/Utils/ELFContainer.h"
 #include "Linux/Utils/ELFParser.h"
 
@@ -139,30 +140,20 @@ template uint64_t GetDentsEmulation<false>(int, FEX::HLE::x64::linux_dirent*, ui
 
 template uint64_t GetDentsEmulation<true>(int, FEX::HLE::x32::linux_dirent_32*, uint32_t);
 
-static bool IsShebangFile(std::span<char> Data) {
+static fextl::string GetShebangInterpFile(std::span<char> Data) {
   // File isn't large enough to even contain a shebang.
   if (Data.size() <= 2) {
-    return false;
+    return {};
   }
 
   // Handle shebang files.
   if (Data[0] == '#' && Data[1] == '!') {
     fextl::string InterpreterLine {Data.begin() + 2, // strip off "#!" prefix
                                    std::find(Data.begin(), Data.end(), '\n')};
-    fextl::vector<fextl::string> ShebangArguments {};
-
-    // Shebang line can have a single argument
-    fextl::istringstream InterpreterSS(InterpreterLine);
-    fextl::string Argument;
-    while (std::getline(InterpreterSS, Argument, ' ')) {
-      if (Argument.empty()) {
-        continue;
-      }
-      ShebangArguments.push_back(std::move(Argument));
-    }
+    fextl::vector<std::string_view> ShebangArguments = FHU::ParseArgumentsFromString(InterpreterLine);
 
     // Executable argument
-    fextl::string& ShebangProgram = ShebangArguments[0];
+    fextl::string ShebangProgram(ShebangArguments[0]);
 
     // If the filename is absolute then prepend the rootfs
     // If it is relative then don't append the rootfs
@@ -170,13 +161,15 @@ static bool IsShebangFile(std::span<char> Data) {
       ShebangProgram = FEX::HLE::_SyscallHandler->RootFSPath() + ShebangProgram;
     }
 
-    return FHU::Filesystem::Exists(ShebangProgram);
+    if (FHU::Filesystem::Exists(ShebangProgram)) {
+      return ShebangProgram;
+    }
   }
 
-  return false;
+  return {};
 }
 
-static bool IsShebangFD(int FD) {
+static fextl::string GetShebangInterpFD(int FD) {
   // We don't know the state of the FD coming in since this might be a guest tracked FD.
   // Need to be extra careful here not to adjust file offsets and status flags.
   //
@@ -187,19 +180,19 @@ static bool IsShebangFD(int FD) {
   const auto ChunkSize = 257l;
   const auto ReadSize = pread(FD, &Header.at(0), ChunkSize, 0);
 
-  return IsShebangFile(std::span<char>(Header.data(), ReadSize));
+  return GetShebangInterpFile(std::span<char>(Header.data(), ReadSize));
 }
 
-static bool IsShebangFilename(const fextl::string& Filename) {
+static fextl::string GetShebangInterpFilename(const fextl::string& Filename) {
   // Open the Filename to determine if it is a shebang file.
   int FD = open(Filename.c_str(), O_RDONLY | O_CLOEXEC);
   if (FD == -1) {
-    return false;
+    return {};
   }
 
-  bool IsShebang = IsShebangFD(FD);
+  auto Interp = GetShebangInterpFD(FD);
   close(FD);
-  return IsShebang;
+  return Interp;
 }
 
 uint64_t ExecveHandler(FEXCore::Core::CpuStateFrame* Frame, const char* pathname, char* const* argv, char* const* envp, ExecveAtArgs Args) {
@@ -208,18 +201,19 @@ uint64_t ExecveHandler(FEXCore::Core::CpuStateFrame* Frame, const char* pathname
 
   fextl::string RootFS = SyscallHandler->RootFSPath();
   ELFLoader::ELFContainer::ELFType Type {};
+  ELFLoader::ELFContainer::ELFType InterpreterType {};
 
   // AT_EMPTY_PATH is only used if the pathname is empty.
   const bool IsFDExec = (Args.flags & AT_EMPTY_PATH) && strlen(pathname) == 0;
   fextl::string FDExecEnv;
   fextl::string FDSeccompEnv;
 
-  bool IsShebang {};
+  fextl::string ShebangInterpreter {};
 
   if (IsFDExec) {
     Type = ELFLoader::ELFContainer::GetELFType(Args.dirfd);
 
-    IsShebang = IsShebangFD(Args.dirfd);
+    ShebangInterpreter = GetShebangInterpFD(Args.dirfd);
   } else {
     // For absolute paths, check the rootfs first (if available)
     if (pathname[0] == '/') {
@@ -253,7 +247,12 @@ uint64_t ExecveHandler(FEXCore::Core::CpuStateFrame* Frame, const char* pathname
 
     Type = ELFLoader::ELFContainer::GetELFType(Filename);
 
-    IsShebang = IsShebangFilename(Filename);
+    ShebangInterpreter = GetShebangInterpFilename(Filename);
+  }
+
+  const bool IsShebang = !ShebangInterpreter.empty();
+  if (IsShebang) {
+    InterpreterType = ELFLoader::ELFContainer::GetELFType(ShebangInterpreter);
   }
 
   if (!IsShebang && Type == ELFLoader::ELFContainer::ELFType::TYPE_NONE) {
@@ -306,6 +305,10 @@ uint64_t ExecveHandler(FEXCore::Core::CpuStateFrame* Frame, const char* pathname
   // - FEXServer FD inheritance (unshare(CLONE_NEWNET))
   const bool NeedsEnvpCopy = (IsFDExec && !(IsBinfmtCompatible || IsOtherELF)) || HasSeccomp;
 
+  // We are trying to execute a shebang handled by a different architecture interpreter (e.g. /usr/bin/python from the host FS).
+  // In this case we just defer to the kernel.
+  const bool IsForeignShebang = (IsShebang && InterpreterType == ELFLoader::ELFContainer::ELFType::TYPE_OTHER_ELF);
+
   if (NeedsEnvpCopy) {
     if (envp) {
       auto OldEnvp = envp;
@@ -354,7 +357,7 @@ uint64_t ExecveHandler(FEXCore::Core::CpuStateFrame* Frame, const char* pathname
     EnvpPtr = const_cast<char* const*>(EnvpArgs.data());
   }
 
-  if (!IsFDExec && (IsShebang || IsOtherELF)) {
+  if (!IsFDExec && (IsForeignShebang || IsOtherELF || !IsBinfmtCompatible)) {
     // With a merged RootFS, the entire real filesystem is visible through the rootfs
     // prefix. If we are executing a non-emulated binary, we should do so through the host
     // path.
@@ -365,11 +368,23 @@ uint64_t ExecveHandler(FEXCore::Core::CpuStateFrame* Frame, const char* pathname
     }
   }
 
-  if (IsBinfmtCompatible || IsOtherELF) {
+  if (IsBinfmtCompatible || IsOtherELF || IsForeignShebang) {
     Result = ::syscall(SYS_execveat, Args.dirfd, Filename.c_str(), argv, EnvpPtr, Args.flags);
     CloseSeccompFD();
     CloseFDExecFD();
     SYSCALL_ERRNO();
+  }
+
+  // If we are executing an emulated interpreter shebang file through the loader,
+  // we need to strip the RootFS prefix. The loader will pass this filename to the
+  // interpreter as-is, which will access it using RootFS redirection.
+  // Note that unlike above, the prefix is stripped unconditionally (AliasedOnly=false),
+  // and the script path need not exist in the host.
+  if (IsShebang) {
+    auto Path = SyscallHandler->FM.GetHostPath(Filename, false);
+    if (!Path.empty()) {
+      Filename = std::move(Path);
+    }
   }
 
   // We don't have an interpreter installed or we are executing a non-ELF executable


### PR DESCRIPTION
This is a new RootFS approach where the entire filesystem hierarchy is bind-mounted under the RootFS directory, with the RootFS itself overlaid. This, in principle, lets FEX avoid all the RootFS merge logic and lets the kernel do it, which should be both faster and more correct. In particular, symlinks between user directories and the RootFS work, and listing a directory correctly returns the merged entries from the RootFS and the host FS, instead of only the RootFS ones.

This PR includes fixes to make a merged-RootFS configuration work (as well as some misc adjacent issues), but does not add an explicit configuration option to disable the filesystem overlay logic in this scenario. That may come later, but it should only be an optimization at that point and may or may not be worth it.

The merged RootFS scenario stress-tests the FEX path handling, since in principle everything is opened through the RootFS and therefore there are more opportunities for the RootFS path to leak to the guest or end up in the wrong place.

Unlike #3831, this PR should *improve* performance, since it removes system calls in a hot path. `open()`/`openat()`/`openat2()` go from (in the common case):

  - `readlink()` * O(directory components) (from `realpath()` in emufd)
  - `fstatat()` (from `GetEmulatedFDPath()`, and possibly more if it's a symlink)
  - The `openat2()` itself

To:
  - One `openat2()` for the RootFS
  - If not found in RootFS, one `openat2()` for the host
  - One single `readlink()` to check for emu files

Tested with Steam and some games under Proton and Portal 2, both with and without the merged-RootFS setup.

When used with a [merged RootFS](https://github.com/AsahiLinux/muvm/pull/130), this finally fixes Wine. This supersedes #3831 *only* in the merged-rootfs case, so the question remains whether the non-merged resolution should be fixed to handle the problem or not...

Note that the fixes here are not comprehensive (proper symlink resolution behavior is limited to `open()` family syscalls, not any others), but it's enough to fix Wine and shouldn't regress any cases.