### PR TITLE
Print arg type f80Bit

### DIFF
--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -240,6 +240,7 @@ static void PrintArg(fextl::stringstream* out, [[maybe_unused]] const IRListView
   case OpSize::i64Bit: *out << "i64"; break;
   case OpSize::i128Bit: *out << "i128"; break;
   case OpSize::i256Bit: *out << "i256"; break;
+  case OpSize::f80Bit: *out << "f80"; break;
   default: *out << "<Unknown OpSize Type>"; break;
   }
 }


### PR DESCRIPTION
Without this the log is full of `<Unknown OpSize Type>` when looking at x87 IR.