### PR TITLE
Windows: Only deinit the thread CRT when destroying the current thread

### DIFF
--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -137,7 +137,6 @@ bool IsDispatcherAddress(uint64_t Address) {
 }
 
 bool IsAddressInJit(uint64_t Address) {
-  const auto& Config = SignalDelegator->GetConfig();
   if (IsDispatcherAddress(Address)) {
     return true;
   }


### PR DESCRIPTION
The thread termination callback can be called for other threads in the
process, not just the current one, in which case we cannot call DeinitCRT.
Deinitializing the CRT of another thread would be awkward so just skip that
and accept the small leak for now.