### PR TITLE
Windows/CRT: Fixes FD leak

### DIFF
--- a/Source/Windows/Common/CRT/IO.cpp
+++ b/Source/Windows/Common/CRT/IO.cpp
@@ -36,6 +36,10 @@ struct FILE {
     : Handle {Handle}
     , FileHandle {FileHandle}
     , Append {Append} {}
+
+  ~FILE() {
+    CloseHandle(Handle);
+  }
 };
 
 namespace {


### PR DESCRIPTION
Noticed that the FEXCore config file was open forever.