### PR TITLE
cmake: Adds some missing STATIC qualifiers

### DIFF
--- a/External/tiny-json/CMakeLists.txt
+++ b/External/tiny-json/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(NAME tiny-json)
 set(SRCS tiny-json.c)
-add_library(${NAME} ${SRCS})
+add_library(${NAME} STATIC ${SRCS})

--- a/ThunkLibs/Generator/CMakeLists.txt
+++ b/ThunkLibs/Generator/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT CLANG_RESOURCE_DIR)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
 
-add_library(thunkgenlib analysis.cpp data_layout.cpp gen.cpp)
+add_library(thunkgenlib STATIC analysis.cpp data_layout.cpp gen.cpp)
 target_include_directories(thunkgenlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(thunkgenlib SYSTEM PUBLIC ${CLANG_INCLUDE_DIRS})
 target_link_libraries(thunkgenlib PUBLIC clang-cpp LLVM)


### PR DESCRIPTION
Noticed this as I was scrolling through some cmake. Usually this doesn't matter as we declare `BUILD_SHARED_LIBS` as False/Off, but this can technically be overridden even when we don't want to.

Updates the two definitions of `add_library` that was missing the static qualifier to ensure they generate the code we want.