### PR TITLE
Fix crashes in Paranoid TSO mode

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -337,6 +337,10 @@ protected:
       AtomicTSOEmulationEnabled = false;
       VectorAtomicTSOEmulationEnabled = false;
       MemcpyAtomicTSOEmulationEnabled = false;
+    } else if (Config.ParanoidTSO) {
+      AtomicTSOEmulationEnabled = true;
+      VectorAtomicTSOEmulationEnabled = true;
+      MemcpyAtomicTSOEmulationEnabled = true;
     } else {
       // Atomic TSO emulation only enabled if the config option is enabled.
       AtomicTSOEmulationEnabled = (IsMemoryShared || !Config.TSOAutoMigration) && Config.TSOEnabled;

--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -245,6 +245,10 @@ private:
   ARMEmitter::ExtendedMemOperand GenerateMemOperand(IR::OpSize AccessSize, ARMEmitter::Register Base, IR::OrderedNodeWrapper Offset,
                                                     IR::MemOffsetType OffsetType, uint8_t OffsetScale);
 
+  [[nodiscard]]
+  ARMEmitter::Register ApplyMemOperand(IR::OpSize AccessSize, ARMEmitter::Register Base, ARMEmitter::Register Tmp,
+                                       IR::OrderedNodeWrapper Offset, IR::MemOffsetType OffsetType, uint8_t OffsetScale);
+
   // NOTE: Will use TMP1 as a way to encode immediates that happen to fall outside
   //       the limits of the scalar plus immediate variant of SVE load/stores.
   //

--- a/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
@@ -1826,7 +1826,6 @@ DEF_OP(MemSet) {
       case 8: stlr(Value.X(), TMP2); break;
       default: LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size); break;
       }
-      nop();
     }
 
     if (Size >= 0) {
@@ -2031,23 +2030,23 @@ DEF_OP(MemCpy) {
         ldaprb(TMP4.W(), TMP3);
         stlrb(TMP4.W(), TMP2);
       } else {
-        nop();
         switch (OpSize) {
         case 2: ldaprh(TMP4.W(), TMP3); break;
         case 4: ldapr(TMP4.W(), TMP3); break;
         case 8: ldapr(TMP4, TMP3); break;
         default: LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size); break;
         }
+
+        // Placeholders for backpatching barriers (one per load/store)
+        nop();
         nop();
 
-        nop();
         switch (OpSize) {
         case 2: stlrh(TMP4.W(), TMP2); break;
         case 4: stlr(TMP4.W(), TMP2); break;
         case 8: stlr(TMP4, TMP2); break;
         default: LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size); break;
         }
-        nop();
       }
     } else {
       if (OpSize == 1) {
@@ -2055,23 +2054,23 @@ DEF_OP(MemCpy) {
         ldarb(TMP4.W(), TMP3);
         stlrb(TMP4.W(), TMP2);
       } else {
-        nop();
         switch (OpSize) {
         case 2: ldarh(TMP4.W(), TMP3); break;
         case 4: ldar(TMP4.W(), TMP3); break;
         case 8: ldar(TMP4, TMP3); break;
         default: LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size); break;
         }
+
+        // Placeholders for backpatching barriers (one per load/store)
+        nop();
         nop();
 
-        nop();
         switch (OpSize) {
         case 2: stlrh(TMP4.W(), TMP2); break;
         case 4: stlr(TMP4.W(), TMP2); break;
         case 8: stlr(TMP4, TMP2); break;
         default: LOGMAN_MSG_A_FMT("Unhandled {} size: {}", __func__, Size); break;
         }
-        nop();
       }
     }
 


### PR DESCRIPTION
This PR fixes two critical issues in Paranoid TSO mode: Many applications that work with FEX's default settings would fail to run since TSO emulation wasn't enabled for most instructions. Further complications arose due to indirect memory addressing not being implemented.

A negative (but expected) side effect of fixing these issues is that Paranoid TSO mode will now make emulation unusably slow (>90% performance impact). I'm not sure there are strong enough reasons to keep around the current PTSO approach, so I wrote a patch that implements backpatching-free TSO without requiring excessive signalling. It's not included here since it's a bit more tricky to maintain at the moment, but this current PR will get things back to a functional state at least.

As a small but related side change, I realized that memcpy/memset emit slightly more `nop`s than needed in either TSO mode.

## Implementation details

The ARM instructions emitted in PTSO mode don't support indirect memory addressing (unlike the instructions emitted with backpatching-based TSO emulation), so the indirect offsets are instead manually computed using `add`.
