### PR TITLE
CodeEmitter: Auto-format .inl headers

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -3,10 +3,13 @@
 # Ignore all files in the External directory
 External/*
 
-# SoftFloat-3e code doesn't belong to us 
+# SoftFloat-3e code doesn't belong to us
 FEXCore/Source/Common/SoftFloat-3e/*
 Source/Common/cpp-optparse/*
 
 # Files with human-indented tables for readability - don't mess with these
 FEXCore/Source/Interface/Core/X86Tables/*
 
+# Inline headers with list-like content that can't be processed individually
+Source/Tools/LinuxEmulation/LinuxSyscalls/x*/SyscallsNames.inl
+Source/Tools/LinuxEmulation/LinuxSyscalls/x*/Ioctl/*.inl

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -13,3 +13,6 @@
 
 # Second reformat to find fixed point PR#3577
 905aa935f5ce344a48ef4d5edab3c31efa8d793e
+
+# Reformat of CodeEmitter inl files
+8760c593ece92d7e9fa94c40da0368fd367c9cad

--- a/CodeEmitter/CodeEmitter/ALUOps.inl
+++ b/CodeEmitter/CodeEmitter/ALUOps.inl
@@ -11,6 +11,14 @@
  * FEX-Emu ALU operations usually have a 32-bit or 64-bit operating size encoded in the IR operation,
  * This allows FEX to use a single helper function which decodes to both handlers.
  */
+
+#pragma once
+#ifndef INCLUDED_BY_EMITTER
+#include <CodeEmitter/Emitter.h>
+namespace ARMEmitter {
+struct EmitterOps : Emitter {
+#endif
+
 private:
   static bool IsADRRange(int64_t Imm) {
     return Imm >= -1048576 && Imm <= 1048575;
@@ -1170,4 +1178,7 @@ private:
     dc32(Instr);
   }
 
-
+#ifndef INCLUDED_BY_EMITTER
+}; // struct LoadstoreEmitterOps
+} // namespace ARMEmitter
+#endif

--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -302,10 +302,10 @@ public:
   }
 
   // Advanced SIMD copy
-  template <typename T>
-  requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
+  template<typename T>
+  requires (std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
   void dup(SubRegSize size, T rd, T rn, uint32_t Index) {
-    if constexpr(std::is_same_v<DRegister, T>) {
+    if constexpr (std::is_same_v<DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
     }
 
@@ -326,7 +326,7 @@ public:
 
   // Advanced SIMD three same (FP16)
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMDThreeSameFP16(uint32_t U, uint32_t a, uint32_t opcode, T rm, T rn, T rd) {
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
     constexpr uint32_t Op = 0b0000'1110'0100'0000'0000'01 << 10;
@@ -344,7 +344,7 @@ public:
 
   // Advanced SIMD two-register miscellaneous (FP16)
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMDTwoRegMiscFP16(uint32_t U, uint32_t a, uint32_t opcode, T rn, T rd) {
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
     constexpr uint32_t Op = 0b0000'1110'0111'1000'0000'10 << 10;
@@ -361,7 +361,7 @@ public:
 
   // Advanced SIMD three-register extension
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMDThreeRegisterExt(uint32_t U, uint32_t opcode, ARMEmitter::SubRegSize size, T rm, T rn, T rd) {
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
     constexpr uint32_t Op = 0b0000'1110'0000'0000'1000'01 << 10;
@@ -377,10 +377,10 @@ public:
     dc32(Instr);
   }
 
-  template <typename T>
-  requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
+  template<typename T>
+  requires (std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
   void dup(SubRegSize size, T rd, Register rn) {
-    if constexpr(std::is_same_v<DRegister, T>) {
+    if constexpr (std::is_same_v<DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
     }
 
@@ -393,12 +393,10 @@ public:
     ASIMDScalarCopy(Op, Q, imm5, 0b0001, rd, ToVReg(rn));
   }
 
-  template <SubRegSize size>
-  requires(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit)
+  template<SubRegSize size>
+  requires (size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit)
   void smov(XRegister rd, VRegister rn, uint32_t Index) {
-    static_assert(size == SubRegSize::i8Bit ||
-                  size == SubRegSize::i16Bit ||
-                  size == SubRegSize::i32Bit, "Unsupported smov size");
+    static_assert(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit, "Unsupported smov size");
 
     constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
 
@@ -413,11 +411,10 @@ public:
 
     ASIMDScalarCopy(Op, 1, imm5, 0b0101, ToVReg(rd), rn);
   }
-  template <SubRegSize size>
-  requires(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit)
+  template<SubRegSize size>
+  requires (size == SubRegSize::i8Bit || size == SubRegSize::i16Bit)
   void smov(WRegister rd, VRegister rn, uint32_t Index) {
-    static_assert(size == SubRegSize::i8Bit ||
-                  size == SubRegSize::i16Bit, "Unsupported smov size");
+    static_assert(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit, "Unsupported smov size");
 
     constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
 
@@ -433,12 +430,10 @@ public:
     ASIMDScalarCopy(Op, 0, imm5, 0b0101, ToVReg(rd), rn);
   }
 
-  template <SubRegSize size>
+  template<SubRegSize size>
   void umov(Register rd, VRegister rn, uint32_t Index) {
-    static_assert(size == SubRegSize::i8Bit ||
-                  size == SubRegSize::i16Bit ||
-                  size == SubRegSize::i32Bit ||
-                  size == SubRegSize::i64Bit, "Unsupported umov size");
+    static_assert(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                  "Unsupported umov size");
 
 
     constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
@@ -456,7 +451,7 @@ public:
     ASIMDScalarCopy(Op, Q, imm5, 0b0111, ToVReg(rd), rn);
   }
 
-  template <SubRegSize size>
+  template<SubRegSize size>
   void ins(VRegister rd, uint32_t Index, Register rn) {
     constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
 
@@ -495,7 +490,7 @@ public:
     const uint32_t ElementSize = 1U << SizeImm;
     [[maybe_unused]] const uint32_t MaxIndex = 128U / (ElementSize * 8);
 
-    LOGMAN_THROW_A_FMT(Index < MaxIndex,  "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
+    LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
     LOGMAN_THROW_A_FMT(Index2 < MaxIndex, "Index2 too large. Index2={}, Max Index: {}", Index2, MaxIndex);
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
@@ -506,334 +501,281 @@ public:
 
   // Advanced SIMD three same (FP16)
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fmaxnm(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 0, 0b000, rm, rn, rd);
   }
 
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fmla(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 0, 0b001, rm, rn, rd);
   }
 
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fadd(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 0, 0b010, rm, rn, rd);
   }
 
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fmulx(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 0, 0b011, rm, rn, rd);
   }
 
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcmeq(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 0, 0b100, rm, rn, rd);
   }
 
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fmax(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 0, 0b110, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frecps(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 0, 0b111, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fminnm(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 1, 0b000, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fmls(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 1, 0b001, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fsub(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 1, 0b010, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fmin(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 1, 0b110, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frsqrts(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(0, 1, 0b111, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fmaxnmp(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 0, 0b000, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void faddp(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 0, 0b010, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fmul(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 0, 0b011, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcmge(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 0, 0b100, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void facge(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 0, 0b101, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fmaxp(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 0, 0b110, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fdiv(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 0, 0b111, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fminnmp(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 1, 0b000, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fabd(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 1, 0b010, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcmgt(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 1, 0b100, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void facgt(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 1, 0b101, rm, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fminp(T rd, T rn, T rm) {
     ASIMDThreeSameFP16(1, 1, 0b110, rm, rn, rd);
   }
 
   // Advanced SIMD two-register miscellaneous (FP16)
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frintn(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 0, 0b11000, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frintm(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 0, 0b11001, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcvtns(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 0, 0b11010, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcvtms(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 0, 0b11011, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcvtas(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 0, 0b11100, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void scvtf(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 0, 0b11101, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcmgt(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 1, 0b01100, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcmeq(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 1, 0b01101, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcmlt(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 1, 0b01110, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fabs(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 1, 0b01111, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frintp(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 1, 0b11000, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frintz(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 1, 0b11001, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcvtps(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 1, 0b11010, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcvtzs(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 1, 0b11011, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frecpe(T rd, T rn) {
     ASIMDTwoRegMiscFP16(0, 1, 0b11101, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frinta(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 0, 0b11000, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frintx(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 0, 0b11001, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcvtnu(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 0, 0b11010, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcvtmu(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 0, 0b11011, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcvtau(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 0, 0b11100, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void ucvtf(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 0, 0b11101, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcmge(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 1, 0b01100, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcmle(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 1, 0b01101, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fneg(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 1, 0b01111, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frinti(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 1, 0b11001, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcvtpu(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 1, 0b11010, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fcvtzu(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 1, 0b11011, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void frsqrte(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 1, 0b11101, rn, rd);
   }
   template<ARMEmitter::SubRegSize size, typename T>
-  requires(size == ARMEmitter::SubRegSize::i16Bit &&
-           (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
+  requires (size == ARMEmitter::SubRegSize::i16Bit && (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>))
   void fsqrt(T rd, T rn) {
     ASIMDTwoRegMiscFP16(1, 1, 0b11111, rn, rd);
   }
 
   // Advanced SIMD three-register extension
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sdot(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -842,13 +784,13 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void usdot(T rd, T rn, T rm) {
     ASIMDThreeRegisterExt(0, 0b0011, ARMEmitter::SubRegSize::i32Bit, rm, rn, rd);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqrdmlah(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -856,7 +798,7 @@ public:
     ASIMDThreeRegisterExt(1, 0b0000, size, rm, rn, rd);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqrdmlsh(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -864,7 +806,7 @@ public:
     ASIMDThreeRegisterExt(1, 0b0001, size, rm, rn, rd);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void udot(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -873,7 +815,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmla(ARMEmitter::SubRegSize size, T rd, T rn, T rm, ARMEmitter::Rotation Rot) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "8-bit subregsize not supported");
 
@@ -883,7 +825,7 @@ public:
     ASIMDThreeRegisterExt(1, 0b1000 | FEXCore::ToUnderlying(Rot), size, rm, rn, rd);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcadd(ARMEmitter::SubRegSize size, T rd, T rn, T rm, ARMEmitter::Rotation Rot) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "8-bit subregsize not supported");
 
@@ -891,12 +833,11 @@ public:
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     LOGMAN_THROW_A_FMT(Rot == ARMEmitter::Rotation::ROTATE_90 || Rot == ARMEmitter::Rotation::ROTATE_270, "Invalid rotation");
-    const uint32_t ConvertedRotation =
-      Rot == ARMEmitter::Rotation::ROTATE_90 ? 0b00 : 0b10;
+    const uint32_t ConvertedRotation = Rot == ARMEmitter::Rotation::ROTATE_90 ? 0b00 : 0b10;
     ASIMDThreeRegisterExt(1, 0b1100 | ConvertedRotation, size, rm, rn, rd);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void bfdot(T rd, T rn, T rm) {
     ASIMDThreeRegisterExt(1, 0b1111, ARMEmitter::SubRegSize::i16Bit, rm, rn, rd);
   }
@@ -921,7 +862,7 @@ public:
 
   // Advanced SIMD two-register miscellaneous
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void rev64(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
@@ -929,7 +870,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void rev16(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
@@ -939,20 +880,20 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void saddlp(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b00010, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void suqadd(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -962,14 +903,14 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cls(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b00100, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cnt(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
@@ -979,20 +920,20 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sadalp(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b00110, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqabs(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -1002,7 +943,7 @@ public:
   }
   // Comparison against zero
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cmgt(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -1012,7 +953,7 @@ public:
   }
   // Comparison against zero
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cmeq(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -1022,7 +963,7 @@ public:
   }
   // Comparison against zero
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cmlt(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -1031,7 +972,7 @@ public:
     ASIMD2RegMisc<T>(Op, 0, size, 0b01010, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void abs(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -1073,24 +1014,20 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void fcvtn(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit ||
-                       size == ARMEmitter::SubRegSize::i16Bit, "Only 16-bit & 32-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i16Bit, "Only 16-bit & 32-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10110, rd.D(), rn.D());
   }
   ///< size is the destination size.
   ///< source size is the next size up.
   void fcvtn2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit ||
-                       size == ARMEmitter::SubRegSize::i16Bit, "Only 16-bit & 32-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i16Bit, "Only 16-bit & 32-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10110, rd.Q(), rn.Q());
   }
@@ -1098,248 +1035,228 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void fcvtl(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10111, rd.D(), rn.D());
   }
   ///< size is the destination size.
   ///< source size is the next size up.
   void fcvtl2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 0, ConvertedSize, 0b10111, rd.Q(), rn.Q());
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frintn(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11000, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frintm(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11001, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtns(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11010, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtms(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11011, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtas(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11100, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void scvtf(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11101, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frint32z(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11110, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frint64z(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 0, ConvertedSize, 0b11111, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmgt(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01100, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmeq(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01101, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmlt(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01110, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fabs(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01111, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frintp(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11000, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frintz(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11001, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtps(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11010, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtzs(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11011, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void urecpe(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
@@ -1347,19 +1264,19 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frecpe(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11101, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void rev32(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit ||
-                       size == ARMEmitter::SubRegSize::i16Bit, "Only 8-bit & 16-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit || size == ARMEmitter::SubRegSize::i16Bit, "Only 8-bit & 16-bit subregsize "
+                                                                                                        "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b00000, rd, rn);
   }
@@ -1367,20 +1284,20 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void uaddlp(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b00010, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void usqadd(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -1390,7 +1307,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void clz(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
@@ -1400,20 +1317,20 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void uadalp(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b00110, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqneg(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -1424,7 +1341,7 @@ public:
 
   // Comparison against zero
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cmge(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -1434,7 +1351,7 @@ public:
   }
   // Comparison against zero
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cmle(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -1443,7 +1360,7 @@ public:
     ASIMD2RegMisc<T>(Op, 1, size, 0b01001, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void neg(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
@@ -1471,10 +1388,10 @@ public:
   void shll(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 1, ConvertedSize, 0b10011, rd, rn);
   }
@@ -1483,10 +1400,10 @@ public:
   void shll2(ARMEmitter::SubRegSize size, ARMEmitter::QRegister rd, ARMEmitter::QRegister rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 1, ConvertedSize, 0b10011, rd, rn);
   }
@@ -1507,9 +1424,9 @@ public:
   void fcvtxn(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 1, ConvertedSize, 0b10110, rd.D(), rn.D());
   }
@@ -1518,119 +1435,119 @@ public:
   void fcvtxn2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc(Op, 1, ConvertedSize, 0b10110, rd.Q(), rn.Q());
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frinta(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11000, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frintx(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11001, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtnu(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11010, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtmu(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11011, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtau(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11100, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ucvtf(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11101, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frint32x(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11110, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frint64x(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD2RegMisc<T>(Op, 1, ConvertedSize, 0b11111, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void not_(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, ARMEmitter::SubRegSize::i8Bit, 0b00101, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void mvn(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
@@ -1638,7 +1555,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void rbit(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
@@ -1646,102 +1563,102 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmge(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b01100, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmle(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b01101, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fneg(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b01111, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frinti(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11001, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtpu(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11010, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtzu(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11011, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ursqrte(ARMEmitter::SubRegSize size, T rd, T rn) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11100, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frsqrte(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11101, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fsqrt(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                       size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize "
+                                                                                                         "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11111, rd, rn);
   }
@@ -1750,148 +1667,157 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void saddlv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMDAcrossLanes<T>(Op, 0, ConvertedSize, 0b00011, rd, rn);
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void smaxv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not "
+                                                                                                           "supported");
     }
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     ASIMDAcrossLanes<T>(Op, 0, size, 0b01010, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sminv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not "
+                                                                                                           "supported");
     }
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     ASIMDAcrossLanes<T>(Op, 0, size, 0b11010, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void addv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not "
+                                                                                                           "supported");
     }
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     ASIMDAcrossLanes<T>(Op, 0, size, 0b11011, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void uaddlv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     ASIMDAcrossLanes<T>(Op, 1, ConvertedSize, 0b00011, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void umaxv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not "
+                                                                                                           "supported");
     }
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     ASIMDAcrossLanes<T>(Op, 1, size, 0b01010, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void uminv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not "
+                                                                                                           "supported");
     }
     LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     ASIMDAcrossLanes<T>(Op, 1, size, 0b11010, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmaxnmv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize "
+                                                                                                        "unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     const auto U = size == ARMEmitter::SubRegSize::i16Bit ? 0 : 1;
 
     ASIMDAcrossLanes<T>(Op, U, ConvertedSize, 0b01100, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmaxv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize "
+                                                                                                        "unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i8Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i8Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i8Bit :
+                                                                        ARMEmitter::SubRegSize::i8Bit;
 
     const auto U = size == ARMEmitter::SubRegSize::i16Bit ? 0 : 1;
 
     ASIMDAcrossLanes<T>(Op, U, ConvertedSize, 0b01111, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fminnmv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize "
+                                                                                                        "unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i64Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i32Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i64Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i32Bit :
+                                                                        ARMEmitter::SubRegSize::i32Bit;
 
     const auto U = size == ARMEmitter::SubRegSize::i16Bit ? 0 : 1;
 
     ASIMDAcrossLanes<T>(Op, U, ConvertedSize, 0b01100, rd, rn);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fminv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
     }
-    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize "
+                                                                                                        "unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
-    const auto ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i64Bit :
-      size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
-      size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i32Bit : ARMEmitter::SubRegSize::i32Bit;
+    const auto ConvertedSize = size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i64Bit :
+                               size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
+                               size == ARMEmitter::SubRegSize::i16Bit ? ARMEmitter::SubRegSize::i32Bit :
+                                                                        ARMEmitter::SubRegSize::i32Bit;
 
     const auto U = size == ARMEmitter::SubRegSize::i16Bit ? 0 : 1;
 
@@ -1906,7 +1832,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0000, ConvertedSize, rd, rn, rm);
   }
@@ -1915,7 +1841,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0000, ConvertedSize, rd, rn, rm);
   }
@@ -1924,7 +1850,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0001, ConvertedSize, rd, rn, rm);
   }
@@ -1933,7 +1859,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0001, ConvertedSize, rd, rn, rm);
   }
@@ -1942,7 +1868,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0010, ConvertedSize, rd, rn, rm);
   }
@@ -1951,7 +1877,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0010, ConvertedSize, rd, rn, rm);
   }
@@ -1960,7 +1886,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0011, ConvertedSize, rd, rn, rm);
   }
@@ -1969,7 +1895,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0011, ConvertedSize, rd, rn, rm);
   }
@@ -1988,7 +1914,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0101, ConvertedSize, rd, rn, rm);
   }
@@ -1997,7 +1923,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0101, ConvertedSize, rd, rn, rm);
   }
@@ -2016,7 +1942,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0111, ConvertedSize, rd, rn, rm);
   }
@@ -2025,7 +1951,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b0111, ConvertedSize, rd, rn, rm);
   }
@@ -2034,7 +1960,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1000, ConvertedSize, rd, rn, rm);
   }
@@ -2043,7 +1969,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1000, ConvertedSize, rd, rn, rm);
   }
@@ -2052,7 +1978,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1001, ConvertedSize, rd, rn, rm);
   }
@@ -2061,7 +1987,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1001, ConvertedSize, rd, rn, rm);
   }
@@ -2070,7 +1996,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1010, ConvertedSize, rd, rn, rm);
   }
@@ -2079,7 +2005,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1010, ConvertedSize, rd, rn, rm);
   }
@@ -2088,7 +2014,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1011, ConvertedSize, rd, rn, rm);
   }
@@ -2097,7 +2023,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1011, ConvertedSize, rd, rn, rm);
   }
@@ -2106,7 +2032,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1100, ConvertedSize, rd, rn, rm);
   }
@@ -2115,7 +2041,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1100, ConvertedSize, rd, rn, rm);
   }
@@ -2124,7 +2050,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1101, ConvertedSize, rd, rn, rm);
   }
@@ -2133,14 +2059,14 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 0, 0b1101, ConvertedSize, rd, rn, rm);
   }
   ///< Size is dest size
   void pmull(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
     LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i128Bit, "Only 16-bit and 128-bit destination supported");
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     ASIMD3Different(Op, 0, 0b1110, ConvertedSize, rd, rn, rm);
@@ -2148,7 +2074,7 @@ public:
   ///< Size is dest size
   void pmull2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
     LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i128Bit, "Only 16-bit and 128-bit destination supported");
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     ASIMD3Different(Op, 0, 0b1110, ConvertedSize, rd, rn, rm);
@@ -2158,7 +2084,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0000, ConvertedSize, rd, rn, rm);
   }
@@ -2167,7 +2093,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0000, ConvertedSize, rd, rn, rm);
   }
@@ -2176,7 +2102,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0001, ConvertedSize, rd, rn, rm);
   }
@@ -2185,7 +2111,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0001, ConvertedSize, rd, rn, rm);
   }
@@ -2194,7 +2120,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0010, ConvertedSize, rd, rn, rm);
   }
@@ -2203,7 +2129,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0010, ConvertedSize, rd, rn, rm);
   }
@@ -2212,7 +2138,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0011, ConvertedSize, rd, rn, rm);
   }
@@ -2221,7 +2147,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0011, ConvertedSize, rd, rn, rm);
   }
@@ -2231,7 +2157,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0101, ConvertedSize, rd, rn, rm);
   }
@@ -2240,7 +2166,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0101, ConvertedSize, rd, rn, rm);
   }
@@ -2250,7 +2176,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0111, ConvertedSize, rd, rn, rm);
   }
@@ -2259,7 +2185,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b0111, ConvertedSize, rd, rn, rm);
   }
@@ -2268,7 +2194,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b1000, ConvertedSize, rd, rn, rm);
   }
@@ -2277,7 +2203,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b1000, ConvertedSize, rd, rn, rm);
   }
@@ -2286,7 +2212,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b1010, ConvertedSize, rd, rn, rm);
   }
@@ -2295,7 +2221,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b1010, ConvertedSize, rd, rn, rm);
   }
@@ -2304,7 +2230,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b1100, ConvertedSize, rd, rn, rm);
   }
@@ -2313,7 +2239,7 @@ public:
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
-    const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size) - 1};
 
     ASIMD3Different(Op, 1, 0b1100, ConvertedSize, rd, rn, rm);
   }
@@ -2487,14 +2413,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11000, rd, rn, rm);
   }
@@ -2503,14 +2427,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11001, rd, rn, rm);
   }
@@ -2519,14 +2441,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11010, rd, rn, rm);
   }
@@ -2535,14 +2455,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11011, rd, rn, rm);
   }
@@ -2551,14 +2469,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11100, rd, rn, rm);
   }
@@ -2567,14 +2483,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11110, rd, rn, rm);
   }
@@ -2583,14 +2497,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 0, ConvertedSize, 0b11111, rd, rn, rm);
   }
@@ -2619,8 +2531,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b11000, rd, rn, rm);
@@ -2630,8 +2542,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b11001, rd, rn, rm);
@@ -2641,8 +2553,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b11010, rd, rn, rm);
@@ -2652,8 +2564,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b11110, rd, rn, rm);
@@ -2663,8 +2575,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b11111, rd, rn, rm);
@@ -2832,7 +2744,8 @@ public:
   }
   template<typename T>
   void sqrdmulh(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit && size != ARMEmitter::SubRegSize::i8Bit, "8/64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit && size != ARMEmitter::SubRegSize::i8Bit, "8/64-bit subregsize not "
+                                                                                                        "supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b10110, rd, rn, rm);
   }
@@ -2841,14 +2754,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11000, rd, rn, rm);
   }
@@ -2857,14 +2768,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11010, rd, rn, rm);
   }
@@ -2873,14 +2782,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11011, rd, rn, rm);
   }
@@ -2889,14 +2796,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11100, rd, rn, rm);
   }
@@ -2905,14 +2810,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11101, rd, rn, rm);
   }
@@ -2921,14 +2824,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11110, rd, rn, rm);
   }
@@ -2937,14 +2838,12 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     const ARMEmitter::SubRegSize ConvertedSize =
-      size == ARMEmitter::SubRegSize::i64Bit ?
-        ARMEmitter::SubRegSize::i16Bit :
-        ARMEmitter::SubRegSize::i8Bit;
+      size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit : ARMEmitter::SubRegSize::i8Bit;
 
     ASIMD3Same<T>(Op, 1, ConvertedSize, 0b11111, rd, rn, rm);
   }
@@ -2963,8 +2862,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b11000, rd, rn, rm);
@@ -2974,8 +2873,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b11010, rd, rn, rm);
@@ -2985,8 +2884,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b11100, rd, rn, rm);
@@ -2996,8 +2895,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b11101, rd, rn, rm);
@@ -3007,8 +2906,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit || size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit "
+                                                                                                         "subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b11110, rd, rn, rm);
@@ -3032,9 +2931,8 @@ public:
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
       LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit ||
-                        size == ARMEmitter::SubRegSize::i64Bit, "Unsupported fmov size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit,
+                       "Unsupported fmov size");
 
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     uint32_t op;
@@ -3044,18 +2942,15 @@ public:
     if (size == SubRegSize::i16Bit) {
       LOGMAN_MSG_A_FMT("Unsupported");
       FEX_UNREACHABLE;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       op = 0;
       o2 = 0;
       Imm = FP32ToImm8(Value);
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       op = 1;
       o2 = 0;
       Imm = FP64ToImm8(Value);
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Invalid subregsize");
       FEX_UNREACHABLE;
     }
@@ -3064,14 +2959,13 @@ public:
   }
   // XXX: MVNI - Shifted immediate
   // XXX: BIC
-  //void ASIMDModifiedImm(uint32_t Op, uint32_t op, uint32_t cmode, uint32_t o2, uint32_t imm, T rd) {
+  // void ASIMDModifiedImm(uint32_t Op, uint32_t op, uint32_t cmode, uint32_t o2, uint32_t imm, T rd) {
 
   template<typename T>
   void movi(ARMEmitter::SubRegSize size, T rd, uint64_t Imm, uint16_t Shift = 0) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit ||
-                        size == ARMEmitter::SubRegSize::i16Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit ||
-                        size == ARMEmitter::SubRegSize::i64Bit, "Unsupported smov size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit || size == ARMEmitter::SubRegSize::i16Bit ||
+                         size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit,
+                       "Unsupported smov size");
 
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     uint32_t cmode;
@@ -3081,20 +2975,17 @@ public:
       LOGMAN_THROW_A_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
       cmode = 0b1110;
       op = 0;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 8, "Shift by invalid amount");
       LOGMAN_THROW_A_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
       cmode = 0b1000 | (Shift ? 0b10 : 0b00);
       op = 0;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 8 || Shift == 16 || Shift == 24, "Shift by invalid amount");
       LOGMAN_THROW_A_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
       cmode = 0b0000 | ((Shift >> 3) << 1);
       op = 0;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Shift == 0, "64-bit can't have shift");
       cmode = 0b1110;
       op = 1;
@@ -3102,7 +2993,7 @@ public:
       // 64-bit movi doesn't behave like the smaller types
       // Each bit of the 8-bit imm encoding is expanded to a full 8-bits.
       // This gives us a full 64-bits for the final result but needs special handling.
-      uint8_t NewImm{};
+      uint8_t NewImm {};
       for (size_t i = 0; i < 8; ++i) {
         const size_t BitOffset = i * 8;
         uint8_t Section = (Imm >> BitOffset) & 0xFF;
@@ -3112,8 +3003,7 @@ public:
         }
       }
       Imm = NewImm;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Invalid subregsize");
       FEX_UNREACHABLE;
     }
@@ -3743,8 +3633,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -3769,8 +3658,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -3795,8 +3683,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -3821,8 +3708,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -3847,8 +3733,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -3873,8 +3758,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -3899,8 +3783,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -3925,8 +3808,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -3936,7 +3818,7 @@ public:
     ASIMDVectorXIndexedElement(0b0, L, M, 0b0111, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void mul(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
@@ -3951,8 +3833,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -3977,8 +3858,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4003,8 +3883,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4029,8 +3908,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4055,8 +3933,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4066,7 +3943,7 @@ public:
     ASIMDVectorXIndexedElement(0b0, L, M, 0b1011, H, EncodedSubRegSize, rm.Q(), rn.Q(), rd.Q());
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqdmulh(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
@@ -4081,8 +3958,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4092,7 +3968,7 @@ public:
     ASIMDVectorXIndexedElement(0b0, L, M, 0b1100, H, size, rm, rn, rd);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqrdmulh(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
@@ -4107,8 +3983,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4119,7 +3994,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sdot(T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(Index < 4, "Index must be less than the source register size");
 
@@ -4133,7 +4008,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sudot(T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(Index < 4, "Index must be less than the source register size");
 
@@ -4147,7 +4022,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void bfdot(T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(Index < 4, "Index must be less than the source register size");
 
@@ -4161,11 +4036,10 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmla(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit ||
-                        size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit,
+                       "Invalid destination size");
     LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
 
     uint32_t H, L, M;
@@ -4178,14 +4052,12 @@ public:
       M = (Index >> 0) & 1;
       // ARM in their infinite wisdom decided to encode 16-bit as an 8-bit operation even though 16-bit was unallocated.
       EncodedSubRegSize = ARMEmitter::SubRegSize::i8Bit;
-    }
-    else if (size == ARMEmitter::SubRegSize::i32Bit) {
+    } else if (size == ARMEmitter::SubRegSize::i32Bit) {
       // Index encoded in H:L
       H = (Index >> 1) & 1;
       L = (Index >> 0) & 1;
       M = 0;
-    }
-    else {
+    } else {
       LOGMAN_THROW_A_FMT(std::is_same_v<ARMEmitter::QRegister, T>, "Can't encode DRegister with i64Bit");
       // Index encoded in H
       H = Index;
@@ -4196,11 +4068,10 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmls(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit ||
-                        size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit,
+                       "Invalid destination size");
     LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
 
     uint32_t H, L, M;
@@ -4213,14 +4084,12 @@ public:
       M = (Index >> 0) & 1;
       // ARM in their infinite wisdom decided to encode 16-bit as an 8-bit operation even though 16-bit was unallocated.
       EncodedSubRegSize = ARMEmitter::SubRegSize::i8Bit;
-    }
-    else if (size == ARMEmitter::SubRegSize::i32Bit) {
+    } else if (size == ARMEmitter::SubRegSize::i32Bit) {
       // Index encoded in H:L
       H = (Index >> 1) & 1;
       L = (Index >> 0) & 1;
       M = 0;
-    }
-    else {
+    } else {
       LOGMAN_THROW_A_FMT(std::is_same_v<ARMEmitter::QRegister, T>, "Can't encode DRegister with i64Bit");
       // Index encoded in H
       H = Index;
@@ -4231,11 +4100,10 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmul(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit ||
-                        size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit,
+                       "Invalid destination size");
     LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
 
     uint32_t H, L, M;
@@ -4248,14 +4116,12 @@ public:
       M = (Index >> 0) & 1;
       // ARM in their infinite wisdom decided to encode 16-bit as an 8-bit operation even though 16-bit was unallocated.
       EncodedSubRegSize = ARMEmitter::SubRegSize::i8Bit;
-    }
-    else if (size == ARMEmitter::SubRegSize::i32Bit) {
+    } else if (size == ARMEmitter::SubRegSize::i32Bit) {
       // Index encoded in H:L
       H = (Index >> 1) & 1;
       L = (Index >> 0) & 1;
       M = 0;
-    }
-    else {
+    } else {
       LOGMAN_THROW_A_FMT(std::is_same_v<ARMEmitter::QRegister, T>, "Can't encode DRegister with i64Bit");
       // Index encoded in H
       H = Index;
@@ -4266,7 +4132,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmlal(T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(Index < 8, "Index must be less than the source register size");
 
@@ -4280,7 +4146,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmlal2(T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(Index < 8, "Index must be less than the source register size");
 
@@ -4294,7 +4160,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmlsl(T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(Index < 8, "Index must be less than the source register size");
 
@@ -4308,7 +4174,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmlsl2(T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(Index < 8, "Index must be less than the source register size");
 
@@ -4322,7 +4188,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void usdot(T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(Index < 4, "Index must be less than the source register size");
 
@@ -4361,7 +4227,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void mla(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
@@ -4376,8 +4242,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4403,8 +4268,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4429,8 +4293,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4441,7 +4304,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void mls(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
@@ -4456,8 +4319,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4483,8 +4345,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4509,8 +4370,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4536,8 +4396,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4562,8 +4421,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4574,7 +4432,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqrdmlah(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
@@ -4589,8 +4447,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4600,7 +4457,7 @@ public:
     ASIMDVectorXIndexedElement(0b1, L, M, 0b1101, H, size, rm, rn, rd);
   }
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void udot(T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(Index < 4, "Index must be less than the source register size");
 
@@ -4614,7 +4471,7 @@ public:
   }
 
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqrdmlsh(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
     LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
@@ -4629,8 +4486,7 @@ public:
       H = (Index >> 2) & 1;
       L = (Index >> 1) & 1;
       M = (Index >> 0) & 1;
-    }
-    else {
+    } else {
       // Index encoded in H:L
       // M overlaps rm register.
       H = (Index >> 1) & 1;
@@ -4649,50 +4505,54 @@ public:
   // Cryptographic two-register SHA 512
   // TODO
   // Conversion between floating-point and fixed-point
-  void scvtf(ARMEmitter::ScalarRegSize ScalarSize, ARMEmitter::VRegister rd, ARMEmitter::Size GPRSize, ARMEmitter::Register rn, uint32_t FractionalBits) {
+  void scvtf(ARMEmitter::ScalarRegSize ScalarSize, ARMEmitter::VRegister rd, ARMEmitter::Size GPRSize, ARMEmitter::Register rn,
+             uint32_t FractionalBits) {
     LOGMAN_THROW_A_FMT(FractionalBits >= 1 && FractionalBits <= ARMEmitter::RegSizeInBits(GPRSize), "Fractional bits out of range");
 
     uint32_t Scale = 64 - FractionalBits;
-    const auto ConvertedSize =
-      ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
-      ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
-      ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
+    const auto ConvertedSize = ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
+                               ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
+                               ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 :
+                                                                                 0;
 
     ScalarConvertBetweenFPAndFixed(0, 0b00, 0b010, Scale, GPRSize, ConvertedSize, rn, rd);
   }
 
-  void ucvtf(ARMEmitter::ScalarRegSize ScalarSize, ARMEmitter::VRegister rd, ARMEmitter::Size GPRSize, ARMEmitter::Register rn, uint32_t FractionalBits) {
+  void ucvtf(ARMEmitter::ScalarRegSize ScalarSize, ARMEmitter::VRegister rd, ARMEmitter::Size GPRSize, ARMEmitter::Register rn,
+             uint32_t FractionalBits) {
     LOGMAN_THROW_A_FMT(FractionalBits >= 1 && FractionalBits <= ARMEmitter::RegSizeInBits(GPRSize), "Fractional bits out of range");
 
     uint32_t Scale = 64 - FractionalBits;
-    const auto ConvertedSize =
-      ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
-      ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
-      ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
+    const auto ConvertedSize = ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
+                               ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
+                               ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 :
+                                                                                 0;
 
     ScalarConvertBetweenFPAndFixed(0, 0b00, 0b011, Scale, GPRSize, ConvertedSize, rn, rd);
   }
 
-  void fcvtzs(ARMEmitter::Size GPRSize, ARMEmitter::Register rd, ARMEmitter::ScalarRegSize ScalarSize, ARMEmitter::VRegister rn, uint32_t FractionalBits) {
+  void fcvtzs(ARMEmitter::Size GPRSize, ARMEmitter::Register rd, ARMEmitter::ScalarRegSize ScalarSize, ARMEmitter::VRegister rn,
+              uint32_t FractionalBits) {
     LOGMAN_THROW_A_FMT(FractionalBits >= 1 && FractionalBits <= ARMEmitter::RegSizeInBits(GPRSize), "Fractional bits out of range");
 
     uint32_t Scale = 64 - FractionalBits;
-    const auto ConvertedSize =
-      ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
-      ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
-      ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
+    const auto ConvertedSize = ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
+                               ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
+                               ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 :
+                                                                                 0;
 
     ScalarConvertBetweenFPAndFixed(0, 0b11, 0b000, Scale, GPRSize, ConvertedSize, rn, rd);
   }
 
-  void fcvtzu(ARMEmitter::Size GPRSize, ARMEmitter::Register rd, ARMEmitter::ScalarRegSize ScalarSize, ARMEmitter::VRegister rn, uint32_t FractionalBits) {
+  void fcvtzu(ARMEmitter::Size GPRSize, ARMEmitter::Register rd, ARMEmitter::ScalarRegSize ScalarSize, ARMEmitter::VRegister rn,
+              uint32_t FractionalBits) {
     LOGMAN_THROW_A_FMT(FractionalBits >= 1 && FractionalBits <= ARMEmitter::RegSizeInBits(GPRSize), "Fractional bits out of range");
 
     uint32_t Scale = 64 - FractionalBits;
-    const auto ConvertedSize =
-      ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
-      ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
-      ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
+    const auto ConvertedSize = ScalarSize == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
+                               ScalarSize == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
+                               ScalarSize == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 :
+                                                                                 0;
 
     ScalarConvertBetweenFPAndFixed(0, 0b11, 0b001, Scale, GPRSize, ConvertedSize, rn, rd);
   }
@@ -4922,7 +4782,8 @@ private:
   }
 
   // Advanced SIMD table lookup
-  void ASIMDTable(uint32_t Op, uint32_t Q, uint32_t op2, uint32_t len, uint32_t op, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm) {
+  void ASIMDTable(uint32_t Op, uint32_t Q, uint32_t op2, uint32_t len, uint32_t op, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn,
+                  ARMEmitter::VRegister rm) {
     uint32_t Instr = Op;
 
     Instr |= Q << 30;
@@ -4936,7 +4797,8 @@ private:
   }
 
   // Advanced SIMD permute
-  void ASIMDPermute(uint32_t Op, uint32_t Q, ARMEmitter::SubRegSize size, uint32_t opcode, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm) {
+  void ASIMDPermute(uint32_t Op, uint32_t Q, ARMEmitter::SubRegSize size, uint32_t opcode, ARMEmitter::VRegister rd,
+                    ARMEmitter::VRegister rn, ARMEmitter::VRegister rm) {
     uint32_t Instr = Op;
 
     Instr |= Q << 30;
@@ -4949,7 +4811,8 @@ private:
   }
 
   // Advanced SIMD extract
-  void ASIMDExtract(uint32_t Op, uint32_t Q, uint32_t op2, uint32_t imm4, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm) {
+  void ASIMDExtract(uint32_t Op, uint32_t Q, uint32_t op2, uint32_t imm4, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn,
+                    ARMEmitter::VRegister rm) {
     uint32_t Instr = Op;
 
     Instr |= Q << 30;
@@ -4963,7 +4826,7 @@ private:
 
   // Advanced SIMD two-register miscellaneous
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMD2RegMisc(uint32_t Op, uint32_t U, ARMEmitter::SubRegSize size, uint32_t opcode, T rd, T rn) {
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
 
@@ -4979,7 +4842,7 @@ private:
 
   // Advanced SIMD across lanes
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMDAcrossLanes(uint32_t Op, uint32_t U, ARMEmitter::SubRegSize size, uint32_t opcode, T rd, T rn) {
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
 
@@ -4995,7 +4858,7 @@ private:
 
   // Advanced SIMD three different
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMD3Different(uint32_t Op, uint32_t U, uint32_t opcode, ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
 
@@ -5012,7 +4875,7 @@ private:
 
   // Advanced SIMD three same
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMD3Same(uint32_t Op, uint32_t U, ARMEmitter::SubRegSize size, uint32_t opcode, T rd, T rn, T rm) {
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
 
@@ -5029,7 +4892,7 @@ private:
 
   // Advanced SIMD modified immediate
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMDModifiedImm(uint32_t Op, uint32_t op, uint32_t cmode, uint32_t o2, uint32_t imm, T rd) {
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
 
@@ -5053,7 +4916,7 @@ private:
 
   // Advanced SIMD shift by immediate
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMDShiftByImm(uint32_t Op, uint32_t U, uint32_t immh, uint32_t immb, uint32_t opcode, T rn, T rd) {
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
     LOGMAN_THROW_A_FMT(immh != 0, "ImmH needs to not be zero");
@@ -5072,7 +4935,7 @@ private:
 
   // Advanced SIMD vector x indexed element
   template<typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMDVectorXIndexedElement(uint32_t U, uint32_t L, uint32_t M, uint32_t opcode, uint32_t H, ARMEmitter::SubRegSize size, T rm, T rn, T rd) {
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'00 << 10;
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
@@ -5096,9 +4959,8 @@ private:
 
   // Conversion between floating-point and fixed-point
   template<typename T, typename T2>
-  void ScalarConvertBetweenFPAndFixed(uint32_t S, uint32_t rmode, uint32_t opcode, uint32_t scale,
-                                      ARMEmitter::Size GPRSize, uint32_t ScalarSize,
-                                      T rn, T2 rd) {
+  void ScalarConvertBetweenFPAndFixed(uint32_t S, uint32_t rmode, uint32_t opcode, uint32_t scale, ARMEmitter::Size GPRSize,
+                                      uint32_t ScalarSize, T rn, T2 rd) {
     constexpr uint32_t Op = 0b0001'1110'000 << 21;
     const uint32_t SF = GPRSize == ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
 
@@ -5115,7 +4977,8 @@ private:
   }
 
   // Conversion between floating-point and integer
-  void ASIMDFloatConvBetweenInt(uint32_t Op, ARMEmitter::Size s, uint32_t S, uint32_t ptype, uint32_t rmode, uint32_t opcode, ARMEmitter::Register rd, ARMEmitter::Register rn) {
+  void ASIMDFloatConvBetweenInt(uint32_t Op, ARMEmitter::Size s, uint32_t S, uint32_t ptype, uint32_t rmode, uint32_t opcode,
+                                ARMEmitter::Register rd, ARMEmitter::Register rn) {
     const uint32_t SF = s == ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
 
     uint32_t Instr = Op;
@@ -5131,14 +4994,14 @@ private:
   }
 
   template<ARMEmitter::SubRegSize size, bool Load, typename T>
-  requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
+  requires (std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ASIMDLoadStoreMultipleStructure(uint32_t Op, uint32_t opcode, T rt, ARMEmitter::Register rn, ARMEmitter::Register rm) {
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1U << 30 : 0;
 
     uint32_t Instr = Op;
 
     Instr |= Q;
-    Instr |= Load ? 1 << 22: 0;
+    Instr |= Load ? 1 << 22 : 0;
     Instr |= Encode_rm(rm);
     Instr |= opcode;
     Instr |= FEXCore::ToUnderlying(size) << 10;
@@ -5148,16 +5011,13 @@ private:
   }
   template<ARMEmitter::SubRegSize size, bool Load, uint32_t Count>
   void ASIMDSTLD(uint32_t Op, uint32_t Opcode, ARMEmitter::VRegister rt, uint32_t Index, ARMEmitter::Register rn, ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && Index < 16) ||
-      (size == SubRegSize::i16Bit && Index < 8) ||
-      (size == SubRegSize::i32Bit && Index < 4) ||
-      (size == SubRegSize::i64Bit && Index < 2),
-      "Invalid Index selected");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && Index < 16) || (size == SubRegSize::i16Bit && Index < 8) ||
+                         (size == SubRegSize::i32Bit && Index < 4) || (size == SubRegSize::i64Bit && Index < 2),
+                       "Invalid Index selected");
 
-    uint32_t Q{};
-    uint32_t S{};
-    uint32_t Size{};
+    uint32_t Q {};
+    uint32_t S {};
+    uint32_t Size {};
 
     // selem is for determining if we are doing 1-3 loadstore single structure operations
     // eg: ST1/2/3/4 or LD1/2/3/4
@@ -5173,17 +5033,14 @@ private:
       Q = ((Index & 0b1000) >> 3) << 30;
       S = ((Index & 0b0100) >> 2);
       Size = Index & 0b11;
-    }
-    else if constexpr (size == SubRegSize::i16Bit) {
+    } else if constexpr (size == SubRegSize::i16Bit) {
       Q = ((Index & 0b0100) >> 2) << 30;
       S = ((Index & 0b0010) >> 1);
       Size = (Index & 0b1) << 1;
-    }
-    else if constexpr (size == SubRegSize::i32Bit) {
+    } else if constexpr (size == SubRegSize::i32Bit) {
       Q = ((Index & 0b0010) >> 1) << 30;
       S = Index & 0b0001;
-    }
-    else if constexpr (size == SubRegSize::i64Bit) {
+    } else if constexpr (size == SubRegSize::i64Bit) {
       Q = (Index & 0b0001) << 30;
       Size = 1;
     }
@@ -5239,7 +5096,8 @@ private:
 
     ASIMDLoadStore(Op | Q, Load, selem & 1, opcode, S, FEXCore::ToUnderlying(size), rt, rn, rm);
   }
-  void ASIMDLoadStore(uint32_t Op, uint32_t L, uint32_t R, uint32_t opcode, uint32_t S, uint32_t size, ARMEmitter::VRegister rt, ARMEmitter::Register rn, ARMEmitter::Register rm) {
+  void ASIMDLoadStore(uint32_t Op, uint32_t L, uint32_t R, uint32_t opcode, uint32_t S, uint32_t size, ARMEmitter::VRegister rt,
+                      ARMEmitter::Register rn, ARMEmitter::Register rm) {
     uint32_t Instr = Op;
 
     Instr |= L << 22;

--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -13,6 +13,14 @@
  *
  * Only two instructions support the `i128Bit` ElementSize.
  */
+
+#pragma once
+#ifndef INCLUDED_BY_EMITTER
+#include <CodeEmitter/Emitter.h>
+namespace ARMEmitter {
+struct EmitterOps : Emitter {
+#endif
+
 public:
   // Data Processing -- Scalar Floating-Point and Advanced SIMD
   // Cryptographic AES
@@ -5246,4 +5254,7 @@ private:
     dc32(Instr);
   }
 
-
+#ifndef INCLUDED_BY_EMITTER
+}; // struct LoadstoreEmitterOps
+} // namespace ARMEmitter
+#endif

--- a/CodeEmitter/CodeEmitter/BranchOps.inl
+++ b/CodeEmitter/CodeEmitter/BranchOps.inl
@@ -3,6 +3,14 @@
  *
  * Most of these instructions will use `BackwardLabel`, `ForwardLabel`, or `BiDirectionLabel` to determine where a branch targets.
  */
+
+#pragma once
+#ifndef INCLUDED_BY_EMITTER
+#include <CodeEmitter/Emitter.h>
+namespace ARMEmitter {
+struct EmitterOps : Emitter {
+#endif
+
 public:
   // Branches, Exception Generating and System instructions
   public:
@@ -339,3 +347,8 @@ private:
       Instr |= Encode_rt(rt);
       dc32(Instr);
     }
+
+#ifndef INCLUDED_BY_EMITTER
+}; // struct LoadstoreEmitterOps
+} // namespace ARMEmitter
+#endif

--- a/CodeEmitter/CodeEmitter/BranchOps.inl
+++ b/CodeEmitter/CodeEmitter/BranchOps.inl
@@ -13,340 +13,331 @@ struct EmitterOps : Emitter {
 
 public:
   // Branches, Exception Generating and System instructions
-  public:
-    // Conditional branch immediate
-    ///< Branch conditional
-    void b(ARMEmitter::Condition Cond, uint32_t Imm) {
-      constexpr uint32_t Op = 0b0101'010 << 25;
-      Branch_Conditional(Op, 0, 0, Cond, Imm);
+public:
+  // Conditional branch immediate
+  ///< Branch conditional
+  void b(ARMEmitter::Condition Cond, uint32_t Imm) {
+    constexpr uint32_t Op = 0b0101'010 << 25;
+    Branch_Conditional(Op, 0, 0, Cond, Imm);
+  }
+  void b(ARMEmitter::Condition Cond, const BackwardLabel* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0101'010 << 25;
+    Branch_Conditional(Op, 0, 0, Cond, Imm >> 2);
+  }
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void b(ARMEmitter::Condition Cond, LabelType* Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC});
+    constexpr uint32_t Op = 0b0101'010 << 25;
+    Branch_Conditional(Op, 0, 0, Cond, 0);
+  }
+
+  void b(ARMEmitter::Condition Cond, BiDirectionalLabel* Label) {
+    if (Label->Backward.Location) {
+      b(Cond, &Label->Backward);
+    } else {
+      b(Cond, &Label->Forward);
     }
-    void b(ARMEmitter::Condition Cond, BackwardLabel const* Label) {
-      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
-      LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-      constexpr uint32_t Op = 0b0101'010 << 25;
-      Branch_Conditional(Op, 0, 0, Cond, Imm >> 2);
+  }
+
+  ///< Branch consistent conditional
+  void bc(ARMEmitter::Condition Cond, uint32_t Imm) {
+    constexpr uint32_t Op = 0b0101'010 << 25;
+    Branch_Conditional(Op, 0, 1, Cond, Imm);
+  }
+  void bc(ARMEmitter::Condition Cond, const BackwardLabel* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0101'010 << 25;
+    Branch_Conditional(Op, 0, 1, Cond, Imm >> 2);
+  }
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void bc(ARMEmitter::Condition Cond, LabelType* Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC});
+    constexpr uint32_t Op = 0b0101'010 << 25;
+    Branch_Conditional(Op, 0, 1, Cond, 0);
+  }
+
+  void bc(ARMEmitter::Condition Cond, BiDirectionalLabel* Label) {
+    if (Label->Backward.Location) {
+      bc(Cond, &Label->Backward);
+    } else {
+      bc(Cond, &Label->Forward);
     }
-    template<typename LabelType>
-    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-    void b(ARMEmitter::Condition Cond, LabelType *Label) {
-      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC });
-      constexpr uint32_t Op = 0b0101'010 << 25;
-      Branch_Conditional(Op, 0, 0, Cond, 0);
+  }
+
+  // Unconditional branch register
+  void br(ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b1101011 << 25 | 0b0'000 << 21 | // opc
+                            0b1'1111 << 16 |                  // op2
+                            0b0000'00 << 10 |                 // op3
+                            0b0'0000;                         // op4
+
+    UnconditionalBranch(Op, rn);
+  }
+  void blr(ARMEmitter::Register rn) {
+    constexpr uint32_t Op = 0b1101011 << 25 | 0b0'001 << 21 | // opc
+                            0b1'1111 << 16 |                  // op2
+                            0b0000'00 << 10 |                 // op3
+                            0b0'0000;                         // op4
+
+    UnconditionalBranch(Op, rn);
+  }
+  void ret(ARMEmitter::Register rn = ARMEmitter::Reg::r30) {
+    constexpr uint32_t Op = 0b1101011 << 25 | 0b0'010 << 21 | // opc
+                            0b1'1111 << 16 |                  // op2
+                            0b0000'00 << 10 |                 // op3
+                            0b0'0000;                         // op4
+
+    UnconditionalBranch(Op, rn);
+  }
+
+  // Unconditional branch immediate
+  void b(uint32_t Imm) {
+    constexpr uint32_t Op = 0b0001'01 << 26;
+
+    UnconditionalBranch(Op, Imm);
+  }
+  void b(const BackwardLabel* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -134217728 && Imm <= 134217724 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b0001'01 << 26;
+
+    UnconditionalBranch(Op, Imm >> 2);
+  }
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void b(LabelType* Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::B});
+    constexpr uint32_t Op = 0b0001'01 << 26;
+
+    UnconditionalBranch(Op, 0);
+  }
+
+  void b(BiDirectionalLabel* Label) {
+    if (Label->Backward.Location) {
+      b(&Label->Backward);
+    } else {
+      b(&Label->Forward);
     }
+  }
 
-    void b(ARMEmitter::Condition Cond, BiDirectionalLabel *Label) {
-      if (Label->Backward.Location) {
-        b(Cond, &Label->Backward);
-      }
-      else {
-        b(Cond, &Label->Forward);
-      }
+  void bl(uint32_t Imm) {
+    constexpr uint32_t Op = 0b1001'01 << 26;
+
+    UnconditionalBranch(Op, Imm);
+  }
+
+  void bl(const BackwardLabel* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -134217728 && Imm <= 134217724 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+    constexpr uint32_t Op = 0b1001'01 << 26;
+
+    UnconditionalBranch(Op, Imm >> 2);
+  }
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void bl(LabelType* Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::B});
+    constexpr uint32_t Op = 0b1001'01 << 26;
+
+    UnconditionalBranch(Op, 0);
+  }
+
+  void bl(BiDirectionalLabel* Label) {
+    if (Label->Backward.Location) {
+      bl(&Label->Backward);
+    } else {
+      bl(&Label->Forward);
     }
+  }
 
-    ///< Branch consistent conditional
-    void bc(ARMEmitter::Condition Cond, uint32_t Imm) {
-      constexpr uint32_t Op = 0b0101'010 << 25;
-      Branch_Conditional(Op, 0, 1, Cond, Imm);
+  // Compare and branch
+  void cbz(ARMEmitter::Size s, ARMEmitter::Register rt, uint32_t Imm) {
+    constexpr uint32_t Op = 0b0011'0100 << 24;
+
+    CompareAndBranch(Op, s, rt, Imm);
+  }
+
+  void cbz(ARMEmitter::Size s, ARMEmitter::Register rt, const BackwardLabel* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'0100 << 24;
+
+    CompareAndBranch(Op, s, rt, Imm >> 2);
+  }
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void cbz(ARMEmitter::Size s, ARMEmitter::Register rt, LabelType* Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC});
+
+    constexpr uint32_t Op = 0b0011'0100 << 24;
+
+    CompareAndBranch(Op, s, rt, 0);
+  }
+
+  void cbz(ARMEmitter::Size s, ARMEmitter::Register rt, BiDirectionalLabel* Label) {
+    if (Label->Backward.Location) {
+      cbz(s, rt, &Label->Backward);
+    } else {
+      cbz(s, rt, &Label->Forward);
     }
-    void bc(ARMEmitter::Condition Cond, BackwardLabel const* Label) {
-      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
-      LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-      constexpr uint32_t Op = 0b0101'010 << 25;
-      Branch_Conditional(Op, 0, 1, Cond, Imm >> 2);
+  }
+
+  void cbnz(ARMEmitter::Size s, ARMEmitter::Register rt, uint32_t Imm) {
+    constexpr uint32_t Op = 0b0011'0101 << 24;
+
+    CompareAndBranch(Op, s, rt, Imm);
+  }
+
+  void cbnz(ARMEmitter::Size s, ARMEmitter::Register rt, const BackwardLabel* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'0101 << 24;
+
+    CompareAndBranch(Op, s, rt, Imm >> 2);
+  }
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void cbnz(ARMEmitter::Size s, ARMEmitter::Register rt, LabelType* Label) {
+    AddLocationToLabel(Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC});
+
+    constexpr uint32_t Op = 0b0011'0101 << 24;
+
+    CompareAndBranch(Op, s, rt, 0);
+  }
+
+  void cbnz(ARMEmitter::Size s, ARMEmitter::Register rt, BiDirectionalLabel* Label) {
+    if (Label->Backward.Location) {
+      cbnz(s, rt, &Label->Backward);
+    } else {
+      cbnz(s, rt, &Label->Forward);
     }
+  }
 
-    template<typename LabelType>
-    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-    void bc(ARMEmitter::Condition Cond, LabelType *Label) {
-      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC });
-      constexpr uint32_t Op = 0b0101'010 << 25;
-      Branch_Conditional(Op, 0, 1, Cond, 0);
+  // Test and branch immediate
+  void tbz(ARMEmitter::Register rt, uint32_t Bit, uint32_t Imm) {
+    constexpr uint32_t Op = 0b0011'0110 << 24;
+
+    TestAndBranch(Op, rt, Bit, Imm);
+  }
+  void tbz(ARMEmitter::Register rt, uint32_t Bit, const BackwardLabel* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -32768 && Imm <= 32764 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'0110 << 24;
+
+    TestAndBranch(Op, rt, Bit, Imm >> 2);
+  }
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void tbz(ARMEmitter::Register rt, uint32_t Bit, LabelType* Label) {
+    AddLocationToLabel(
+      Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::TEST_BRANCH});
+
+    constexpr uint32_t Op = 0b0011'0110 << 24;
+
+    TestAndBranch(Op, rt, Bit, 0);
+  }
+
+  void tbz(ARMEmitter::Register rt, uint32_t Bit, BiDirectionalLabel* Label) {
+    if (Label->Backward.Location) {
+      tbz(rt, Bit, &Label->Backward);
+    } else {
+      tbz(rt, Bit, &Label->Forward);
     }
+  }
 
-    void bc(ARMEmitter::Condition Cond, BiDirectionalLabel *Label) {
-      if (Label->Backward.Location) {
-        bc(Cond, &Label->Backward);
-      }
-      else {
-        bc(Cond, &Label->Forward);
-      }
+  void tbnz(ARMEmitter::Register rt, uint32_t Bit, uint32_t Imm) {
+    constexpr uint32_t Op = 0b0011'0111 << 24;
+
+    TestAndBranch(Op, rt, Bit, Imm);
+  }
+  void tbnz(ARMEmitter::Register rt, uint32_t Bit, const BackwardLabel* Label) {
+    int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
+    LOGMAN_THROW_A_FMT(Imm >= -32768 && Imm <= 32764 && ((Imm & 0b11) == 0), "Unscaled offset too large");
+
+    constexpr uint32_t Op = 0b0011'0111 << 24;
+
+    TestAndBranch(Op, rt, Bit, Imm >> 2);
+  }
+
+  template<typename LabelType>
+  requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
+  void tbnz(ARMEmitter::Register rt, uint32_t Bit, LabelType* Label) {
+    AddLocationToLabel(
+      Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::TEST_BRANCH});
+    constexpr uint32_t Op = 0b0011'0111 << 24;
+
+    TestAndBranch(Op, rt, Bit, 0);
+  }
+
+  void tbnz(ARMEmitter::Register rt, uint32_t Bit, BiDirectionalLabel* Label) {
+    if (Label->Backward.Location) {
+      tbnz(rt, Bit, &Label->Backward);
+    } else {
+      tbnz(rt, Bit, &Label->Forward);
     }
-
-    // Unconditional branch register
-    void br(ARMEmitter::Register rn) {
-      constexpr uint32_t Op = 0b1101011 << 25 |
-                              0b0'000 << 21 |   // opc
-                              0b1'1111 << 16 |  // op2
-                              0b0000'00 << 10 | // op3
-                              0b0'0000;         // op4
-
-      UnconditionalBranch(Op, rn);
-    }
-    void blr(ARMEmitter::Register rn) {
-      constexpr uint32_t Op = 0b1101011 << 25 |
-                              0b0'001 << 21 |   // opc
-                              0b1'1111 << 16 |  // op2
-                              0b0000'00 << 10 | // op3
-                              0b0'0000;         // op4
-
-      UnconditionalBranch(Op, rn);
-    }
-    void ret(ARMEmitter::Register rn = ARMEmitter::Reg::r30) {
-      constexpr uint32_t Op = 0b1101011 << 25 |
-                              0b0'010 << 21 |   // opc
-                              0b1'1111 << 16 |  // op2
-                              0b0000'00 << 10 | // op3
-                              0b0'0000;         // op4
-
-      UnconditionalBranch(Op, rn);
-    }
-
-    // Unconditional branch immediate
-    void b(uint32_t Imm) {
-      constexpr uint32_t Op = 0b0001'01 << 26;
-
-      UnconditionalBranch(Op, Imm);
-    }
-    void b(BackwardLabel const* Label) {
-      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
-      LOGMAN_THROW_A_FMT(Imm >= -134217728 && Imm <= 134217724 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-      constexpr uint32_t Op = 0b0001'01 << 26;
-
-      UnconditionalBranch(Op, Imm >> 2);
-    }
-    template<typename LabelType>
-    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-    void b(LabelType *Label) {
-      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::B });
-      constexpr uint32_t Op = 0b0001'01 << 26;
-
-      UnconditionalBranch(Op, 0);
-    }
-
-    void b(BiDirectionalLabel *Label) {
-      if (Label->Backward.Location) {
-        b(&Label->Backward);
-      }
-      else {
-        b(&Label->Forward);
-      }
-    }
-
-    void bl(uint32_t Imm) {
-      constexpr uint32_t Op = 0b1001'01 << 26;
-
-      UnconditionalBranch(Op, Imm);
-    }
-
-    void bl(BackwardLabel const* Label) {
-      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
-      LOGMAN_THROW_A_FMT(Imm >= -134217728 && Imm <= 134217724 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-      constexpr uint32_t Op = 0b1001'01 << 26;
-
-      UnconditionalBranch(Op, Imm >> 2);
-    }
-    template<typename LabelType>
-    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-    void bl(LabelType *Label) {
-      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::B });
-      constexpr uint32_t Op = 0b1001'01 << 26;
-
-      UnconditionalBranch(Op, 0);
-    }
-
-    void bl(BiDirectionalLabel *Label) {
-      if (Label->Backward.Location) {
-        bl(&Label->Backward);
-      }
-      else {
-        bl(&Label->Forward);
-      }
-    }
-
-    // Compare and branch
-    void cbz(ARMEmitter::Size s, ARMEmitter::Register rt, uint32_t Imm) {
-      constexpr uint32_t Op = 0b0011'0100 << 24;
-
-      CompareAndBranch(Op, s, rt, Imm);
-    }
-
-    void cbz(ARMEmitter::Size s, ARMEmitter::Register rt, BackwardLabel const* Label) {
-      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
-      LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-
-      constexpr uint32_t Op = 0b0011'0100 << 24;
-
-      CompareAndBranch(Op, s, rt, Imm >> 2);
-    }
-
-    template<typename LabelType>
-    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-    void cbz(ARMEmitter::Size s, ARMEmitter::Register rt, LabelType *Label) {
-      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC });
-
-      constexpr uint32_t Op = 0b0011'0100 << 24;
-
-      CompareAndBranch(Op, s, rt, 0);
-    }
-
-    void cbz(ARMEmitter::Size s, ARMEmitter::Register rt, BiDirectionalLabel *Label) {
-      if (Label->Backward.Location) {
-        cbz(s, rt, &Label->Backward);
-      }
-      else {
-        cbz(s, rt, &Label->Forward);
-      }
-    }
-
-    void cbnz(ARMEmitter::Size s, ARMEmitter::Register rt, uint32_t Imm) {
-      constexpr uint32_t Op = 0b0011'0101 << 24;
-
-      CompareAndBranch(Op, s, rt, Imm);
-    }
-
-    void cbnz(ARMEmitter::Size s, ARMEmitter::Register rt, BackwardLabel const* Label) {
-      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
-      LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-
-      constexpr uint32_t Op = 0b0011'0101 << 24;
-
-      CompareAndBranch(Op, s, rt, Imm >> 2);
-    }
-
-    template<typename LabelType>
-    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-    void cbnz(ARMEmitter::Size s, ARMEmitter::Register rt, LabelType *Label) {
-      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::BC });
-
-      constexpr uint32_t Op = 0b0011'0101 << 24;
-
-      CompareAndBranch(Op, s, rt, 0);
-    }
-
-    void cbnz(ARMEmitter::Size s, ARMEmitter::Register rt, BiDirectionalLabel *Label) {
-      if (Label->Backward.Location) {
-        cbnz(s, rt, &Label->Backward);
-      }
-      else {
-        cbnz(s, rt, &Label->Forward);
-      }
-    }
-
-    // Test and branch immediate
-    void tbz(ARMEmitter::Register rt, uint32_t Bit, uint32_t Imm) {
-      constexpr uint32_t Op = 0b0011'0110 << 24;
-
-      TestAndBranch(Op, rt, Bit, Imm);
-    }
-    void tbz(ARMEmitter::Register rt, uint32_t Bit, BackwardLabel const* Label) {
-      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
-      LOGMAN_THROW_A_FMT(Imm >= -32768 && Imm <= 32764 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-
-      constexpr uint32_t Op = 0b0011'0110 << 24;
-
-      TestAndBranch(Op, rt, Bit, Imm >> 2);
-    }
-
-    template<typename LabelType>
-    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-    void tbz(ARMEmitter::Register rt, uint32_t Bit, LabelType *Label) {
-      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::TEST_BRANCH });
-
-      constexpr uint32_t Op = 0b0011'0110 << 24;
-
-      TestAndBranch(Op, rt, Bit, 0);
-    }
-
-    void tbz(ARMEmitter::Register rt, uint32_t Bit, BiDirectionalLabel *Label) {
-      if (Label->Backward.Location) {
-        tbz(rt, Bit, &Label->Backward);
-      }
-      else {
-        tbz(rt, Bit, &Label->Forward);
-      }
-    }
-
-    void tbnz(ARMEmitter::Register rt, uint32_t Bit, uint32_t Imm) {
-      constexpr uint32_t Op = 0b0011'0111 << 24;
-
-      TestAndBranch(Op, rt, Bit, Imm);
-    }
-    void tbnz(ARMEmitter::Register rt, uint32_t Bit, BackwardLabel const* Label) {
-      int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
-      LOGMAN_THROW_A_FMT(Imm >= -32768 && Imm <= 32764 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-
-      constexpr uint32_t Op = 0b0011'0111 << 24;
-
-      TestAndBranch(Op, rt, Bit, Imm >> 2);
-    }
-
-    template<typename LabelType>
-    requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-    void tbnz(ARMEmitter::Register rt, uint32_t Bit, LabelType *Label) {
-      AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::TEST_BRANCH });
-      constexpr uint32_t Op = 0b0011'0111 << 24;
-
-      TestAndBranch(Op, rt, Bit, 0);
-    }
-
-    void tbnz(ARMEmitter::Register rt, uint32_t Bit, BiDirectionalLabel *Label) {
-      if (Label->Backward.Location) {
-        tbnz(rt, Bit, &Label->Backward);
-      }
-      else {
-        tbnz(rt, Bit, &Label->Forward);
-      }
-    }
+  }
 
 private:
-    // Conditional branch immediate
-    void Branch_Conditional(uint32_t Op, uint32_t Op1, uint32_t Op0, ARMEmitter::Condition Cond, uint32_t Imm) {
-      uint32_t Instr = Op;
+  // Conditional branch immediate
+  void Branch_Conditional(uint32_t Op, uint32_t Op1, uint32_t Op0, ARMEmitter::Condition Cond, uint32_t Imm) {
+    uint32_t Instr = Op;
 
-      Instr |= Op1 << 24;
-      Instr |= (Imm & 0x7'FFFF) << 5;
-      Instr |= Op0 << 4;
-      Instr |= FEXCore::ToUnderlying(Cond);
+    Instr |= Op1 << 24;
+    Instr |= (Imm & 0x7'FFFF) << 5;
+    Instr |= Op0 << 4;
+    Instr |= FEXCore::ToUnderlying(Cond);
 
-      dc32(Instr);
-    }
+    dc32(Instr);
+  }
 
-    // Unconditional branch register
-    void UnconditionalBranch(uint32_t Op, ARMEmitter::Register rn) {
-      uint32_t Instr = Op;
-      Instr |= Encode_rn(rn);
-      dc32(Instr);
-    }
+  // Unconditional branch register
+  void UnconditionalBranch(uint32_t Op, ARMEmitter::Register rn) {
+    uint32_t Instr = Op;
+    Instr |= Encode_rn(rn);
+    dc32(Instr);
+  }
 
-    // Unconditional branch - immediate
-    void UnconditionalBranch(uint32_t Op, uint32_t Imm) {
-      uint32_t Instr = Op;
-      Instr |= Imm & 0x3FF'FFFF;
-      dc32(Instr);
-    }
+  // Unconditional branch - immediate
+  void UnconditionalBranch(uint32_t Op, uint32_t Imm) {
+    uint32_t Instr = Op;
+    Instr |= Imm & 0x3FF'FFFF;
+    dc32(Instr);
+  }
 
-    // Compare and branch
-    void CompareAndBranch(uint32_t Op, ARMEmitter::Size s, ARMEmitter::Register rt, uint32_t Imm) {
-      const uint32_t SF = s == ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
+  // Compare and branch
+  void CompareAndBranch(uint32_t Op, ARMEmitter::Size s, ARMEmitter::Register rt, uint32_t Imm) {
+    const uint32_t SF = s == ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
 
-      uint32_t Instr = Op;
+    uint32_t Instr = Op;
 
-      Instr |= SF;
-      Instr |= (Imm & 0x7'FFFF) << 5;
-      Instr |= Encode_rt(rt);
-      dc32(Instr);
-    }
+    Instr |= SF;
+    Instr |= (Imm & 0x7'FFFF) << 5;
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
 
-    // Test and branch - immediate
-    void TestAndBranch(uint32_t Op, ARMEmitter::Register rt, uint32_t Bit, uint32_t Imm) {
-      uint32_t Instr = Op;
+  // Test and branch - immediate
+  void TestAndBranch(uint32_t Op, ARMEmitter::Register rt, uint32_t Bit, uint32_t Imm) {
+    uint32_t Instr = Op;
 
-      Instr |= (Bit >> 5) << 31;
-      Instr |= (Bit & 0b1'1111) << 19;
-      Instr |= (Imm & 0x3FFF) << 5;
-      Instr |= Encode_rt(rt);
-      dc32(Instr);
-    }
+    Instr |= (Bit >> 5) << 31;
+    Instr |= (Bit & 0b1'1111) << 19;
+    Instr |= (Imm & 0x3FFF) << 5;
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
 
 #ifndef INCLUDED_BY_EMITTER
 }; // struct LoadstoreEmitterOps

--- a/CodeEmitter/CodeEmitter/Emitter.h
+++ b/CodeEmitter/CodeEmitter/Emitter.h
@@ -772,6 +772,12 @@ public:
 #include <CodeEmitter/VixlUtils.inl>
 
 public:
+
+// This symbol is used to allow external tooling (IDEs, clang-format, ...) to process the included files individually:
+// If defined, the files will inject member functions into this class.
+// If not, the files will wrap the member functions in a class so that tooling will process them properly.
+#define INCLUDED_BY_EMITTER
+
   // TODO: Implement SME when it matters.
 #include <CodeEmitter/ALUOps.inl>
 #include <CodeEmitter/BranchOps.inl>
@@ -781,7 +787,9 @@ public:
 #include <CodeEmitter/ASIMDOps.inl>
 #include <CodeEmitter/SVEOps.inl>
 
-private:
+#undef INCLUDED_BY_EMITTER
+
+protected:
   template<typename T>
   uint32_t Encode_ra(T Reg) const {
     return Reg.Idx() << 10;

--- a/CodeEmitter/CodeEmitter/LoadstoreOps.inl
+++ b/CodeEmitter/CodeEmitter/LoadstoreOps.inl
@@ -10,6 +10,14 @@
  * There are some load-store helper functions which take a `ExtendedMemOperand` argument.
  * This helper will select the viable load-store that can work with the provided encapsulated arguments.
  */
+
+#pragma once
+#ifndef INCLUDED_BY_EMITTER
+#include <CodeEmitter/Emitter.h>
+namespace ARMEmitter {
+struct EmitterOps : Emitter {
+#endif
+
 public:
   // Compare and swap pair
   void casp(ARMEmitter::Size s, ARMEmitter::Register rs, ARMEmitter::Register rs2, ARMEmitter::Register rt, ARMEmitter::Register rt2, ARMEmitter::Register rn) {
@@ -4687,4 +4695,7 @@ private:
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
 
-
+#ifndef INCLUDED_BY_EMITTER
+}; // struct LoadstoreEmitterOps
+} // namespace ARMEmitter
+#endif

--- a/CodeEmitter/CodeEmitter/LoadstoreOps.inl
+++ b/CodeEmitter/CodeEmitter/LoadstoreOps.inl
@@ -20,25 +20,29 @@ struct EmitterOps : Emitter {
 
 public:
   // Compare and swap pair
-  void casp(ARMEmitter::Size s, ARMEmitter::Register rs, ARMEmitter::Register rs2, ARMEmitter::Register rt, ARMEmitter::Register rt2, ARMEmitter::Register rn) {
+  void casp(ARMEmitter::Size s, ARMEmitter::Register rs, ARMEmitter::Register rs2, ARMEmitter::Register rt, ARMEmitter::Register rt2,
+            ARMEmitter::Register rn) {
     LOGMAN_THROW_A_FMT((rs.Idx() + 1) == rs2.Idx(), "These must be sequential");
     LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
     constexpr uint32_t Op = 0b0000'1000'001 << 21;
     AtomicOp(Op, s, 0, 0, rs, rt, ARMEmitter::Reg::r31, rn);
   }
-  void caspa(ARMEmitter::Size s, ARMEmitter::Register rs, ARMEmitter::Register rs2, ARMEmitter::Register rt, ARMEmitter::Register rt2, ARMEmitter::Register rn) {
+  void caspa(ARMEmitter::Size s, ARMEmitter::Register rs, ARMEmitter::Register rs2, ARMEmitter::Register rt, ARMEmitter::Register rt2,
+             ARMEmitter::Register rn) {
     LOGMAN_THROW_A_FMT((rs.Idx() + 1) == rs2.Idx(), "These must be sequential");
     LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
     constexpr uint32_t Op = 0b0000'1000'001 << 21;
     AtomicOp(Op, s, 1, 0, rs, rt, ARMEmitter::Reg::r31, rn);
   }
-  void caspl(ARMEmitter::Size s, ARMEmitter::Register rs, ARMEmitter::Register rs2, ARMEmitter::Register rt, ARMEmitter::Register rt2, ARMEmitter::Register rn) {
+  void caspl(ARMEmitter::Size s, ARMEmitter::Register rs, ARMEmitter::Register rs2, ARMEmitter::Register rt, ARMEmitter::Register rt2,
+             ARMEmitter::Register rn) {
     LOGMAN_THROW_A_FMT((rs.Idx() + 1) == rs2.Idx(), "These must be sequential");
     LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
     constexpr uint32_t Op = 0b0000'1000'001 << 21;
     AtomicOp(Op, s, 0, 1, rs, rt, ARMEmitter::Reg::r31, rn);
   }
-  void caspal(ARMEmitter::Size s, ARMEmitter::Register rs, ARMEmitter::Register rs2, ARMEmitter::Register rt, ARMEmitter::Register rt2, ARMEmitter::Register rn) {
+  void caspal(ARMEmitter::Size s, ARMEmitter::Register rs, ARMEmitter::Register rs2, ARMEmitter::Register rt, ARMEmitter::Register rt2,
+              ARMEmitter::Register rn) {
     LOGMAN_THROW_A_FMT((rs.Idx() + 1) == rs2.Idx(), "These must be sequential");
     LOGMAN_THROW_A_FMT((rt.Idx() + 1) == rt2.Idx(), "These must be sequential");
     constexpr uint32_t Op = 0b0000'1000'001 << 21;
@@ -151,10 +155,8 @@ public:
   }
   template<SubRegSize size, typename T>
   void ld1(T rt, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 16)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 8)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 16)) || (std::is_same_v<DRegister, T> && (PostOffset == 8)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0111 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -168,10 +170,8 @@ public:
   template<SubRegSize size, typename T>
   void ld1(T rt, T rt2, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 32)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 16)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 32)) || (std::is_same_v<DRegister, T> && (PostOffset == 16)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b1010 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -185,10 +185,8 @@ public:
   template<SubRegSize size, typename T>
   void ld1(T rt, T rt2, T rt3, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 48)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 24)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 48)) || (std::is_same_v<DRegister, T> && (PostOffset == 24)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0110 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -202,10 +200,8 @@ public:
   template<SubRegSize size, typename T>
   void ld1(T rt, T rt2, T rt3, T rt4, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 64)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 32)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 64)) || (std::is_same_v<DRegister, T> && (PostOffset == 32)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0010 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -218,10 +214,8 @@ public:
   }
   template<SubRegSize size, typename T>
   void st1(T rt, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 16)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 8)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 16)) || (std::is_same_v<DRegister, T> && (PostOffset == 8)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0111 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -235,10 +229,8 @@ public:
   template<SubRegSize size, typename T>
   void st1(T rt, T rt2, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 32)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 16)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 32)) || (std::is_same_v<DRegister, T> && (PostOffset == 16)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b1010 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -252,10 +244,8 @@ public:
   template<SubRegSize size, typename T>
   void st1(T rt, T rt2, T rt3, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 48)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 24)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 48)) || (std::is_same_v<DRegister, T> && (PostOffset == 24)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0110 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -269,10 +259,8 @@ public:
   template<SubRegSize size, typename T>
   void st1(T rt, T rt2, T rt3, T rt4, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 64)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 32)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 64)) || (std::is_same_v<DRegister, T> && (PostOffset == 32)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0010 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -287,10 +275,8 @@ public:
   template<SubRegSize size, typename T>
   void ld2(T rt, T rt2, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 32)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 16)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 32)) || (std::is_same_v<DRegister, T> && (PostOffset == 16)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b1000 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -304,10 +290,8 @@ public:
   template<SubRegSize size, typename T>
   void st2(T rt, T rt2, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 32)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 16)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 32)) || (std::is_same_v<DRegister, T> && (PostOffset == 16)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b1000 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -321,10 +305,8 @@ public:
   template<SubRegSize size, typename T>
   void ld3(T rt, T rt2, T rt3, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 48)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 24)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 48)) || (std::is_same_v<DRegister, T> && (PostOffset == 24)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0100 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -338,10 +320,8 @@ public:
   template<SubRegSize size, typename T>
   void st3(T rt, T rt2, T rt3, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 48)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 24)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 48)) || (std::is_same_v<DRegister, T> && (PostOffset == 24)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0100 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -355,10 +335,8 @@ public:
   template<SubRegSize size, typename T>
   void ld4(T rt, T rt2, T rt3, T rt4, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 64)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 32)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 64)) || (std::is_same_v<DRegister, T> && (PostOffset == 32)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0000 << 12;
     ASIMDLoadStoreMultipleStructure<size, true>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -372,10 +350,8 @@ public:
   template<SubRegSize size, typename T>
   void st4(T rt, T rt2, T rt3, T rt4, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (std::is_same_v<QRegister, T> && (PostOffset == 64)) ||
-      (std::is_same_v<DRegister, T> && (PostOffset == 32)),
-      "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((std::is_same_v<QRegister, T> && (PostOffset == 64)) || (std::is_same_v<DRegister, T> && (PostOffset == 32)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Opcode = 0b0000 << 12;
     ASIMDLoadStoreMultipleStructure<size, false>(ASIMDLoadstoreMultiplePost_Op, Opcode, rt, rn, Reg::r31);
@@ -441,7 +417,7 @@ public:
     ASIMDSTLD<size, true, 1>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
   template<SubRegSize size, typename T>
-  requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
+  requires (std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
   void ld1r(T rt, Register rn) {
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
     constexpr uint32_t Opcode = 0b110;
@@ -460,7 +436,7 @@ public:
     ASIMDSTLD<size, true, 2>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
   template<SubRegSize size, typename T>
-  requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
+  requires (std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
   void ld2r(T rt, T rt2, Register rn) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
@@ -480,7 +456,7 @@ public:
     ASIMDSTLD<size, true, 3>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
   template<SubRegSize size, typename T>
-  requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
+  requires (std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
   void ld3r(T rt, T rt2, T rt3, Register rn) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
@@ -500,7 +476,7 @@ public:
     ASIMDSTLD<size, true, 4>(Op, Opcode, rt, Index, rn, Reg::r0);
   }
   template<SubRegSize size, typename T>
-  requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
+  requires (std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
   void ld4r(T rt, T rt2, T rt3, T rt4, Register rn) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
     constexpr uint32_t Op = 0b0000'1101'000 << 21;
@@ -522,11 +498,9 @@ public:
   }
   template<SubRegSize size>
   void st1(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 1)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 4)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 8)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 1)) || (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 4)) || (size == SubRegSize::i64Bit && (PostOffset == 8)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
@@ -551,11 +525,9 @@ public:
   }
   template<SubRegSize size>
   void st2(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 2)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 8)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 2)) || (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 8)) || (size == SubRegSize::i64Bit && (PostOffset == 16)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
@@ -580,11 +552,9 @@ public:
   }
   template<SubRegSize size>
   void st3(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 3)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 8)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 24)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 3)) || (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 8)) || (size == SubRegSize::i64Bit && (PostOffset == 24)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
@@ -609,11 +579,9 @@ public:
   }
   template<SubRegSize size>
   void st4(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 4)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 16)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 32)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 4)) || (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 16)) || (size == SubRegSize::i64Bit && (PostOffset == 32)),
+                       "Post-index offset needs to match number of elements times their size");
 
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
@@ -637,11 +605,9 @@ public:
   }
   template<SubRegSize size>
   void ld1(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 1)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 4)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 8)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 1)) || (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 4)) || (size == SubRegSize::i64Bit && (PostOffset == 8)),
+                       "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -659,11 +625,9 @@ public:
   }
   template<SubRegSize size>
   void ld1r(VRegister rt, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 1)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 4)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 8)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 1)) || (size == SubRegSize::i16Bit && (PostOffset == 2)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 4)) || (size == SubRegSize::i64Bit && (PostOffset == 8)),
+                       "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
     ASIMDSTLD<size, true, 1>(Op, Opcode, rt, 0, rn, Reg::r31);
@@ -682,11 +646,9 @@ public:
   }
   template<SubRegSize size>
   void ld2(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 2)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 8)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 2)) || (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 8)) || (size == SubRegSize::i64Bit && (PostOffset == 16)),
+                       "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -706,11 +668,9 @@ public:
   template<SubRegSize size>
   void ld2r(VRegister rt, VRegister rt2, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 2)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 8)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 2)) || (size == SubRegSize::i16Bit && (PostOffset == 4)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 8)) || (size == SubRegSize::i64Bit && (PostOffset == 16)),
+                       "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
     ASIMDSTLD<size, true, 2>(Op, Opcode, rt, 0, rn, Reg::r31);
@@ -729,11 +689,9 @@ public:
   }
   template<SubRegSize size>
   void ld3(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 3)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 12)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 3)) || (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 12)) || (size == SubRegSize::i64Bit && (PostOffset == 16)),
+                       "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -753,11 +711,9 @@ public:
   template<SubRegSize size>
   void ld3r(VRegister rt, VRegister rt2, VRegister rt3, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 3)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 12)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 16)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 3)) || (size == SubRegSize::i16Bit && (PostOffset == 6)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 12)) || (size == SubRegSize::i64Bit && (PostOffset == 16)),
+                       "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
     ASIMDSTLD<size, true, 3>(Op, Opcode, rt, 0, rn, Reg::r31);
@@ -776,11 +732,9 @@ public:
   }
   template<SubRegSize size>
   void ld4(VRegister rt, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 4)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 16)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 32)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 4)) || (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 16)) || (size == SubRegSize::i64Bit && (PostOffset == 32)),
+                       "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode =
         size == SubRegSize::i8Bit  ? 0b000 : // Scale = 0
@@ -800,11 +754,9 @@ public:
   template<SubRegSize size>
   void ld4r(VRegister rt, VRegister rt2, VRegister rt3, VRegister rt4, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
-    LOGMAN_THROW_A_FMT(
-      (size == SubRegSize::i8Bit && (PostOffset == 4)) ||
-      (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
-      (size == SubRegSize::i32Bit && (PostOffset == 16)) ||
-      (size == SubRegSize::i64Bit && (PostOffset == 32)), "Post-index offset needs to match number of elements times their size");
+    LOGMAN_THROW_A_FMT((size == SubRegSize::i8Bit && (PostOffset == 4)) || (size == SubRegSize::i16Bit && (PostOffset == 8)) ||
+                         (size == SubRegSize::i32Bit && (PostOffset == 16)) || (size == SubRegSize::i64Bit && (PostOffset == 32)),
+                       "Post-index offset needs to match number of elements times their size");
     constexpr uint32_t Op = 0b0000'1101'100 << 21;
     constexpr uint32_t Opcode = 0b110;
     ASIMDSTLD<size, true, 4>(Op, Opcode, rt, 0, rn, Reg::r31);
@@ -813,7 +765,8 @@ public:
   // Advanced SIMD load/store single structure (post-indexed)
   template<typename T>
   void st1(ARMEmitter::SubRegSize size, T rt, uint32_t Index, ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
     uint32_t R = 0;
@@ -826,29 +779,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -857,7 +806,8 @@ public:
   }
   template<typename T>
   void ld1(ARMEmitter::SubRegSize size, T rt, uint32_t Index, ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
     uint32_t R = 0;
@@ -870,29 +820,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -951,7 +897,8 @@ public:
 
   template<typename T>
   void st2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -966,29 +913,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -997,7 +940,8 @@ public:
   }
   template<typename T>
   void ld2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1012,29 +956,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1043,7 +983,8 @@ public:
   }
   template<typename T>
   void st3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1058,29 +999,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1089,7 +1026,8 @@ public:
   }
   template<typename T>
   void ld3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1104,29 +1042,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1135,7 +1069,8 @@ public:
   }
   template<typename T>
   void st4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1150,29 +1085,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1181,7 +1112,8 @@ public:
   }
   template<typename T>
   void ld4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1196,29 +1128,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1228,7 +1156,8 @@ public:
 
   template<typename T>
   void st1(ARMEmitter::SubRegSize size, T rt, uint32_t Index, ARMEmitter::Register rn, ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
     uint32_t R = 0;
@@ -1241,29 +1170,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1272,7 +1197,8 @@ public:
   }
   template<typename T>
   void ld1(ARMEmitter::SubRegSize size, T rt, uint32_t Index, ARMEmitter::Register rn, ARMEmitter::Register rm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
     uint32_t R = 0;
@@ -1285,29 +1211,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1362,7 +1284,8 @@ public:
 
   template<typename T>
   void st2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1377,29 +1300,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1408,7 +1327,8 @@ public:
   }
   template<typename T>
   void ld2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1423,29 +1343,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1454,7 +1370,8 @@ public:
   }
   template<typename T>
   void st3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1469,29 +1386,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1500,7 +1413,8 @@ public:
   }
   template<typename T>
   void ld3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1515,29 +1429,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1546,7 +1456,8 @@ public:
   }
   template<typename T>
   void st4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1561,29 +1472,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1592,7 +1499,8 @@ public:
   }
   template<typename T>
   void ld4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+                       "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1607,29 +1515,25 @@ public:
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
-    }
-    else if (size == SubRegSize::i16Bit) {
+    } else if (size == SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
-    }
-    else if (size == SubRegSize::i32Bit) {
+    } else if (size == SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
-    }
-    else if (size == SubRegSize::i64Bit) {
+    } else if (size == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
       Size = 0b01;
-    }
-    else {
+    } else {
       LOGMAN_MSG_A_FMT("Unknown size");
       FEX_UNREACHABLE;
     }
@@ -1738,8 +1642,10 @@ public:
   }
 
   template<typename T>
-  void ASIMDLoadStoreSinglePost(uint32_t Op, uint32_t Q, uint32_t L, uint32_t R, uint32_t opcode, uint32_t S, uint32_t size, ARMEmitter::Register rm, ARMEmitter::Register rn, T rt) {
-    LOGMAN_THROW_A_FMT(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>, "Only supports 128-bit and 64-bit vector registers.");
+  void ASIMDLoadStoreSinglePost(uint32_t Op, uint32_t Q, uint32_t L, uint32_t R, uint32_t opcode, uint32_t S, uint32_t size,
+                                ARMEmitter::Register rm, ARMEmitter::Register rn, T rt) {
+    LOGMAN_THROW_A_FMT(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>, "Only supports 128-bit and "
+                                                                                                             "64-bit vector registers.");
     uint32_t Instr = Op;
 
     Instr |= Q << 30;
@@ -2086,43 +1992,43 @@ public:
     constexpr uint32_t Op = 0b1101'1000 << 24;
     LoadStoreLiteral(Op, prfop, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
   }
-  void ldr(ARMEmitter::WRegister rt, BackwardLabel const* Label) {
+  void ldr(ARMEmitter::WRegister rt, const BackwardLabel* Label) {
     int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
     LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
     constexpr uint32_t Op = 0b0001'1000 << 24;
     LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
   }
-  void ldr(ARMEmitter::SRegister rt, BackwardLabel const* Label) {
+  void ldr(ARMEmitter::SRegister rt, const BackwardLabel* Label) {
     int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
     LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
     constexpr uint32_t Op = 0b0001'1100 << 24;
     LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
   }
-  void ldr(ARMEmitter::XRegister rt, BackwardLabel const* Label) {
+  void ldr(ARMEmitter::XRegister rt, const BackwardLabel* Label) {
     int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
     LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
     constexpr uint32_t Op = 0b0101'1000 << 24;
     LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
   }
-  void ldr(ARMEmitter::DRegister rt, BackwardLabel const* Label) {
+  void ldr(ARMEmitter::DRegister rt, const BackwardLabel* Label) {
     int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
     LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
     constexpr uint32_t Op = 0b0101'1100 << 24;
     LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
   }
-  void ldrsw(ARMEmitter::XRegister rt, BackwardLabel const* Label) {
+  void ldrsw(ARMEmitter::XRegister rt, const BackwardLabel* Label) {
     int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
     LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
     constexpr uint32_t Op = 0b1001'1000 << 24;
     LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
   }
-  void ldr(ARMEmitter::QRegister rt, BackwardLabel const* Label) {
+  void ldr(ARMEmitter::QRegister rt, const BackwardLabel* Label) {
     int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
     LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
     constexpr uint32_t Op = 0b1001'1100 << 24;
     LoadStoreLiteral(Op, rt, static_cast<uint32_t>(Imm >> 2) & 0x7'FFFF);
   }
-  void prfm(ARMEmitter::Prefetch prfop, BackwardLabel const* Label) {
+  void prfm(ARMEmitter::Prefetch prfop, const BackwardLabel* Label) {
     int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
     LOGMAN_THROW_A_FMT(Imm >= -1048576 && Imm <= 1048575 && ((Imm & 0b11) == 0), "Unscaled offset too large");
     constexpr uint32_t Op = 0b1101'1000 << 24;
@@ -2131,113 +2037,113 @@ public:
 
   template<typename LabelType>
   requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-  void ldr(ARMEmitter::WRegister rt, LabelType *Label) {
-    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
+  void ldr(ARMEmitter::WRegister rt, LabelType* Label) {
+    AddLocationToLabel(
+      Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD});
     constexpr uint32_t Op = 0b0001'1000 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
 
   template<typename LabelType>
   requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-  void ldr(ARMEmitter::SRegister rt, LabelType *Label) {
-    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
+  void ldr(ARMEmitter::SRegister rt, LabelType* Label) {
+    AddLocationToLabel(
+      Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD});
     constexpr uint32_t Op = 0b0001'1100 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
 
   template<typename LabelType>
   requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-  void ldr(ARMEmitter::XRegister rt, LabelType *Label) {
-    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
+  void ldr(ARMEmitter::XRegister rt, LabelType* Label) {
+    AddLocationToLabel(
+      Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD});
     constexpr uint32_t Op = 0b0101'1000 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
 
   template<typename LabelType>
   requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-  void ldr(ARMEmitter::DRegister rt, LabelType *Label) {
-    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
+  void ldr(ARMEmitter::DRegister rt, LabelType* Label) {
+    AddLocationToLabel(
+      Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD});
     constexpr uint32_t Op = 0b0101'1100 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
 
   template<typename LabelType>
   requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-  void ldrsw(ARMEmitter::XRegister rt, LabelType *Label) {
-    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
+  void ldrsw(ARMEmitter::XRegister rt, LabelType* Label) {
+    AddLocationToLabel(
+      Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD});
     constexpr uint32_t Op = 0b1001'1000 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
 
   template<typename LabelType>
   requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-  void ldr(ARMEmitter::QRegister rt, LabelType *Label) {
-    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
+  void ldr(ARMEmitter::QRegister rt, LabelType* Label) {
+    AddLocationToLabel(
+      Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD});
     constexpr uint32_t Op = 0b1001'1100 << 24;
     LoadStoreLiteral(Op, rt, 0);
   }
 
   template<typename LabelType>
   requires (std::is_same_v<LabelType, ForwardLabel> || std::is_same_v<LabelType, SingleUseForwardLabel>)
-  void prfm(ARMEmitter::Prefetch prfop, LabelType *Label) {
-    AddLocationToLabel(Label, SingleUseForwardLabel{ .Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD });
+  void prfm(ARMEmitter::Prefetch prfop, LabelType* Label) {
+    AddLocationToLabel(
+      Label, SingleUseForwardLabel {.Location = GetCursorAddress<uint8_t*>(), .Type = SingleUseForwardLabel::InstType::RELATIVE_LOAD});
     constexpr uint32_t Op = 0b1101'1000 << 24;
     LoadStoreLiteral(Op, prfop, 0);
   }
 
-  void ldr(ARMEmitter::WRegister rt, BiDirectionalLabel *Label) {
+  void ldr(ARMEmitter::WRegister rt, BiDirectionalLabel* Label) {
     if (Label->Backward.Location) {
       ldr(rt, &Label->Backward);
-    }
-    else {
+    } else {
       ldr(rt, &Label->Forward);
     }
   }
-  void ldr(ARMEmitter::SRegister rt, BiDirectionalLabel *Label) {
+  void ldr(ARMEmitter::SRegister rt, BiDirectionalLabel* Label) {
     if (Label->Backward.Location) {
       ldr(rt, &Label->Backward);
-    }
-    else {
+    } else {
       ldr(rt, &Label->Forward);
     }
   }
-  void ldr(ARMEmitter::XRegister rt, BiDirectionalLabel *Label) {
+  void ldr(ARMEmitter::XRegister rt, BiDirectionalLabel* Label) {
     if (Label->Backward.Location) {
       ldr(rt, &Label->Backward);
-    }
-    else {
+    } else {
       ldr(rt, &Label->Forward);
     }
   }
-  void ldr(ARMEmitter::DRegister rt, BiDirectionalLabel *Label) {
+  void ldr(ARMEmitter::DRegister rt, BiDirectionalLabel* Label) {
     if (Label->Backward.Location) {
       ldr(rt, &Label->Backward);
-    }
-    else {
+    } else {
       ldr(rt, &Label->Forward);
     }
   }
-  void ldrs(ARMEmitter::WRegister rt, BiDirectionalLabel *Label) {
+  void ldrs(ARMEmitter::WRegister rt, BiDirectionalLabel* Label) {
     if (Label->Backward.Location) {
       ldr(rt, &Label->Backward);
-    }
-    else {
+    } else {
       ldr(rt, &Label->Forward);
     }
   }
-  void ldr(ARMEmitter::QRegister rt, BiDirectionalLabel *Label) {
+  void ldr(ARMEmitter::QRegister rt, BiDirectionalLabel* Label) {
     if (Label->Backward.Location) {
       ldr(rt, &Label->Backward);
-    }
-    else {
+    } else {
       ldr(rt, &Label->Forward);
     }
   }
-  void prfm(ARMEmitter::Prefetch prfop, BiDirectionalLabel *Label) {
+  void prfm(ARMEmitter::Prefetch prfop, BiDirectionalLabel* Label) {
     if (Label->Backward.Location) {
       prfm(prfop, &Label->Backward);
-    }
-    else {
+    } else {
       prfm(prfop, &Label->Forward);
     }
   }
@@ -2301,83 +2207,73 @@ public:
   template<IndexType Index>
   void stp(ARMEmitter::WRegister rt, ARMEmitter::WRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b0010'1000'00 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b0010'1000'00 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
 
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 2) & 0b111'1111);
   }
   template<IndexType Index>
   void ldp(ARMEmitter::WRegister rt, ARMEmitter::WRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b0010'1000'01 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b0010'1000'01 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
 
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 2) & 0b111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldpsw(ARMEmitter::XRegister rt, ARMEmitter::XRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b0110'1000'01 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b0110'1000'01 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 2) & 0b111'1111);
   }
   template<IndexType Index>
   void stp(ARMEmitter::XRegister rt, ARMEmitter::XRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b1010'1000'00 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b1010'1000'00 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
 
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 3) & 0b111'1111);
   }
   template<IndexType Index>
   void ldp(ARMEmitter::XRegister rt, ARMEmitter::XRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b1010'1000'01 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b1010'1000'01 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
 
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 3) & 0b111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stp(ARMEmitter::SRegister rt, ARMEmitter::SRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     stp_w<Index>(rt.V(), rt2.V(), rn, Imm);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldp(ARMEmitter::SRegister rt, ARMEmitter::SRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldp_w<Index>(rt.V(), rt2.V(), rn, Imm);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stp(ARMEmitter::DRegister rt, ARMEmitter::DRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     stp_x<Index>(rt.V(), rt2.V(), rn, Imm);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldp(ARMEmitter::DRegister rt, ARMEmitter::DRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldp_x<Index>(rt.V(), rt2.V(), rn, Imm);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stp(ARMEmitter::QRegister rt, ARMEmitter::QRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     stp_q<Index>(rt.V(), rt2.V(), rn, Imm);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldp(ARMEmitter::QRegister rt, ARMEmitter::QRegister rt2, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldp_q<Index>(rt.V(), rt2.V(), rn, Imm);
   }
@@ -2452,7 +2348,7 @@ public:
   void ldur(ARMEmitter::QRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXr<IndexType::OFFSET>(rt, rn, Imm);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void prfum(ARMEmitter::Prefetch prfop, ARMEmitter::Register rn, int32_t Imm = 0) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
     static_assert(Index == IndexType::OFFSET, "Doesn't support another index type");
@@ -2465,118 +2361,118 @@ public:
 
   // Loadstore register immediate post-indexed
   // Loadstore register immediate pre-indexed
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void strb(ARMEmitter::Register rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     stXrb<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldrb(ARMEmitter::Register rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXrb<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void strb(ARMEmitter::VRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     stXrb<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldrb(ARMEmitter::VRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXrb<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldrsb(ARMEmitter::XRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXrsb<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldrsb(ARMEmitter::WRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXrsb<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void strh(ARMEmitter::Register rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     stXrh<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldrh(ARMEmitter::Register rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXrh<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void strh(ARMEmitter::VRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     stXrh<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldrh(ARMEmitter::VRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXrh<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldrsh(ARMEmitter::XRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXrsh<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldrsh(ARMEmitter::WRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXrsh<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void str(ARMEmitter::WRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     stXr<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldr(ARMEmitter::WRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXr<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void str(ARMEmitter::SRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     stXr<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldr(ARMEmitter::SRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXr<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldrsw(ARMEmitter::XRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXrsw<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void str(ARMEmitter::XRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     stXr<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldr(ARMEmitter::XRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXr<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void str(ARMEmitter::DRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     stXr<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldr(ARMEmitter::DRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXr<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void str(ARMEmitter::QRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     stXr<Index>(rt, rn, Imm);
   }
-  template <IndexType Index>
-  requires(Index == IndexType::POST || Index == IndexType::PRE)
+  template<IndexType Index>
+  requires (Index == IndexType::POST || Index == IndexType::PRE)
   void ldr(ARMEmitter::QRegister rt, ARMEmitter::Register rn, int32_t Imm = 0) {
     ldXr<Index>(rt, rn, Imm);
   }
@@ -3387,26 +3283,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       strb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       strb(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if (MemSrc.MetaType.ImmType.Imm < 0) {
           sturb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           strb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         strb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         strb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3416,26 +3306,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldrb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldrb(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if (MemSrc.MetaType.ImmType.Imm < 0) {
           ldurb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldrb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldrb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldrb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3445,26 +3329,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldrsb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldrsb(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if (MemSrc.MetaType.ImmType.Imm < 0) {
           ldursb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldrsb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldrsb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldrsb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3474,26 +3352,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldrsb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldrsb(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if (MemSrc.MetaType.ImmType.Imm < 0) {
           ldursb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldrsb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldrsb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldrsb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3503,26 +3375,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       strh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       strh(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
           sturh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           strh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         strh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         strh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3532,26 +3398,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldrh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldrh(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
           ldurh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldrh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldrh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldrh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3561,26 +3421,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldrsh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldrsh(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
           ldursh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldrsh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldrsh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldrsh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3590,26 +3444,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldrsh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldrsh(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
           ldursh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldrsh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldrsh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldrsh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3619,26 +3467,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       str(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       str(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b11) || MemSrc.MetaType.ImmType.Imm < 0) {
           stur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           str(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         str<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         str<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3648,26 +3490,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldr(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldr(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b11) || MemSrc.MetaType.ImmType.Imm < 0) {
           ldur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldr(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldr<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldr<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3677,26 +3513,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldrsw(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldrsw(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b11) || MemSrc.MetaType.ImmType.Imm < 0) {
           ldursw(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldrsw(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldrsw<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldrsw<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3706,26 +3536,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       str(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       str(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b111) || MemSrc.MetaType.ImmType.Imm < 0) {
           stur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           str(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         str<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         str<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3735,26 +3559,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldr(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldr(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b111) || MemSrc.MetaType.ImmType.Imm < 0) {
           ldur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldr(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldr<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldr<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3764,20 +3582,16 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       prfm(prfop, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       prfm(prfop, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b111) || MemSrc.MetaType.ImmType.Imm < 0) {
           prfum<IndexType::OFFSET>(prfop, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           prfm(prfop, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3789,26 +3603,20 @@ public:
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       LOGMAN_THROW_A_FMT(MemSrc.MetaType.ExtendedType.Shift == false, "Can't shift byte");
       strb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       strb(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if (MemSrc.MetaType.ImmType.Imm < 0) {
           sturb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           strb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         strb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         strb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3819,26 +3627,20 @@ public:
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       LOGMAN_THROW_A_FMT(MemSrc.MetaType.ExtendedType.Shift == false, "Can't shift byte");
       ldrb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldrb(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if (MemSrc.MetaType.ImmType.Imm < 0) {
           ldurb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldrb(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldrb<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldrb<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3848,26 +3650,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       strh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       strh(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
           sturh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           strh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         strh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         strh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3877,26 +3673,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldrh(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldrh(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b1) || MemSrc.MetaType.ImmType.Imm < 0) {
           ldurh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldrh(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldrh<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldrh<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3906,26 +3696,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       str(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       str(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b11) || MemSrc.MetaType.ImmType.Imm < 0) {
           stur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           str(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         str<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         str<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3935,26 +3719,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldr(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldr(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b11) || MemSrc.MetaType.ImmType.Imm < 0) {
           ldur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldr(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldr<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldr<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3964,26 +3742,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       str(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       str(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b111) || MemSrc.MetaType.ImmType.Imm < 0) {
           stur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           str(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         str<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         str<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -3993,26 +3765,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldr(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldr(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b111) || MemSrc.MetaType.ImmType.Imm < 0) {
           ldur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldr(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldr<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldr<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -4022,26 +3788,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       str(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       str(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b1111) || MemSrc.MetaType.ImmType.Imm < 0) {
           stur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           str(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         str<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         str<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -4051,26 +3811,20 @@ public:
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
       ldr(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option, MemSrc.MetaType.ExtendedType.Shift);
-    }
-    else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
+    } else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
       ldr(rt, MemSrc.rn);
-    }
-    else {
+    } else {
       if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::OFFSET) {
         if ((MemSrc.MetaType.ImmType.Imm & 0b1111) || MemSrc.MetaType.ImmType.Imm < 0) {
           ldur(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-        }
-        else {
+        } else {
           ldr(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
         }
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::POST) {
         ldr<ARMEmitter::IndexType::POST>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
+      } else if (MemSrc.MetaType.ImmType.Index == ARMEmitter::IndexType::PRE) {
         ldr<ARMEmitter::IndexType::PRE>(rt, MemSrc.rn, MemSrc.MetaType.ImmType.Imm);
-      }
-      else {
+      } else {
         LOGMAN_MSG_A_FMT("Unexpected loadstore index type");
         FEX_UNREACHABLE;
       }
@@ -4172,7 +3926,8 @@ public:
   }
 
 private:
-  void AtomicOp(uint32_t Op, ARMEmitter::Size s, uint32_t L, uint32_t o0, ARMEmitter::Register rs, ARMEmitter::Register rt, ARMEmitter::Register rt2, ARMEmitter::Register rn) {
+  void AtomicOp(uint32_t Op, ARMEmitter::Size s, uint32_t L, uint32_t o0, ARMEmitter::Register rs, ARMEmitter::Register rt,
+                ARMEmitter::Register rt2, ARMEmitter::Register rn) {
     const uint32_t sz = s == ARMEmitter::Size::i64Bit ? (1U << 30) : 0;
     uint32_t Instr = Op;
 
@@ -4264,8 +4019,7 @@ private:
   }
 
   // Atomic memory operations
-  void LoadStoreAtomicLSE(SubRegSize s, uint32_t A, uint32_t R, uint32_t o3, uint32_t opc,
-                          Register rs, Register rt, Register rn) {
+  void LoadStoreAtomicLSE(SubRegSize s, uint32_t A, uint32_t R, uint32_t o3, uint32_t opc, Register rs, Register rt, Register rn) {
     uint32_t Instr = 0b0011'1000'0010'0000'0000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(s) << 30;
     Instr |= A << 23;
@@ -4280,7 +4034,8 @@ private:
 
   // Loadstore register-register offset
   template<typename T>
-  void LoadStoreRegisterOffset(uint32_t Op, uint32_t opc, T rt, ARMEmitter::Register rn, ARMEmitter::Register rm, ARMEmitter::ExtendedType Option, uint32_t Shift) {
+  void LoadStoreRegisterOffset(uint32_t Op, uint32_t opc, T rt, ARMEmitter::Register rn, ARMEmitter::Register rm,
+                               ARMEmitter::ExtendedType Option, uint32_t Shift) {
     uint32_t Instr = Op;
 
     Instr |= opc << 22;
@@ -4293,7 +4048,7 @@ private:
   }
 
   // Loadstore unsigned immediate
-  template <typename T>
+  template<typename T>
   void LoadStoreUnsigned(uint32_t size, uint32_t V, uint32_t opc, T rt, Register rn, uint32_t Imm) {
     uint32_t SizeShift = size;
     if constexpr (std::is_same_v<T, QRegister>) {
@@ -4325,372 +4080,360 @@ private:
   template<IndexType Index>
   void ldp_w(ARMEmitter::VRegister rt, ARMEmitter::VRegister rt2, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b0010'1100'01 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b0010'1100'01 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
 
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 2) & 0b111'1111);
   }
   template<IndexType Index>
   void ldp_x(ARMEmitter::VRegister rt, ARMEmitter::VRegister rt2, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b0110'1100'01 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b0110'1100'01 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
 
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 3) & 0b111'1111);
   }
   template<IndexType Index>
   void stp_w(ARMEmitter::VRegister rt, ARMEmitter::VRegister rt2, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 252 && ((Imm & 0b11) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b0010'1100'00 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b0010'1100'00 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
 
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 2) & 0b111'1111);
   }
   template<IndexType Index>
   void stp_x(ARMEmitter::VRegister rt, ARMEmitter::VRegister rt2, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -512 && Imm <= 504 && ((Imm & 0b111) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b0110'1100'00 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b0110'1100'00 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
 
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 3) & 0b111'1111);
   }
   template<IndexType Index>
   void ldp_q(ARMEmitter::VRegister rt, ARMEmitter::VRegister rt2, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -1024 && Imm <= 1008 && ((Imm & 0b1111) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b1010'1100'01 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b1010'1100'01 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
 
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 4) & 0b111'1111);
   }
   template<IndexType Index>
   void stp_q(ARMEmitter::VRegister rt, ARMEmitter::VRegister rt2, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -1024 && Imm <= 1008 && ((Imm & 0b1111) == 0), "Unscaled offset too large");
-    constexpr uint32_t Op = (0b1010'1100'00 << 22) |
-      (
-        Index == IndexType::POST   ? (0b01 << 23) :
-        Index == IndexType::PRE    ? (0b11 << 23) :
-        Index == IndexType::OFFSET ? (0b10 << 23) : -1
-      );
+    constexpr uint32_t Op = (0b1010'1100'00 << 22) | (Index == IndexType::POST   ? (0b01 << 23) :
+                                                      Index == IndexType::PRE    ? (0b11 << 23) :
+                                                      Index == IndexType::OFFSET ? (0b10 << 23) :
+                                                                                   -1);
 
     LoadStorePair(Op, rt, rt2, rn, (Imm >> 4) & 0b111'1111);
   }
 
-  template <IndexType Index>
+  template<IndexType Index>
   void stXrb(ARMEmitter::Register rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0011'1000'00 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXrb(ARMEmitter::Register rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0011'1000'01 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stXrb(ARMEmitter::VRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0011'1100'00 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXrb(ARMEmitter::VRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0011'1100'01 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXrsb(ARMEmitter::XRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0011'1000'10 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXrsb(ARMEmitter::WRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0011'1000'11 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stXrh(ARMEmitter::Register rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0111'1000'00 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXrh(ARMEmitter::Register rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0111'1000'01 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stXrh(ARMEmitter::VRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0111'1100'00 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXrh(ARMEmitter::VRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0111'1100'01 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXrsh(ARMEmitter::XRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0111'1000'10 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXrsh(ARMEmitter::WRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0111'1000'11 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stXr(ARMEmitter::WRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b1011'1000'00 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXr(ARMEmitter::WRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b1011'1000'01 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stXr(ARMEmitter::SRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b1011'1100'00 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXr(ARMEmitter::SRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b1011'1100'01 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXrsw(ARMEmitter::XRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b1011'1000'10 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stXr(ARMEmitter::XRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b1111'1000'00 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXr(ARMEmitter::XRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b1111'1000'01 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stXr(ARMEmitter::DRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b1111'1100'00 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXr(ARMEmitter::DRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b1111'1100'01 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void stXr(ARMEmitter::QRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0011'1100'10 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }
-  template <IndexType Index>
+  template<IndexType Index>
   void ldXr(ARMEmitter::QRegister rt, ARMEmitter::Register rn, int32_t Imm) {
     LOGMAN_THROW_A_FMT(Imm >= -256 && Imm <= 255, "Unscaled offset too large");
 
     constexpr uint32_t Op = 0b0011'1100'11 << 22;
-    constexpr uint32_t o2 =
-      Index == IndexType::POST   ? 0b01 :
-      Index == IndexType::PRE    ? 0b11 :
-      Index == IndexType::OFFSET ? 0b00 :
-      Index == IndexType::UNPRIVILEGED ? 0b10 :  -1;
+    constexpr uint32_t o2 = Index == IndexType::POST         ? 0b01 :
+                            Index == IndexType::PRE          ? 0b11 :
+                            Index == IndexType::OFFSET       ? 0b00 :
+                            Index == IndexType::UNPRIVILEGED ? 0b10 :
+                                                               -1;
 
     LoadStoreImm(Op, o2, rt, rn, Imm & 0b1'1111'1111);
   }

--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -60,8 +60,8 @@ public:
   }
 
   void fcmla(SubRegSize size, ZRegister zda, PRegisterMerge pv, ZRegister zn, ZRegister zm, Rotation rot) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "SubRegSize must be 16-bit, 32-bit, or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 16-bit, "
+                                                                                                               "32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT(pv <= PReg::p7.Merging(), "fcmla can only use p0 to p7");
 
     uint32_t Op = 0b0110'0100'0000'0000'0000'0000'0000'0000;
@@ -76,11 +76,10 @@ public:
   }
 
   void fcadd(SubRegSize size, ZRegister zd, PRegisterMerge pv, ZRegister zn, ZRegister zm, Rotation rot) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "SubRegSize must be 16-bit, 32-bit, or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 16-bit, "
+                                                                                                               "32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT(pv <= PReg::p7.Merging(), "fcadd can only use p0 to p7");
-    LOGMAN_THROW_A_FMT(rot == Rotation::ROTATE_90 || rot == Rotation::ROTATE_270,
-                        "fcadd rotation may only be 90 or 270 degrees");
+    LOGMAN_THROW_A_FMT(rot == Rotation::ROTATE_90 || rot == Rotation::ROTATE_270, "fcadd rotation may only be 90 or 270 degrees");
     LOGMAN_THROW_A_FMT(zd == zn, "fcadd zd and zn must be the same register");
 
     const uint32_t ConvertedRotation = rot == Rotation::ROTATE_90 ? 0 : 1;
@@ -116,8 +115,7 @@ public:
   }
 
   // SVE address generation
-  void adr(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm,
-           SVEModType mod = SVEModType::MOD_NONE, uint32_t scale = 0) {
+  void adr(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm, SVEModType mod = SVEModType::MOD_NONE, uint32_t scale = 0) {
     SVEAddressGeneration(size, zd, zn, zm, mod, scale);
   }
 
@@ -276,32 +274,22 @@ public:
   }
   ///< Size is destination size
   void fcvtnt(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i16Bit,
-                        "Unsupported size in {}", __func__);
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i16Bit, "Unsupported size in {}", __func__);
 
-    const auto ConvertedDestSize =
-      size == SubRegSize::i16Bit ? 0b00 :
-      size == SubRegSize::i32Bit ? 0b10 : 0b00;
+    const auto ConvertedDestSize = size == SubRegSize::i16Bit ? 0b00 : size == SubRegSize::i32Bit ? 0b10 : 0b00;
 
-    const auto ConvertedSrcSize =
-      size == SubRegSize::i16Bit ? 0b10 :
-      size == SubRegSize::i32Bit ? 0b11 : 0b00;
+    const auto ConvertedSrcSize = size == SubRegSize::i16Bit ? 0b10 : size == SubRegSize::i32Bit ? 0b11 : 0b00;
 
     SVEFloatConvertOdd(ConvertedSrcSize, ConvertedDestSize, pg, zn, zd);
   }
 
   ///< Size is destination size
   void fcvtlt(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i64Bit || size == SubRegSize::i32Bit,
-                        "Unsupported size in {}", __func__);
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i64Bit || size == SubRegSize::i32Bit, "Unsupported size in {}", __func__);
 
-    const auto ConvertedDestSize =
-      size == SubRegSize::i32Bit ? 0b01 :
-      size == SubRegSize::i64Bit ? 0b11 : 0b00;
+    const auto ConvertedDestSize = size == SubRegSize::i32Bit ? 0b01 : size == SubRegSize::i64Bit ? 0b11 : 0b00;
 
-    const auto ConvertedSrcSize =
-      size == SubRegSize::i32Bit ? 0b10 :
-      size == SubRegSize::i64Bit ? 0b11 : 0b00;
+    const auto ConvertedSrcSize = size == SubRegSize::i32Bit ? 0b10 : size == SubRegSize::i64Bit ? 0b11 : 0b00;
 
     SVEFloatConvertOdd(ConvertedSrcSize, ConvertedDestSize, pg, zn, zd);
   }
@@ -335,8 +323,7 @@ public:
 
   // SVE floating-point complex multiply-add (indexed)
   void fcmla(SubRegSize size, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index, Rotation rot) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit,
-                        "SubRegSize must be 16-bit or 32-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit, "SubRegSize must be 16-bit or 32-bit");
 
     // 16 -> 32, 32 -> 64, since fcmla (indexed)'s restrictions and encodings
     // are essentially as if 16-bit were 32-bit and 32-bit were 64-bit.
@@ -513,14 +500,16 @@ public:
   // SVE Integer Reduction
   // SVE integer add reduction (predicated)
   void saddv(SubRegSize size, DRegister vd, PRegister pg, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit,
-                       "saddv may only use 8-bit, 16-bit, or 32-bit elements.");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit, "saddv may only use 8-bit, "
+                                                                                                              "16-bit, or 32-bit "
+                                                                                                              "elements.");
     constexpr uint32_t Op = 0b0000'0100'0000'0000'0010'0000'0000'0000;
     SVEIntegerReductionOperation(Op, 0b00, size, vd, pg, zn);
   }
   void uaddv(SubRegSize size, DRegister vd, PRegister pg, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit,
-                       "uaddv may only use 8-bit, 16-bit, or 32-bit elements.");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit, "uaddv may only use 8-bit, "
+                                                                                                              "16-bit, or 32-bit "
+                                                                                                              "elements.");
     constexpr uint32_t Op = 0b0000'0100'0000'0000'0010'0000'0000'0000;
     SVEIntegerReductionOperation(Op, 0b01, size, vd, pg, zn);
   }
@@ -545,7 +534,7 @@ public:
 
   // SVE constructive prefix (predicated)
   template<typename T>
-  requires(std::is_same_v<PRegisterZero, T> || std::is_same_v<PRegisterMerge, T>)
+  requires (std::is_same_v<PRegisterZero, T> || std::is_same_v<PRegisterMerge, T>)
   void movprfx(SubRegSize size, ZRegister zd, T pg, ZRegister zn) {
     constexpr uint32_t M = std::is_same_v<PRegisterMerge, T> ? 1 : 0;
     SVEConstructivePrefixPredicated(0b00, M, size, pg, zn, zd);
@@ -826,14 +815,16 @@ public:
   // SVE Integer Misc - Unpredicated
   // SVE floating-point trig select coefficient
   void ftssel(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "ftssel may only have 16-bit, 32-bit, or 64-bit element sizes");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "ftssel may only have "
+                                                                                                               "16-bit, 32-bit, or 64-bit "
+                                                                                                               "element sizes");
     SVEIntegerMiscUnpredicated(0b00, zm.Idx(), FEXCore::ToUnderlying(size), zd, zn);
   }
   // SVE floating-point exponential accelerator
   void fexpa(SubRegSize size, ZRegister zd, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "fexpa may only have 16-bit, 32-bit, or 64-bit element sizes");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "fexpa may only have "
+                                                                                                               "16-bit, 32-bit, or 64-bit "
+                                                                                                               "element sizes");
     SVEIntegerMiscUnpredicated(0b10, 0b00000, FEXCore::ToUnderlying(size), zd, zn);
   }
   // SVE constructive prefix (unpredicated)
@@ -882,16 +873,16 @@ public:
 
   // SVE element count
   void cntb(XRegister rd, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1000, SubRegSize::i8Bit, ZRegister{rd.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1000, SubRegSize::i8Bit, ZRegister {rd.Idx()}, pattern, imm);
   }
   void cnth(XRegister rd, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1000, SubRegSize::i16Bit, ZRegister{rd.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1000, SubRegSize::i16Bit, ZRegister {rd.Idx()}, pattern, imm);
   }
   void cntw(XRegister rd, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1000, SubRegSize::i32Bit, ZRegister{rd.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1000, SubRegSize::i32Bit, ZRegister {rd.Idx()}, pattern, imm);
   }
   void cntd(XRegister rd, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1000, SubRegSize::i64Bit, ZRegister{rd.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1000, SubRegSize::i64Bit, ZRegister {rd.Idx()}, pattern, imm);
   }
 
   // SVE inc/dec vector by element count
@@ -916,129 +907,129 @@ public:
 
   // SVE inc/dec register by element count
   void incb(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1000, SubRegSize::i8Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1000, SubRegSize::i8Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void decb(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1001, SubRegSize::i8Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1001, SubRegSize::i8Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void inch(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1000, SubRegSize::i16Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1000, SubRegSize::i16Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void dech(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1001, SubRegSize::i16Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1001, SubRegSize::i16Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void incw(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1000, SubRegSize::i32Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1000, SubRegSize::i32Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void decw(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1001, SubRegSize::i32Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1001, SubRegSize::i32Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void incd(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1000, SubRegSize::i64Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1000, SubRegSize::i64Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void decd(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1001, SubRegSize::i64Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1001, SubRegSize::i64Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
 
   // SVE saturating inc/dec register by element count
   void sqincb(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1100, SubRegSize::i8Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1100, SubRegSize::i8Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqincb(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1100, SubRegSize::i8Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1100, SubRegSize::i8Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqincb(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1101, SubRegSize::i8Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1101, SubRegSize::i8Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqincb(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1101, SubRegSize::i8Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1101, SubRegSize::i8Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqdecb(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1110, SubRegSize::i8Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1110, SubRegSize::i8Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqdecb(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1110, SubRegSize::i8Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1110, SubRegSize::i8Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqdecb(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1111, SubRegSize::i8Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1111, SubRegSize::i8Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqdecb(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1111, SubRegSize::i8Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1111, SubRegSize::i8Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
 
   void sqinch(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1100, SubRegSize::i16Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1100, SubRegSize::i16Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqinch(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1100, SubRegSize::i16Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1100, SubRegSize::i16Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqinch(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1101, SubRegSize::i16Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1101, SubRegSize::i16Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqinch(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1101, SubRegSize::i16Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1101, SubRegSize::i16Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqdech(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1110, SubRegSize::i16Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1110, SubRegSize::i16Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqdech(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1110, SubRegSize::i16Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1110, SubRegSize::i16Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqdech(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1111, SubRegSize::i16Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1111, SubRegSize::i16Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqdech(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1111, SubRegSize::i16Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1111, SubRegSize::i16Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
 
   void sqincw(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1100, SubRegSize::i32Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1100, SubRegSize::i32Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqincw(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1100, SubRegSize::i32Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1100, SubRegSize::i32Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqincw(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1101, SubRegSize::i32Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1101, SubRegSize::i32Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqincw(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1101, SubRegSize::i32Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1101, SubRegSize::i32Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqdecw(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1110, SubRegSize::i32Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1110, SubRegSize::i32Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqdecw(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1110, SubRegSize::i32Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1110, SubRegSize::i32Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqdecw(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1111, SubRegSize::i32Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1111, SubRegSize::i32Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqdecw(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1111, SubRegSize::i32Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1111, SubRegSize::i32Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
 
   void sqincd(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1100, SubRegSize::i64Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1100, SubRegSize::i64Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqincd(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1100, SubRegSize::i64Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1100, SubRegSize::i64Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqincd(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1101, SubRegSize::i64Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1101, SubRegSize::i64Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqincd(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1101, SubRegSize::i64Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1101, SubRegSize::i64Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqdecd(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1110, SubRegSize::i64Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1110, SubRegSize::i64Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void sqdecd(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1110, SubRegSize::i64Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1110, SubRegSize::i64Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqdecd(XRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(1, 0b1111, SubRegSize::i64Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(1, 0b1111, SubRegSize::i64Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
   void uqdecd(WRegister rdn, PredicatePattern pattern, uint32_t imm) {
-    SVEElementCount(0, 0b1111, SubRegSize::i64Bit, ZRegister{rdn.Idx()}, pattern, imm);
+    SVEElementCount(0, 0b1111, SubRegSize::i64Bit, ZRegister {rdn.Idx()}, pattern, imm);
   }
 
   // SVE Bitwise Immediate
@@ -1070,13 +1061,13 @@ public:
 
   // SVE Permute Vector - Unpredicated
   void dup(SubRegSize size, ZRegister zd, Register rn) {
-    SVEPermuteUnpredicated(size, 0b00000, zd, ZRegister{rn.Idx()});
+    SVEPermuteUnpredicated(size, 0b00000, zd, ZRegister {rn.Idx()});
   }
   void mov(SubRegSize size, ZRegister zd, Register rn) {
     dup(size, zd, rn);
   }
   void insr(SubRegSize size, ZRegister zdn, Register rm) {
-    SVEPermuteUnpredicated(size, 0b00100, zdn, ZRegister{rm.Idx()});
+    SVEPermuteUnpredicated(size, 0b00100, zdn, ZRegister {rm.Idx()});
   }
   void insr(SubRegSize size, ZRegister zdn, VRegister vm) {
     SVEPermuteUnpredicated(size, 0b10100, zdn, vm.Z());
@@ -1139,29 +1130,28 @@ public:
   // SVE Permute Vector - Predicated - Base
   // CPY (SIMD&FP scalar)
   void cpy(SubRegSize size, ZRegister zd, PRegisterMerge pg, VRegister vn) {
-    SVEPermuteVectorPredicated(0b00000, 0b0, size, zd, pg, ZRegister{vn.Idx()});
+    SVEPermuteVectorPredicated(0b00000, 0b0, size, zd, pg, ZRegister {vn.Idx()});
   }
 
   void compact(SubRegSize size, ZRegister zd, PRegister pg, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i64Bit || size == SubRegSize::i32Bit,
-                        "Invalid element size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i64Bit || size == SubRegSize::i32Bit, "Invalid element size");
     SVEPermuteVectorPredicated(0b00001, 0b0, size, zd, pg, zn);
   }
 
   // CPY (scalar)
   void cpy(SubRegSize size, ZRegister zd, PRegisterMerge pg, Register rn) {
-    SVEPermuteVectorPredicated(0b01000, 0b1, size, zd, pg, ZRegister{rn.Idx()});
+    SVEPermuteVectorPredicated(0b01000, 0b1, size, zd, pg, ZRegister {rn.Idx()});
   }
 
   template<OpType optype>
-  requires(optype == OpType::Constructive)
+  requires (optype == OpType::Constructive)
   void splice(SubRegSize size, ZRegister zd, PRegister pv, ZRegister zn, ZRegister zn2) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(zn, zn2), "zn and zn2 must be sequential registers");
     SVEPermuteVectorPredicated(0b01101, 0b0, size, zd, pv, zn);
   }
 
   template<OpType optype>
-  requires(optype == OpType::Destructive)
+  requires (optype == OpType::Destructive)
   void splice(SubRegSize size, ZRegister zd, PRegister pv, ZRegister zn, ZRegister zm) {
     LOGMAN_THROW_A_FMT(zd == zn, "zd needs to equal zn");
     SVEPermuteVectorPredicated(0b01100, 0b0, size, zd, pv, zm);
@@ -1170,18 +1160,18 @@ public:
   // SVE Permute Vector - Predicated
   // SVE extract element to general register
   void lasta(SubRegSize size, Register rd, PRegister pg, ZRegister zn) {
-    SVEPermuteVectorPredicated(0b00000, 0b1, size, ZRegister{rd.Idx()}, pg, zn);
+    SVEPermuteVectorPredicated(0b00000, 0b1, size, ZRegister {rd.Idx()}, pg, zn);
   }
   void lastb(SubRegSize size, Register rd, PRegister pg, ZRegister zn) {
-    SVEPermuteVectorPredicated(0b00001, 0b1, size, ZRegister{rd.Idx()}, pg, zn);
+    SVEPermuteVectorPredicated(0b00001, 0b1, size, ZRegister {rd.Idx()}, pg, zn);
   }
 
   // SVE extract element to SIMD&FP scalar register
   void lasta(SubRegSize size, VRegister vd, PRegister pg, ZRegister zn) {
-    SVEPermuteVectorPredicated(0b00010, 0b0, size, ZRegister{vd.Idx()}, pg, zn);
+    SVEPermuteVectorPredicated(0b00010, 0b0, size, ZRegister {vd.Idx()}, pg, zn);
   }
   void lastb(SubRegSize size, VRegister vd, PRegister pg, ZRegister zn) {
-    SVEPermuteVectorPredicated(0b00011, 0b0, size, ZRegister{vd.Idx()}, pg, zn);
+    SVEPermuteVectorPredicated(0b00011, 0b0, size, ZRegister {vd.Idx()}, pg, zn);
   }
 
   // SVE reverse within elements
@@ -1190,8 +1180,7 @@ public:
     SVEPermuteVectorPredicated(0b00100, 0b0, size, zd, pg, zn);
   }
   void revh(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit,
-                        "Can't use 8/16-bit element sizes");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "Can't use 8/16-bit element sizes");
     SVEPermuteVectorPredicated(0b00101, 0b0, size, zd, pg, zn);
   }
   void revw(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
@@ -1215,11 +1204,11 @@ public:
   // SVE conditionally extract element to SIMD&FP scalar
   void clasta(SubRegSize size, VRegister vd, PRegister pg, VRegister vn, ZRegister zm) {
     LOGMAN_THROW_A_FMT(vd == vn, "vd must be the same as vn");
-    SVEPermuteVectorPredicated(0b01010, 0b0, size, ZRegister{vd.Idx()}, pg, zm);
+    SVEPermuteVectorPredicated(0b01010, 0b0, size, ZRegister {vd.Idx()}, pg, zm);
   }
   void clastb(SubRegSize size, VRegister vd, PRegister pg, VRegister vn, ZRegister zm) {
     LOGMAN_THROW_A_FMT(vd == vn, "vd must be the same as vn");
-    SVEPermuteVectorPredicated(0b01011, 0b0, size, ZRegister{vd.Idx()}, pg, zm);
+    SVEPermuteVectorPredicated(0b01011, 0b0, size, ZRegister {vd.Idx()}, pg, zm);
   }
 
   // SVE reverse doublewords (SME)
@@ -1228,17 +1217,17 @@ public:
   // SVE conditionally extract element to general register
   void clasta(SubRegSize size, Register rd, PRegister pg, Register rn, ZRegister zm) {
     LOGMAN_THROW_A_FMT(rd == rn, "rd must be the same as rn");
-    SVEPermuteVectorPredicated(0b10000, 0b1, size, ZRegister{rd.Idx()}, pg, zm);
+    SVEPermuteVectorPredicated(0b10000, 0b1, size, ZRegister {rd.Idx()}, pg, zm);
   }
   void clastb(SubRegSize size, Register rd, PRegister pg, Register rn, ZRegister zm) {
     LOGMAN_THROW_A_FMT(rd == rn, "rd must be the same as rn");
-    SVEPermuteVectorPredicated(0b10001, 0b1, size, ZRegister{rd.Idx()}, pg, zm);
+    SVEPermuteVectorPredicated(0b10001, 0b1, size, ZRegister {rd.Idx()}, pg, zm);
   }
 
   // SVE Permute Vector - Extract
   // Constructive
   template<OpType optype>
-  requires(optype == OpType::Constructive)
+  requires (optype == OpType::Constructive)
   void ext(ZRegister zd, ZRegister zn, ZRegister zn2, uint8_t Imm) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(zn, zn2), "zn and zn2 must be sequential registers");
     SVEPermuteVector(1, zd, zn, Imm);
@@ -1246,7 +1235,7 @@ public:
 
   // Destructive
   template<OpType optype>
-  requires(optype == OpType::Destructive)
+  requires (optype == OpType::Destructive)
   void ext(ZRegister zd, ZRegister zdn, ZRegister zm, uint8_t Imm) {
     LOGMAN_THROW_A_FMT(zd == zdn, "Dest needs to equal zdn");
     SVEPermuteVector(0, zd, zm, Imm);
@@ -1401,54 +1390,54 @@ public:
 
   // SVE Integer Compare - Scalars
   // SVE integer compare scalar count and limit
-  template <IsXOrWRegister T>
+  template<IsXOrWRegister T>
   void whilege(SubRegSize size, PRegister pd, T rn, T rm) {
     constexpr auto IsXRegister = static_cast<uint32_t>(std::is_same_v<T, XRegister>);
     SVEIntCompareScalar(IsXRegister << 2, 0, pd.Idx(), size, rn, rm);
   }
-  template <IsXOrWRegister T>
+  template<IsXOrWRegister T>
   void whilegt(SubRegSize size, PRegister pd, T rn, T rm) {
     constexpr auto IsXRegister = static_cast<uint32_t>(std::is_same_v<T, XRegister>);
     SVEIntCompareScalar(IsXRegister << 2, 1, pd.Idx(), size, rn, rm);
   }
-  template <IsXOrWRegister T>
+  template<IsXOrWRegister T>
   void whilelt(SubRegSize size, PRegister pd, T rn, T rm) {
     constexpr auto IsXRegister = static_cast<uint32_t>(std::is_same_v<T, XRegister>);
     SVEIntCompareScalar((IsXRegister << 2) | 0b001, 0, pd.Idx(), size, rn, rm);
   }
-  template <IsXOrWRegister T>
+  template<IsXOrWRegister T>
   void whilele(SubRegSize size, PRegister pd, T rn, T rm) {
     constexpr auto IsXRegister = static_cast<uint32_t>(std::is_same_v<T, XRegister>);
     SVEIntCompareScalar((IsXRegister << 2) | 0b001, 1, pd.Idx(), size, rn, rm);
   }
-  template <IsXOrWRegister T>
+  template<IsXOrWRegister T>
   void whilehs(SubRegSize size, PRegister pd, T rn, T rm) {
     constexpr auto IsXRegister = static_cast<uint32_t>(std::is_same_v<T, XRegister>);
     SVEIntCompareScalar((IsXRegister << 2) | 0b010, 0, pd.Idx(), size, rn, rm);
   }
-  template <IsXOrWRegister T>
+  template<IsXOrWRegister T>
   void whilehi(SubRegSize size, PRegister pd, T rn, T rm) {
     constexpr auto IsXRegister = static_cast<uint32_t>(std::is_same_v<T, XRegister>);
     SVEIntCompareScalar((IsXRegister << 2) | 0b010, 1, pd.Idx(), size, rn, rm);
   }
-  template <IsXOrWRegister T>
+  template<IsXOrWRegister T>
   void whilelo(SubRegSize size, PRegister pd, T rn, T rm) {
     constexpr auto IsXRegister = static_cast<uint32_t>(std::is_same_v<T, XRegister>);
     SVEIntCompareScalar((IsXRegister << 2) | 0b011, 0, pd.Idx(), size, rn, rm);
   }
-  template <IsXOrWRegister T>
+  template<IsXOrWRegister T>
   void whilels(SubRegSize size, PRegister pd, T rn, T rm) {
     constexpr auto IsXRegister = static_cast<uint32_t>(std::is_same_v<T, XRegister>);
     SVEIntCompareScalar((IsXRegister << 2) | 0b011, 1, pd.Idx(), size, rn, rm);
   }
 
   // SVE conditionally terminate scalars
-  template <IsXOrWRegister T>
+  template<IsXOrWRegister T>
   void ctermeq(T rn, T rm) {
     constexpr auto size = std::is_same_v<T, XRegister> ? SubRegSize::i64Bit : SubRegSize::i32Bit;
     SVEIntCompareScalar(0b1000, 0, 0b0000, size, rn, rm);
   }
-  template <IsXOrWRegister T>
+  template<IsXOrWRegister T>
   void ctermne(T rn, T rm) {
     constexpr auto size = std::is_same_v<T, XRegister> ? SubRegSize::i64Bit : SubRegSize::i32Bit;
     SVEIntCompareScalar(0b1000, 1, 0b0000, size, rn, rm);
@@ -1515,10 +1504,9 @@ public:
 
   // SVE broadcast floating-point immediate (unpredicated)
   void fdup(ARMEmitter::SubRegSize size, ARMEmitter::ZRegister zd, float Value) {
-    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
-                        size == ARMEmitter::SubRegSize::i32Bit ||
-                        size == ARMEmitter::SubRegSize::i64Bit, "Unsupported fmov size");
-    uint32_t Imm{};
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit,
+                       "Unsupported fmov size");
+    uint32_t Imm {};
     if (size == SubRegSize::i16Bit) {
       LOGMAN_MSG_A_FMT("Unsupported");
       FEX_UNREACHABLE;
@@ -2337,31 +2325,16 @@ public:
       LOGMAN_THROW_A_FMT(dstsize == SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       opc1 = 0b01;
       opc2 = 0b01;
-    }
-    else if (srcsize == SubRegSize::i32Bit) {
+    } else if (srcsize == SubRegSize::i32Bit) {
       // Srcsize = fp32, opc1 encodes dst size
-      opc1 =
-        dstsize == SubRegSize::i64Bit ? 0b11 :
-        dstsize == SubRegSize::i32Bit ? 0b10 :
-        dstsize == SubRegSize::i16Bit ? 0b01 :0b00;
+      opc1 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b10 : dstsize == SubRegSize::i16Bit ? 0b01 : 0b00;
 
-      opc2 =
-        dstsize == SubRegSize::i64Bit ? 0b00 :
-        dstsize == SubRegSize::i32Bit ? 0b10 :
-        dstsize == SubRegSize::i16Bit ? 0b10 :0b00;
-    }
-    else if (srcsize == SubRegSize::i64Bit) {
+      opc2 = dstsize == SubRegSize::i64Bit ? 0b00 : dstsize == SubRegSize::i32Bit ? 0b10 : dstsize == SubRegSize::i16Bit ? 0b10 : 0b00;
+    } else if (srcsize == SubRegSize::i64Bit) {
       // SrcSize = fp64, opc2 encodes dst size
-      opc1 =
-        dstsize == SubRegSize::i64Bit ? 0b11 :
-        dstsize == SubRegSize::i32Bit ? 0b11 :
-        dstsize == SubRegSize::i16Bit ? 0b01 :0b00;
-      opc2 =
-        dstsize == SubRegSize::i64Bit ? 0b11 :
-        dstsize == SubRegSize::i32Bit ? 0b10 :
-        dstsize == SubRegSize::i16Bit ? 0b11 :0b00;
-    }
-    else {
+      opc1 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b11 : dstsize == SubRegSize::i16Bit ? 0b01 : 0b00;
+      opc2 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b10 : dstsize == SubRegSize::i16Bit ? 0b11 : 0b00;
+    } else {
       FEX_UNREACHABLE;
     }
     SVEIntegerConvertToFloat(dstsize, srcsize, opc1, opc2, 0, pg, zn, zd);
@@ -2373,31 +2346,16 @@ public:
       LOGMAN_THROW_A_FMT(dstsize == SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       opc1 = 0b01;
       opc2 = 0b01;
-    }
-    else if (srcsize == SubRegSize::i32Bit) {
+    } else if (srcsize == SubRegSize::i32Bit) {
       // Srcsize = fp32, opc1 encodes dst size
-      opc1 =
-        dstsize == SubRegSize::i64Bit ? 0b11 :
-        dstsize == SubRegSize::i32Bit ? 0b10 :
-        dstsize == SubRegSize::i16Bit ? 0b01 :0b00;
+      opc1 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b10 : dstsize == SubRegSize::i16Bit ? 0b01 : 0b00;
 
-      opc2 =
-        dstsize == SubRegSize::i64Bit ? 0b00 :
-        dstsize == SubRegSize::i32Bit ? 0b10 :
-        dstsize == SubRegSize::i16Bit ? 0b10 :0b00;
-    }
-    else if (srcsize == SubRegSize::i64Bit) {
+      opc2 = dstsize == SubRegSize::i64Bit ? 0b00 : dstsize == SubRegSize::i32Bit ? 0b10 : dstsize == SubRegSize::i16Bit ? 0b10 : 0b00;
+    } else if (srcsize == SubRegSize::i64Bit) {
       // SrcSize = fp64, opc2 encodes dst size
-      opc1 =
-        dstsize == SubRegSize::i64Bit ? 0b11 :
-        dstsize == SubRegSize::i32Bit ? 0b11 :
-        dstsize == SubRegSize::i16Bit ? 0b01 :0b00;
-      opc2 =
-        dstsize == SubRegSize::i64Bit ? 0b11 :
-        dstsize == SubRegSize::i32Bit ? 0b10 :
-        dstsize == SubRegSize::i16Bit ? 0b11 :0b00;
-    }
-    else {
+      opc1 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b11 : dstsize == SubRegSize::i16Bit ? 0b01 : 0b00;
+      opc2 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b10 : dstsize == SubRegSize::i16Bit ? 0b11 : 0b00;
+    } else {
       FEX_UNREACHABLE;
     }
     SVEIntegerConvertToFloat(dstsize, srcsize, opc1, opc2, 1, pg, zn, zd);
@@ -2405,10 +2363,10 @@ public:
 
   // SVE floating-point convert to integer
   void flogb(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    const auto ConvertedSize =
-      size == SubRegSize::i64Bit ? 0b11 :
-      size == SubRegSize::i32Bit ? 0b10 :
-      size == SubRegSize::i16Bit ? 0b01 : 0b00;
+    const auto ConvertedSize = size == SubRegSize::i64Bit ? 0b11 :
+                               size == SubRegSize::i32Bit ? 0b10 :
+                               size == SubRegSize::i16Bit ? 0b01 :
+                                                            0b00;
 
     SVEFloatConvertToInt(size, size, 1, 0b00, ConvertedSize, 0, pg, zn, zd);
   }
@@ -2417,25 +2375,18 @@ public:
     if (srcsize == SubRegSize::i16Bit) {
       // Srcsize = fp16, opc2 encodes dst size
       opc1 = 0b01;
-      opc2 = dstsize == SubRegSize::i64Bit ? 0b11 :
-             dstsize == SubRegSize::i32Bit ? 0b10 :
-             dstsize == SubRegSize::i16Bit ? 0b01 : 0b00;
-    }
-    else if (srcsize == SubRegSize::i32Bit) {
+      opc2 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b10 : dstsize == SubRegSize::i16Bit ? 0b01 : 0b00;
+    } else if (srcsize == SubRegSize::i32Bit) {
       // Srcsize = fp32, opc1 encodes dst size
       LOGMAN_THROW_A_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       opc2 = 0b10;
-      opc1 = dstsize == SubRegSize::i64Bit ? 0b11 :
-             dstsize == SubRegSize::i32Bit ? 0b10 : 0b00;
-    }
-    else if (srcsize == SubRegSize::i64Bit) {
+      opc1 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b10 : 0b00;
+    } else if (srcsize == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       // SrcSize = fp64, opc2 encodes dst size
       opc1 = 0b11;
-      opc2 = dstsize == SubRegSize::i64Bit ? 0b11 :
-             dstsize == SubRegSize::i32Bit ? 0b00 : 0b00;
-    }
-    else {
+      opc2 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b00 : 0b00;
+    } else {
       FEX_UNREACHABLE;
     }
     SVEFloatConvertToInt(dstsize, srcsize, 1, opc1, opc2, 0, pg, zn, zd);
@@ -2445,25 +2396,18 @@ public:
     if (srcsize == SubRegSize::i16Bit) {
       // Srcsize = fp16, opc2 encodes dst size
       opc1 = 0b01;
-      opc2 = dstsize == SubRegSize::i64Bit ? 0b11 :
-             dstsize == SubRegSize::i32Bit ? 0b10 :
-             dstsize == SubRegSize::i16Bit ? 0b01 : 0b00;
-    }
-    else if (srcsize == SubRegSize::i32Bit) {
+      opc2 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b10 : dstsize == SubRegSize::i16Bit ? 0b01 : 0b00;
+    } else if (srcsize == SubRegSize::i32Bit) {
       // Srcsize = fp32, opc1 encodes dst size
       LOGMAN_THROW_A_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       opc2 = 0b10;
-      opc1 = dstsize == SubRegSize::i64Bit ? 0b11 :
-             dstsize == SubRegSize::i32Bit ? 0b10 : 0b00;
-    }
-    else if (srcsize == SubRegSize::i64Bit) {
+      opc1 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b10 : 0b00;
+    } else if (srcsize == SubRegSize::i64Bit) {
       LOGMAN_THROW_A_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       // SrcSize = fp64, opc2 encodes dst size
       opc1 = 0b11;
-      opc2 = dstsize == SubRegSize::i64Bit ? 0b11 :
-             dstsize == SubRegSize::i32Bit ? 0b00 : 0b00;
-    }
-    else {
+      opc2 = dstsize == SubRegSize::i64Bit ? 0b11 : dstsize == SubRegSize::i32Bit ? 0b00 : 0b00;
+    } else {
       FEX_UNREACHABLE;
     }
     SVEFloatConvertToInt(dstsize, srcsize, 1, opc1, opc2, 1, pg, zn, zd);
@@ -2536,7 +2480,7 @@ public:
 
   // SVE Memory - 32-bit Gather and Unsized Contiguous
   void ldr(PRegister pt, XRegister rn, int32_t imm = 0) {
-    SVEUnsizedLoadStoreContiguous(0b0, imm, ZRegister{pt.Idx()}, rn, false);
+    SVEUnsizedLoadStoreContiguous(0b0, imm, ZRegister {pt.Idx()}, rn, false);
   }
   void ldr(ZRegister zt, XRegister rn, int32_t imm = 0) {
     SVEUnsizedLoadStoreContiguous(0b1, imm, zt, rn, false);
@@ -2647,17 +2591,13 @@ public:
   void ld1b(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ld1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       ld1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i8Bit, zt, pg, Src, true, false);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(size, SubRegSize::i8Bit, zt, pg, Src, true, false);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2666,17 +2606,13 @@ public:
   void ldff1b(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ldff1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "ldff1b doesn't have a scalar plus immediate variant");
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i8Bit, zt, pg, Src, true, true);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(size, SubRegSize::i8Bit, zt, pg, Src, true, true);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2684,17 +2620,13 @@ public:
   void ld1sw(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ld1sw(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       ld1sw(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(SubRegSize::i64Bit, SubRegSize::i32Bit, zt, pg, Src, false, false);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(SubRegSize::i64Bit, SubRegSize::i32Bit, zt, pg, Src, false, false);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2703,17 +2635,13 @@ public:
   void ld1h(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ld1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       ld1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i16Bit, zt, pg, Src, true, false);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(size, SubRegSize::i16Bit, zt, pg, Src, true, false);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2722,17 +2650,13 @@ public:
   void ld1sh(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ld1sh<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       ld1sh<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i16Bit, zt, pg, Src, false, false);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(size, SubRegSize::i16Bit, zt, pg, Src, false, false);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2741,17 +2665,13 @@ public:
   void ldff1h(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ldff1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "ldff1h doesn't have a scalar plus immediate variant");
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i16Bit, zt, pg, Src, true, true);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(size, SubRegSize::i16Bit, zt, pg, Src, true, true);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2760,17 +2680,13 @@ public:
   void ldff1sh(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ldff1sh<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "ldff1sh doesn't have a scalar plus immediate variant");
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i16Bit, zt, pg, Src, false, true);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(size, SubRegSize::i16Bit, zt, pg, Src, false, true);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2779,17 +2695,13 @@ public:
   void ld1w(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ld1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       ld1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i32Bit, zt, pg, Src, true, false);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(size, SubRegSize::i32Bit, zt, pg, Src, true, false);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2798,17 +2710,13 @@ public:
   void ldff1w(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ldff1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "ldff1w doesn't have a scalar plus immediate variant");
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i32Bit, zt, pg, Src, true, true);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(size, SubRegSize::i32Bit, zt, pg, Src, true, true);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2816,17 +2724,13 @@ public:
   void ldff1sw(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ldff1sw(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "ldff1sw doesn't have a scalar plus immediate variant");
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(SubRegSize::i64Bit, SubRegSize::i32Bit, zt, pg, Src, false, true);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(SubRegSize::i64Bit, SubRegSize::i32Bit, zt, pg, Src, false, true);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2835,17 +2739,13 @@ public:
   void ld1sb(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ld1sb<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       ld1sb<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i8Bit, zt, pg, Src, false, false);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(size, SubRegSize::i8Bit, zt, pg, Src, false, false);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2854,17 +2754,13 @@ public:
   void ldff1sb(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ldff1sb<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "ldff1sb doesn't have a scalar plus immediate variant");
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(size, SubRegSize::i8Bit, zt, pg, Src, false, true);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(size, SubRegSize::i8Bit, zt, pg, Src, false, true);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2872,17 +2768,13 @@ public:
   void ld1d(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ld1d(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       ld1d(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src, true, false);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src, true, false);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2890,17 +2782,13 @@ public:
   void ldff1d(ZRegister zt, PRegisterZero pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       ldff1d(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       LOGMAN_THROW_A_FMT(false, "ldff1d doesn't have a scalar plus immediate variant");
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEGatherLoadScalarPlusVector(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src, true, true);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEGatherLoadVectorPlusImm(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src, true, true);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2909,17 +2797,13 @@ public:
   void st1b(ZRegister zt, PRegister pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       st1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       st1b<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEScatterStoreScalarPlusVector(size, SubRegSize::i8Bit, zt, pg, Src);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEScatterStoreVectorPlusImm(size, SubRegSize::i8Bit, zt, pg, Src);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2928,17 +2812,13 @@ public:
   void st1h(ZRegister zt, PRegister pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       st1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       st1h<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEScatterStoreScalarPlusVector(size, SubRegSize::i16Bit, zt, pg, Src);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEScatterStoreVectorPlusImm(size, SubRegSize::i16Bit, zt, pg, Src);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2947,17 +2827,13 @@ public:
   void st1w(ZRegister zt, PRegister pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       st1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       st1w<size>(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEScatterStoreScalarPlusVector(size, SubRegSize::i32Bit, zt, pg, Src);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEScatterStoreVectorPlusImm(size, SubRegSize::i32Bit, zt, pg, Src);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -2965,17 +2841,13 @@ public:
   void st1d(ZRegister zt, PRegister pg, SVEMemOperand Src) {
     if (Src.IsScalarPlusScalar()) {
       st1d(zt, pg, Src.rn, Src.MetaType.ScalarScalarType.rm);
-    }
-    else if (Src.IsScalarPlusImm()) {
+    } else if (Src.IsScalarPlusImm()) {
       st1d(zt, pg, Src.rn, Src.MetaType.ScalarImmType.Imm);
-    }
-    else if (Src.IsScalarPlusVector()) {
+    } else if (Src.IsScalarPlusVector()) {
       SVEScatterStoreScalarPlusVector(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src);
-    }
-    else if (Src.IsVectorPlusImm()) {
+    } else if (Src.IsVectorPlusImm()) {
       SVEScatterStoreVectorPlusImm(SubRegSize::i64Bit, SubRegSize::i64Bit, zt, pg, Src);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
   }
@@ -3076,9 +2948,7 @@ public:
   void ld1sh(ZRegister zt, PRegisterZero pg, Register rn, int32_t Imm = 0) {
     static_assert(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
 
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i32Bit ? 1 :
-      size == SubRegSize::i64Bit ? 0 : -1;
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i32Bit ? 1 : size == SubRegSize::i64Bit ? 0 : -1;
 
     SVEContiguousLoadImm(false, 0b1000 | ConvertedSize, Imm, pg, rn, zt);
   }
@@ -3087,23 +2957,19 @@ public:
   void ld1w(ZRegister zt, PRegisterZero pg, Register rn, int32_t Imm = 0) {
     static_assert(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
 
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i32Bit ? 0 :
-      size == SubRegSize::i64Bit ? 1 : -1;
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i32Bit ? 0 : size == SubRegSize::i64Bit ? 1 : -1;
 
     SVEContiguousLoadImm(false, 0b1010 | ConvertedSize, Imm, pg, rn, zt);
   }
 
   template<SubRegSize size>
   void ld1sb(ZRegister zt, PRegisterZero pg, Register rn, int32_t Imm = 0) {
-    static_assert(size == SubRegSize::i16Bit ||
-                  size == SubRegSize::i32Bit ||
-                  size == SubRegSize::i64Bit, "Invalid size");
+    static_assert(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
 
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i16Bit ? 0b10 :
-      size == SubRegSize::i32Bit ? 0b01 :
-      size == SubRegSize::i64Bit ? 0b00 : -1;
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i16Bit ? 0b10 :
+                                       size == SubRegSize::i32Bit ? 0b01 :
+                                       size == SubRegSize::i64Bit ? 0b00 :
+                                                                    -1;
 
     SVEContiguousLoadImm(false, 0b1100 | ConvertedSize, Imm, pg, rn, zt);
   }
@@ -3158,32 +3024,24 @@ public:
 
   template<SubRegSize size>
   void ld1sh(ZRegister zt, PRegisterZero pg, Register rn, Register rm) {
-    static_assert(size == SubRegSize::i32Bit ||
-                  size == SubRegSize::i64Bit, "Invalid size");
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i32Bit ? 1 :
-      size == SubRegSize::i64Bit ? 0 : -1;
+    static_assert(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i32Bit ? 1 : size == SubRegSize::i64Bit ? 0 : -1;
     SVEContiguousLoadStore(0, 0, 0b1000 | ConvertedSize, rm, pg, rn, zt);
   }
 
   template<SubRegSize size>
   void ld1w(ZRegister zt, PRegisterZero pg, Register rn, Register rm) {
-    static_assert(size == SubRegSize::i32Bit ||
-                  size == SubRegSize::i64Bit, "Invalid size");
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i32Bit ? 0 :
-      size == SubRegSize::i64Bit ? 1 : -1;
+    static_assert(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i32Bit ? 0 : size == SubRegSize::i64Bit ? 1 : -1;
     SVEContiguousLoadStore(0, 0, 0b1010 | ConvertedSize, rm, pg, rn, zt);
   }
   template<SubRegSize size>
   void ld1sb(ZRegister zt, PRegisterZero pg, Register rn, Register rm) {
-    static_assert(size == SubRegSize::i16Bit ||
-                  size == SubRegSize::i32Bit ||
-                  size == SubRegSize::i64Bit, "Invalid size");
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i16Bit ? 0b10 :
-      size == SubRegSize::i32Bit ? 0b01 :
-      size == SubRegSize::i64Bit ? 0b00 : -1;
+    static_assert(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i16Bit ? 0b10 :
+                                       size == SubRegSize::i32Bit ? 0b01 :
+                                       size == SubRegSize::i64Bit ? 0b00 :
+                                                                    -1;
     SVEContiguousLoadStore(0, 0, 0b1100 | ConvertedSize, rm, pg, rn, zt);
   }
 
@@ -3198,13 +3056,11 @@ public:
   }
   template<SubRegSize size>
   void ldff1sb(ZRegister zt, PRegisterZero pg, Register rn, Register rm) {
-    static_assert(size == SubRegSize::i16Bit ||
-                  size == SubRegSize::i32Bit ||
-                  size == SubRegSize::i64Bit, "Invalid size");
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i16Bit ? 0b10 :
-      size == SubRegSize::i32Bit ? 0b01 :
-      size == SubRegSize::i64Bit ? 0b00 : -1;
+    static_assert(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i16Bit ? 0b10 :
+                                       size == SubRegSize::i32Bit ? 0b01 :
+                                       size == SubRegSize::i64Bit ? 0b00 :
+                                                                    -1;
     SVEContiguousLoadStore(0, 1, 0b1100 | ConvertedSize, rm, pg, rn, zt);
   }
   template<SubRegSize size>
@@ -3214,20 +3070,14 @@ public:
   }
   template<SubRegSize size>
   void ldff1sh(ZRegister zt, PRegisterZero pg, Register rn, Register rm) {
-    static_assert(size == SubRegSize::i32Bit ||
-                  size == SubRegSize::i64Bit, "Invalid size");
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i32Bit ? 1 :
-      size == SubRegSize::i64Bit ? 0 : -1;
+    static_assert(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i32Bit ? 1 : size == SubRegSize::i64Bit ? 0 : -1;
     SVEContiguousLoadStore(0, 1, 0b1000 | ConvertedSize, rm, pg, rn, zt);
   }
   template<SubRegSize size>
   void ldff1w(ZRegister zt, PRegisterZero pg, Register rn, Register rm) {
-    static_assert(size == SubRegSize::i32Bit ||
-                  size == SubRegSize::i64Bit, "Invalid size");
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i32Bit ? 0 :
-      size == SubRegSize::i64Bit ? 1 : -1;
+    static_assert(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i32Bit ? 0 : size == SubRegSize::i64Bit ? 1 : -1;
     SVEContiguousLoadStore(0, 1, 0b1010 | ConvertedSize, rm, pg, rn, zt);
   }
   void ldff1sw(ZRegister zt, PRegisterZero pg, Register rn, Register rm) {
@@ -3249,7 +3099,7 @@ public:
 
   // SVE Memory - Contiguous Store and Unsized Contiguous
   void str(PRegister pt, XRegister rn, int32_t imm = 0) {
-    SVEUnsizedLoadStoreContiguous(0b0, imm, ZRegister{pt.Idx()}, rn, true);
+    SVEUnsizedLoadStoreContiguous(0b0, imm, ZRegister {pt.Idx()}, rn, true);
   }
   void str(ZRegister zt, XRegister rn, int32_t imm = 0) {
     SVEUnsizedLoadStoreContiguous(0b1, imm, zt, rn, true);
@@ -3269,11 +3119,8 @@ public:
 
   template<SubRegSize size>
   void st1w(ZRegister zt, PRegister pg, Register rn, Register rm) {
-    static_assert(size == SubRegSize::i32Bit ||
-                  size == SubRegSize::i64Bit, "Invalid size");
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i32Bit ? 0 :
-      size == SubRegSize::i64Bit ? 1 : -1;
+    static_assert(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i32Bit ? 0 : size == SubRegSize::i64Bit ? 1 : -1;
 
     SVEContiguousLoadStore(1, 0, 0b1010 | ConvertedSize, rm, pg, rn, zt);
   }
@@ -3420,9 +3267,7 @@ public:
   void st1w(ZRegister zt, PRegister pg, Register rn, int32_t Imm = 0) {
     static_assert(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid size");
 
-    constexpr uint32_t ConvertedSize =
-      size == SubRegSize::i32Bit ? 0 :
-      size == SubRegSize::i64Bit ? 1 : -1;
+    constexpr uint32_t ConvertedSize = size == SubRegSize::i32Bit ? 0 : size == SubRegSize::i64Bit ? 1 : -1;
 
     SVEContiguousLoadImm(true, 0b1010 | ConvertedSize, Imm, pg, rn, zt);
   }
@@ -3438,8 +3283,7 @@ private:
 
     // We can index up to 512-bit registers with dup
     [[maybe_unused]] const auto max_index = (64U >> log2_size_bytes) - 1;
-    LOGMAN_THROW_A_FMT(Index <= max_index, "dup index ({}) too large. Must be within [0, {}].",
-                        Index, max_index);
+    LOGMAN_THROW_A_FMT(Index <= max_index, "dup index ({}) too large. Must be within [0, {}].", Index, max_index);
 
     // imm2:tsz make up a 7 bit wide field, with each increasing element size
     // restricting the range of those 7 bits (e.g. B: tsz=xxxx1, H: tsz=xxx10,
@@ -3492,11 +3336,9 @@ private:
 
     const bool is_signed = (opc & 1) == 0;
     if (is_signed) {
-      LOGMAN_THROW_A_FMT(imm >= -128 && imm <= 127,
-                          "Invalid immediate ({}). Must be within [-127, 128]", imm);
+      LOGMAN_THROW_A_FMT(imm >= -128 && imm <= 127, "Invalid immediate ({}). Must be within [-127, 128]", imm);
     } else {
-      LOGMAN_THROW_A_FMT(imm >= 0 && imm <= 255,
-                          "Invalid immediate ({}). Must be within [0, 255]", imm);
+      LOGMAN_THROW_A_FMT(imm >= 0 && imm <= 255, "Invalid immediate ({}). Must be within [0, 255]", imm);
     }
 
     const auto imm8 = static_cast<uint32_t>(imm) & 0xFF;
@@ -3512,8 +3354,7 @@ private:
   void SVEMultiplyImmediateUnpred(uint32_t opc, SubRegSize size, ZRegister zd, ZRegister zn, int32_t imm) {
     LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
     LOGMAN_THROW_A_FMT(zd == zn, "zd needs to equal zn");
-    LOGMAN_THROW_A_FMT(imm >= -128 && imm <= 127,
-                        "Invalid immediate ({}). Must be within [-127, 128]", imm);
+    LOGMAN_THROW_A_FMT(imm >= -128 && imm <= 127, "Invalid immediate ({}). Must be within [-127, 128]", imm);
 
     const auto imm8 = static_cast<uint32_t>(imm) & 0xFF;
 
@@ -3540,10 +3381,9 @@ private:
   }
 
   void SVEBroadcastFloatImmPredicated(SubRegSize size, ZRegister zd, PRegister pg, float value) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit ||
-                        size == SubRegSize::i32Bit ||
-                        size == SubRegSize::i64Bit, "Unsupported fcpy/fmov size");
-    uint32_t imm{};
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Unsupported fcpy/fmov "
+                                                                                                               "size");
+    uint32_t imm {};
     if (size == SubRegSize::i16Bit) {
       LOGMAN_MSG_A_FMT("Unsupported");
       FEX_UNREACHABLE;
@@ -3605,11 +3445,9 @@ private:
     case SVEModType::MOD_NONE:
     case SVEModType::MOD_LSL: {
       if (mod == SVEModType::MOD_NONE) {
-        LOGMAN_THROW_A_FMT(scale == 0,
-                            "Cannot scale packed ADR without a modifier");
+        LOGMAN_THROW_A_FMT(scale == 0, "Cannot scale packed ADR without a modifier");
       }
-      LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                          "Packed ADR must be using 32-bit or 64-bit elements");
+      LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Packed ADR must be using 32-bit or 64-bit elements");
       Instr |= FEXCore::ToUnderlying(size) << 22;
       break;
     }
@@ -3691,8 +3529,7 @@ private:
   }
 
   // SVE predicate logical operations
-  void SVEPredicateLogical(uint32_t op, uint32_t S, uint32_t o2, uint32_t o3,
-                           PRegister pm, PRegister pg, PRegister pn, PRegister pd) {
+  void SVEPredicateLogical(uint32_t op, uint32_t S, uint32_t o2, uint32_t o3, PRegister pm, PRegister pg, PRegister pn, PRegister pd) {
     uint32_t Instr = 0b0010'0101'0000'0000'0100'0000'0000'0000;
     Instr |= op << 23;
     Instr |= S << 22;
@@ -3721,8 +3558,7 @@ private:
   // SVE2 floating-point pairwise operations
   void SVEFloatPairwiseArithmetic(uint32_t opc, SubRegSize size, PRegister pg, ZRegister zd, ZRegister zn, ZRegister zm) {
     LOGMAN_THROW_A_FMT(zd == zn, "zd needs to equal zn");
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                       "Invalid float size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid float size");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0110'0100'0001'0000'1000'0000'0000'0000;
@@ -3736,8 +3572,7 @@ private:
 
   // SVE floating-point arithmetic (unpredicated)
   void SVEFloatArithmeticUnpredicated(uint32_t opc, SubRegSize size, ZRegister zm, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "Invalid float size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Invalid float size");
 
     uint32_t Instr = 0b0110'0101'0000'0000'0000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -3859,8 +3694,7 @@ private:
   }
 
   void SVECharacterMatch(uint32_t opc, SubRegSize size, PRegister pd, PRegisterZero pg, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit,
-                        "match/nmatch can only use 8-bit or 16-bit element sizes");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit, "match/nmatch can only use 8-bit or 16-bit element sizes");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7.Zeroing(), "match/nmatch can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0100'0101'0010'0000'1000'0000'0000'0000;
@@ -3874,8 +3708,9 @@ private:
   }
 
   void SVEFPRecursiveReduction(uint32_t opc, SubRegSize size, VRegister vd, PRegister pg, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "FP reduction operation can only use 16-bit, 32-bit, or 64-bit element sizes");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "FP reduction operation can "
+                                                                                                               "only use 16-bit, 32-bit, "
+                                                                                                               "or 64-bit element sizes");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "FP reduction operation can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0110'0101'0000'0000'0010'0000'0000'0000;
@@ -3906,8 +3741,8 @@ private:
 
     // Division instruction
     if (b18 != 0) {
-      LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                          "Predicated divide only handles 32-bit or 64-bit elements");
+      LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Predicated divide only handles 32-bit or 64-bit "
+                                                                                   "elements");
     }
 
     uint32_t Instr = 0b0000'0100'0001'0000'0000'0000'0000'0000;
@@ -3949,8 +3784,7 @@ private:
   }
 
   void SVEStackFrameOperation(uint32_t opc, XRegister rd, XRegister rn, int32_t imm) {
-    LOGMAN_THROW_A_FMT(imm >= -32 && imm <= 31,
-                        "Stack frame operation immediate must be within -32 to 31");
+    LOGMAN_THROW_A_FMT(imm >= -32 && imm <= 31, "Stack frame operation immediate must be within -32 to 31");
 
     uint32_t Instr = 0b0000'0100'0010'0000'0101'0000'0000'0000;
     Instr |= opc << 22;
@@ -3961,8 +3795,7 @@ private:
   }
 
   void SVEBitwiseShiftByWideElementPredicated(SubRegSize size, uint32_t opc, ZRegister zd, PRegisterMerge pg, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit && size != SubRegSize::i128Bit,
-                       "Can't use 64-bit or 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit && size != SubRegSize::i128Bit, "Can't use 64-bit or 128-bit element size");
     LOGMAN_THROW_A_FMT(zd == zn, "zd and zn must be the same register");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7.Merging(), "Wide shift can only use p0-p7 as a governing predicate");
 
@@ -3976,8 +3809,7 @@ private:
   }
 
   void SVEBitwiseShiftByWideElementsUnpredicated(SubRegSize size, uint32_t opc, ZRegister zd, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit && size != SubRegSize::i128Bit,
-                       "Can't use 64-bit or 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit && size != SubRegSize::i128Bit, "Can't use 64-bit or 128-bit element size");
 
     uint32_t Instr = 0b0000'0100'0010'0000'1000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -3990,8 +3822,7 @@ private:
 
   void SVEFPArithWithImmediate(uint32_t opc, SubRegSize size, ZRegister zd, PRegister pg, uint32_t i1) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit,
-                       "Can't use 8-bit or 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
 
     uint32_t Instr = 0b0110'0101'0001'1000'1000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -4005,8 +3836,7 @@ private:
   void SVEFPConvertPrecision(SubRegSize to, SubRegSize from, ZRegister zd, PRegister pg, ZRegister zn) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
     LOGMAN_THROW_A_FMT(to != from, "to and from sizes cannot be the same.");
-    LOGMAN_THROW_A_FMT(to != SubRegSize::i8Bit && to != SubRegSize::i128Bit &&
-                       from != SubRegSize::i8Bit && from != SubRegSize::i128Bit,
+    LOGMAN_THROW_A_FMT(to != SubRegSize::i8Bit && to != SubRegSize::i128Bit && from != SubRegSize::i8Bit && from != SubRegSize::i128Bit,
                        "Can't use 8-bit or 128-bit element size");
 
     // Encodings for the to and from sizes can get a little funky
@@ -4015,39 +3845,29 @@ private:
       switch (from) {
       case SubRegSize::i16Bit: {
         switch (to) {
-        case SubRegSize::i32Bit:
-          return 0x00810000U;
-        case SubRegSize::i64Bit:
-          return 0x00C10000U;
-        default:
-          return UINT32_MAX;
+        case SubRegSize::i32Bit: return 0x00810000U;
+        case SubRegSize::i64Bit: return 0x00C10000U;
+        default: return UINT32_MAX;
         }
-        }
+      }
 
       case SubRegSize::i32Bit: {
         switch (to) {
-        case SubRegSize::i16Bit:
-          return 0x00800000U;
-        case SubRegSize::i64Bit:
-          return 0x00C30000U;
-        default:
-          return UINT32_MAX;
+        case SubRegSize::i16Bit: return 0x00800000U;
+        case SubRegSize::i64Bit: return 0x00C30000U;
+        default: return UINT32_MAX;
         }
       }
 
       case SubRegSize::i64Bit: {
         switch (to) {
-        case SubRegSize::i16Bit:
-          return 0x00C00000U;
-        case SubRegSize::i32Bit:
-          return 0x00C20000U;
-        default:
-          return UINT32_MAX;
+        case SubRegSize::i16Bit: return 0x00C00000U;
+        case SubRegSize::i32Bit: return 0x00C20000U;
+        default: return UINT32_MAX;
         }
       }
 
-      default:
-        return UINT32_MAX;
+      default: return UINT32_MAX;
       }
     }();
     LOGMAN_THROW_A_FMT(op != UINT32_MAX, "Invalid conversion op value: {}", op);
@@ -4061,8 +3881,7 @@ private:
   }
 
   void SVE2IntegerAddSubNarrowHighPart(SubRegSize size, uint32_t opc, ZRegister zd, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit && size != SubRegSize::i128Bit,
-                       "Can't use 64-bit or 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit && size != SubRegSize::i128Bit, "Can't use 64-bit or 128-bit element size");
 
     uint32_t Instr = 0b0100'0101'0010'0000'0110'0000'0000'0000;
     Instr |= (FEXCore::ToUnderlying(size) + 1) << 22;
@@ -4107,8 +3926,7 @@ private:
   }
 
   void SVE2IntegerAddSubInterleavedLong(SubRegSize size, uint32_t opc, ZRegister zd, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit,
-                       "Can't use 8-bit or 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
 
     uint32_t Instr = 0b0100'0101'0000'0000'1000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -4132,8 +3950,7 @@ private:
   }
 
   void SVE2IntegerAddSubLongWithCarry(SubRegSize size, uint32_t sizep1, uint32_t T, ZRegister zda, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                       "Element size must be 32-bit or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Element size must be 32-bit or 64-bit");
 
     const uint32_t NewSize = size == SubRegSize::i32Bit ? 0 : 1;
 
@@ -4177,13 +3994,12 @@ private:
   }
 
   void SVE2BitwiseShiftLeftLong(SubRegSize size, uint32_t opc, ZRegister zd, ZRegister zn, uint32_t shift) {
-    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit,
-                       "Can't use 8-bit or 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
 
     // The size provided in is the size to expand to (e.g. 16-bit means a long shift
     // expanding from 8-bit) so we just need to subtract the size by 1 so that our
     // encoding helper will perform the proper encoding.
-    const auto size_minus_1 = SubRegSize{FEXCore::ToUnderlying(size) - 1};
+    const auto size_minus_1 = SubRegSize {FEXCore::ToUnderlying(size) - 1};
     const auto [tszh, tszl_imm3] = EncodeSVEShiftImmediate(size_minus_1, shift, true);
 
     uint32_t Instr = 0b0100'0101'0000'0000'1010'0000'0000'0000;
@@ -4198,8 +4014,7 @@ private:
   void SVE2ComplexIntAdd(SubRegSize size, uint32_t opc, Rotation rot, ZRegister zd, ZRegister zn, ZRegister zm) {
     LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Complex add cannot use 128-bit element size");
     LOGMAN_THROW_A_FMT(zd == zn, "zd and zn must be the same register");
-    LOGMAN_THROW_A_FMT(rot == Rotation::ROTATE_90 || rot == Rotation::ROTATE_270,
-                       "Rotation must be 90 or 270 degrees");
+    LOGMAN_THROW_A_FMT(rot == Rotation::ROTATE_90 || rot == Rotation::ROTATE_270, "Rotation must be 90 or 270 degrees");
 
     const uint32_t SanitizedRot = rot == Rotation::ROTATE_90 ? 0 : 1;
 
@@ -4213,8 +4028,7 @@ private:
   }
 
   void SVE2AbsDiffAccLong(SubRegSize size, uint32_t opc, ZRegister zda, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit,
-                      "Cannot use 8-bit or 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Cannot use 8-bit or 128-bit element size");
 
     uint32_t Instr = 0b0100'0101'0000'0000'1100'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -4249,8 +4063,7 @@ private:
     // 0b111 - I - Current
 
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "Unsupported size in {}", __func__);
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Unsupported size in {}", __func__);
 
     uint32_t Instr = 0b0110'0101'0000'0000'1010'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -4262,12 +4075,13 @@ private:
   }
 
   // SVE floating-point convert to integer
-  void SVEFloatConvertToInt(SubRegSize dstsize, SubRegSize srcsize, uint32_t b19, uint32_t opc, uint32_t opc2, uint32_t U, PRegister pg, ZRegister zn, ZRegister zd) {
+  void SVEFloatConvertToInt(SubRegSize dstsize, SubRegSize srcsize, uint32_t b19, uint32_t opc, uint32_t opc2, uint32_t U, PRegister pg,
+                            ZRegister zn, ZRegister zd) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
     LOGMAN_THROW_A_FMT(srcsize == SubRegSize::i16Bit || srcsize == SubRegSize::i32Bit || srcsize == SubRegSize::i64Bit,
-                        "Unsupported src size in {}", __func__);
+                       "Unsupported src size in {}", __func__);
     LOGMAN_THROW_A_FMT(dstsize == SubRegSize::i16Bit || dstsize == SubRegSize::i32Bit || dstsize == SubRegSize::i64Bit,
-                        "Unsupported dst size in {}", __func__);
+                       "Unsupported dst size in {}", __func__);
 
     uint32_t Instr = 0b0110'0101'0001'0000'1010'0000'0000'0000;
     Instr |= opc << 22;
@@ -4282,7 +4096,8 @@ private:
   // SVE integer convert to floating-point
   // We can implement this in terms of the floating-point to int version above,
   // since the only difference in encoding is setting bit 19 to 0.
-  void SVEIntegerConvertToFloat(SubRegSize dstsize, SubRegSize srcsize, uint32_t opc, uint32_t opc2, uint32_t U, PRegister pg, ZRegister zn, ZRegister zd) {
+  void SVEIntegerConvertToFloat(SubRegSize dstsize, SubRegSize srcsize, uint32_t opc, uint32_t opc2, uint32_t U, PRegister pg, ZRegister zn,
+                                ZRegister zd) {
     SVEFloatConvertToInt(dstsize, srcsize, 0, opc, opc2, U, pg, zn, zd);
   }
 
@@ -4291,16 +4106,14 @@ private:
   //       compact and in the same place.
   void SVEGatherLoadScalarPlusVector(SubRegSize esize, SubRegSize msize, ZRegister zt, PRegisterZero pg, SVEMemOperand mem_op,
                                      bool is_unsigned, bool is_fault_first) {
-    LOGMAN_THROW_A_FMT(esize == SubRegSize::i32Bit || esize == SubRegSize::i64Bit,
-                       "Gather load element size must be 32-bit or 64-bit");
+    LOGMAN_THROW_A_FMT(esize == SubRegSize::i32Bit || esize == SubRegSize::i64Bit, "Gather load element size must be 32-bit or 64-bit");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     const auto& op_data = mem_op.MetaType.ScalarVectorType;
     const bool is_scaled = op_data.scale != 0;
     [[maybe_unused]] const auto msize_value = FEXCore::ToUnderlying(msize);
 
-    LOGMAN_THROW_A_FMT(op_data.scale == 0 || op_data.scale == msize_value,
-                       "scale may only be 0 or {}", msize_value);
+    LOGMAN_THROW_A_FMT(op_data.scale == 0 || op_data.scale == msize_value, "scale may only be 0 or {}", msize_value);
 
     uint32_t mod_value = FEXCore::ToUnderlying(op_data.mod);
     uint32_t Instr = 0b1000'0100'0000'0000'0000'0000'0000'0000;
@@ -4315,20 +4128,17 @@ private:
       // LSL and no modifier encodings should be setting bit 22 to 1.
       if (is_lsl || is_none) {
         if (is_lsl) {
-          LOGMAN_THROW_A_FMT(op_data.scale == msize_value,
-                             "mod type of LSL must have a scale of {}", msize_value);
+          LOGMAN_THROW_A_FMT(op_data.scale == msize_value, "mod type of LSL must have a scale of {}", msize_value);
         } else {
-          LOGMAN_THROW_A_FMT(op_data.scale == 0,
-                             "mod type of none must have a scale of 0");
+          LOGMAN_THROW_A_FMT(op_data.scale == 0, "mod type of none must have a scale of 0");
         }
 
         Instr |= 1U << 15;
         mod_value = 1;
       }
     } else {
-      LOGMAN_THROW_A_FMT(op_data.mod == SVEModType::MOD_UXTW ||
-                         op_data.mod == SVEModType::MOD_SXTW,
-                         "mod type for 32-bit lane size may only be UXTW or SXTW");
+      LOGMAN_THROW_A_FMT(op_data.mod == SVEModType::MOD_UXTW || op_data.mod == SVEModType::MOD_SXTW, "mod type for 32-bit lane size may "
+                                                                                                     "only be UXTW or SXTW");
     }
 
     Instr |= FEXCore::ToUnderlying(msize) << 23;
@@ -4345,8 +4155,7 @@ private:
   }
 
   void SVEScatterStoreScalarPlusVector(SubRegSize esize, SubRegSize msize, ZRegister zt, PRegister pg, SVEMemOperand mem_op) {
-    LOGMAN_THROW_A_FMT(esize == SubRegSize::i32Bit || esize == SubRegSize::i64Bit,
-                       "Gather load element size must be 32-bit or 64-bit");
+    LOGMAN_THROW_A_FMT(esize == SubRegSize::i32Bit || esize == SubRegSize::i64Bit, "Gather load element size must be 32-bit or 64-bit");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     const auto& op_data = mem_op.MetaType.ScalarVectorType;
@@ -4355,8 +4164,7 @@ private:
     const auto msize_value = FEXCore::ToUnderlying(msize);
     uint32_t mod_value = FEXCore::ToUnderlying(op_data.mod);
 
-    LOGMAN_THROW_A_FMT(op_data.scale == 0 || op_data.scale == msize_value,
-                       "scale may only be 0 or {}", msize_value);
+    LOGMAN_THROW_A_FMT(op_data.scale == 0 || op_data.scale == msize_value, "scale may only be 0 or {}", msize_value);
 
     uint32_t Instr = 0b1110'0100'0000'0000'1000'0000'0000'0000;
 
@@ -4367,16 +4175,13 @@ private:
 
       if (is_lsl || is_none) {
         if (is_lsl) {
-          LOGMAN_THROW_A_FMT(op_data.scale == msize_value,
-                             "mod type of LSL must have a scale of {}", msize_value);
+          LOGMAN_THROW_A_FMT(op_data.scale == msize_value, "mod type of LSL must have a scale of {}", msize_value);
         } else {
-          LOGMAN_THROW_A_FMT(op_data.scale == 0,
-                             "mod type of none must have a scale of 0");
+          LOGMAN_THROW_A_FMT(op_data.scale == 0, "mod type of none must have a scale of 0");
         }
         if (is_lsl || is_scaled) {
-          LOGMAN_THROW_A_FMT(msize != SubRegSize::i8Bit,
-                           "Cannot use 8-bit store elements with unpacked 32-bit scaled offset and "
-                           "64-bit scaled offset variants. Instructions not allocated.");
+          LOGMAN_THROW_A_FMT(msize != SubRegSize::i8Bit, "Cannot use 8-bit store elements with unpacked 32-bit scaled offset and "
+                                                         "64-bit scaled offset variants. Instructions not allocated.");
         }
 
         // 64-bit scaled/unscaled scatters need to set bit 13
@@ -4385,18 +4190,16 @@ private:
       }
     } else {
       if (is_scaled) {
-        LOGMAN_THROW_A_FMT(msize != SubRegSize::i8Bit && msize != SubRegSize::i64Bit,
-                           "Cannot use 8-bit or 64-bit store elements with 32-bit scaled offset variant. "
-                           "Instructions not allocated");
+        LOGMAN_THROW_A_FMT(msize != SubRegSize::i8Bit && msize != SubRegSize::i64Bit, "Cannot use 8-bit or 64-bit store elements with "
+                                                                                      "32-bit scaled offset variant. "
+                                                                                      "Instructions not allocated");
       } else {
-        LOGMAN_THROW_A_FMT(msize != SubRegSize::i64Bit,
-                           "Cannot use 64-bit store elements with 32-bit unscaled offset variant. "
-                           "Instruction not allocated.");
+        LOGMAN_THROW_A_FMT(msize != SubRegSize::i64Bit, "Cannot use 64-bit store elements with 32-bit unscaled offset variant. "
+                                                        "Instruction not allocated.");
       }
 
-      LOGMAN_THROW_A_FMT(op_data.mod == SVEModType::MOD_UXTW ||
-                         op_data.mod == SVEModType::MOD_SXTW,
-                         "mod type for 32-bit lane size may only be UXTW or SXTW");
+      LOGMAN_THROW_A_FMT(op_data.mod == SVEModType::MOD_UXTW || op_data.mod == SVEModType::MOD_SXTW, "mod type for 32-bit lane size may "
+                                                                                                     "only be UXTW or SXTW");
 
       // 32-bit scatters need to set bit 22.
       Instr |= 1U << 22;
@@ -4413,10 +4216,10 @@ private:
     dc32(Instr);
   }
 
-  void SVEGatherScatterVectorPlusImm(SubRegSize esize, SubRegSize msize, ZRegister zt, PRegister pg, SVEMemOperand mem_op,
-                                     bool is_store, bool is_unsigned, bool is_fault_first) {
-    LOGMAN_THROW_A_FMT(esize == SubRegSize::i32Bit || esize == SubRegSize::i64Bit,
-                       "Gather load/store element size must be 32-bit or 64-bit");
+  void SVEGatherScatterVectorPlusImm(SubRegSize esize, SubRegSize msize, ZRegister zt, PRegister pg, SVEMemOperand mem_op, bool is_store,
+                                     bool is_unsigned, bool is_fault_first) {
+    LOGMAN_THROW_A_FMT(esize == SubRegSize::i32Bit || esize == SubRegSize::i64Bit, "Gather load/store element size must be 32-bit or "
+                                                                                   "64-bit");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     const auto msize_value = FEXCore::ToUnderlying(msize);
@@ -4427,8 +4230,7 @@ private:
     const auto imm_to_encode = imm >> msize_value;
 
     LOGMAN_THROW_A_FMT(imm <= imm_limit, "Immediate must be within [0, {}]", imm_limit);
-    LOGMAN_THROW_A_FMT(imm == 0 || (imm % msize_bytes) == 0,
-                       "Immediate must be cleanly divisible by {}", msize_bytes);
+    LOGMAN_THROW_A_FMT(imm == 0 || (imm % msize_bytes) == 0, "Immediate must be cleanly divisible by {}", msize_bytes);
 
     uint32_t Instr = 0b1000'0100'0000'0000'1000'0000'0000'0000;
 
@@ -4465,8 +4267,7 @@ private:
   }
 
   void SVEUnsizedLoadStoreContiguous(uint32_t op2, int32_t imm, ZRegister zt, Register rn, bool is_store) {
-    LOGMAN_THROW_A_FMT(imm >= -256 && imm <= 255,
-                        "Immediate offset ({}) too large. Must be within [-256, 255].", imm);
+    LOGMAN_THROW_A_FMT(imm >= -256 && imm <= 255, "Immediate offset ({}) too large. Must be within [-256, 255].", imm);
 
     const auto imm9 = static_cast<uint32_t>(imm) & 0b1'1111'1111;
 
@@ -4493,8 +4294,8 @@ private:
     [[maybe_unused]] const auto min_offset = -8 * num_regs;
     [[maybe_unused]] const auto max_offset = 7 * num_regs;
     LOGMAN_THROW_A_FMT(imm >= min_offset && imm <= max_offset,
-                        "Invalid load/store offset ({}). Offset must be a multiple of {} and be within [{}, {}]",
-                        imm, num_regs, min_offset, max_offset);
+                       "Invalid load/store offset ({}). Offset must be a multiple of {} and be within [{}, {}]", imm, num_regs, min_offset,
+                       max_offset);
 
     const auto imm4 = static_cast<uint32_t>(imm / num_regs) & 0xF;
     const auto opc = static_cast<uint32_t>(num_regs - 1);
@@ -4515,8 +4316,7 @@ private:
   // SVE contiguous non-temporal load (scalar plus immediate)
   void SVEContiguousNontemporalLoad(uint32_t msz, ZRegister zt, PRegister pg, Register rn, int32_t imm) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_A_FMT(imm >= -8 && imm <= 7,
-                        "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
+    LOGMAN_THROW_A_FMT(imm >= -8 && imm <= 7, "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
 
     const auto imm4 = static_cast<uint32_t>(imm) & 0xF;
     uint32_t Instr = 0b1010'0100'0000'0000'1110'0000'0000'0000;
@@ -4531,8 +4331,7 @@ private:
   // SVE contiguous non-temporal store (scalar plus immediate)
   void SVEContiguousNontemporalStore(uint32_t msz, ZRegister zt, PRegister pg, Register rn, int32_t imm) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_A_FMT(imm >= -8 && imm <= 7,
-                        "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
+    LOGMAN_THROW_A_FMT(imm >= -8 && imm <= 7, "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
 
     const auto imm4 = static_cast<uint32_t>(imm) & 0xF;
     uint32_t Instr = 0b1110'0100'0001'0000'1110'0000'0000'0000;
@@ -4546,8 +4345,7 @@ private:
 
   void SVEContiguousLoadImm(bool is_store, uint32_t dtype, int32_t imm, PRegister pg, Register rn, ZRegister zt) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_A_FMT(imm >= -8 && imm <= 7,
-                        "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
+    LOGMAN_THROW_A_FMT(imm >= -8 && imm <= 7, "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
 
     const auto imm4 = static_cast<uint32_t>(imm) & 0xF;
 
@@ -4578,8 +4376,7 @@ private:
     dc32(Instr);
   }
 
-  void SVEContiguousLoadStoreMultipleScalar(bool is_store, SubRegSize msz, uint32_t opc, ZRegister zt,
-                                            PRegister pg, Register rn, Register rm) {
+  void SVEContiguousLoadStoreMultipleScalar(bool is_store, SubRegSize msz, uint32_t opc, ZRegister zt, PRegister pg, Register rn, Register rm) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
     LOGMAN_THROW_A_FMT(rm != Reg::rsp, "rm cannot be the stack pointer");
 
@@ -4598,8 +4395,7 @@ private:
     dc32(Instr);
   }
 
-  void SVELoadBroadcastQuadScalarPlusImm(uint32_t msz, uint32_t ssz, ZRegister zt,
-                                         PRegister pg, Register rn, int imm) {
+  void SVELoadBroadcastQuadScalarPlusImm(uint32_t msz, uint32_t ssz, ZRegister zt, PRegister pg, Register rn, int imm) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     const auto esize = static_cast<int>(16 << ssz);
@@ -4607,8 +4403,7 @@ private:
     [[maybe_unused]] const auto min_imm = -(max_imm + esize);
 
     LOGMAN_THROW_A_FMT((imm % esize) == 0, "imm ({}) must be a multiple of {}", imm, esize);
-    LOGMAN_THROW_A_FMT(imm >= min_imm && imm <= max_imm, "imm ({}) must be within [{}, {}]",
-                        imm, min_imm, max_imm);
+    LOGMAN_THROW_A_FMT(imm >= min_imm && imm <= max_imm, "imm ({}) must be within [{}, {}]", imm, min_imm, max_imm);
 
     const auto sanitized_imm = static_cast<uint32_t>(imm / esize) & 0b1111;
 
@@ -4622,8 +4417,7 @@ private:
     dc32(Instr);
   }
 
-  void SVELoadBroadcastQuadScalarPlusScalar(uint32_t msz, uint32_t ssz, ZRegister zt,
-                                            PRegister pg, Register rn, Register rm) {
+  void SVELoadBroadcastQuadScalarPlusScalar(uint32_t msz, uint32_t ssz, ZRegister zt, PRegister pg, Register rn, Register rm) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
     LOGMAN_THROW_A_FMT(rm != Reg::rsp, "rm may not be the stack pointer");
 
@@ -4637,15 +4431,13 @@ private:
     dc32(Instr);
   }
 
-  void SVELoadAndBroadcastElement(bool is_signed, SubRegSize esize, SubRegSize msize,
-                                  ZRegister zt, PRegister pg, Register rn, uint32_t imm) {
+  void SVELoadAndBroadcastElement(bool is_signed, SubRegSize esize, SubRegSize msize, ZRegister zt, PRegister pg, Register rn, uint32_t imm) {
     LOGMAN_THROW_A_FMT(esize != SubRegSize::i128Bit, "Cannot use 128-bit elements.");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
     if (is_signed) {
       // The element size needs to be larger than memory size, otherwise you tell
       // me how we're gonna sign extend this bad boy in memory.
-      LOGMAN_THROW_A_FMT(esize > msize,
-                          "Signed broadcast element size must be greater than memory size.");
+      LOGMAN_THROW_A_FMT(esize > msize, "Signed broadcast element size must be greater than memory size.");
     }
 
     const auto esize_value = FEXCore::ToUnderlying(esize);
@@ -4653,9 +4445,8 @@ private:
 
     const auto data_size_bytes = 1U << msize_value;
     [[maybe_unused]] const auto max_imm = (64U << msize_value) - data_size_bytes;
-    LOGMAN_THROW_A_FMT((imm % data_size_bytes) == 0 && imm <= max_imm,
-                        "imm must be a multiple of {} and be within [0, {}]",
-                        data_size_bytes, max_imm);
+    LOGMAN_THROW_A_FMT((imm % data_size_bytes) == 0 && imm <= max_imm, "imm must be a multiple of {} and be within [0, {}]",
+                       data_size_bytes, max_imm);
 
     const auto sanitized_imm = imm / data_size_bytes;
 
@@ -4672,8 +4463,9 @@ private:
     // being passed in. Unsigned variants will always have dtypeh be less than
     // or equal to dtypel. The only time this isn't the case is with signed variants.
     LOGMAN_THROW_A_FMT(is_signed == (dtypeh > dtypel),
-                        "Invalid element size used with load broadcast instruction "
-                        "(esize: {}, msize: {})", esize_value, msize_value);
+                       "Invalid element size used with load broadcast instruction "
+                       "(esize: {}, msize: {})",
+                       esize_value, msize_value);
 
     uint32_t Instr = 0b1000'0100'0100'0000'1000'0000'0000'0000;
     Instr |= dtypeh << 23;
@@ -4762,7 +4554,8 @@ private:
     dc32(Instr);
   }
 
-  void SVEBitWiseShiftImmediatePred(SubRegSize size, uint32_t opc, uint32_t L, uint32_t U, PRegister pg, ZRegister zd, ZRegister zdn, uint32_t Shift) {
+  void SVEBitWiseShiftImmediatePred(SubRegSize size, uint32_t opc, uint32_t L, uint32_t U, PRegister pg, ZRegister zd, ZRegister zdn,
+                                    uint32_t Shift) {
     LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
     LOGMAN_THROW_A_FMT(zd == zdn, "zd needs to equal zdn");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
@@ -4879,9 +4672,7 @@ private:
 
   void SVEFloatUnary(uint32_t opc, SubRegSize size, PRegister pg, ZRegister zn, ZRegister zd) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit ||
-                        size == SubRegSize::i32Bit ||
-                        size == SubRegSize::i64Bit, "Unsupported size in {}", __func__);
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Unsupported size in {}", __func__);
 
     uint32_t Instr = 0b0110'0101'0000'1100'1010'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -4969,8 +4760,8 @@ private:
   }
 
   void SVEFPUnaryOpsUnpredicated(uint32_t opc, SubRegSize size, ZRegister zd, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "SubRegSize must be 16-bit, 32-bit, or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 16-bit, "
+                                                                                                               "32-bit, or 64-bit");
 
     uint32_t Instr = 0b0110'0101'0000'1000'0011'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -4981,8 +4772,8 @@ private:
   }
 
   void SVEFPSerialReductionPredicated(uint32_t opc, SubRegSize size, VRegister vd, PRegister pg, VRegister vn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "SubRegSize must be 16-bit, 32-bit, or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 16-bit, "
+                                                                                                               "32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
     LOGMAN_THROW_A_FMT(vd == vn, "vn must be the same as vd");
 
@@ -4996,8 +4787,8 @@ private:
   }
 
   void SVEFPCompareWithZero(uint32_t eqlt, uint32_t ne, SubRegSize size, PRegister pd, PRegister pg, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "SubRegSize must be 16-bit, 32-bit, or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 16-bit, "
+                                                                                                               "32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0110'0101'0001'0000'0010'0000'0000'0000;
@@ -5012,8 +4803,8 @@ private:
 
   void SVEFPMultiplyAdd(uint32_t opc, SubRegSize size, ZRegister zd, PRegister pg, ZRegister zn, ZRegister zm) {
     // NOTE: opc also includes the op0 bit (bit 15) like op0:opc, since the fields are adjacent
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "SubRegSize must be 16-bit, 32-bit, or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 16-bit, "
+                                                                                                               "32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0110'0101'0010'0000'0000'0000'0000'0000;
@@ -5027,11 +4818,11 @@ private:
   }
 
   void SVEFPMultiplyAddIndexed(uint32_t op, SubRegSize size, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "SubRegSize must be 16-bit, 32-bit, or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 16-bit, "
+                                                                                                               "32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT((size <= SubRegSize::i32Bit && zm <= ZReg::z7) || (size == SubRegSize::i64Bit && zm <= ZReg::z15),
-                        "16-bit and 32-bit indexed variants may only use Zm between z0-z7\n"
-                        "64-bit variants may only use Zm between z0-z15");
+                       "16-bit and 32-bit indexed variants may only use Zm between z0-z7\n"
+                       "64-bit variants may only use Zm between z0-z15");
 
     const auto Underlying = FEXCore::ToUnderlying(size);
     [[maybe_unused]] const uint32_t IndexMax = (16 / (1U << Underlying)) - 1;
@@ -5051,8 +4842,8 @@ private:
     dc32(Instr);
   }
 
-  void SVEFPMultiplyAddLongIndexed(uint32_t o2, uint32_t op, uint32_t T, SubRegSize dstsize,
-                                   ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
+  void SVEFPMultiplyAddLongIndexed(uint32_t o2, uint32_t op, uint32_t T, SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm,
+                                   uint32_t index) {
     LOGMAN_THROW_A_FMT(dstsize == SubRegSize::i32Bit, "Destination size must be 32-bit.");
     LOGMAN_THROW_A_FMT(index <= 7, "Index ({}) must be within [0, 7]", index);
     LOGMAN_THROW_A_FMT(zm <= ZReg::z7, "zm (z{}) must be within [z0, z7]", zm.Idx());
@@ -5069,8 +4860,7 @@ private:
     dc32(Inst);
   }
 
-  void SVEFPMultiplyAddLong(uint32_t o2, uint32_t op, uint32_t T, SubRegSize dstsize,
-                            ZRegister zda, ZRegister zn, ZRegister zm) {
+  void SVEFPMultiplyAddLong(uint32_t o2, uint32_t op, uint32_t T, SubRegSize dstsize, ZRegister zda, ZRegister zn, ZRegister zm) {
     LOGMAN_THROW_A_FMT(dstsize == SubRegSize::i32Bit, "Destination size must be 32-bit.");
 
     uint32_t Instr = 0b0110'0100'1010'0000'1000'0000'0000'0000;
@@ -5084,8 +4874,7 @@ private:
   }
 
   void SVEFPMatrixMultiplyAccumulate(SubRegSize size, ZRegister zda, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "SubRegSize must be 32-bit or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 32-bit or 64-bit");
 
     uint32_t Instr = 0b0110'0100'0010'0000'1110'0100'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -5137,7 +4926,7 @@ private:
   }
   void SVEIncDecPredicateCountVector(uint32_t op0, uint32_t op1, uint32_t opc, uint32_t b16, SubRegSize size, ZRegister zdn, PRegister pm) {
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "Cannot use 8-bit element size");
-    SVEIncDecPredicateCountScalar(op0, op1, opc, b16, size, Register{zdn.Idx()}, pm);
+    SVEIncDecPredicateCountScalar(op0, op1, opc, b16, size, Register {zdn.Idx()}, pm);
   }
 
   void SVE2IntegerPredicated(uint32_t op0, uint32_t op1, SubRegSize size, ZRegister zd, PRegister pg, ZRegister zn) {
@@ -5155,8 +4944,8 @@ private:
   }
 
   void SVE2IntegerPairwiseAddAccumulateLong(uint32_t U, SubRegSize size, ZRegister zda, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                        "SubRegSize must be 16-bit, 32-bit, or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 16-bit, "
+                                                                                                               "32-bit, or 64-bit");
     SVE2IntegerPredicated((0b0010 << 1) | U, 0b101, size, zda, pg, zn);
   }
 
@@ -5197,8 +4986,8 @@ private:
   }
 
   void SVEIntegerDotProduct(uint32_t op, SubRegSize size, ZRegister zda, ZRegister zn, ZRegister zm, Rotation rot) {
-    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
-                       "Dot product must only use 32-bit or 64-bit element sizes");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Dot product must only use 32-bit or 64-bit element "
+                                                                                 "sizes");
     SVEIntegerComplexMulAdd(op, size, zda, zn, zm, rot);
   }
 
@@ -5208,8 +4997,7 @@ private:
   }
 
   void SVE2SaturatingMulAddInterleaved(uint32_t op0, SubRegSize size, ZRegister zda, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit,
-                       "Element size may only be 16-bit, 32-bit, or 64-bit");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "Element size may only be 16-bit, 32-bit, or 64-bit");
     SVEIntegerMultiplyAddUnpredicated(op0, size, zda, zn, zm);
   }
 
@@ -5263,11 +5051,9 @@ private:
     const uint32_t element_size = SubRegSizeInBits(size);
 
     if (is_left_shift) {
-      LOGMAN_THROW_A_FMT(shift >= 0 && shift < element_size,
-                         "Invalid left shift value ({}). Must be within [0, {}]", shift, element_size - 1);
+      LOGMAN_THROW_A_FMT(shift >= 0 && shift < element_size, "Invalid left shift value ({}). Must be within [0, {}]", shift, element_size - 1);
     } else {
-      LOGMAN_THROW_A_FMT(shift > 0 && shift <= element_size,
-                         "Invalid right shift value ({}). Must be within [1, {}]", shift, element_size);
+      LOGMAN_THROW_A_FMT(shift > 0 && shift <= element_size, "Invalid right shift value ({}). Must be within [1, {}]", shift, element_size);
     }
 
     // Both left and right shifts encodes their shift as if it were
@@ -5282,8 +5068,7 @@ private:
     // Right shifts instead encode it like a subtraction. e.g. A shift of 1
     // would encode like (S: tsize=0b0111 imm3=0b111, where 64 - 1 = 63, etc).
     // so the more lower in value the bits are set, the larger the shift.
-    const uint32_t encoded_shift = is_left_shift ? element_size + shift
-                                                 : (2 * element_size) - shift;
+    const uint32_t encoded_shift = is_left_shift ? element_size + shift : (2 * element_size) - shift;
 
     return {
       .tszh = encoded_shift >> 5,
@@ -5292,20 +5077,21 @@ private:
   }
 
   // Alias that returns the equivalently sized unsigned type for a floating-point type T.
-  template <typename T>
-  requires(std::is_same_v<T, float> || std::is_same_v<T, double>)
+  template<typename T>
+  requires (std::is_same_v<T, float> || std::is_same_v<T, double>)
   using FloatToEquivalentUInt = std::conditional_t<std::is_same_v<T, float>, uint32_t, uint64_t>;
 
   // Determines if a floating-point value is capable of being converted
   // into an 8-bit immediate. See pseudocode definition of VFPExpandImm
   // in ARM A-profile reference manual for a general overview of how this was derived.
-  template <typename T>
-  requires(std::is_same_v<T, float> || std::is_same_v<T, double>)
-  [[nodiscard, maybe_unused]] static bool IsValidFPValueForImm8(T value) {
+  template<typename T>
+  requires (std::is_same_v<T, float> || std::is_same_v<T, double>)
+  [[nodiscard, maybe_unused]]
+  static bool IsValidFPValueForImm8(T value) {
     const uint64_t bits = FEXCore::BitCast<FloatToEquivalentUInt<T>>(value);
     const uint64_t datasize_idx = FEXCore::ilog2(sizeof(T)) - 1;
 
-    static constexpr std::array mantissa_masks{
+    static constexpr std::array mantissa_masks {
       0x00000000'0000003FULL, // half (bits [5:0])
       0x00000000'0007FFFFULL, // single (bits [18:0])
       0x0000FFFF'FFFFFFFFULL, // double (bits [47:0])
@@ -5317,7 +5103,7 @@ private:
       return false;
     }
 
-    static constexpr std::array exponent_masks{
+    static constexpr std::array exponent_masks {
       0x00000000'00003000ULL, // half (bits [13:12])
       0x00000000'3E000000ULL, // single (bits [29:25])
       0x3FC00000'00000000ULL, // double (bits [61:54])
@@ -5343,8 +5129,7 @@ private:
 
 protected:
   static uint32_t FP32ToImm8(float value) {
-    LOGMAN_THROW_A_FMT(IsValidFPValueForImm8(value),
-                       "Value ({}) cannot be encoded into an 8-bit immediate", value);
+    LOGMAN_THROW_A_FMT(IsValidFPValueForImm8(value), "Value ({}) cannot be encoded into an 8-bit immediate", value);
 
     const auto bits = FEXCore::BitCast<uint32_t>(value);
     const auto sign = (bits & 0x80000000) >> 24;
@@ -5355,8 +5140,7 @@ protected:
   }
 
   static uint32_t FP64ToImm8(double value) {
-    LOGMAN_THROW_A_FMT(IsValidFPValueForImm8(value),
-                       "Value ({}) cannot be encoded into an 8-bit immediate", value);
+    LOGMAN_THROW_A_FMT(IsValidFPValueForImm8(value), "Value ({}) cannot be encoded into an 8-bit immediate", value);
 
     const auto bits = FEXCore::BitCast<uint64_t>(value);
     const auto sign = (bits & 0x80000000'00000000) >> 56;

--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -17,6 +17,14 @@
  * There are some SVE load-store helper functions which take a `SVEMemOperand` argument.
  * This helper will select the viable SVE load-store that can work with the provided encapsulated arguments.
  */
+
+#pragma once
+#ifndef INCLUDED_BY_EMITTER
+#include <CodeEmitter/Emitter.h>
+namespace ARMEmitter {
+struct EmitterOps : Emitter {
+#endif
+
 public:
   // SVE encodings
   void dup(SubRegSize size, ZRegister zd, ZRegister zn, uint32_t Index) {
@@ -5333,6 +5341,7 @@ private:
     return true;
   }
 
+protected:
   static uint32_t FP32ToImm8(float value) {
     LOGMAN_THROW_A_FMT(IsValidFPValueForImm8(value),
                        "Value ({}) cannot be encoded into an 8-bit immediate", value);
@@ -5357,6 +5366,7 @@ private:
     return static_cast<uint32_t>(sign | expb2 | b5_to_0);
   }
 
+private:
   // Handling for signed 8-bit immediate shifts (e.g. in cpy/dup)
   struct HandledSImm8Shift {
     int32_t imm;
@@ -5386,3 +5396,8 @@ private:
       .is_shift = shift,
     };
   }
+
+#ifndef INCLUDED_BY_EMITTER
+}; // struct LoadstoreEmitterOps
+} // namespace ARMEmitter
+#endif

--- a/CodeEmitter/CodeEmitter/ScalarOps.inl
+++ b/CodeEmitter/CodeEmitter/ScalarOps.inl
@@ -16,6 +16,14 @@
  * Exceptions to this rule will have asserts in the emitter implementation when misused.
  *
  */
+
+#pragma once
+#ifndef INCLUDED_BY_EMITTER
+#include <CodeEmitter/Emitter.h>
+namespace ARMEmitter {
+struct EmitterOps : Emitter {
+#endif
+
 public:
 // Advanced SIMD scalar copy
   void dup(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Index) {
@@ -1485,3 +1493,8 @@ private:
     Instr |= Encode_rd(rd);
     dc32(Instr);
   }
+
+#ifndef INCLUDED_BY_EMITTER
+}; // struct LoadstoreEmitterOps
+} // namespace ARMEmitter
+#endif

--- a/CodeEmitter/CodeEmitter/ScalarOps.inl
+++ b/CodeEmitter/CodeEmitter/ScalarOps.inl
@@ -25,7 +25,7 @@ struct EmitterOps : Emitter {
 #endif
 
 public:
-// Advanced SIMD scalar copy
+  // Advanced SIMD scalar copy
   void dup(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Index) {
     constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'01 << 10;
 
@@ -45,7 +45,7 @@ public:
     dup(size, rd, rn, Index);
   }
 
-// Advanced SIMD scalar three same FP16
+  // Advanced SIMD scalar three same FP16
   void fmulx(HRegister rd, HRegister rn, HRegister rm) {
     ASIMDScalarThreeSameFP16(0, 0, 0b011, rm, rn, rd);
   }
@@ -74,7 +74,7 @@ public:
     ASIMDScalarThreeSameFP16(1, 1, 0b101, rm, rn, rd);
   }
 
-// Advanced SIMD scalar two-register miscellaneous FP16
+  // Advanced SIMD scalar two-register miscellaneous FP16
   void fcvtns(HRegister rd, HRegister rn) {
     ASIMDScalarTwoRegMiscFP16(0, 0, 0b11010, rn, rd);
   }
@@ -136,9 +136,9 @@ public:
     ASIMDScalarTwoRegMiscFP16(1, 1, 0b11101, rn, rd);
   }
 
-// Advanced SIMD scalar three same extra
-// XXX:
-// Advanced SIMD scalar two-register miscellaneous
+  // Advanced SIMD scalar three same extra
+  // XXX:
+  // Advanced SIMD scalar two-register miscellaneous
   void suqadd(ScalarRegSize size, VRegister rd, VRegister rn) {
     ASIMDScalar2RegMisc(0, 0, size, 0b00011, rd, rn);
   }
@@ -175,40 +175,28 @@ public:
   void fcvtns(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(0, 0, ConvertedSize, 0b11010, rd, rn);
   }
   void fcvtms(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(0, 0, ConvertedSize, 0b11011, rd, rn);
   }
   void fcvtas(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(0, 0, ConvertedSize, 0b11100, rd, rn);
   }
   void scvtf(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(0, 0, ConvertedSize, 0b11101, rd, rn);
   }
@@ -287,40 +275,28 @@ public:
   void fcvtnu(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(0, 1, ConvertedSize, 0b11010, rd, rn);
   }
   void fcvtmu(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(0, 1, ConvertedSize, 0b11011, rd, rn);
   }
   void fcvtau(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(0, 1, ConvertedSize, 0b11100, rd, rn);
   }
   void ucvtf(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(0, 1, ConvertedSize, 0b11101, rd, rn);
   }
@@ -376,30 +352,21 @@ public:
   void fmaxnmp(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(1, 1, ConvertedSize, 0b01100, rd, rn);
   }
   void faddp(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(1, 1, ConvertedSize, 0b01101, rd, rn);
   }
   void fmaxp(ScalarRegSize size, VRegister rd, VRegister rn) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMDScalar2RegMisc(1, 1, ConvertedSize, 0b01111, rd, rn);
   }
@@ -411,36 +378,27 @@ public:
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     ASIMDScalar2RegMisc(1, 1, size, 0b01111, rd, rn);
   }
-// Advanced SIMD scalar three different
+  // Advanced SIMD scalar three different
   ///< size is destination.
   void sqdmlal(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i32Bit :
-        ScalarRegSize::i16Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i32Bit : ScalarRegSize::i16Bit;
     ASIMD3RegDifferent(0, ConvertedSize, 0b1001, rd, rn, rm);
   }
   ///< size is destination.
   void sqdmlsl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i32Bit :
-        ScalarRegSize::i16Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i32Bit : ScalarRegSize::i16Bit;
     ASIMD3RegDifferent(0, ConvertedSize, 0b1011, rd, rn, rm);
   }
 
   ///< size is destination.
   void sqdmull(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i32Bit :
-        ScalarRegSize::i16Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i32Bit : ScalarRegSize::i16Bit;
     ASIMD3RegDifferent(0, ConvertedSize, 0b1101, rd, rn, rm);
   }
-// Advanced SIMD scalar three same
+  // Advanced SIMD scalar three same
   void sqadd(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     ASIMD3RegSame(0, size, 0b00001, rd, rn, rm);
   }
@@ -484,30 +442,21 @@ public:
   void fmulx(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMD3RegSame(0, ConvertedSize, 0b11011, rd, rn, rm);
   }
   void fcmeq(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMD3RegSame(0, ConvertedSize, 0b11100, rd, rn, rm);
   }
   void frecps(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMD3RegSame(0, ConvertedSize, 0b11111, rd, rn, rm);
   }
@@ -558,20 +507,14 @@ public:
   void fcmge(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMD3RegSame(1, ConvertedSize, 0b11100, rd, rn, rm);
   }
   void facge(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
-    const ScalarRegSize ConvertedSize =
-      size == ScalarRegSize::i64Bit ?
-        ScalarRegSize::i16Bit :
-        ScalarRegSize::i8Bit;
+    const ScalarRegSize ConvertedSize = size == ScalarRegSize::i64Bit ? ScalarRegSize::i16Bit : ScalarRegSize::i8Bit;
 
     ASIMD3RegSame(1, ConvertedSize, 0b11101, rd, rn, rm);
   }
@@ -587,7 +530,7 @@ public:
     LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     ASIMD3RegSame(1, size, 0b11101, rd, rn, rm);
   }
-// Advanced SIMD scalar shift by immediate
+  // Advanced SIMD scalar shift by immediate
   void sshr(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
     LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
@@ -802,10 +745,10 @@ public:
     ASIMDScalarShiftByImm(1, immh, immb, 0b10011, rd, rn);
   }
   // TODO: UCVTF, FCVTZU
-// Advanced SIMD scalar x indexed element
-// XXX:
-//
-// Floating-point data-processing (1 source)
+  // Advanced SIMD scalar x indexed element
+  // XXX:
+  //
+  // Floating-point data-processing (1 source)
   void fmov(ScalarRegSize size, VRegister rd, VRegister rn) {
     Float1Source(size, 0, 0, 0b000000, rd, rn);
   }
@@ -999,14 +942,14 @@ public:
     Float1Source(0, 0, 0b11, 0b001111, rd.V(), rn.V());
   }
 
-// Floating-point compare
+  // Floating-point compare
   void fcmp(ScalarRegSize Size, VRegister rn, VRegister rm) {
     LOGMAN_THROW_A_FMT(Size != ScalarRegSize::i8Bit, "8-bit destination not supported");
 
-    const auto ConvertedSize =
-      Size == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
-      Size == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
-      Size == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 : 0;
+    const auto ConvertedSize = Size == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
+                               Size == ARMEmitter::ScalarRegSize::i32Bit ? 0b00 :
+                               Size == ARMEmitter::ScalarRegSize::i16Bit ? 0b11 :
+                                                                           0;
 
     FloatCompare(0, 0, ConvertedSize, 0b00, 0b00000, rn, rm);
   }
@@ -1059,7 +1002,7 @@ public:
     FloatCompare(0, 0, 0b11, 0b00, 0b11000, rn.V(), VReg::v0);
   }
 
-// Floating-point immediate
+  // Floating-point immediate
   void fmov(ARMEmitter::ScalarRegSize size, ARMEmitter::VRegister rd, float Value) {
     uint32_t M = 0;
     uint32_t S = 0;
@@ -1069,16 +1012,13 @@ public:
     if (size == ARMEmitter::ScalarRegSize::i16Bit) {
       LOGMAN_MSG_A_FMT("Unsupported");
       FEX_UNREACHABLE;
-    }
-    else if (size == ARMEmitter::ScalarRegSize::i32Bit) {
+    } else if (size == ARMEmitter::ScalarRegSize::i32Bit) {
       ptype = 0b00;
       imm8 = FP32ToImm8(Value);
-    }
-    else if (size == ARMEmitter::ScalarRegSize::i64Bit) {
+    } else if (size == ARMEmitter::ScalarRegSize::i64Bit) {
       ptype = 0b01;
       imm8 = FP64ToImm8(Value);
-    }
-    else {
+    } else {
       FEX_UNREACHABLE;
     }
 
@@ -1098,7 +1038,7 @@ public:
     dc32(Instr);
   }
 
-// Floating-point conditional compare
+  // Floating-point conditional compare
   void fccmp(SRegister rn, SRegister rm, StatusFlags flags, Condition Cond) {
     FloatConditionalCompare(0, 0, 0b00, 0b0, rn.V(), rm.V(), flags, Cond);
   }
@@ -1118,7 +1058,7 @@ public:
     FloatConditionalCompare(0, 0, 0b11, 0b1, rn.V(), rm.V(), flags, Cond);
   }
 
-// Floating-point data-processing (2 source)
+  // Floating-point data-processing (2 source)
   void fmul(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     Float2Source(size, 0, 0, 0b0000, rd, rn, rm);
   }
@@ -1233,11 +1173,10 @@ public:
 
   // Floating-point conditional select
   void fcsel(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, Condition Cond) {
-    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for {}", __func__);
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit,
+                       "Invalid size selected for {}", __func__);
 
-    const uint32_t ConvertedSize =
-      size == ScalarRegSize::i64Bit ? 0b01 :
-      size == ScalarRegSize::i32Bit ? 0b00 : 0b11;
+    const uint32_t ConvertedSize = size == ScalarRegSize::i64Bit ? 0b01 : size == ScalarRegSize::i32Bit ? 0b00 : 0b11;
 
     FloatConditionalSelect(0, 0, ConvertedSize, rd, rn, rm, Cond);
   }
@@ -1252,7 +1191,7 @@ public:
     FloatConditionalSelect(0, 0, 0b11, rd.V(), rn.V(), rm.V(), Cond);
   }
 
-// Floating-point data-processing (3 source)
+  // Floating-point data-processing (3 source)
   void fmadd(SRegister rd, SRegister rn, SRegister rm, SRegister ra) {
     Float3Source(0, 0, 0b00, 0, 0, rd.V(), rn.V(), rm.V(), ra.V());
   }
@@ -1293,7 +1232,7 @@ public:
   }
 
 private:
-// Advanced SIMD scalar copy
+  // Advanced SIMD scalar copy
   void ASIMDScalarCopy(uint32_t Op, uint32_t Q, uint32_t imm5, uint32_t imm4, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
     uint32_t Instr = Op;
 
@@ -1305,7 +1244,7 @@ private:
     dc32(Instr);
   }
 
-// Advanced SIMD scalar three same FP16
+  // Advanced SIMD scalar three same FP16
   void ASIMDScalarThreeSameFP16(uint32_t U, uint32_t a, uint32_t opcode, HRegister rm, HRegister rn, HRegister rd) {
     uint32_t Instr = 0b0101'1110'0100'0000'0000'0100'0000'0000;
 
@@ -1317,7 +1256,7 @@ private:
     Instr |= rd.Idx();
     dc32(Instr);
   }
-// Advanced SIMD scalar two-register miscellaneous FP16
+  // Advanced SIMD scalar two-register miscellaneous FP16
   void ASIMDScalarTwoRegMiscFP16(uint32_t U, uint32_t a, uint32_t opcode, HRegister rn, HRegister rd) {
     uint32_t Instr = 0b0101'1110'0111'1000'0000'1000'0000'0000;
 
@@ -1329,9 +1268,9 @@ private:
     dc32(Instr);
   }
 
-// Advanced SIMD scalar three same extra
-// XXX:
-// Advanced SIMD scalar two-register miscellaneous
+  // Advanced SIMD scalar three same extra
+  // XXX:
+  // Advanced SIMD scalar two-register miscellaneous
   void ASIMDScalar2RegMisc(uint32_t b20, uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rd, VRegister rn) {
     uint32_t Instr = 0b0101'1110'0010'0000'0000'1000'0000'0000;
 
@@ -1344,9 +1283,9 @@ private:
     dc32(Instr);
   }
 
-// Advanced SIMD scalar pairwise
-// XXX:
-// Advanced SIMD scalar three different
+  // Advanced SIMD scalar pairwise
+  // XXX:
+  // Advanced SIMD scalar three different
   void ASIMD3RegDifferent(uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rd, VRegister rn, VRegister rm) {
     uint32_t Instr = 0b0101'1110'0010'0000'0000'0000'0000'0000;
 
@@ -1358,7 +1297,7 @@ private:
     Instr |= Encode_rd(rd);
     dc32(Instr);
   }
-// Advanced SIMD scalar three same
+  // Advanced SIMD scalar three same
   void ASIMD3RegSame(uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rd, VRegister rn, VRegister rm) {
     uint32_t Instr = 0b0101'1110'0010'0000'0000'0100'0000'0000;
 
@@ -1370,7 +1309,7 @@ private:
     Instr |= Encode_rd(rd);
     dc32(Instr);
   }
-// Advanced SIMD scalar shift by immediate
+  // Advanced SIMD scalar shift by immediate
   void ASIMDScalarShiftByImm(uint32_t U, uint32_t immh, uint32_t immb, uint32_t opcode, VRegister rd, VRegister rn) {
     uint32_t Instr = 0b0101'1111'0000'0000'0000'0100'0000'0000;
 
@@ -1382,9 +1321,9 @@ private:
     Instr |= Encode_rd(rd);
     dc32(Instr);
   }
-// Advanced SIMD scalar x indexed element
-// XXX:
-// Floating-point data-processing (1 source)
+  // Advanced SIMD scalar x indexed element
+  // XXX:
+  // Floating-point data-processing (1 source)
   void Float1Source(uint32_t M, uint32_t S, uint32_t ptype, uint32_t opcode, VRegister rd, VRegister rn) {
     uint32_t Instr = 0b0001'1110'0010'0000'0100'0000'0000'0000;
 
@@ -1398,16 +1337,15 @@ private:
     dc32(Instr);
   }
   void Float1Source(ScalarRegSize size, uint32_t M, uint32_t S, uint32_t opcode, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for {}", __func__);
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit,
+                       "Invalid size selected for {}", __func__);
 
-    const uint32_t ConvertedSize =
-      size == ScalarRegSize::i64Bit ? 0b01 :
-      size == ScalarRegSize::i32Bit ? 0b00 : 0b11;
+    const uint32_t ConvertedSize = size == ScalarRegSize::i64Bit ? 0b01 : size == ScalarRegSize::i32Bit ? 0b00 : 0b11;
 
     Float1Source(M, S, ConvertedSize, opcode, rd, rn);
   }
 
-// Floating-point compare
+  // Floating-point compare
   void FloatCompare(uint32_t M, uint32_t S, uint32_t ftype, uint32_t op, uint32_t opcode2, VRegister rn, VRegister rm) {
     uint32_t Instr = 0b0001'1110'0010'0000'0010'0000'0000'0000;
 
@@ -1421,9 +1359,9 @@ private:
 
     dc32(Instr);
   }
-// Floating-point immediate
-// XXX:
-// Floating-point conditional compare
+  // Floating-point immediate
+  // XXX:
+  // Floating-point conditional compare
   void FloatConditionalCompare(uint32_t M, uint32_t S, uint32_t ptype, uint32_t op, VRegister rn, VRegister rm, StatusFlags flags, Condition Cond) {
     uint32_t Instr = 0b0001'1110'0010'0000'0000'0100'0000'0000;
 
@@ -1438,7 +1376,7 @@ private:
 
     dc32(Instr);
   }
-// Floating-point data-processing (2 source)
+  // Floating-point data-processing (2 source)
 
   void Float2Source(uint32_t M, uint32_t S, uint32_t ptype, uint32_t opcode, VRegister rd, VRegister rn, VRegister rm) {
     uint32_t Instr = 0b0001'1110'0010'0000'0000'1000'0000'0000;
@@ -1455,16 +1393,15 @@ private:
   }
 
   void Float2Source(ScalarRegSize size, uint32_t M, uint32_t S, uint32_t opcode, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for {}", __func__);
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit,
+                       "Invalid size selected for {}", __func__);
 
-    const uint32_t ConvertedSize =
-      size == ScalarRegSize::i64Bit ? 0b01 :
-      size == ScalarRegSize::i32Bit ? 0b00 : 0b11;
+    const uint32_t ConvertedSize = size == ScalarRegSize::i64Bit ? 0b01 : size == ScalarRegSize::i32Bit ? 0b00 : 0b11;
 
     Float2Source(M, S, ConvertedSize, opcode, rd, rn, rm);
   }
 
-// Floating-point conditional select
+  // Floating-point conditional select
   void FloatConditionalSelect(uint32_t M, uint32_t S, uint32_t ptype, VRegister rd, VRegister rn, VRegister rm, Condition Cond) {
     uint32_t Instr = 0b0001'1110'0010'0000'0000'1100'0000'0000;
 
@@ -1478,7 +1415,7 @@ private:
     dc32(Instr);
   }
 
-// Floating-point data-processing (3 source)
+  // Floating-point data-processing (3 source)
   void Float3Source(uint32_t M, uint32_t S, uint32_t ptype, uint32_t o1, uint32_t o0, VRegister rd, VRegister rn, VRegister rm, VRegister ra) {
     uint32_t Instr = 0b0001'1111'0000'0000'0000'0000'0000'0000;
 

--- a/CodeEmitter/CodeEmitter/SystemOps.inl
+++ b/CodeEmitter/CodeEmitter/SystemOps.inl
@@ -13,174 +13,174 @@ struct EmitterOps : Emitter {
 #endif
 
 public:
-    // System with result
-    // TODO: SYSL
-    // System Instruction
-    // TODO: AT
-    // TODO: CFP
-    // TODO: CPP
-    void dc(ARMEmitter::DataCacheOperation DCOp, ARMEmitter::Register rt) {
-      constexpr uint32_t Op = 0b1101'0101'0000'1000'0111 << 12;
-      SystemInstruction(Op, 0, FEXCore::ToUnderlying(DCOp), rt);
-    }
-    // TODO: DVP
-    // TODO: IC
-    // TODO: TLBI
+  // System with result
+  // TODO: SYSL
+  // System Instruction
+  // TODO: AT
+  // TODO: CFP
+  // TODO: CPP
+  void dc(ARMEmitter::DataCacheOperation DCOp, ARMEmitter::Register rt) {
+    constexpr uint32_t Op = 0b1101'0101'0000'1000'0111 << 12;
+    SystemInstruction(Op, 0, FEXCore::ToUnderlying(DCOp), rt);
+  }
+  // TODO: DVP
+  // TODO: IC
+  // TODO: TLBI
 
-    // Exception generation
-    void svc(uint32_t Imm) {
-      ExceptionGeneration(0b000, 0b000, 0b01, Imm);
-    }
-    void hvc(uint32_t Imm) {
-      ExceptionGeneration(0b000, 0b000, 0b10, Imm);
-    }
-    void smc(uint32_t Imm) {
-      ExceptionGeneration(0b000, 0b000, 0b11, Imm);
-    }
-    void brk(uint32_t Imm) {
-      ExceptionGeneration(0b001, 0b000, 0b00, Imm);
-    }
-    void hlt(uint32_t Imm) {
-      ExceptionGeneration(0b010, 0b000, 0b00, Imm);
-    }
-    void tcancel(uint32_t Imm) {
-      ExceptionGeneration(0b011, 0b000, 0b00, Imm);
-    }
-    void dcps1(uint32_t Imm) {
-      ExceptionGeneration(0b101, 0b000, 0b01, Imm);
-    }
-    void dcps2(uint32_t Imm) {
-      ExceptionGeneration(0b101, 0b000, 0b10, Imm);
-    }
-    void dcps3(uint32_t Imm) {
-      ExceptionGeneration(0b101, 0b000, 0b11, Imm);
-    }
-    // System instructions with register argument
-    void wfet(ARMEmitter::Register rt) {
-      SystemInstructionWithReg(0b0000, 0b000, rt);
-    }
-    void wfit(ARMEmitter::Register rt) {
-      SystemInstructionWithReg(0b0000, 0b001, rt);
-    }
+  // Exception generation
+  void svc(uint32_t Imm) {
+    ExceptionGeneration(0b000, 0b000, 0b01, Imm);
+  }
+  void hvc(uint32_t Imm) {
+    ExceptionGeneration(0b000, 0b000, 0b10, Imm);
+  }
+  void smc(uint32_t Imm) {
+    ExceptionGeneration(0b000, 0b000, 0b11, Imm);
+  }
+  void brk(uint32_t Imm) {
+    ExceptionGeneration(0b001, 0b000, 0b00, Imm);
+  }
+  void hlt(uint32_t Imm) {
+    ExceptionGeneration(0b010, 0b000, 0b00, Imm);
+  }
+  void tcancel(uint32_t Imm) {
+    ExceptionGeneration(0b011, 0b000, 0b00, Imm);
+  }
+  void dcps1(uint32_t Imm) {
+    ExceptionGeneration(0b101, 0b000, 0b01, Imm);
+  }
+  void dcps2(uint32_t Imm) {
+    ExceptionGeneration(0b101, 0b000, 0b10, Imm);
+  }
+  void dcps3(uint32_t Imm) {
+    ExceptionGeneration(0b101, 0b000, 0b11, Imm);
+  }
+  // System instructions with register argument
+  void wfet(ARMEmitter::Register rt) {
+    SystemInstructionWithReg(0b0000, 0b000, rt);
+  }
+  void wfit(ARMEmitter::Register rt) {
+    SystemInstructionWithReg(0b0000, 0b001, rt);
+  }
 
-    // Hints
-    void nop() {
-      Hint(ARMEmitter::HintRegister::NOP);
-    }
-    void yield() {
-      Hint(ARMEmitter::HintRegister::YIELD);
-    }
-    void wfe() {
-      Hint(ARMEmitter::HintRegister::WFE);
-    }
-    void wfi() {
-      Hint(ARMEmitter::HintRegister::WFI);
-    }
-    void sev() {
-      Hint(ARMEmitter::HintRegister::SEV);
-    }
-    void sevl() {
-      Hint(ARMEmitter::HintRegister::SEVL);
-    }
-    void dgh() {
-      Hint(ARMEmitter::HintRegister::DGH);
-    }
-    void csdb() {
-      Hint(ARMEmitter::HintRegister::CSDB);
-    }
+  // Hints
+  void nop() {
+    Hint(ARMEmitter::HintRegister::NOP);
+  }
+  void yield() {
+    Hint(ARMEmitter::HintRegister::YIELD);
+  }
+  void wfe() {
+    Hint(ARMEmitter::HintRegister::WFE);
+  }
+  void wfi() {
+    Hint(ARMEmitter::HintRegister::WFI);
+  }
+  void sev() {
+    Hint(ARMEmitter::HintRegister::SEV);
+  }
+  void sevl() {
+    Hint(ARMEmitter::HintRegister::SEVL);
+  }
+  void dgh() {
+    Hint(ARMEmitter::HintRegister::DGH);
+  }
+  void csdb() {
+    Hint(ARMEmitter::HintRegister::CSDB);
+  }
 
-    // Barriers
-    void clrex(uint32_t imm = 15) {
-      LOGMAN_THROW_A_FMT(imm < 16, "Immediate out of range");
-      Barrier(ARMEmitter::BarrierRegister::CLREX, imm);
-    }
-    void dsb(ARMEmitter::BarrierScope Scope) {
-      Barrier(ARMEmitter::BarrierRegister::DSB, FEXCore::ToUnderlying(Scope));
-    }
-    void dmb(ARMEmitter::BarrierScope Scope) {
-      Barrier(ARMEmitter::BarrierRegister::DMB, FEXCore::ToUnderlying(Scope));
-    }
-    void isb() {
-      Barrier(ARMEmitter::BarrierRegister::ISB, FEXCore::ToUnderlying(ARMEmitter::BarrierScope::SY));
-    }
-    void sb() {
-      Barrier(ARMEmitter::BarrierRegister::SB, 0);
-    }
-    void tcommit() {
-      Barrier(ARMEmitter::BarrierRegister::TCOMMIT, 0);
-    }
+  // Barriers
+  void clrex(uint32_t imm = 15) {
+    LOGMAN_THROW_A_FMT(imm < 16, "Immediate out of range");
+    Barrier(ARMEmitter::BarrierRegister::CLREX, imm);
+  }
+  void dsb(ARMEmitter::BarrierScope Scope) {
+    Barrier(ARMEmitter::BarrierRegister::DSB, FEXCore::ToUnderlying(Scope));
+  }
+  void dmb(ARMEmitter::BarrierScope Scope) {
+    Barrier(ARMEmitter::BarrierRegister::DMB, FEXCore::ToUnderlying(Scope));
+  }
+  void isb() {
+    Barrier(ARMEmitter::BarrierRegister::ISB, FEXCore::ToUnderlying(ARMEmitter::BarrierScope::SY));
+  }
+  void sb() {
+    Barrier(ARMEmitter::BarrierRegister::SB, 0);
+  }
+  void tcommit() {
+    Barrier(ARMEmitter::BarrierRegister::TCOMMIT, 0);
+  }
 
-    // System register move
-    void msr(ARMEmitter::SystemRegister reg, ARMEmitter::Register rt) {
-      constexpr uint32_t Op = 0b1101'0101'0001 << 20;
-      SystemRegisterMove(Op, rt, reg);
-    }
+  // System register move
+  void msr(ARMEmitter::SystemRegister reg, ARMEmitter::Register rt) {
+    constexpr uint32_t Op = 0b1101'0101'0001 << 20;
+    SystemRegisterMove(Op, rt, reg);
+  }
 
-    void mrs(ARMEmitter::Register rd, ARMEmitter::SystemRegister reg) {
-      constexpr uint32_t Op = 0b1101'0101'0011 << 20;
-      SystemRegisterMove(Op, rd, reg);
-    }
+  void mrs(ARMEmitter::Register rd, ARMEmitter::SystemRegister reg) {
+    constexpr uint32_t Op = 0b1101'0101'0011 << 20;
+    SystemRegisterMove(Op, rd, reg);
+  }
 
 private:
 
-    // Exception Generation
-    void ExceptionGeneration(uint32_t opc, uint32_t op2, uint32_t LL, uint32_t Imm) {
-      LOGMAN_THROW_A_FMT((Imm & 0xFFFF'0000) == 0, "Imm amount too large");
+  // Exception Generation
+  void ExceptionGeneration(uint32_t opc, uint32_t op2, uint32_t LL, uint32_t Imm) {
+    LOGMAN_THROW_A_FMT((Imm & 0xFFFF'0000) == 0, "Imm amount too large");
 
-      uint32_t Instr = 0b1101'0100 << 24;
+    uint32_t Instr = 0b1101'0100 << 24;
 
-      Instr |= opc << 21;
-      Instr |= Imm << 5;
-      Instr |= op2 << 2;
-      Instr |= LL;
+    Instr |= opc << 21;
+    Instr |= Imm << 5;
+    Instr |= op2 << 2;
+    Instr |= LL;
 
-      dc32(Instr);
-    }
+    dc32(Instr);
+  }
 
-    // System instructions with register argument
-    void SystemInstructionWithReg(uint32_t CRm, uint32_t op2, ARMEmitter::Register rt) {
-      uint32_t Instr = 0b1101'0101'0000'0011'0001 << 12;
+  // System instructions with register argument
+  void SystemInstructionWithReg(uint32_t CRm, uint32_t op2, ARMEmitter::Register rt) {
+    uint32_t Instr = 0b1101'0101'0000'0011'0001 << 12;
 
-      Instr |= CRm << 8;
-      Instr |= op2 << 5;
-      Instr |= Encode_rt(rt);
-      dc32(Instr);
-    }
+    Instr |= CRm << 8;
+    Instr |= op2 << 5;
+    Instr |= Encode_rt(rt);
+    dc32(Instr);
+  }
 
-    // Hints
-    void Hint(ARMEmitter::HintRegister Reg) {
-      uint32_t Instr = 0b1101'0101'0000'0011'0010'0000'0001'1111U;
-      Instr |= FEXCore::ToUnderlying(Reg);
-      dc32(Instr);
-    }
-    // Barriers
-    void Barrier(ARMEmitter::BarrierRegister Reg, uint32_t CRm) {
-      uint32_t Instr = 0b1101'0101'0000'0011'0011'0000'0001'1111U;
-      Instr |= CRm << 8;
-      Instr |= FEXCore::ToUnderlying(Reg);
-      dc32(Instr);
-    }
+  // Hints
+  void Hint(ARMEmitter::HintRegister Reg) {
+    uint32_t Instr = 0b1101'0101'0000'0011'0010'0000'0001'1111U;
+    Instr |= FEXCore::ToUnderlying(Reg);
+    dc32(Instr);
+  }
+  // Barriers
+  void Barrier(ARMEmitter::BarrierRegister Reg, uint32_t CRm) {
+    uint32_t Instr = 0b1101'0101'0000'0011'0011'0000'0001'1111U;
+    Instr |= CRm << 8;
+    Instr |= FEXCore::ToUnderlying(Reg);
+    dc32(Instr);
+  }
 
-    // System Instruction
-    void SystemInstruction(uint32_t Op, uint32_t L, uint32_t SubOp, ARMEmitter::Register rt) {
-      uint32_t Instr = Op;
+  // System Instruction
+  void SystemInstruction(uint32_t Op, uint32_t L, uint32_t SubOp, ARMEmitter::Register rt) {
+    uint32_t Instr = Op;
 
-      Instr |= L << 21;
-      Instr |= SubOp;
-      Instr |= Encode_rt(rt);
+    Instr |= L << 21;
+    Instr |= SubOp;
+    Instr |= Encode_rt(rt);
 
-      dc32(Instr);
-    }
+    dc32(Instr);
+  }
 
-    // System register move
-    void SystemRegisterMove(uint32_t Op, ARMEmitter::Register rt, ARMEmitter::SystemRegister reg) {
-      uint32_t Instr = Op;
+  // System register move
+  void SystemRegisterMove(uint32_t Op, ARMEmitter::Register rt, ARMEmitter::SystemRegister reg) {
+    uint32_t Instr = Op;
 
-      Instr |= FEXCore::ToUnderlying(reg);
-      Instr |= Encode_rt(rt);
+    Instr |= FEXCore::ToUnderlying(reg);
+    Instr |= Encode_rt(rt);
 
-      dc32(Instr);
-    }
+    dc32(Instr);
+  }
 
 #ifndef INCLUDED_BY_EMITTER
 }; // struct LoadstoreEmitterOps

--- a/CodeEmitter/CodeEmitter/SystemOps.inl
+++ b/CodeEmitter/CodeEmitter/SystemOps.inl
@@ -4,6 +4,14 @@
  * This is mostly a mashup of various instruction types.
  * Nothing follows an explicit pattern since they are mostly different.
  */
+
+#pragma once
+#ifndef INCLUDED_BY_EMITTER
+#include <CodeEmitter/Emitter.h>
+namespace ARMEmitter {
+struct EmitterOps : Emitter {
+#endif
+
 public:
     // System with result
     // TODO: SYSL
@@ -174,3 +182,7 @@ private:
       dc32(Instr);
     }
 
+#ifndef INCLUDED_BY_EMITTER
+}; // struct LoadstoreEmitterOps
+} // namespace ARMEmitter
+#endif

--- a/CodeEmitter/CodeEmitter/VixlUtils.inl
+++ b/CodeEmitter/CodeEmitter/VixlUtils.inl
@@ -34,11 +34,7 @@
 // by the corresponding fields in the logical instruction.
 // If it can not be encoded, the function returns false, and the values pointed
 // to by n, imm_s and imm_r are undefined.
-static bool IsImmLogical(uint64_t value,
-                             unsigned width,
-                             unsigned* n = nullptr,
-                             unsigned* imm_s = nullptr,
-                             unsigned* imm_r = nullptr) {
+static bool IsImmLogical(uint64_t value, unsigned width, unsigned* n = nullptr, unsigned* imm_s = nullptr, unsigned* imm_r = nullptr) {
   [[maybe_unused]] constexpr auto kBRegSize = 8;
   [[maybe_unused]] constexpr auto kHRegSize = 16;
   [[maybe_unused]] constexpr auto kSRegSize = 32;
@@ -47,8 +43,7 @@ static bool IsImmLogical(uint64_t value,
   constexpr auto kWRegSize = 32;
   constexpr auto kXRegSize = 64;
 
-  LOGMAN_THROW_A_FMT((width == kBRegSize) || (width == kHRegSize) ||
-              (width == kSRegSize) || (width == kDRegSize), "Unexpected imm size");
+  LOGMAN_THROW_A_FMT((width == kBRegSize) || (width == kHRegSize) || (width == kSRegSize) || (width == kDRegSize), "Unexpected imm size");
 
   bool negate = false;
 
@@ -182,12 +177,7 @@ static bool IsImmLogical(uint64_t value,
   // (1 + 2^d + 2^(2d) + ...), i.e. 0x0001000100010001 or similar. These can
   // be derived using a table lookup on CLZ(d).
   static const uint64_t multipliers[] = {
-      0x0000000000000001UL,
-      0x0000000100000001UL,
-      0x0001000100010001UL,
-      0x0101010101010101UL,
-      0x1111111111111111UL,
-      0x5555555555555555UL,
+    0x0000000000000001UL, 0x0000000100000001UL, 0x0001000100010001UL, 0x0101010101010101UL, 0x1111111111111111UL, 0x5555555555555555UL,
   };
   uint64_t multiplier = multipliers[CountLeadingZeros(d, kXRegSize) - 57];
   uint64_t candidate = (b - a) * multiplier;
@@ -244,7 +234,9 @@ static bool IsImmLogical(uint64_t value,
 }
 
 static inline bool IsIntN(unsigned n, int64_t x) {
-  if (n == 64) return true;
+  if (n == 64) {
+    return true;
+  }
   int64_t limit = INT64_C(1) << (n - 1);
   return (-limit <= x) && (x < limit);
 }
@@ -271,11 +263,15 @@ V(57) V(58) V(59) V(60) V(61) V(62) V(63)
 
 // clang-format on
 
-#define DECLARE_IS_INT_N(N)                                       \
-  static inline bool IsInt##N(int64_t x) { return IsIntN(N, x); }
+#define DECLARE_IS_INT_N(N)                \
+  static inline bool IsInt##N(int64_t x) { \
+    return IsIntN(N, x);                   \
+  }
 
-#define DECLARE_IS_UINT_N(N)                                        \
-  static inline bool IsUint##N(int64_t x) { return IsUintN(N, x); }
+#define DECLARE_IS_UINT_N(N)                \
+  static inline bool IsUint##N(int64_t x) { \
+    return IsUintN(N, x);                   \
+  }
 
 INT_1_TO_63_LIST(DECLARE_IS_INT_N)
 INT_1_TO_63_LIST(DECLARE_IS_UINT_N)
@@ -285,14 +281,14 @@ INT_1_TO_63_LIST(DECLARE_IS_UINT_N)
 
 private:
 
-template <typename V>
+template<typename V>
 static inline bool IsPowerOf2(V value) {
   return (value != 0) && ((value & (value - 1)) == 0);
 }
 
 // Some compilers dislike negating unsigned integers,
 // so we provide an equivalent.
-template <typename T>
+template<typename T>
 static inline T UnsignedNegate(T value) {
   static_assert(std::is_unsigned<T>::value);
   return ~value + 1;
@@ -302,7 +298,7 @@ static inline uint64_t LowestSetBit(uint64_t value) {
   return value & UnsignedNegate(value);
 }
 
-template <typename V>
+template<typename V>
 static inline int CountLeadingZeros(V value, int width = (sizeof(V) * 8)) {
 #if COMPILER_HAS_BUILTIN_CLZ
   if (width == 32) {

--- a/Scripts/reformat.sh
+++ b/Scripts/reformat.sh
@@ -10,5 +10,5 @@ fi
 
 # Reformat whole tree.
 # This is run by the reformat target.
-git ls-files -z '*.cpp' '*.h' | xargs -0 -n 1 -P $(nproc) python3 Scripts/clang-format.py -i  
+git ls-files -z '*.cpp' '*.h' '*.inl' | xargs -0 -n 1 -P $(nproc) python3 Scripts/clang-format.py -i
 cd $DIR


### PR DESCRIPTION
External tooling couldn't process these files before since there was no context, but with a little preprocessor hack this can be supported. I'm not too happy about needing this, but we only need it for these 8 files.

As a nice bonus, other tooling (IDEs in particular) can process these files as well now, allowing "go to definition", error highlighting, and other features to work out of the box.

Best reviewed per patch, since the second patch reformats 18.000 lines of code that hadn't been auto-formatted before.
