### PR TITLE
LinuxSyscalls: Log unhandled clone3 fork flags

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -676,9 +676,7 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args
 
   if (!(flags & CLONE_THREAD)) {
     // CLONE_PARENT is ignored (Implied by CLONE_THREAD)
-    return FEX::HLE::ForkGuest(Thread, Frame, flags, reinterpret_cast<void*>(args->args.stack), args->args.stack_size,
-                               reinterpret_cast<pid_t*>(args->args.parent_tid), reinterpret_cast<pid_t*>(args->args.child_tid),
-                               reinterpret_cast<void*>(args->args.tls), args->args.exit_signal);
+    return FEX::HLE::ForkGuest(Thread, Frame, args);
   } else {
     auto NewThread = FEX::HLE::CreateNewThread(Thread->CTX, Frame, args);
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.h
@@ -20,6 +20,5 @@ struct ThreadStateObject;
 FEX::HLE::ThreadStateObject* CreateNewThread(FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args* args);
 uint64_t HandleNewClone(FEX::HLE::ThreadStateObject* Thread, FEXCore::Context::Context* CTX, FEXCore::Core::CpuStateFrame* Frame,
                         FEX::HLE::clone3_args* GuestArgs);
-uint64_t ForkGuest(FEXCore::Core::InternalThreadState* Thread, FEXCore::Core::CpuStateFrame* Frame, uint32_t flags, void* stack,
-                   size_t StackSize, pid_t* parent_tid, pid_t* child_tid, void* tls, uint64_t exit_signal);
+uint64_t ForkGuest(FEXCore::Core::InternalThreadState* Thread, FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args* args);
 } // namespace FEX::HLE


### PR DESCRIPTION
Make sure to pass the clone3 arguments all the way to the fork handler so it can check the flags. Currently nothing I know of uses fork plus the new clone3 flags, but it would be hard to see without any logging.