### PR TITLE
FEXLoader: Enable early logs output to stderr

### DIFF
--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -64,8 +64,8 @@ $end_info$
 #include <sys/signal.h>
 
 namespace {
-static bool SilentLog;
-static int OutputFD {-1};
+static bool SilentLog {};
+static int OutputFD {STDERR_FILENO};
 
 void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
   if (SilentLog) {


### PR DESCRIPTION
Some early FEXServer startup log failures weren't getting printed correctly. They were going through the LogManager but before FEXServer setup, or even stderr/stdout logman setup. So they were just getting written to -1 and failing.

Fixes #4155