### PR TITLE
CPUBackend: Make guest RIP reconstruction offsets signed

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -115,7 +115,7 @@ namespace CPU {
       uint16_t HostPCOffset;
 
       // How much to offset the RIP from the previous entry.
-      uint16_t GuestRIPOffset;
+      int16_t GuestRIPOffset;
     };
 
     /**


### PR DESCRIPTION
With multiblock enabled, host code generated from guest code with a lower address may be placed after host code generated from guest code with a higher address in a multiblock. As each guest RIP reconstruction entry is always relative to the one before it the offset needs to be signed to allow this.