### PR TITLE
FEXInterpreter: Punch through a /sys/fex/rootfs node

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -573,6 +573,12 @@ EmulatedFDManager::EmulatedFDManager(FEXCore::Context::Context* ctx)
   fextl::string procCmdLine = fextl::fmt::format("/proc/{}/cmdline", getpid());
   FDReadCreators[procCmdLine] = cmdline_handler;
 
+  // FEX-Emu specific file handles
+  FDReadCreators["/sys/fex/rootfs"] = [&](FEXCore::Context::Context* ctx, int32_t fd, const char* pathname, int32_t flags, mode_t mode) -> int32_t {
+    // Redirect to the guest rootfs
+    return ::syscall(SYSCALL_DEF(openat), fd, LDPath().c_str(), flags, mode);
+  };
+
   if (ThreadsConfig > 1) {
     cpus_online = fextl::fmt::format("0-{}", ThreadsConfig - 1);
   } else {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.h
@@ -35,5 +35,7 @@ private:
 
   static int32_t ProcAuxv(FEXCore::Context::Context* ctx, int32_t fd, const char* pathname, int32_t flags, mode_t mode);
   const uint32_t ThreadsConfig;
+
+  FEX_CONFIG_OPT(LDPath, ROOTFS);
 };
 } // namespace FEX::EmulatedFile


### PR DESCRIPTION
Currently pressure-vessel does a bit of a bodge to get the x86 rootfs path when running inside of FEX. It does this by opening `/.` which works around our pseudo-overlayfs tracking. While this worked, it wasn't guaranteed to work forever. With #4225 working to fix more issues around how rootfs is laid out, it had to break this path (while adding a workaround for it to keep working).

Give pressure-vessel a blessed path from the EmulatedFiles code paths to get a real fd back to the x86 rootfs, that way if we break this code path it is entirely our problem to fix.

Still need to have a conversation with upstream pressure-vessel to see if they'll accept this path or if we need to do something different.

We can also use this same mechanism in the future if we want to expose more FEX specific data to the application through this.