### PR TITLE
InstCountCI: Adds more LRCPC2 tests that are missed

### DIFF
--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
@@ -1,0 +1,91 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "TSO",
+      "LRCPC",
+      "LRCPC2",
+      "FLAGM",
+      "FLAGM2"
+    ],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256",
+      "RPRES",
+      "AFP"
+    ]
+  },
+  "Comment": [
+    "These are instruction combinations that could be more optimal if FEX optimized for them"
+  ],
+  "Instructions": {
+    "Load variables from memory": {
+      "x86InstructionCount": 6,
+      "ExpectedInstructionCount": 18,
+      "Comment": [
+        "Just to ensure small atomic offset loads are using LRCPC2"
+      ],
+      "x86Insts": [
+        "mov edi, [rcx]",
+        "mov edx, [rcx + 4]",
+        "mov rbx, [rcx + 8]",
+        "mov rsi, [rcx + 16]",
+        "mov ax, [rcx + 24]",
+        "mov bl, [rcx + 26]"
+      ],
+      "ExpectedArm64ASM": [
+        "ldapur w11, [x7]",
+        "nop",
+        "add x20, x7, #0x4 (4)",
+        "ldapur w5, [x20]",
+        "nop",
+        "add x20, x7, #0x8 (8)",
+        "ldapur x6, [x20]",
+        "nop",
+        "add x20, x7, #0x10 (16)",
+        "ldapur x10, [x20]",
+        "nop",
+        "add x20, x7, #0x18 (24)",
+        "ldapurh w20, [x20]",
+        "nop",
+        "bfxil x4, x20, #0, #16",
+        "add x20, x7, #0x1a (26)",
+        "ldapurb w20, [x20]",
+        "bfxil x6, x20, #0, #8"
+      ]
+    },
+    "Store variables to memory": {
+      "x86InstructionCount": 6,
+      "ExpectedInstructionCount": 16,
+      "Comment": [
+        "Just to ensure small atomic offset stores are using LRCPC2"
+      ],
+      "x86Insts": [
+        "mov [rcx], edi",
+        "mov [rcx + 4], edx",
+        "mov [rcx + 8], rbx",
+        "mov [rcx + 16], rsi",
+        "mov [rcx + 24], ax",
+        "mov [rcx + 26], bl"
+      ],
+      "ExpectedArm64ASM": [
+        "nop",
+        "stlur w11, [x7]",
+        "add x20, x7, #0x4 (4)",
+        "nop",
+        "stlur w5, [x20]",
+        "add x20, x7, #0x8 (8)",
+        "nop",
+        "stlur x6, [x20]",
+        "add x20, x7, #0x10 (16)",
+        "nop",
+        "stlur x10, [x20]",
+        "add x20, x7, #0x18 (24)",
+        "nop",
+        "stlurh w4, [x20]",
+        "add x20, x7, #0x1a (26)",
+        "stlurb w6, [x20]"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
@@ -65,6 +65,66 @@
         "subs w26, w4, w20",
         "mov x4, x26"
       ]
+    },
+    "Load variables from memory": {
+      "x86InstructionCount": 4,
+      "ExpectedInstructionCount": 16,
+      "Comment": [
+        "Just to ensure small atomic offset loads are using LRCPC2"
+      ],
+      "x86Insts": [
+        "mov edi, [ecx]",
+        "mov edx, [ecx + 4]",
+        "mov ax, [ecx + 24]",
+        "mov bl, [ecx + 26]"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w20, w7",
+        "ldapur w11, [x20]",
+        "nop",
+        "add x20, x7, #0x4 (4)",
+        "mov w20, w20",
+        "ldapur w5, [x20]",
+        "nop",
+        "add x20, x7, #0x18 (24)",
+        "mov w20, w20",
+        "ldapurh w20, [x20]",
+        "nop",
+        "bfxil x4, x20, #0, #16",
+        "add x20, x7, #0x1a (26)",
+        "mov w20, w20",
+        "ldapurb w20, [x20]",
+        "bfxil x6, x20, #0, #8"
+      ]
+    },
+    "Store variables to memory": {
+      "x86InstructionCount": 4,
+      "ExpectedInstructionCount": 14,
+      "Comment": [
+        "Just to ensure small atomic offset stores are using LRCPC2"
+      ],
+      "x86Insts": [
+        "mov [ecx], edi",
+        "mov [ecx + 4], edx",
+        "mov [ecx + 24], ax",
+        "mov [ecx + 26], bl"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w20, w7",
+        "nop",
+        "stlur w11, [x20]",
+        "add x20, x7, #0x4 (4)",
+        "mov w20, w20",
+        "nop",
+        "stlur w5, [x20]",
+        "add x20, x7, #0x18 (24)",
+        "mov w20, w20",
+        "nop",
+        "stlurh w4, [x20]",
+        "add x20, x7, #0x1a (26)",
+        "mov w20, w20",
+        "stlurb w6, [x20]"
+      ]
     }
   }
 }


### PR DESCRIPTION
We weren't testing 64-bit variants, and we also weren't testing 8-bit and 16-bit loadstores. Add some more to ensure we are hitting these.