### PR TITLE
Drop assume-asserting logging macros

### DIFF
--- a/CodeEmitter/CodeEmitter/ALUOps.inl
+++ b/CodeEmitter/CodeEmitter/ALUOps.inl
@@ -666,12 +666,12 @@ public:
   }
 
   void add(ARMEmitter::Size s, ARMEmitter::Register rd, ARMEmitter::Register rn, ARMEmitter::Register rm, ARMEmitter::ShiftType Shift = ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
-    LOGMAN_THROW_AA_FMT(Shift != ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
+    LOGMAN_THROW_A_FMT(Shift != ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
     constexpr uint32_t Op = 0b000'1011'000U << 21;
     DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
   }
   void adds(ARMEmitter::Size s, ARMEmitter::Register rd, ARMEmitter::Register rn, ARMEmitter::Register rm, ARMEmitter::ShiftType Shift = ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
-    LOGMAN_THROW_AA_FMT(Shift != ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
+    LOGMAN_THROW_A_FMT(Shift != ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
     constexpr uint32_t Op = 0b010'1011'000U << 21;
     DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
   }
@@ -679,7 +679,7 @@ public:
     adds(s, ARMEmitter::Reg::zr, rn, rm, Shift, amt);
   }
   void sub(ARMEmitter::Size s, ARMEmitter::Register rd, ARMEmitter::Register rn, ARMEmitter::Register rm, ARMEmitter::ShiftType Shift = ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
-    LOGMAN_THROW_AA_FMT(Shift != ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
+    LOGMAN_THROW_A_FMT(Shift != ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
     constexpr uint32_t Op = 0b100'1011'000U << 21;
     DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
   }
@@ -691,7 +691,7 @@ public:
   }
 
   void subs(ARMEmitter::Size s, ARMEmitter::Register rd, ARMEmitter::Register rn, ARMEmitter::Register rm, ARMEmitter::ShiftType Shift = ARMEmitter::ShiftType::LSL, uint32_t amt = 0) {
-    LOGMAN_THROW_AA_FMT(Shift != ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
+    LOGMAN_THROW_A_FMT(Shift != ARMEmitter::ShiftType::ROR, "Doesn't support ROR");
     constexpr uint32_t Op = 0b110'1011'000U << 21;
     DataProcessing_Shifted_Reg(Op, s, rd, rn, rm, Shift, amt);
   }
@@ -701,7 +701,7 @@ public:
 
   // AddSub - extended register
   void add(ARMEmitter::Size s, ARMEmitter::Register rd, ARMEmitter::Register rn, ARMEmitter::Register rm, ARMEmitter::ExtendedType Option, uint32_t Shift = 0) {
-    LOGMAN_THROW_AA_FMT(Shift <= 4, "Shift amount is too large");
+    LOGMAN_THROW_A_FMT(Shift <= 4, "Shift amount is too large");
     constexpr uint32_t Op = 0b000'1011'001U << 21;
     DataProcessing_Extended_Reg(Op, s, rd, rn, rm, Option, Shift);
   }
@@ -751,8 +751,8 @@ public:
 
   // Rotate right into flags
   void rmif(XRegister rn, uint32_t shift, uint32_t mask) {
-    LOGMAN_THROW_AA_FMT(shift <= 63, "Shift must be within 0-63. Shift: {}", shift);
-    LOGMAN_THROW_AA_FMT(mask <= 15, "Mask must be within 0-15. Mask: {}", mask);
+    LOGMAN_THROW_A_FMT(shift <= 63, "Shift must be within 0-63. Shift: {}", shift);
+    LOGMAN_THROW_A_FMT(mask <= 15, "Mask must be within 0-15. Mask: {}", mask);
 
     uint32_t Op = 0b1011'1010'0000'0000'0000'0100'0000'0000;
     Op |= rn.Idx() << 5;
@@ -898,7 +898,7 @@ public:
 private:
   static constexpr Condition InvertCondition(Condition cond) {
     // These behave as always, so it makes no sense to allow inverting these.
-    LOGMAN_THROW_AA_FMT(cond != Condition::CC_AL && cond != Condition::CC_NV,
+    LOGMAN_THROW_A_FMT(cond != Condition::CC_AL && cond != Condition::CC_NV,
                         "Cannot invert CC_AL or CC_NV");
     return static_cast<Condition>(FEXCore::ToUnderlying(cond) ^ 1);
   }
@@ -950,7 +950,7 @@ private:
       LSL12 = true;
       Imm >>= 12;
     }
-    LOGMAN_THROW_AA_FMT(TooLarge == false, "Imm amount too large: 0x{:x}", Imm);
+    LOGMAN_THROW_A_FMT(TooLarge == false, "Imm amount too large: 0x{:x}", Imm);
 
     const uint32_t SF = s == ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
 
@@ -1014,9 +1014,9 @@ private:
     [[maybe_unused]] const auto lsb_p_width = lsb + width;
     const auto reg_size_bits = RegSizeInBits(s);
 
-    LOGMAN_THROW_AA_FMT(lsb_p_width <= reg_size_bits, "lsb + width ({}) must be <= {}. lsb={}, width={}",
+    LOGMAN_THROW_A_FMT(lsb_p_width <= reg_size_bits, "lsb + width ({}) must be <= {}. lsb={}, width={}",
                         lsb_p_width, reg_size_bits, lsb, width);
-    LOGMAN_THROW_AA_FMT(width >= 1, "xbfiz width must be >= 1");
+    LOGMAN_THROW_A_FMT(width >= 1, "xbfiz width must be >= 1");
 
     const auto immr = (reg_size_bits - lsb) & (reg_size_bits - 1);
     const auto imms = width - 1;
@@ -1077,9 +1077,9 @@ private:
 
   // AddSub - shifted register
   void DataProcessing_Shifted_Reg(uint32_t Op, ARMEmitter::Size s, ARMEmitter::Register rd, ARMEmitter::Register rn, ARMEmitter::Register rm, ARMEmitter::ShiftType Shift, uint32_t amt) {
-    LOGMAN_THROW_AA_FMT((amt & ~0b11'1111U) == 0, "Shift amount too large");
+    LOGMAN_THROW_A_FMT((amt & ~0b11'1111U) == 0, "Shift amount too large");
     if (s == ARMEmitter::Size::i32Bit) {
-      LOGMAN_THROW_AA_FMT(amt < 32, "Shift amount for 32-bit must be below 32");
+      LOGMAN_THROW_A_FMT(amt < 32, "Shift amount for 32-bit must be below 32");
     }
 
     const uint32_t SF = s == ARMEmitter::Size::i64Bit ? (1U << 31) : 0;

--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -231,7 +231,7 @@ public:
     ASIMDPermute(Op, 1, size, 0b001, rd.V(), rn.V(), rm.V());
   }
   void uzp1(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
     constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
     ASIMDPermute(Op, 0, size, 0b001, rd.V(), rn.V(), rm.V());
   }
@@ -240,7 +240,7 @@ public:
     ASIMDPermute(Op, 1, size, 0b010, rd.V(), rn.V(), rm.V());
   }
   void trn1(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
     constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
     ASIMDPermute(Op, 0, size, 0b010, rd.V(), rn.V(), rm.V());
   }
@@ -249,7 +249,7 @@ public:
     ASIMDPermute(Op, 1, size, 0b011, rd.V(), rn.V(), rm.V());
   }
   void zip1(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
     constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
     ASIMDPermute(Op, 0, size, 0b011, rd.V(), rn.V(), rm.V());
   }
@@ -258,7 +258,7 @@ public:
     ASIMDPermute(Op, 1, size, 0b101, rd.V(), rn.V(), rm.V());
   }
   void uzp2(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
     constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
     ASIMDPermute(Op, 0, size, 0b101, rd.V(), rn.V(), rm.V());
   }
@@ -267,7 +267,7 @@ public:
     ASIMDPermute(Op, 1, size, 0b110, rd.V(), rn.V(), rm.V());
   }
   void trn2(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
     constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
     ASIMDPermute(Op, 0, size, 0b110, rd.V(), rn.V(), rm.V());
   }
@@ -276,19 +276,19 @@ public:
     ASIMDPermute(Op, 1, size, 0b111, rd.V(), rn.V(), rm.V());
   }
   void zip2(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, ARMEmitter::DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid 64-bit size on 64-bit permute");
     constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'10 << 10;
     ASIMDPermute(Op, 0, size, 0b111, rd.V(), rn.V(), rm.V());
   }
 
   // Advanced SIMD extract
   void ext(ARMEmitter::QRegister rd, ARMEmitter::QRegister rn, ARMEmitter::QRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(Index < 16, "Index can't be more than 15");
+    LOGMAN_THROW_A_FMT(Index < 16, "Index can't be more than 15");
     constexpr uint32_t Op = 0b0010'1110'000 << 21;
     ASIMDExtract(Op, 1, 0b00, Index, rd.V(), rn.V(), rm.V());
   }
   void ext(ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, ARMEmitter::DRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(Index < 8, "Index can't be more than 7");
+    LOGMAN_THROW_A_FMT(Index < 8, "Index can't be more than 7");
     constexpr uint32_t Op = 0b0010'1110'000 << 21;
     ASIMDExtract(Op, 0, 0b00, Index, rd.V(), rn.V(), rm.V());
   }
@@ -298,7 +298,7 @@ public:
   requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
   void dup(SubRegSize size, T rd, T rn, uint32_t Index) {
     if constexpr(std::is_same_v<DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+      LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
     }
 
     constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
@@ -309,7 +309,7 @@ public:
     const uint32_t ElementSize = 1U << SizeImm;
     const uint32_t MaxIndex = 128U / (ElementSize * 8);
 
-    LOGMAN_THROW_AA_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
+    LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
@@ -373,7 +373,7 @@ public:
   requires(std::is_same_v<QRegister, T> || std::is_same_v<DRegister, T>)
   void dup(SubRegSize size, T rd, Register rn) {
     if constexpr(std::is_same_v<DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
+      LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "Invalid element size with 64-bit dup");
     }
 
     constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
@@ -399,7 +399,7 @@ public:
     constexpr uint32_t ElementSize = 1U << SizeImm;
     constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
 
-    LOGMAN_THROW_AA_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
+    LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
@@ -418,7 +418,7 @@ public:
     constexpr uint32_t ElementSize = 1U << SizeImm;
     constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
 
-    LOGMAN_THROW_AA_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
+    LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
@@ -441,7 +441,7 @@ public:
     constexpr uint32_t ElementSize = 1U << SizeImm;
     constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
 
-    LOGMAN_THROW_AA_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
+    LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
@@ -457,7 +457,7 @@ public:
     constexpr uint32_t ElementSize = 1U << SizeImm;
     constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
 
-    LOGMAN_THROW_AA_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
+    LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
@@ -472,7 +472,7 @@ public:
     const uint32_t ElementSize = 1U << SizeImm;
     const uint32_t MaxIndex = 128U / (ElementSize * 8);
 
-    LOGMAN_THROW_AA_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
+    LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
@@ -487,8 +487,8 @@ public:
     const uint32_t ElementSize = 1U << SizeImm;
     const uint32_t MaxIndex = 128U / (ElementSize * 8);
 
-    LOGMAN_THROW_AA_FMT(Index < MaxIndex,  "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
-    LOGMAN_THROW_AA_FMT(Index2 < MaxIndex, "Index2 too large. Index2={}, Max Index: {}", Index2, MaxIndex);
+    LOGMAN_THROW_A_FMT(Index < MaxIndex,  "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
+    LOGMAN_THROW_A_FMT(Index2 < MaxIndex, "Index2 too large. Index2={}, Max Index: {}", Index2, MaxIndex);
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
     const uint32_t imm4 = Index2 << SizeImm;
@@ -828,7 +828,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sdot(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     ASIMDThreeRegisterExt(0, 0b0010, size, rm, rn, rd);
   }
@@ -843,7 +843,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqrdmlah(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     ASIMDThreeRegisterExt(1, 0b0000, size, rm, rn, rd);
   }
@@ -851,7 +851,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqrdmlsh(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     ASIMDThreeRegisterExt(1, 0b0001, size, rm, rn, rd);
   }
@@ -859,7 +859,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void udot(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     ASIMDThreeRegisterExt(1, 0b0010, size, rm, rn, rd);
   }
@@ -867,20 +867,20 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmla(ARMEmitter::SubRegSize size, T rd, T rn, T rm, ARMEmitter::Rotation Rot) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "8-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "8-bit subregsize not supported");
 
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     ASIMDThreeRegisterExt(1, 0b1000 | FEXCore::ToUnderlying(Rot), size, rm, rn, rd);
   }
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcadd(ARMEmitter::SubRegSize size, T rd, T rn, T rm, ARMEmitter::Rotation Rot) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "8-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "8-bit subregsize not supported");
 
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     LOGMAN_THROW_A_FMT(Rot == ARMEmitter::Rotation::ROTATE_90 || Rot == ARMEmitter::Rotation::ROTATE_270, "Invalid rotation");
     const uint32_t ConvertedRotation =
@@ -915,7 +915,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void rev64(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b00000, rd, rn);
   }
@@ -923,7 +923,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void rev16(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b00001, rd, rn);
   }
@@ -933,7 +933,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void saddlp(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
@@ -947,7 +947,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void suqadd(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b00011, rd, rn);
@@ -956,14 +956,14 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cls(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b00100, rd, rn);
   }
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cnt(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b00101, rd, rn);
   }
@@ -973,7 +973,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sadalp(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
@@ -987,7 +987,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqabs(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b00111, rd, rn);
@@ -997,7 +997,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cmgt(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01000, rd, rn);
@@ -1007,7 +1007,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cmeq(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01001, rd, rn);
@@ -1017,7 +1017,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cmlt(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01010, rd, rn);
@@ -1026,7 +1026,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void abs(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01011, rd, rn);
@@ -1035,14 +1035,14 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void xtn(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc(Op, 0, size, 0b10010, rd.D(), rn.D());
   }
   ///< size is the destination size.
   ///< source size is the next size up.
   void xtn2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc(Op, 0, size, 0b10010, rd.Q(), rn.Q());
   }
@@ -1050,14 +1050,14 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void sqxtn(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc(Op, 0, size, 0b10100, rd.D(), rn.D());
   }
   ///< size is the destination size.
   ///< source size is the next size up.
   void sqxtn2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc(Op, 0, size, 0b10100, rd.Q(), rn.Q());
   }
@@ -1065,7 +1065,7 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void fcvtn(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit ||
                        size == ARMEmitter::SubRegSize::i16Bit, "Only 16-bit & 32-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1077,7 +1077,7 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void fcvtn2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit ||
                        size == ARMEmitter::SubRegSize::i16Bit, "Only 16-bit & 32-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1090,7 +1090,7 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void fcvtl(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1102,7 +1102,7 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void fcvtl2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1116,9 +1116,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frintn(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1131,9 +1131,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frintm(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1147,9 +1147,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtns(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1162,9 +1162,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtms(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1177,9 +1177,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtas(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1192,9 +1192,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void scvtf(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1207,9 +1207,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frint32z(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1222,9 +1222,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frint64z(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1238,9 +1238,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmgt(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01100, rd, rn);
@@ -1250,9 +1250,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmeq(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01101, rd, rn);
@@ -1262,9 +1262,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmlt(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01110, rd, rn);
@@ -1274,9 +1274,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fabs(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b01111, rd, rn);
@@ -1286,9 +1286,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frintp(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11000, rd, rn);
@@ -1298,9 +1298,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frintz(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11001, rd, rn);
@@ -1310,9 +1310,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtps(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11010, rd, rn);
@@ -1322,9 +1322,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtzs(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11011, rd, rn);
@@ -1333,7 +1333,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void urecpe(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11100, rd, rn);
   }
@@ -1341,7 +1341,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frecpe(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 0, size, 0b11101, rd, rn);
@@ -1350,7 +1350,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void rev32(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i8Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit ||
                        size == ARMEmitter::SubRegSize::i16Bit, "Only 8-bit & 16-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b00000, rd, rn);
@@ -1361,7 +1361,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void uaddlp(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
@@ -1375,7 +1375,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void usqadd(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b00011, rd, rn);
@@ -1384,7 +1384,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void clz(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b00100, rd, rn);
   }
@@ -1394,7 +1394,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void uadalp(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
@@ -1408,7 +1408,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqneg(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b00111, rd, rn);
@@ -1419,7 +1419,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cmge(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b01000, rd, rn);
@@ -1429,7 +1429,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void cmle(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b01001, rd, rn);
@@ -1438,7 +1438,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void neg(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b01011, rd, rn);
@@ -1446,14 +1446,14 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void sqxtun(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc(Op, 1, size, 0b10010, rd.D(), rn.D());
   }
   ///< size is the destination size.
   ///< source size is the next size up.
   void sqxtun2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit destination subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc(Op, 1, size, 0b10010, rd.Q(), rn.Q());
   }
@@ -1461,7 +1461,7 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void shll(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
@@ -1473,7 +1473,7 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void shll2(ARMEmitter::SubRegSize size, ARMEmitter::QRegister rd, ARMEmitter::QRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
@@ -1497,7 +1497,7 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void fcvtxn(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
@@ -1508,7 +1508,7 @@ public:
   ///< size is the destination size.
   ///< source size is the next size up.
   void fcvtxn2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i32Bit ? ARMEmitter::SubRegSize::i16Bit :
@@ -1519,7 +1519,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frinta(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1531,7 +1531,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frintx(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1544,7 +1544,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtnu(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1556,7 +1556,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtmu(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1568,7 +1568,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtau(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1580,7 +1580,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ucvtf(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1592,7 +1592,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frint32x(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1604,7 +1604,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frint64x(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1617,14 +1617,14 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void not_(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, ARMEmitter::SubRegSize::i8Bit, 0b00101, rd, rn);
   }
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void mvn(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, ARMEmitter::SubRegSize::i8Bit, 0b00101, rd, rn);
   }
@@ -1632,7 +1632,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void rbit(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit, "Only 8-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, ARMEmitter::SubRegSize::i16Bit, 0b00101, rd, rn);
   }
@@ -1641,9 +1641,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmge(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b01100, rd, rn);
@@ -1652,9 +1652,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcmle(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b01101, rd, rn);
@@ -1664,9 +1664,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fneg(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b01111, rd, rn);
@@ -1676,9 +1676,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frinti(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11001, rd, rn);
@@ -1688,9 +1688,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtpu(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11010, rd, rn);
@@ -1699,9 +1699,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fcvtzu(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11011, rd, rn);
@@ -1710,7 +1710,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void ursqrte(ARMEmitter::SubRegSize size, T rd, T rn) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11100, rd, rn);
   }
@@ -1718,9 +1718,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void frsqrte(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11101, rd, rn);
@@ -1730,9 +1730,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fsqrt(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                        size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit & 64-bit subregsize supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'10 << 10;
     ASIMD2RegMisc<T>(Op, 1, size, 0b11111, rd, rn);
@@ -1745,9 +1745,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void saddlv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Destination 8-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i32Bit :
@@ -1761,9 +1761,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void smaxv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     ASIMDAcrossLanes<T>(Op, 0, size, 0b01010, rd, rn);
   }
@@ -1771,9 +1771,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sminv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     ASIMDAcrossLanes<T>(Op, 0, size, 0b11010, rd, rn);
   }
@@ -1781,9 +1781,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void addv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     ASIMDAcrossLanes<T>(Op, 0, size, 0b11011, rd, rn);
   }
@@ -1791,7 +1791,7 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void uaddlv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     }
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     const auto ConvertedSize =
@@ -1805,9 +1805,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void umaxv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     ASIMDAcrossLanes<T>(Op, 1, size, 0b01010, rd, rn);
   }
@@ -1815,9 +1815,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void uminv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit && size != ARMEmitter::SubRegSize::i64Bit, "32/64-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Destination 64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     ASIMDAcrossLanes<T>(Op, 1, size, 0b11010, rd, rn);
   }
@@ -1825,9 +1825,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmaxnmv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
@@ -1842,9 +1842,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmaxv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i16Bit :
@@ -1859,9 +1859,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fminnmv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i64Bit :
@@ -1876,9 +1876,9 @@ public:
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fminv(ARMEmitter::SubRegSize size, T rd, T rn) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i32Bit, "32-bit subregsize not supported");
     }
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit && size != ARMEmitter::SubRegSize::i64Bit, "Destination 8/64-bit subregsize unsupported");
     constexpr uint32_t Op = 0b0000'1110'0011'0000'0000'10 << 10;
     const auto ConvertedSize =
       size == ARMEmitter::SubRegSize::i64Bit ? ARMEmitter::SubRegSize::i64Bit :
@@ -1895,7 +1895,7 @@ public:
   // TODO: Don't enforce DRegister/QRegister for Q check
   ///< Size is dest size
   void saddl(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -1904,7 +1904,7 @@ public:
   }
   ///< Size is dest size
   void saddl2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -1913,7 +1913,7 @@ public:
   }
   ///< Size is dest size
   void saddw(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -1922,7 +1922,7 @@ public:
   }
   ///< Size is dest size
   void saddw2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -1931,7 +1931,7 @@ public:
   }
   ///< Size is dest size
   void ssubl(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -1940,7 +1940,7 @@ public:
   }
   ///< Size is dest size
   void ssubl2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -1949,7 +1949,7 @@ public:
   }
   ///< Size is dest size
   void ssubw(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -1958,7 +1958,7 @@ public:
   }
   ///< Size is dest size
   void ssubw2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -1966,18 +1966,18 @@ public:
     ASIMD3Different(Op, 0, 0b0011, ConvertedSize, rd, rn, rm);
   }
   void addhn(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     ASIMD3Different(Op, 0, 0b0100, size, rd, rn, rm);
   }
   void addhn2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     ASIMD3Different(Op, 0, 0b0100, size, rd, rn, rm);
   }
   ///< Size is dest size
   void sabal(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -1986,7 +1986,7 @@ public:
   }
   ///< Size is dest size
   void sabal2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -1994,18 +1994,18 @@ public:
     ASIMD3Different(Op, 0, 0b0101, ConvertedSize, rd, rn, rm);
   }
   void subhn(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     ASIMD3Different(Op, 0, 0b0110, size, rd, rn, rm);
   }
   void subhn2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     ASIMD3Different(Op, 0, 0b0110, size, rd, rn, rm);
   }
   ///< Size is dest size
   void sabdl(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2014,7 +2014,7 @@ public:
   }
   ///< Size is dest size
   void sabdl2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2023,7 +2023,7 @@ public:
   }
   ///< Size is dest size
   void smlal(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2032,7 +2032,7 @@ public:
   }
   ///< Size is dest size
   void smlal2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2041,7 +2041,7 @@ public:
   }
   ///< Size is dest size
   void sqdmlal(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2050,7 +2050,7 @@ public:
   }
   ///< Size is dest size
   void sqdmlal2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2059,7 +2059,7 @@ public:
   }
   ///< Size is dest size
   void smlsl(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2068,7 +2068,7 @@ public:
   }
   ///< Size is dest size
   void smlsl2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2077,7 +2077,7 @@ public:
   }
   ///< Size is dest size
   void sqdmlsl(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2086,7 +2086,7 @@ public:
   }
   ///< Size is dest size
   void sqdmlsl2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2095,7 +2095,7 @@ public:
   }
   ///< Size is dest size
   void smull(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2104,7 +2104,7 @@ public:
   }
   ///< Size is dest size
   void smull2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2113,7 +2113,7 @@ public:
   }
   ///< Size is dest size
   void sqdmull(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2122,7 +2122,7 @@ public:
   }
   ///< Size is dest size
   void sqdmull2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit, "No 8/16-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2131,7 +2131,7 @@ public:
   }
   ///< Size is dest size
   void pmull(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i128Bit, "Only 16-bit and 128-bit destination supported");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i128Bit, "Only 16-bit and 128-bit destination supported");
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
@@ -2139,7 +2139,7 @@ public:
   }
   ///< Size is dest size
   void pmull2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i128Bit, "Only 16-bit and 128-bit destination supported");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i128Bit, "Only 16-bit and 128-bit destination supported");
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
@@ -2147,7 +2147,7 @@ public:
   }
   ///< Size is dest size
   void uaddl(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2156,7 +2156,7 @@ public:
   }
   ///< Size is dest size
   void uaddl2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2165,7 +2165,7 @@ public:
   }
   ///< Size is dest size
   void uaddw(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2174,7 +2174,7 @@ public:
   }
   ///< Size is dest size
   void uaddw2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2183,7 +2183,7 @@ public:
   }
   ///< Size is dest size
   void usubl(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2192,7 +2192,7 @@ public:
   }
   ///< Size is dest size
   void usubl2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2201,7 +2201,7 @@ public:
   }
   ///< Size is dest size
   void usubw(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2210,7 +2210,7 @@ public:
   }
   ///< Size is dest size
   void usubw2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2220,7 +2220,7 @@ public:
   // XXX: RADDHN/2
   ///< Size is dest size
   void uabal(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2229,7 +2229,7 @@ public:
   }
   ///< Size is dest size
   void uabal2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2239,7 +2239,7 @@ public:
   // XXX: RSUBHN/2
   ///< Size is dest size
   void uabdl(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2248,7 +2248,7 @@ public:
   }
   ///< Size is dest size
   void uabdl2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2257,7 +2257,7 @@ public:
   }
   ///< Size is dest size
   void umlal(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2266,7 +2266,7 @@ public:
   }
   ///< Size is dest size
   void umlal2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2275,7 +2275,7 @@ public:
   }
   ///< Size is dest size
   void umlsl(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2284,7 +2284,7 @@ public:
   }
   ///< Size is dest size
   void umlsl2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2293,7 +2293,7 @@ public:
   }
   ///< Size is dest size
   void umull(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2302,7 +2302,7 @@ public:
   }
   ///< Size is dest size
   void umull2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
     const auto ConvertedSize = SubRegSize{FEXCore::ToUnderlying(size) - 1};
@@ -2313,7 +2313,7 @@ public:
   // Advanced SIMD three same
   template<typename T>
   void shadd(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b00000, rd, rn, rm);
   }
@@ -2321,7 +2321,7 @@ public:
   template<typename T>
   void sqadd(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit sqadd");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit sqadd");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b00001, rd, rn, rm);
@@ -2329,20 +2329,20 @@ public:
 
   template<typename T>
   void srhadd(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b00010, rd, rn, rm);
   }
   template<typename T>
   void shsub(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b00100, rd, rn, rm);
   }
   template<typename T>
   void sqsub(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit sqsub");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit sqsub");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b00101, rd, rn, rm);
@@ -2350,7 +2350,7 @@ public:
   template<typename T>
   void cmgt(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit cmgt");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit cmgt");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b00110, rd, rn, rm);
@@ -2358,7 +2358,7 @@ public:
   template<typename T>
   void cmge(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit cmge");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit cmge");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b00111, rd, rn, rm);
@@ -2366,7 +2366,7 @@ public:
   template<typename T>
   void sshl(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit sshl");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit sshl");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b01000, rd, rn, rm);
@@ -2374,7 +2374,7 @@ public:
   template<typename T>
   void sqshl(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit sqshl");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit sqshl");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b01001, rd, rn, rm);
@@ -2382,7 +2382,7 @@ public:
   template<typename T>
   void srshl(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit srshl");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit srshl");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b01010, rd, rn, rm);
@@ -2390,39 +2390,39 @@ public:
   template<typename T>
   void sqrshl(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit sqrshl");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit sqrshl");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b01011, rd, rn, rm);
   }
   template<typename T>
   void smax(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b01100, rd, rn, rm);
   }
   template<typename T>
   void smin(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b01101, rd, rn, rm);
   }
   template<typename T>
   void sabd(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b01110, rd, rn, rm);
   }
   template<typename T>
   void saba(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b01111, rd, rn, rm);
   }
   template<typename T>
   void add(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit add");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit add");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b10000, rd, rn, rm);
@@ -2430,46 +2430,46 @@ public:
   template<typename T>
   void cmtst(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit cmtst");
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit cmtst");
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b10001, rd, rn, rm);
   }
   template<typename T>
   void mla(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b10010, rd, rn, rm);
   }
   template<typename T>
   void mul(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b10011, rd, rn, rm);
   }
   template<typename T>
   void smaxp(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b10100, rd, rn, rm);
   }
   template<typename T>
   void sminp(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b10101, rd, rn, rm);
   }
   template<typename T>
   void sqdmulh(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "No 8-bit dest support.");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b10110, rd, rn, rm);
   }
   template<typename T>
   void addp(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 0, size, 0b10111, rd, rn, rm);
@@ -2477,9 +2477,9 @@ public:
   template<typename T>
   void fmaxnm(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2493,9 +2493,9 @@ public:
   template<typename T>
   void fmla(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2509,9 +2509,9 @@ public:
   template<typename T>
   void fadd(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2525,9 +2525,9 @@ public:
   template<typename T>
   void fmulx(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2541,9 +2541,9 @@ public:
   template<typename T>
   void fcmeq(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2557,9 +2557,9 @@ public:
   template<typename T>
   void fmax(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2573,9 +2573,9 @@ public:
   template<typename T>
   void frecps(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2609,9 +2609,9 @@ public:
   template<typename T>
   void fminnm(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2620,9 +2620,9 @@ public:
   template<typename T>
   void fmls(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2631,9 +2631,9 @@ public:
   template<typename T>
   void fsub(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2642,9 +2642,9 @@ public:
   template<typename T>
   void fmin(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2653,9 +2653,9 @@ public:
   template<typename T>
   void frsqrts(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2687,7 +2687,7 @@ public:
   }
   template<typename T>
   void uhadd(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b00000, rd, rn, rm);
   }
@@ -2698,26 +2698,26 @@ public:
   }
   template<typename T>
   void urhadd(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b00010, rd, rn, rm);
   }
   template<typename T>
   void uhsub(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b00100, rd, rn, rm);
   }
   template<typename T>
   void uqsub(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b00101, rd, rn, rm);
   }
   template<typename T>
   void cmhi(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b00110, rd, rn, rm);
@@ -2725,7 +2725,7 @@ public:
   template<typename T>
   void cmhs(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2734,59 +2734,59 @@ public:
   template<typename T>
   void ushl(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b01000, rd, rn, rm);
   }
   template<typename T>
   void uqshl(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b01001, rd, rn, rm);
   }
   template<typename T>
   void urshl(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b01010, rd, rn, rm);
   }
   template<typename T>
   void uqrshl(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b01011, rd, rn, rm);
   }
   template<typename T>
   void umax(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b01100, rd, rn, rm);
   }
   template<typename T>
   void umin(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b01101, rd, rn, rm);
   }
   template<typename T>
   void uabd(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b01110, rd, rn, rm);
   }
   template<typename T>
   void uaba(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b01111, rd, rn, rm);
   }
   template<typename T>
   void sub(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b10000, rd, rn, rm);
@@ -2794,14 +2794,14 @@ public:
   template<typename T>
   void cmeq(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b10001, rd, rn, rm);
   }
   template<typename T>
   void mls(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b10010, rd, rn, rm);
   }
@@ -2812,28 +2812,28 @@ public:
   }
   template<typename T>
   void umaxp(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b10100, rd, rn, rm);
   }
   template<typename T>
   void uminp(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b10101, rd, rn, rm);
   }
   template<typename T>
   void sqrdmulh(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit && size != ARMEmitter::SubRegSize::i8Bit, "8/64-bit subregsize not supported");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit && size != ARMEmitter::SubRegSize::i8Bit, "8/64-bit subregsize not supported");
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
     ASIMD3Same<T>(Op, 1, size, 0b10110, rd, rn, rm);
   }
   template<typename T>
   void fmaxnmp(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2847,9 +2847,9 @@ public:
   template<typename T>
   void faddp(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2863,9 +2863,9 @@ public:
   template<typename T>
   void fmul(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2879,9 +2879,9 @@ public:
   template<typename T>
   void fcmge(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2895,9 +2895,9 @@ public:
   template<typename T>
   void facge(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2911,9 +2911,9 @@ public:
   template<typename T>
   void fmaxp(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2927,9 +2927,9 @@ public:
   template<typename T>
   void fdiv(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2953,9 +2953,9 @@ public:
   template<typename T>
   void fminnmp(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2964,9 +2964,9 @@ public:
   template<typename T>
   void fabd(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2975,9 +2975,9 @@ public:
   template<typename T>
   void fcmgt(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2986,9 +2986,9 @@ public:
   template<typename T>
   void facgt(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -2997,9 +2997,9 @@ public:
   template<typename T>
   void fminp(ARMEmitter::SubRegSize size, T rd, T rn, T rm) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i64Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit, "Only 32-bit and 64-bit subregsize supported");
 
     constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'01 << 10;
@@ -3022,9 +3022,9 @@ public:
   template<typename T>
   void fmov(ARMEmitter::SubRegSize size, T rd, float Value) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit ||
                         size == ARMEmitter::SubRegSize::i64Bit, "Unsupported fmov size");
 
@@ -3060,7 +3060,7 @@ public:
 
   template<typename T>
   void movi(ARMEmitter::SubRegSize size, T rd, uint64_t Imm, uint16_t Shift = 0) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i8Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i8Bit ||
                         size == ARMEmitter::SubRegSize::i16Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit ||
                         size == ARMEmitter::SubRegSize::i64Bit, "Unsupported smov size");
@@ -3069,25 +3069,25 @@ public:
     uint32_t cmode;
     uint32_t op;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Shift == 0, "8-bit can't have shift");
-      LOGMAN_THROW_AA_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
+      LOGMAN_THROW_A_FMT(Shift == 0, "8-bit can't have shift");
+      LOGMAN_THROW_A_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
       cmode = 0b1110;
       op = 0;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Shift == 0 || Shift == 8, "Shift by invalid amount");
-      LOGMAN_THROW_AA_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
+      LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 8, "Shift by invalid amount");
+      LOGMAN_THROW_A_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
       cmode = 0b1000 | (Shift ? 0b10 : 0b00);
       op = 0;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Shift == 0 || Shift == 8 || Shift == 16 || Shift == 24, "Shift by invalid amount");
-      LOGMAN_THROW_AA_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
+      LOGMAN_THROW_A_FMT(Shift == 0 || Shift == 8 || Shift == 16 || Shift == 24, "Shift by invalid amount");
+      LOGMAN_THROW_A_FMT((Imm & ~0xFF) == 0, "Larger than 8-bit Imm not supported");
       cmode = 0b0000 | ((Shift >> 3) << 1);
       op = 0;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Shift == 0, "64-bit can't have shift");
+      LOGMAN_THROW_A_FMT(Shift == 0, "64-bit can't have shift");
       cmode = 0b1110;
       op = 1;
 
@@ -3098,7 +3098,7 @@ public:
       for (size_t i = 0; i < 8; ++i) {
         const size_t BitOffset = i * 8;
         uint8_t Section = (Imm >> BitOffset) & 0xFF;
-        LOGMAN_THROW_AA_FMT(Section == 0 || Section == 0xFF, "Invalid 64-bit constant encoding");
+        LOGMAN_THROW_A_FMT(Section == 0 || Section == 0xFF, "Invalid 64-bit constant encoding");
         if (Section == 0xFF) {
           NewImm |= (1 << i);
         }
@@ -3117,7 +3117,7 @@ public:
   template<typename T>
   void sshr(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3133,7 +3133,7 @@ public:
   template<typename T>
   void ssra(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3149,7 +3149,7 @@ public:
   template<typename T>
   void srshr(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3165,7 +3165,7 @@ public:
   template<typename T>
   void srsra(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3181,7 +3181,7 @@ public:
   template<typename T>
   void shl(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3197,7 +3197,7 @@ public:
   template<typename T>
   void sqshl(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3212,7 +3212,7 @@ public:
   }
   ///< size is destination size
   void shrn(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3226,7 +3226,7 @@ public:
   }
   ///< size is destination size
   void shrn2(ARMEmitter::SubRegSize size, ARMEmitter::QRegister rd, ARMEmitter::QRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3240,7 +3240,7 @@ public:
   }
   ///< size is destination size
   void rshrn(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3254,7 +3254,7 @@ public:
   }
   ///< size is destination size
   void rshrn2(ARMEmitter::SubRegSize size, ARMEmitter::QRegister rd, ARMEmitter::QRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3268,7 +3268,7 @@ public:
   }
   ///< size is destination size
   void sqshrn(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3282,7 +3282,7 @@ public:
   }
   ///< size is destination size
   void sqshrn2(ARMEmitter::SubRegSize size, ARMEmitter::QRegister rd, ARMEmitter::QRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3296,7 +3296,7 @@ public:
   }
   ///< size is destination size
   void sqrshrn(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3310,7 +3310,7 @@ public:
   }
   ///< size is destination size
   void sqrshrn2(ARMEmitter::SubRegSize size, ARMEmitter::QRegister rd, ARMEmitter::QRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3324,12 +3324,12 @@ public:
   }
   ///< size is destination size
   void sshll(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
     size = ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
 
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
-    LOGMAN_THROW_AA_FMT(Shift < SubregSizeInBits, "Shift must not be larger than incoming element size");
+    LOGMAN_THROW_A_FMT(Shift < SubregSizeInBits, "Shift must not be larger than incoming element size");
 
     // Shift encoded a bit weirdly.
     // shift = immh:immb - esize but immh is /also/ used for element size.
@@ -3342,12 +3342,12 @@ public:
 
   ///< size is destination size
   void sshll2(ARMEmitter::SubRegSize size, ARMEmitter::QRegister rd, ARMEmitter::QRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
     size = ARMEmitter::SubRegSize(FEXCore::ToUnderlying(size) - 1);
 
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
-    LOGMAN_THROW_AA_FMT(Shift < SubregSizeInBits, "Shift must not be larger than incoming element size");
+    LOGMAN_THROW_A_FMT(Shift < SubregSizeInBits, "Shift must not be larger than incoming element size");
 
     // Shift encoded a bit weirdly.
     // shift = immh:immb - esize but immh is /also/ used for element size.
@@ -3368,14 +3368,14 @@ public:
 
   template<typename T>
   void scvtf(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t FractionalBits) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
 
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
-    LOGMAN_THROW_AA_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
+    LOGMAN_THROW_A_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
 
     // fbits encoded a bit weirdly.
     // fbits = (esize * 2) - immh:immb but immh is /also/ used for element size.
@@ -3388,14 +3388,14 @@ public:
 
   template<typename T>
   void fcvtzs(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t FractionalBits) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
 
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
-    LOGMAN_THROW_AA_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
+    LOGMAN_THROW_A_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
 
     // fbits encoded a bit weirdly.
     // fbits = (esize * 2) - immh:immb but immh is /also/ used for element size.
@@ -3409,7 +3409,7 @@ public:
   template<typename T>
   void ushr(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3425,7 +3425,7 @@ public:
   template<typename T>
   void usra(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3441,7 +3441,7 @@ public:
   template<typename T>
   void urshr(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3457,7 +3457,7 @@ public:
   template<typename T>
   void ursra(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3473,7 +3473,7 @@ public:
   template<typename T>
   void sri(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3489,7 +3489,7 @@ public:
   template<typename T>
   void sli(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3505,7 +3505,7 @@ public:
   template<typename T>
   void sqshlu(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3522,7 +3522,7 @@ public:
   template<typename T>
   void uqshl(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t Shift) {
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
@@ -3537,7 +3537,7 @@ public:
   }
   ///< size is destination size
   void sqshrun(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3551,7 +3551,7 @@ public:
   }
   ///< size is destination size
   void sqshrun2(ARMEmitter::SubRegSize size, ARMEmitter::QRegister rd, ARMEmitter::QRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3565,7 +3565,7 @@ public:
   }
   ///< size is destination size
   void sqrshrun(ARMEmitter::SubRegSize size, ARMEmitter::DRegister rd, ARMEmitter::DRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3579,7 +3579,7 @@ public:
   }
   ///< size is destination size
   void sqrshrun2(ARMEmitter::SubRegSize size, ARMEmitter::QRegister rd, ARMEmitter::QRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
 
@@ -3680,14 +3680,14 @@ public:
   }
   template<typename T>
   void ucvtf(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t FractionalBits) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
 
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
-    LOGMAN_THROW_AA_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
+    LOGMAN_THROW_A_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
 
     // fbits encoded a bit weirdly.
     // fbits = (esize * 2) - immh:immb but immh is /also/ used for element size.
@@ -3700,14 +3700,14 @@ public:
 
   template<typename T>
   void fcvtzu(ARMEmitter::SubRegSize size, T rd, T rn, uint32_t FractionalBits) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i8Bit, "Invalid size");
     if constexpr (std::is_same_v<ARMEmitter::DRegister, T>) {
-      LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
+      LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i64Bit, "Invalid element size with 64-bit {}", __func__);
     }
 
     constexpr uint32_t Op = 0b0000'1111'0000'0000'0000'01 << 10;
     const size_t SubregSizeInBits = SubRegSizeInBits(size);
-    LOGMAN_THROW_AA_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
+    LOGMAN_THROW_A_FMT(FractionalBits < SubregSizeInBits, "FractionalBits must not be larger than incoming element size");
 
     // fbits encoded a bit weirdly.
     // fbits = (esize * 2) - immh:immb but immh is /also/ used for element size.
@@ -3721,7 +3721,7 @@ public:
   // Advanced SIMD vector x indexed element
   ///< size is destination size
   void smlal(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -3747,7 +3747,7 @@ public:
   }
   ///< size is destination size
   void smlal2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -3773,7 +3773,7 @@ public:
   }
   ///< size is destination size
   void sqdmlal(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -3799,7 +3799,7 @@ public:
   }
   ///< size is destination size
   void sqdmlal2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -3825,7 +3825,7 @@ public:
   }
   ///< size is destination size
   void smlsl(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -3851,7 +3851,7 @@ public:
   }
   ///< size is destination size
   void smlsl2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -3877,7 +3877,7 @@ public:
   }
   ///< size is destination size
   void sqdmlsl(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -3903,7 +3903,7 @@ public:
   }
   ///< size is destination size
   void sqdmlsl2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -3930,7 +3930,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void mul(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -3955,7 +3955,7 @@ public:
   }
   ///< size is destination size
   void smull(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -3981,7 +3981,7 @@ public:
   }
   ///< size is destination size
   void smull2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4007,7 +4007,7 @@ public:
   }
   ///< size is destination size
   void sqdmull(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4033,7 +4033,7 @@ public:
   }
   ///< size is destination size
   void sqdmull2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4060,7 +4060,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqdmulh(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4086,7 +4086,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqrdmulh(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4155,7 +4155,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmla(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit ||
                         size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
     LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
@@ -4190,7 +4190,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmls(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit ||
                         size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
     LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
@@ -4225,7 +4225,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void fmul(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit ||
                         size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
     LOGMAN_THROW_A_FMT(Index < SubRegSizeInBits(size), "Index must be less than the source register size");
@@ -4355,7 +4355,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void mla(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4381,7 +4381,7 @@ public:
 
   ///< size is destination size
   void umlal(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4407,7 +4407,7 @@ public:
   }
   ///< size is destination size
   void umlal2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4435,7 +4435,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void mls(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4461,7 +4461,7 @@ public:
 
   ///< size is destination size
   void umlsl(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4487,7 +4487,7 @@ public:
   }
   ///< size is destination size
   void umlsl2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4514,7 +4514,7 @@ public:
 
   ///< size is destination size
   void umull(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4540,7 +4540,7 @@ public:
   }
   ///< size is destination size
   void umull2(ARMEmitter::SubRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, ARMEmitter::VRegister rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i32Bit || size == ARMEmitter::SubRegSize::i64Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i32Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4568,7 +4568,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqrdmlah(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4608,7 +4608,7 @@ public:
   template<typename T>
   requires(std::is_same_v<ARMEmitter::QRegister, T> || std::is_same_v<ARMEmitter::DRegister, T>)
   void sqrdmlsh(ARMEmitter::SubRegSize size, T rd, T rn, T rm, uint32_t Index) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit || size == ARMEmitter::SubRegSize::i32Bit, "Invalid destination size");
 
     if (size == ARMEmitter::SubRegSize::i16Bit) {
       LOGMAN_THROW_A_FMT(rm.Idx() < 16, "Rm can't be v16-v31 with half source size");
@@ -4767,18 +4767,18 @@ public:
     ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b110, rd, ARMEmitter::ToReg(rn));
   }
   void fmov(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::Size::i64Bit, "Can't move SReg to 64-bit");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::Size::i64Bit, "Can't move SReg to 64-bit");
     constexpr uint32_t Op = 0b0001'1110'001 << 21;
     ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b110, rd, ARMEmitter::ToReg(rn));
   }
   void fmov(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::Size::i32Bit, "Can't move DReg to 32-bit");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::Size::i32Bit, "Can't move DReg to 32-bit");
     constexpr uint32_t Op = 0b0001'1110'001 << 21;
     ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b110, rd, ARMEmitter::ToReg(rn));
   }
   void fmov(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::VRegister rn, bool Upper) {
     if (Upper) {
-      LOGMAN_THROW_AA_FMT(size == ARMEmitter::Size::i64Bit, "Can only move upper with 64-bit elements");
+      LOGMAN_THROW_A_FMT(size == ARMEmitter::Size::i64Bit, "Can only move upper with 64-bit elements");
     }
     constexpr uint32_t Op = 0b0001'1110'001 << 21;
     ASIMDFloatConvBetweenInt(Op, size, 0, Upper ? 0b10 : 0b01, Upper ? 0b01 : 0b00, 0b110, rd, ARMEmitter::ToReg(rn));
@@ -4788,18 +4788,18 @@ public:
     ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b111, ARMEmitter::ToReg(rd), rn);
   }
   void fmov(ARMEmitter::Size size, ARMEmitter::SRegister rd, ARMEmitter::Register rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::Size::i64Bit, "Can't move SReg to 64-bit");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::Size::i64Bit, "Can't move SReg to 64-bit");
     constexpr uint32_t Op = 0b0001'1110'001 << 21;
     ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b111, ARMEmitter::ToReg(rd), rn);
   }
   void fmov(ARMEmitter::Size size, ARMEmitter::DRegister rd, ARMEmitter::Register rn) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::Size::i32Bit, "Can't move DReg to 32-bit");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::Size::i32Bit, "Can't move DReg to 32-bit");
     constexpr uint32_t Op = 0b0001'1110'001 << 21;
     ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b111, ARMEmitter::ToReg(rd), rn);
   }
   void fmov(ARMEmitter::Size size, ARMEmitter::VRegister rd, ARMEmitter::Register rn, bool Upper) {
     if (Upper) {
-      LOGMAN_THROW_AA_FMT(size == ARMEmitter::Size::i64Bit, "Can only move upper with 64-bit elements");
+      LOGMAN_THROW_A_FMT(size == ARMEmitter::Size::i64Bit, "Can only move upper with 64-bit elements");
     }
     constexpr uint32_t Op = 0b0001'1110'001 << 21;
     ASIMDFloatConvBetweenInt(Op, size, 0, Upper ? 0b10 : 0b01, Upper ? 0b01 : 0b00, 0b111, ARMEmitter::ToReg(rd), rn);

--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -307,7 +307,7 @@ public:
     const uint32_t SizeImm = FEXCore::ToUnderlying(size);
     const uint32_t IndexShift = SizeImm + 1;
     const uint32_t ElementSize = 1U << SizeImm;
-    const uint32_t MaxIndex = 128U / (ElementSize * 8);
+    [[maybe_unused]] const uint32_t MaxIndex = 128U / (ElementSize * 8);
 
     LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
@@ -397,7 +397,7 @@ public:
     constexpr uint32_t SizeImm = FEXCore::ToUnderlying(size);
     constexpr uint32_t IndexShift = SizeImm + 1;
     constexpr uint32_t ElementSize = 1U << SizeImm;
-    constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
+    [[maybe_unused]] constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
 
     LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
@@ -416,7 +416,7 @@ public:
     constexpr uint32_t SizeImm = FEXCore::ToUnderlying(size);
     constexpr uint32_t IndexShift = SizeImm + 1;
     constexpr uint32_t ElementSize = 1U << SizeImm;
-    constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
+    [[maybe_unused]] constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
 
     LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
@@ -439,7 +439,7 @@ public:
     constexpr uint32_t SizeImm = FEXCore::ToUnderlying(size);
     constexpr uint32_t IndexShift = SizeImm + 1;
     constexpr uint32_t ElementSize = 1U << SizeImm;
-    constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
+    [[maybe_unused]] constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
 
     LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
@@ -455,7 +455,7 @@ public:
     constexpr uint32_t SizeImm = FEXCore::ToUnderlying(size);
     constexpr uint32_t IndexShift = SizeImm + 1;
     constexpr uint32_t ElementSize = 1U << SizeImm;
-    constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
+    [[maybe_unused]] constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
 
     LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
@@ -470,7 +470,7 @@ public:
     const uint32_t SizeImm = FEXCore::ToUnderlying(size);
     const uint32_t IndexShift = SizeImm + 1;
     const uint32_t ElementSize = 1U << SizeImm;
-    const uint32_t MaxIndex = 128U / (ElementSize * 8);
+    [[maybe_unused]] const uint32_t MaxIndex = 128U / (ElementSize * 8);
 
     LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
@@ -481,11 +481,11 @@ public:
 
   void ins(SubRegSize size, VRegister rd, uint32_t Index, VRegister rn, uint32_t Index2) {
     constexpr uint32_t Op = 0b0110'1110'0000'0000'0000'01 << 10;
-    
+
     const uint32_t SizeImm = FEXCore::ToUnderlying(size);
     const uint32_t IndexShift = SizeImm + 1;
     const uint32_t ElementSize = 1U << SizeImm;
-    const uint32_t MaxIndex = 128U / (ElementSize * 8);
+    [[maybe_unused]] const uint32_t MaxIndex = 128U / (ElementSize * 8);
 
     LOGMAN_THROW_A_FMT(Index < MaxIndex,  "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
     LOGMAN_THROW_A_FMT(Index2 < MaxIndex, "Index2 too large. Index2={}, Max Index: {}", Index2, MaxIndex);

--- a/CodeEmitter/CodeEmitter/Emitter.h
+++ b/CodeEmitter/CodeEmitter/Emitter.h
@@ -631,7 +631,7 @@ public:
   // Bind a backward label to an address.
   // Address that is bound is the current emitter location.
   void Bind(BackwardLabel* Label) {
-    LOGMAN_THROW_AA_FMT(Label->Location == nullptr, "Trying to bind a label twice");
+    LOGMAN_THROW_A_FMT(Label->Location == nullptr, "Trying to bind a label twice");
     Label->Location = GetCursorAddress<uint8_t*>();
   }
 

--- a/CodeEmitter/CodeEmitter/LoadstoreOps.inl
+++ b/CodeEmitter/CodeEmitter/LoadstoreOps.inl
@@ -805,7 +805,7 @@ public:
   // Advanced SIMD load/store single structure (post-indexed)
   template<typename T>
   void st1(ARMEmitter::SubRegSize size, T rt, uint32_t Index, ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
     uint32_t R = 0;
@@ -813,28 +813,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
@@ -849,7 +849,7 @@ public:
   }
   template<typename T>
   void ld1(ARMEmitter::SubRegSize size, T rt, uint32_t Index, ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
     uint32_t R = 0;
@@ -857,28 +857,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
@@ -893,7 +893,7 @@ public:
   }
   template<typename T>
   void ld1r(ARMEmitter::SubRegSize size, T rt, ARMEmitter::Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_AA_FMT(PostOffset == 1 || PostOffset == 2 || PostOffset == 4 || PostOffset == 8, "Index too large");
+    LOGMAN_THROW_A_FMT(PostOffset == 1 || PostOffset == 2 || PostOffset == 4 || PostOffset == 8, "Index too large");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     constexpr uint32_t Q = std::is_same_v<ARMEmitter::QRegister, T> ? 1 : 0;
     uint32_t R = 0;
@@ -906,7 +906,7 @@ public:
   template<typename T>
   void ld2r(SubRegSize size, T rt, T rt2, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
-    LOGMAN_THROW_AA_FMT(PostOffset == 2 || PostOffset == 4 || PostOffset == 8 || PostOffset == 16, "Index too large");
+    LOGMAN_THROW_A_FMT(PostOffset == 2 || PostOffset == 4 || PostOffset == 8 || PostOffset == 16, "Index too large");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
     uint32_t R = 1;
@@ -919,7 +919,7 @@ public:
   template<typename T>
   void ld3r(SubRegSize size, T rt, T rt2, T rt3, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
-    LOGMAN_THROW_AA_FMT(PostOffset == 3 || PostOffset == 6 || PostOffset == 12 || PostOffset == 24, "Index too large");
+    LOGMAN_THROW_A_FMT(PostOffset == 3 || PostOffset == 6 || PostOffset == 12 || PostOffset == 24, "Index too large");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
     uint32_t R = 0;
@@ -931,7 +931,7 @@ public:
   template<typename T>
   void ld4r(SubRegSize size, T rt, T rt2, T rt3, T rt4, Register rn, uint32_t PostOffset) {
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
-    LOGMAN_THROW_AA_FMT(PostOffset == 4 || PostOffset == 8 || PostOffset == 16 || PostOffset == 32, "Index too large");
+    LOGMAN_THROW_A_FMT(PostOffset == 4 || PostOffset == 8 || PostOffset == 16 || PostOffset == 32, "Index too large");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
     uint32_t R = 1;
@@ -943,7 +943,7 @@ public:
 
   template<typename T>
   void st2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -953,28 +953,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
@@ -989,7 +989,7 @@ public:
   }
   template<typename T>
   void ld2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -999,28 +999,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
@@ -1035,7 +1035,7 @@ public:
   }
   template<typename T>
   void st3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1045,28 +1045,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
@@ -1081,7 +1081,7 @@ public:
   }
   template<typename T>
   void ld3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1091,28 +1091,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
@@ -1127,7 +1127,7 @@ public:
   }
   template<typename T>
   void st4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1137,28 +1137,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
@@ -1173,7 +1173,7 @@ public:
   }
   template<typename T>
   void ld4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, uint32_t PostOffset) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1183,28 +1183,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
@@ -1220,7 +1220,7 @@ public:
 
   template<typename T>
   void st1(ARMEmitter::SubRegSize size, T rt, uint32_t Index, ARMEmitter::Register rn, ARMEmitter::Register rm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
     uint32_t R = 0;
@@ -1228,28 +1228,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
@@ -1264,7 +1264,7 @@ public:
   }
   template<typename T>
   void ld1(ARMEmitter::SubRegSize size, T rt, uint32_t Index, ARMEmitter::Register rn, ARMEmitter::Register rm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
     uint32_t Q;
     uint32_t R = 0;
@@ -1272,28 +1272,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
@@ -1354,7 +1354,7 @@ public:
 
   template<typename T>
   void st2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1364,28 +1364,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
@@ -1400,7 +1400,7 @@ public:
   }
   template<typename T>
   void ld2(SubRegSize size, T rt, T rt2, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2), "rt and rt2 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1410,28 +1410,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b000;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b010;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b100;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b100;
@@ -1446,7 +1446,7 @@ public:
   }
   template<typename T>
   void st3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1456,28 +1456,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
@@ -1492,7 +1492,7 @@ public:
   }
   template<typename T>
   void ld3(SubRegSize size, T rt, T rt2, T rt3, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3), "rt, rt2, and rt3 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1502,28 +1502,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
@@ -1538,7 +1538,7 @@ public:
   }
   template<typename T>
   void st4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1548,28 +1548,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
@@ -1584,7 +1584,7 @@ public:
   }
   template<typename T>
   void ld4(SubRegSize size, T rt, T rt2, T rt3, T rt4, uint32_t Index, Register rn, Register rm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "Incorrect size");
     LOGMAN_THROW_A_FMT(AreVectorsSequential(rt, rt2, rt3, rt4), "rt, rt2, rt3, and rt4 must be sequential");
 
     constexpr uint32_t Op = 0b0000'1101'1 << 23;
@@ -1594,28 +1594,28 @@ public:
     uint32_t S;
     uint32_t Size;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 16, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 16, "Index too large");
       Q = Index >> 3;
       S = (Index >> 2) & 1;
       opcode = 0b001;
       Size = Index & 0b11;
     }
     else if (size == SubRegSize::i16Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 8, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 8, "Index too large");
       Q = Index >> 2;
       S = (Index >> 1) & 1;
       opcode = 0b011;
       Size = (Index & 0b1) << 1;
     }
     else if (size == SubRegSize::i32Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 4, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 4, "Index too large");
       Q = Index >> 1;
       S = Index & 1;
       opcode = 0b101;
       Size = 0b00;
     }
     else if (size == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(Index < 2, "Index too large");
+      LOGMAN_THROW_A_FMT(Index < 2, "Index too large");
       Q = Index;
       S = 0;
       opcode = 0b101;
@@ -3779,7 +3779,7 @@ public:
   void strb(ARMEmitter::VRegister rt, ARMEmitter::ExtendedMemOperand MemSrc) {
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
-      LOGMAN_THROW_AA_FMT(MemSrc.MetaType.ExtendedType.Shift == false, "Can't shift byte");
+      LOGMAN_THROW_A_FMT(MemSrc.MetaType.ExtendedType.Shift == false, "Can't shift byte");
       strb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option);
     }
     else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
@@ -3809,7 +3809,7 @@ public:
   void ldrb(ARMEmitter::VRegister rt, ARMEmitter::ExtendedMemOperand MemSrc) {
     if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED &&
         MemSrc.MetaType.ExtendedType.rm.Idx() != ARMEmitter::Reg::r31.Idx()) {
-      LOGMAN_THROW_AA_FMT(MemSrc.MetaType.ExtendedType.Shift == false, "Can't shift byte");
+      LOGMAN_THROW_A_FMT(MemSrc.MetaType.ExtendedType.Shift == false, "Can't shift byte");
       ldrb(rt, MemSrc.rn, MemSrc.MetaType.ExtendedType.rm, MemSrc.MetaType.ExtendedType.Option);
     }
     else if (MemSrc.MetaType.Header.MemType == ARMEmitter::ExtendedMemOperand::Type::TYPE_EXTENDED) {
@@ -4139,11 +4139,11 @@ public:
   }
 
   void ldr(SubRegSize size, Register rt, Register rn, uint32_t Imm = 0) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
     LoadStoreUnsigned(FEXCore::ToUnderlying(size), 0, 0b01, rt, rn, Imm);
   }
   void str(SubRegSize size, Register rt, Register rn, uint32_t Imm = 0) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
     LoadStoreUnsigned(FEXCore::ToUnderlying(size), 0, 0b00, rt, rn, Imm);
   }
 

--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -31,7 +31,7 @@ public:
   }
 
   void histcnt(SubRegSize size, ZRegister zd, PRegisterZero pv, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 32-bit or 64-bit");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit, "SubRegSize must be 32-bit or 64-bit");
     LOGMAN_THROW_A_FMT(pv <= PReg::p7.Zeroing(), "histcnt can only use p0 to p7");
 
     uint32_t Op = 0b0100'0101'0010'0000'1100'0000'0000'0000;
@@ -52,7 +52,7 @@ public:
   }
 
   void fcmla(SubRegSize size, ZRegister zda, PRegisterMerge pv, ZRegister zn, ZRegister zm, Rotation rot) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "SubRegSize must be 16-bit, 32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT(pv <= PReg::p7.Merging(), "fcmla can only use p0 to p7");
 
@@ -68,10 +68,10 @@ public:
   }
 
   void fcadd(SubRegSize size, ZRegister zd, PRegisterMerge pv, ZRegister zn, ZRegister zm, Rotation rot) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "SubRegSize must be 16-bit, 32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT(pv <= PReg::p7.Merging(), "fcadd can only use p0 to p7");
-    LOGMAN_THROW_AA_FMT(rot == Rotation::ROTATE_90 || rot == Rotation::ROTATE_270,
+    LOGMAN_THROW_A_FMT(rot == Rotation::ROTATE_90 || rot == Rotation::ROTATE_270,
                         "fcadd rotation may only be 90 or 270 degrees");
     LOGMAN_THROW_A_FMT(zd == zn, "fcadd zd and zn must be the same register");
 
@@ -268,7 +268,7 @@ public:
   }
   ///< Size is destination size
   void fcvtnt(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i16Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i16Bit,
                         "Unsupported size in {}", __func__);
 
     const auto ConvertedDestSize =
@@ -284,7 +284,7 @@ public:
 
   ///< Size is destination size
   void fcvtlt(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i64Bit || size == SubRegSize::i32Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i64Bit || size == SubRegSize::i32Bit,
                         "Unsupported size in {}", __func__);
 
     const auto ConvertedDestSize =
@@ -327,7 +327,7 @@ public:
 
   // SVE floating-point complex multiply-add (indexed)
   void fcmla(SubRegSize size, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index, Rotation rot) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit,
                         "SubRegSize must be 16-bit or 32-bit");
 
     // 16 -> 32, 32 -> 64, since fcmla (indexed)'s restrictions and encodings
@@ -665,11 +665,11 @@ public:
     SVEIntegerUnaryPredicated(0b11, 0b011, size, pg, zn, zd);
   }
   void fabs(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "Invalid size");
     SVEIntegerUnaryPredicated(0b11, 0b100, size, pg, zn, zd);
   }
   void fneg(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "Invalid size");
     SVEIntegerUnaryPredicated(0b11, 0b101, size, pg, zn, zd);
   }
   void not_(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
@@ -818,13 +818,13 @@ public:
   // SVE Integer Misc - Unpredicated
   // SVE floating-point trig select coefficient
   void ftssel(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "ftssel may only have 16-bit, 32-bit, or 64-bit element sizes");
     SVEIntegerMiscUnpredicated(0b00, zm.Idx(), FEXCore::ToUnderlying(size), zd, zn);
   }
   // SVE floating-point exponential accelerator
   void fexpa(SubRegSize size, ZRegister zd, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "fexpa may only have 16-bit, 32-bit, or 64-bit element sizes");
     SVEIntegerMiscUnpredicated(0b10, 0b00000, FEXCore::ToUnderlying(size), zd, zn);
   }
@@ -1135,7 +1135,7 @@ public:
   }
 
   void compact(SubRegSize size, ZRegister zd, PRegister pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i64Bit || size == SubRegSize::i32Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i64Bit || size == SubRegSize::i32Bit,
                         "Invalid element size");
     SVEPermuteVectorPredicated(0b00001, 0b0, size, zd, pg, zn);
   }
@@ -1178,16 +1178,16 @@ public:
 
   // SVE reverse within elements
   void revb(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "Can't use 8-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "Can't use 8-bit element size");
     SVEPermuteVectorPredicated(0b00100, 0b0, size, zd, pg, zn);
   }
   void revh(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit,
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i16Bit,
                         "Can't use 8/16-bit element sizes");
     SVEPermuteVectorPredicated(0b00101, 0b0, size, zd, pg, zn);
   }
   void revw(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i64Bit, "Can't use 8/16/32-bit element sizes");
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i64Bit, "Can't use 8/16/32-bit element sizes");
     SVEPermuteVectorPredicated(0b00110, 0b0, size, zd, pg, zn);
   }
   void rbit(SubRegSize size, ZRegister zd, PRegisterMerge pg, ZRegister zn) {
@@ -1507,7 +1507,7 @@ public:
 
   // SVE broadcast floating-point immediate (unpredicated)
   void fdup(ARMEmitter::SubRegSize size, ARMEmitter::ZRegister zd, float Value) {
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::SubRegSize::i16Bit ||
                         size == ARMEmitter::SubRegSize::i32Bit ||
                         size == ARMEmitter::SubRegSize::i64Bit, "Unsupported fmov size");
     uint32_t Imm{};
@@ -2206,7 +2206,7 @@ public:
 
   // SVE Floating Point Arithmetic - Predicated
   void ftmad(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm, uint32_t imm) {
-    LOGMAN_THROW_AA_FMT(imm <= 7, "ftmad immediate must be within 0-7");
+    LOGMAN_THROW_A_FMT(imm <= 7, "ftmad immediate must be within 0-7");
     SVEFloatArithmeticPredicated(0b10000 | imm, size, PReg::p0, zd, zn, zm);
   }
   // SVE floating-point arithmetic (predicated)
@@ -2326,7 +2326,7 @@ public:
     uint32_t opc1, opc2;
     if (srcsize == SubRegSize::i16Bit) {
       // Srcsize = fp16, opc2 encodes dst size
-      LOGMAN_THROW_AA_FMT(dstsize == SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      LOGMAN_THROW_A_FMT(dstsize == SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       opc1 = 0b01;
       opc2 = 0b01;
     }
@@ -2362,7 +2362,7 @@ public:
     uint32_t opc1, opc2;
     if (srcsize == SubRegSize::i16Bit) {
       // Srcsize = fp16, opc2 encodes dst size
-      LOGMAN_THROW_AA_FMT(dstsize == SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      LOGMAN_THROW_A_FMT(dstsize == SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       opc1 = 0b01;
       opc2 = 0b01;
     }
@@ -2415,13 +2415,13 @@ public:
     }
     else if (srcsize == SubRegSize::i32Bit) {
       // Srcsize = fp32, opc1 encodes dst size
-      LOGMAN_THROW_AA_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      LOGMAN_THROW_A_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       opc2 = 0b10;
       opc1 = dstsize == SubRegSize::i64Bit ? 0b11 :
              dstsize == SubRegSize::i32Bit ? 0b10 : 0b00;
     }
     else if (srcsize == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      LOGMAN_THROW_A_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       // SrcSize = fp64, opc2 encodes dst size
       opc1 = 0b11;
       opc2 = dstsize == SubRegSize::i64Bit ? 0b11 :
@@ -2443,13 +2443,13 @@ public:
     }
     else if (srcsize == SubRegSize::i32Bit) {
       // Srcsize = fp32, opc1 encodes dst size
-      LOGMAN_THROW_AA_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      LOGMAN_THROW_A_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       opc2 = 0b10;
       opc1 = dstsize == SubRegSize::i64Bit ? 0b11 :
              dstsize == SubRegSize::i32Bit ? 0b10 : 0b00;
     }
     else if (srcsize == SubRegSize::i64Bit) {
-      LOGMAN_THROW_AA_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
+      LOGMAN_THROW_A_FMT(dstsize != SubRegSize::i16Bit, "Unsupported size in {}", __func__);
       // SrcSize = fp64, opc2 encodes dst size
       opc1 = 0b11;
       opc2 = dstsize == SubRegSize::i64Bit ? 0b11 :
@@ -3430,7 +3430,7 @@ private:
 
     // We can index up to 512-bit registers with dup
     [[maybe_unused]] const auto max_index = (64U >> log2_size_bytes) - 1;
-    LOGMAN_THROW_AA_FMT(Index <= max_index, "dup index ({}) too large. Must be within [0, {}].",
+    LOGMAN_THROW_A_FMT(Index <= max_index, "dup index ({}) too large. Must be within [0, {}].",
                         Index, max_index);
 
     // imm2:tsz make up a 7 bit wide field, with each increasing element size
@@ -3450,20 +3450,20 @@ private:
   }
 
   void SVEAddSubImmediateUnpred(uint32_t opc, SubRegSize size, ZRegister zd, ZRegister zn, uint32_t imm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
     LOGMAN_THROW_A_FMT(zd == zn, "zd needs to equal zn");
 
     const bool is_uint8_imm = (imm >> 8) == 0;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(is_uint8_imm, "Can't perform LSL #8 shift on 8-bit elements.");
+      LOGMAN_THROW_A_FMT(is_uint8_imm, "Can't perform LSL #8 shift on 8-bit elements.");
     }
 
     uint32_t shift = 0;
     if (!is_uint8_imm) {
       const bool is_uint16_imm = (imm >> 16) == 0;
 
-      LOGMAN_THROW_AA_FMT(is_uint16_imm, "Immediate ({}) must be a 16-bit value within [256, 65280]", imm);
-      LOGMAN_THROW_AA_FMT((imm % 256) == 0, "Immediate ({}) must be a multiple of 256", imm);
+      LOGMAN_THROW_A_FMT(is_uint16_imm, "Immediate ({}) must be a 16-bit value within [256, 65280]", imm);
+      LOGMAN_THROW_A_FMT((imm % 256) == 0, "Immediate ({}) must be a multiple of 256", imm);
 
       imm /= 256;
       shift = 1;
@@ -3479,15 +3479,15 @@ private:
   }
 
   void SVEMinMaxImmediateUnpred(uint32_t opc, SubRegSize size, ZRegister zd, ZRegister zn, int32_t imm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
     LOGMAN_THROW_A_FMT(zd == zn, "zd needs to equal zn");
 
     const bool is_signed = (opc & 1) == 0;
     if (is_signed) {
-      LOGMAN_THROW_AA_FMT(imm >= -128 && imm <= 127,
+      LOGMAN_THROW_A_FMT(imm >= -128 && imm <= 127,
                           "Invalid immediate ({}). Must be within [-127, 128]", imm);
     } else {
-      LOGMAN_THROW_AA_FMT(imm >= 0 && imm <= 255,
+      LOGMAN_THROW_A_FMT(imm >= 0 && imm <= 255,
                           "Invalid immediate ({}). Must be within [0, 255]", imm);
     }
 
@@ -3502,9 +3502,9 @@ private:
   }
 
   void SVEMultiplyImmediateUnpred(uint32_t opc, SubRegSize size, ZRegister zd, ZRegister zn, int32_t imm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
     LOGMAN_THROW_A_FMT(zd == zn, "zd needs to equal zn");
-    LOGMAN_THROW_AA_FMT(imm >= -128 && imm <= 127,
+    LOGMAN_THROW_A_FMT(imm >= -128 && imm <= 127,
                         "Invalid immediate ({}). Must be within [-127, 128]", imm);
 
     const auto imm8 = static_cast<uint32_t>(imm) & 0xFF;
@@ -3518,7 +3518,7 @@ private:
   }
 
   void SVEBroadcastImm(uint32_t opc, int32_t imm, SubRegSize size, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
 
     const auto [new_imm, is_shift] = HandleSVESImm8Shift(size, imm);
 
@@ -3532,7 +3532,7 @@ private:
   }
 
   void SVEBroadcastFloatImmPredicated(SubRegSize size, ZRegister zd, PRegister pg, float value) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit ||
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit ||
                         size == SubRegSize::i32Bit ||
                         size == SubRegSize::i64Bit, "Unsupported fcpy/fmov size");
     uint32_t imm{};
@@ -3564,7 +3564,7 @@ private:
   }
 
   void SVEBroadcastIntegerImmPredicated(uint32_t m, SubRegSize size, ZRegister zd, PRegister pg, int32_t imm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
 
     const auto [new_imm, is_shift] = HandleSVESImm8Shift(size, imm);
 
@@ -3579,14 +3579,14 @@ private:
   }
 
   void SVEAddressGeneration(SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm, SVEModType mod, uint32_t scale) {
-    LOGMAN_THROW_AA_FMT(scale <= 3, "Scale ({}) must be within [0, 3]", scale);
+    LOGMAN_THROW_A_FMT(scale <= 3, "Scale ({}) must be within [0, 3]", scale);
 
     uint32_t Instr = 0b0000'0100'0010'0000'1010'0000'0000'0000;
 
     switch (mod) {
     case SVEModType::MOD_UXTW:
     case SVEModType::MOD_SXTW: {
-      LOGMAN_THROW_AA_FMT(size == SubRegSize::i64Bit, "Unpacked ADR must be using 64-bit elements");
+      LOGMAN_THROW_A_FMT(size == SubRegSize::i64Bit, "Unpacked ADR must be using 64-bit elements");
 
       const auto is_unsigned = mod == SVEModType::MOD_UXTW;
       if (is_unsigned) {
@@ -3597,10 +3597,10 @@ private:
     case SVEModType::MOD_NONE:
     case SVEModType::MOD_LSL: {
       if (mod == SVEModType::MOD_NONE) {
-        LOGMAN_THROW_AA_FMT(scale == 0,
+        LOGMAN_THROW_A_FMT(scale == 0,
                             "Cannot scale packed ADR without a modifier");
       }
-      LOGMAN_THROW_AA_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+      LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                           "Packed ADR must be using 32-bit or 64-bit elements");
       Instr |= FEXCore::ToUnderlying(size) << 22;
       break;
@@ -3615,7 +3615,7 @@ private:
   }
 
   void SVESel(SubRegSize size, ZRegister zm, PRegister pv, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
 
     uint32_t Instr = 0b0000'0101'0010'0000'1100'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -3627,7 +3627,7 @@ private:
   }
 
   void SVEBitwiseShiftbyVector(uint32_t R, uint32_t L, uint32_t U, SubRegSize size, PRegister pg, ZRegister zd, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
     LOGMAN_THROW_A_FMT(zd == zn, "Dest needs to equal zn");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
@@ -3645,7 +3645,7 @@ private:
 
   // SVE integer add/subtract vectors (unpredicated)
   void SVEIntegerAddSubUnpredicated(uint32_t opc, SubRegSize size, ZRegister zm, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
 
     uint32_t Instr = 0b0000'0100'0010'0000'0000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -3658,7 +3658,7 @@ private:
 
   // SVE table lookup (three sources)
   void SVETableLookup(uint32_t op, SubRegSize size, ZRegister zm, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
 
     uint32_t Instr = 0b0000'0101'0010'0000'0010'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -3671,7 +3671,7 @@ private:
 
   // SVE permute vector elements
   void SVEPermute(uint32_t opc, SubRegSize size, ZRegister zm, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
 
     uint32_t Instr = 0b0000'0101'0010'0000'0110'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -3728,7 +3728,7 @@ private:
 
   // SVE floating-point arithmetic (unpredicated)
   void SVEFloatArithmeticUnpredicated(uint32_t opc, SubRegSize size, ZRegister zm, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "Invalid float size");
 
     uint32_t Instr = 0b0110'0101'0000'0000'0000'0000'0000'0000;
@@ -3742,7 +3742,7 @@ private:
 
   // SVE bitwise logical operations (predicated)
   void SVEBitwiseLogicalPredicated(uint32_t opc, SubRegSize size, PRegister pg, ZRegister zdn, ZRegister zm, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::SubRegSize::i128Bit, "Can't use 128-bit size");
     LOGMAN_THROW_A_FMT(zd == zdn, "zd needs to equal zdn");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
@@ -3757,7 +3757,7 @@ private:
 
   // SVE constructive prefix (predicated)
   void SVEConstructivePrefixPredicated(uint32_t opc, uint32_t M, SubRegSize size, PRegister pg, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0000'0100'0001'0000'0010'0000'0000'0000;
@@ -3772,7 +3772,7 @@ private:
 
   // SVE bitwise unary operations (predicated)
   void SVEIntegerUnaryPredicated(uint32_t op0, uint32_t opc, SubRegSize size, PRegister pg, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0000'0100'0000'0000'1010'0000'0000'0000;
@@ -3851,7 +3851,7 @@ private:
   }
 
   void SVECharacterMatch(uint32_t opc, SubRegSize size, PRegister pd, PRegisterZero pg, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit,
                         "match/nmatch can only use 8-bit or 16-bit element sizes");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7.Zeroing(), "match/nmatch can only use p0-p7 as a governing predicate");
 
@@ -3866,7 +3866,7 @@ private:
   }
 
   void SVEFPRecursiveReduction(uint32_t opc, SubRegSize size, VRegister vd, PRegister pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "FP reduction operation can only use 16-bit, 32-bit, or 64-bit element sizes");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "FP reduction operation can only use p0-p7 as a governing predicate");
 
@@ -3898,7 +3898,7 @@ private:
 
     // Division instruction
     if (b18 != 0) {
-      LOGMAN_THROW_AA_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+      LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                           "Predicated divide only handles 32-bit or 64-bit elements");
     }
 
@@ -3913,7 +3913,7 @@ private:
   }
 
   void SVEIntegerReductionOperation(uint32_t op, uint32_t opc, SubRegSize size, VRegister vd, PRegister pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size for reduction operation");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size for reduction operation");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Integer reduction operation can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = op;
@@ -3926,7 +3926,7 @@ private:
   }
 
   void SVEIntegerMultiplyAddSubPredicated(uint32_t op0, uint32_t opc, SubRegSize size, ZRegister zd, PRegister pg, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0000'0100'0000'0000'0100'0000'0000'0000;
@@ -3941,7 +3941,7 @@ private:
   }
 
   void SVEStackFrameOperation(uint32_t opc, XRegister rd, XRegister rn, int32_t imm) {
-    LOGMAN_THROW_AA_FMT(imm >= -32 && imm <= 31,
+    LOGMAN_THROW_A_FMT(imm >= -32 && imm <= 31,
                         "Stack frame operation immediate must be within -32 to 31");
 
     uint32_t Instr = 0b0000'0100'0010'0000'0101'0000'0000'0000;
@@ -4241,7 +4241,7 @@ private:
     // 0b111 - I - Current
 
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "Unsupported size in {}", __func__);
 
     uint32_t Instr = 0b0110'0101'0000'0000'1010'0000'0000'0000;
@@ -4256,9 +4256,9 @@ private:
   // SVE floating-point convert to integer
   void SVEFloatConvertToInt(SubRegSize dstsize, SubRegSize srcsize, uint32_t b19, uint32_t opc, uint32_t opc2, uint32_t U, PRegister pg, ZRegister zn, ZRegister zd) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_AA_FMT(srcsize == SubRegSize::i16Bit || srcsize == SubRegSize::i32Bit || srcsize == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(srcsize == SubRegSize::i16Bit || srcsize == SubRegSize::i32Bit || srcsize == SubRegSize::i64Bit,
                         "Unsupported src size in {}", __func__);
-    LOGMAN_THROW_AA_FMT(dstsize == SubRegSize::i16Bit || dstsize == SubRegSize::i32Bit || dstsize == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(dstsize == SubRegSize::i16Bit || dstsize == SubRegSize::i32Bit || dstsize == SubRegSize::i64Bit,
                         "Unsupported dst size in {}", __func__);
 
     uint32_t Instr = 0b0110'0101'0001'0000'1010'0000'0000'0000;
@@ -4457,7 +4457,7 @@ private:
   }
 
   void SVEUnsizedLoadStoreContiguous(uint32_t op2, int32_t imm, ZRegister zt, Register rn, bool is_store) {
-    LOGMAN_THROW_AA_FMT(imm >= -256 && imm <= 255,
+    LOGMAN_THROW_A_FMT(imm >= -256 && imm <= 255,
                         "Immediate offset ({}) too large. Must be within [-256, 255].", imm);
 
     const auto imm9 = static_cast<uint32_t>(imm) & 0b1'1111'1111;
@@ -4480,11 +4480,11 @@ private:
   // SVE load/store multiple structures (scalar plus immediate)
   void SVEContiguousMultipleStructures(int32_t num_regs, bool is_store, uint32_t msz, int32_t imm, ZRegister zt, PRegister pg, Register rn) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_AA_FMT((imm % num_regs) == 0, "Offset must be a multiple of {}", num_regs);
+    LOGMAN_THROW_A_FMT((imm % num_regs) == 0, "Offset must be a multiple of {}", num_regs);
 
     [[maybe_unused]] const auto min_offset = -8 * num_regs;
     [[maybe_unused]] const auto max_offset = 7 * num_regs;
-    LOGMAN_THROW_AA_FMT(imm >= min_offset && imm <= max_offset,
+    LOGMAN_THROW_A_FMT(imm >= min_offset && imm <= max_offset,
                         "Invalid load/store offset ({}). Offset must be a multiple of {} and be within [{}, {}]",
                         imm, num_regs, min_offset, max_offset);
 
@@ -4507,7 +4507,7 @@ private:
   // SVE contiguous non-temporal load (scalar plus immediate)
   void SVEContiguousNontemporalLoad(uint32_t msz, ZRegister zt, PRegister pg, Register rn, int32_t imm) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_AA_FMT(imm >= -8 && imm <= 7,
+    LOGMAN_THROW_A_FMT(imm >= -8 && imm <= 7,
                         "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
 
     const auto imm4 = static_cast<uint32_t>(imm) & 0xF;
@@ -4523,7 +4523,7 @@ private:
   // SVE contiguous non-temporal store (scalar plus immediate)
   void SVEContiguousNontemporalStore(uint32_t msz, ZRegister zt, PRegister pg, Register rn, int32_t imm) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_AA_FMT(imm >= -8 && imm <= 7,
+    LOGMAN_THROW_A_FMT(imm >= -8 && imm <= 7,
                         "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
 
     const auto imm4 = static_cast<uint32_t>(imm) & 0xF;
@@ -4538,7 +4538,7 @@ private:
 
   void SVEContiguousLoadImm(bool is_store, uint32_t dtype, int32_t imm, PRegister pg, Register rn, ZRegister zt) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_AA_FMT(imm >= -8 && imm <= 7,
+    LOGMAN_THROW_A_FMT(imm >= -8 && imm <= 7,
                         "Invalid loadstore offset ({}). Must be between [-8, 7]", imm);
 
     const auto imm4 = static_cast<uint32_t>(imm) & 0xF;
@@ -4598,8 +4598,8 @@ private:
     [[maybe_unused]] const auto max_imm = (esize << 3) - esize;
     [[maybe_unused]] const auto min_imm = -(max_imm + esize);
 
-    LOGMAN_THROW_AA_FMT((imm % esize) == 0, "imm ({}) must be a multiple of {}", imm, esize);
-    LOGMAN_THROW_AA_FMT(imm >= min_imm && imm <= max_imm, "imm ({}) must be within [{}, {}]",
+    LOGMAN_THROW_A_FMT((imm % esize) == 0, "imm ({}) must be a multiple of {}", imm, esize);
+    LOGMAN_THROW_A_FMT(imm >= min_imm && imm <= max_imm, "imm ({}) must be within [{}, {}]",
                         imm, min_imm, max_imm);
 
     const auto sanitized_imm = static_cast<uint32_t>(imm / esize) & 0b1111;
@@ -4631,12 +4631,12 @@ private:
 
   void SVELoadAndBroadcastElement(bool is_signed, SubRegSize esize, SubRegSize msize,
                                   ZRegister zt, PRegister pg, Register rn, uint32_t imm) {
-    LOGMAN_THROW_AA_FMT(esize != SubRegSize::i128Bit, "Cannot use 128-bit elements.");
+    LOGMAN_THROW_A_FMT(esize != SubRegSize::i128Bit, "Cannot use 128-bit elements.");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
     if (is_signed) {
       // The element size needs to be larger than memory size, otherwise you tell
       // me how we're gonna sign extend this bad boy in memory.
-      LOGMAN_THROW_AA_FMT(esize > msize,
+      LOGMAN_THROW_A_FMT(esize > msize,
                           "Signed broadcast element size must be greater than memory size.");
     }
 
@@ -4645,7 +4645,7 @@ private:
 
     const auto data_size_bytes = 1U << msize_value;
     [[maybe_unused]] const auto max_imm = (64U << msize_value) - data_size_bytes;
-    LOGMAN_THROW_AA_FMT((imm % data_size_bytes) == 0 && imm <= max_imm,
+    LOGMAN_THROW_A_FMT((imm % data_size_bytes) == 0 && imm <= max_imm,
                         "imm must be a multiple of {} and be within [0, {}]",
                         data_size_bytes, max_imm);
 
@@ -4663,7 +4663,7 @@ private:
     // Guards against bogus combinations of element size and memory size values
     // being passed in. Unsigned variants will always have dtypeh be less than
     // or equal to dtypel. The only time this isn't the case is with signed variants. 
-    LOGMAN_THROW_AA_FMT(is_signed == (dtypeh > dtypel),
+    LOGMAN_THROW_A_FMT(is_signed == (dtypeh > dtypel),
                         "Invalid element size used with load broadcast instruction "
                         "(esize: {}, msize: {})", esize_value, msize_value);
 
@@ -4690,8 +4690,8 @@ private:
   }
 
   void SVEIntegerCompareImm(uint32_t lt, uint32_t ne, uint32_t imm7, SubRegSize size, PRegister pg, ZRegister zn, PRegister pd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
-    LOGMAN_THROW_AA_FMT(imm7 < 128, "Invalid imm ({}). Must be within [0, 128]", imm7);
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(imm7 < 128, "Invalid imm ({}). Must be within [0, 128]", imm7);
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0010'0100'0010'0000'0000'0000'0000'0000;
@@ -4706,8 +4706,8 @@ private:
   }
 
   void SVEIntegerCompareSignedImm(uint32_t op, uint32_t o2, uint32_t ne, int32_t imm5, SubRegSize size, PRegister pg, ZRegister zn, PRegister pd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
-    LOGMAN_THROW_AA_FMT(imm5 >= -16 && imm5 <= 15, "Invalid imm ({}). Must be within [-16, 15].", imm5);
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(imm5 >= -16 && imm5 <= 15, "Invalid imm ({}). Must be within [-16, 15].", imm5);
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0010'0101'0000'0000'0000'0000'0000'0000;
@@ -4723,8 +4723,8 @@ private:
   }
 
   void SVEFloatCompareVector(uint32_t op, uint32_t o2, uint32_t o3, SubRegSize size, ZRegister zm, PRegister pg, ZRegister zn, PRegister pd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "Can't use 8-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "Can't use 8-bit size");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0110'0101'0000'0000'0100'0000'0000'0000;
@@ -4740,7 +4740,7 @@ private:
   }
 
   void SVEIntegerMinMaxDifferencePredicated(uint32_t opc, uint32_t U, SubRegSize size, PRegister pg, ZRegister zdn, ZRegister zm, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
     LOGMAN_THROW_A_FMT(zd == zdn, "zd needs to equal zdn");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
@@ -4755,7 +4755,7 @@ private:
   }
 
   void SVEBitWiseShiftImmediatePred(SubRegSize size, uint32_t opc, uint32_t L, uint32_t U, PRegister pg, ZRegister zd, ZRegister zdn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
     LOGMAN_THROW_A_FMT(zd == zdn, "zd needs to equal zdn");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
@@ -4774,7 +4774,7 @@ private:
   }
 
   void SVEBitWiseShiftImmediateUnpred(SubRegSize size, uint32_t opc, ZRegister zd, ZRegister zn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit element size");
 
     const bool IsLeftShift = opc == 0b11;
     const auto [tszh, tszl_imm3] = EncodeSVEShiftImmediate(size, Shift, IsLeftShift);
@@ -4836,7 +4836,7 @@ private:
   }
 
   void SVE2SaturatingExtractNarrow(SubRegSize size, uint32_t opc, uint32_t T, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit && size != SubRegSize::i64Bit, "Can't use 64/128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit && size != SubRegSize::i64Bit, "Can't use 64/128-bit size");
 
     // While not necessarily a left shift, we can piggyback off its
     // encoding behavior to encode the tszh and tszl bits.
@@ -4853,7 +4853,7 @@ private:
   }
 
   void SVE2BitwiseShiftRightNarrow(SubRegSize size, uint32_t shift, uint32_t opc, uint32_t U, uint32_t R, uint32_t T, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit && size != SubRegSize::i64Bit, "Can't use 64/128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit && size != SubRegSize::i64Bit, "Can't use 64/128-bit element size");
 
     const auto [tszh, tszl_imm3] = EncodeSVEShiftImmediate(size, shift);
 
@@ -4871,7 +4871,7 @@ private:
 
   void SVEFloatUnary(uint32_t opc, SubRegSize size, PRegister pg, ZRegister zn, ZRegister zd) {
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit ||
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit ||
                         size == SubRegSize::i32Bit ||
                         size == SubRegSize::i64Bit, "Unsupported size in {}", __func__);
 
@@ -4885,7 +4885,7 @@ private:
   }
 
   void SVE2IntegerMultiplyVectors(uint32_t opc, SubRegSize size, ZRegister zm, ZRegister zn, ZRegister zd) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Can't use 128-bit size");
 
     constexpr uint32_t Op = 0b0000'0100'0010'0000'0110 << 12;
     uint32_t Instr = Op;
@@ -4961,7 +4961,7 @@ private:
   }
 
   void SVEFPUnaryOpsUnpredicated(uint32_t opc, SubRegSize size, ZRegister zd, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "SubRegSize must be 16-bit, 32-bit, or 64-bit");
 
     uint32_t Instr = 0b0110'0101'0000'1000'0011'0000'0000'0000;
@@ -4973,7 +4973,7 @@ private:
   }
 
   void SVEFPSerialReductionPredicated(uint32_t opc, SubRegSize size, VRegister vd, PRegister pg, VRegister vn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "SubRegSize must be 16-bit, 32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
     LOGMAN_THROW_A_FMT(vd == vn, "vn must be the same as vd");
@@ -4988,7 +4988,7 @@ private:
   }
 
   void SVEFPCompareWithZero(uint32_t eqlt, uint32_t ne, SubRegSize size, PRegister pd, PRegister pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "SubRegSize must be 16-bit, 32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
@@ -5004,7 +5004,7 @@ private:
 
   void SVEFPMultiplyAdd(uint32_t opc, SubRegSize size, ZRegister zd, PRegister pg, ZRegister zn, ZRegister zm) {
     // NOTE: opc also includes the op0 bit (bit 15) like op0:opc, since the fields are adjacent
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "SubRegSize must be 16-bit, 32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
@@ -5019,7 +5019,7 @@ private:
   }
 
   void SVEFPMultiplyAddIndexed(uint32_t op, SubRegSize size, ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "SubRegSize must be 16-bit, 32-bit, or 64-bit");
     LOGMAN_THROW_A_FMT((size <= SubRegSize::i32Bit && zm <= ZReg::z7) || (size == SubRegSize::i64Bit && zm <= ZReg::z15),
                         "16-bit and 32-bit indexed variants may only use Zm between z0-z7\n"
@@ -5027,7 +5027,7 @@ private:
 
     const auto Underlying = FEXCore::ToUnderlying(size);
     [[maybe_unused]] const uint32_t IndexMax = (16 / (1U << Underlying)) - 1;
-    LOGMAN_THROW_AA_FMT(index <= IndexMax, "Index must be within 0-{}", IndexMax);
+    LOGMAN_THROW_A_FMT(index <= IndexMax, "Index must be within 0-{}", IndexMax);
 
     // Can be bit 20 or 19 depending on whether or not the element size is 64-bit.
     const auto IndexShift = 19 + static_cast<uint32_t>(size == SubRegSize::i64Bit);
@@ -5045,8 +5045,8 @@ private:
 
   void SVEFPMultiplyAddLongIndexed(uint32_t o2, uint32_t op, uint32_t T, SubRegSize dstsize,
                                    ZRegister zda, ZRegister zn, ZRegister zm, uint32_t index) {
-    LOGMAN_THROW_AA_FMT(dstsize == SubRegSize::i32Bit, "Destination size must be 32-bit.");
-    LOGMAN_THROW_AA_FMT(index <= 7, "Index ({}) must be within [0, 7]", index);
+    LOGMAN_THROW_A_FMT(dstsize == SubRegSize::i32Bit, "Destination size must be 32-bit.");
+    LOGMAN_THROW_A_FMT(index <= 7, "Index ({}) must be within [0, 7]", index);
     LOGMAN_THROW_A_FMT(zm <= ZReg::z7, "zm (z{}) must be within [z0, z7]", zm.Idx());
 
     uint32_t Inst = 0b0110'0100'1010'0000'0100'0000'0000'0000;
@@ -5063,7 +5063,7 @@ private:
 
   void SVEFPMultiplyAddLong(uint32_t o2, uint32_t op, uint32_t T, SubRegSize dstsize,
                             ZRegister zda, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(dstsize == SubRegSize::i32Bit, "Destination size must be 32-bit.");
+    LOGMAN_THROW_A_FMT(dstsize == SubRegSize::i32Bit, "Destination size must be 32-bit.");
 
     uint32_t Instr = 0b0110'0100'1010'0000'1000'0000'0000'0000;
     Instr |= o2 << 22;
@@ -5076,7 +5076,7 @@ private:
   }
 
   void SVEFPMatrixMultiplyAccumulate(SubRegSize size, ZRegister zda, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "SubRegSize must be 32-bit or 64-bit");
 
     uint32_t Instr = 0b0110'0100'0010'0000'1110'0100'0000'0000;
@@ -5088,7 +5088,7 @@ private:
   }
 
   void SVEPredicateCount(uint32_t opc, SubRegSize size, XRegister rd, PRegister pg, PRegister pn) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Cannot use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Cannot use 128-bit element size");
 
     uint32_t Instr = 0b0010'0101'0010'0000'1000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -5101,8 +5101,8 @@ private:
   }
 
   void SVEElementCount(uint32_t b20, uint32_t op1, SubRegSize size, ZRegister zdn, PredicatePattern pattern, uint32_t imm4) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Cannot use 128-bit element size");
-    LOGMAN_THROW_AA_FMT(imm4 >= 1 && imm4 <= 16, "Immediate must be between 1-16 inclusive");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Cannot use 128-bit element size");
+    LOGMAN_THROW_A_FMT(imm4 >= 1 && imm4 <= 16, "Immediate must be between 1-16 inclusive");
 
     uint32_t Instr = 0b0000'0100'0010'0000'1100'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -5115,7 +5115,7 @@ private:
   }
 
   void SVEIncDecPredicateCountScalar(uint32_t op0, uint32_t op1, uint32_t opc, uint32_t b16, SubRegSize size, Register rdn, PRegister pm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Cannot use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Cannot use 128-bit element size");
 
     uint32_t Instr = 0b0010'0101'0010'1000'1000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -5128,12 +5128,12 @@ private:
     dc32(Instr);
   }
   void SVEIncDecPredicateCountVector(uint32_t op0, uint32_t op1, uint32_t opc, uint32_t b16, SubRegSize size, ZRegister zdn, PRegister pm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "Cannot use 8-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "Cannot use 8-bit element size");
     SVEIncDecPredicateCountScalar(op0, op1, opc, b16, size, Register{zdn.Idx()}, pm);
   }
 
   void SVE2IntegerPredicated(uint32_t op0, uint32_t op1, SubRegSize size, ZRegister zd, PRegister pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Cannot use 128-bit size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Cannot use 128-bit size");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     uint32_t Instr = 0b0100'0100'0000'0000'0000'0000'0000'0000;
@@ -5147,7 +5147,7 @@ private:
   }
 
   void SVE2IntegerPairwiseAddAccumulateLong(uint32_t U, SubRegSize size, ZRegister zda, PRegisterMerge pg, ZRegister zn) {
-    LOGMAN_THROW_AA_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
+    LOGMAN_THROW_A_FMT(size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                         "SubRegSize must be 16-bit, 32-bit, or 64-bit");
     SVE2IntegerPredicated((0b0010 << 1) | U, 0b101, size, zda, pg, zn);
   }
@@ -5177,7 +5177,7 @@ private:
   }
 
   void SVEIntegerMultiplyAddUnpredicated(uint32_t op0, SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i128Bit, "Cannot use 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i128Bit, "Cannot use 128-bit element size");
 
     uint32_t Instr = 0b0100'0100'0000'0000'0000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
@@ -5221,26 +5221,26 @@ private:
   }
 
   void SVE2IntegerAddSubLong(uint32_t op, uint32_t SUT, SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
     SVE2WideningIntegerArithmetic(op, SUT, size, zd, zn, zm);
   }
 
   void SVE2IntegerAddSubWide(uint32_t SUT, SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
-    LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
     SVE2WideningIntegerArithmetic(0b10, SUT, size, zd, zn, zm);
   }
 
   void SVE2IntegerMultiplyLong(uint32_t SUT, SubRegSize size, ZRegister zd, ZRegister zn, ZRegister zm) {
     // PMULLB and PMULLT support the use of 128-bit element sizes (with the SVE2PMULL128 extension)
     if (SUT == 0b010 || SUT == 0b011) {
-      LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit, "Can't use 8-bit element size");
+      LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "Can't use 8-bit element size");
 
       // 128-bit variant is encoded as if it were 8-bit (0b00)
       if (size == SubRegSize::i128Bit) {
         size = SubRegSize::i8Bit;
       }
     } else {
-      LOGMAN_THROW_AA_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
+      LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit && size != SubRegSize::i128Bit, "Can't use 8-bit or 128-bit element size");
     }
 
     SVE2WideningIntegerArithmetic(0b11, SUT, size, zd, zn, zm);
@@ -5366,7 +5366,7 @@ private:
     const int32_t imm8_limit = 128;
     const bool is_int8_imm = -imm8_limit <= imm && imm < imm8_limit;
     if (size == SubRegSize::i8Bit) {
-      LOGMAN_THROW_AA_FMT(is_int8_imm, "Can't perform LSL #8 shift on 8-bit elements.");
+      LOGMAN_THROW_A_FMT(is_int8_imm, "Can't perform LSL #8 shift on 8-bit elements.");
     }
 
     uint32_t shift = 0;
@@ -5374,8 +5374,8 @@ private:
       const int32_t imm16_limit = 32768;
       const bool is_int16_imm = -imm16_limit <= imm && imm < imm16_limit;
 
-      LOGMAN_THROW_AA_FMT(is_int16_imm, "Immediate ({}) must be a 16-bit value within [-32768, 32512]", imm);
-      LOGMAN_THROW_AA_FMT((imm % 256) == 0, "Immediate ({}) must be a multiple of 256", imm);
+      LOGMAN_THROW_A_FMT(is_int16_imm, "Immediate ({}) must be a 16-bit value within [-32768, 32512]", imm);
+      LOGMAN_THROW_A_FMT((imm % 256) == 0, "Immediate ({}) must be a multiple of 256", imm);
 
       imm /= 256;
       shift = 1;

--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -3460,7 +3460,7 @@ private:
 
     uint32_t shift = 0;
     if (!is_uint8_imm) {
-      const bool is_uint16_imm = (imm >> 16) == 0;
+      [[maybe_unused]] const bool is_uint16_imm = (imm >> 16) == 0;
 
       LOGMAN_THROW_A_FMT(is_uint16_imm, "Immediate ({}) must be a 16-bit value within [256, 65280]", imm);
       LOGMAN_THROW_A_FMT((imm % 256) == 0, "Immediate ({}) must be a multiple of 256", imm);
@@ -3957,7 +3957,7 @@ private:
                        "Can't use 64-bit or 128-bit element size");
     LOGMAN_THROW_A_FMT(zd == zn, "zd and zn must be the same register");
     LOGMAN_THROW_A_FMT(pg <= PReg::p7.Merging(), "Wide shift can only use p0-p7 as a governing predicate");
-    
+
     uint32_t Instr = 0b0000'0100'0001'1000'1000'0000'0000'0000;
     Instr |= FEXCore::ToUnderlying(size) << 22;
     Instr |= opc << 16;
@@ -4313,7 +4313,7 @@ private:
           LOGMAN_THROW_A_FMT(op_data.scale == 0,
                              "mod type of none must have a scale of 0");
         }
-        
+
         Instr |= 1U << 15;
         mod_value = 1;
       }
@@ -4662,7 +4662,7 @@ private:
     }
     // Guards against bogus combinations of element size and memory size values
     // being passed in. Unsigned variants will always have dtypeh be less than
-    // or equal to dtypel. The only time this isn't the case is with signed variants. 
+    // or equal to dtypel. The only time this isn't the case is with signed variants.
     LOGMAN_THROW_A_FMT(is_signed == (dtypeh > dtypel),
                         "Invalid element size used with load broadcast instruction "
                         "(esize: {}, msize: {})", esize_value, msize_value);
@@ -5372,7 +5372,7 @@ private:
     uint32_t shift = 0;
     if (!is_int8_imm) {
       const int32_t imm16_limit = 32768;
-      const bool is_int16_imm = -imm16_limit <= imm && imm < imm16_limit;
+      [[maybe_unused]] const bool is_int16_imm = -imm16_limit <= imm && imm < imm16_limit;
 
       LOGMAN_THROW_A_FMT(is_int16_imm, "Immediate ({}) must be a 16-bit value within [-32768, 32512]", imm);
       LOGMAN_THROW_A_FMT((imm % 256) == 0, "Immediate ({}) must be a multiple of 256", imm);

--- a/CodeEmitter/CodeEmitter/ScalarOps.inl
+++ b/CodeEmitter/CodeEmitter/ScalarOps.inl
@@ -26,7 +26,7 @@ public:
     const uint32_t ElementSize = 1U << SizeImm;
     const uint32_t MaxIndex = 128U / (ElementSize * 8);
 
-    LOGMAN_THROW_AA_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
+    LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
@@ -140,27 +140,27 @@ public:
 
   ///< Comparison against 0.0
   void cmgt(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMDScalar2RegMisc(0, 0, size, 0b01000, rd, rn);
   }
   ///< Comparison against 0.0
   void cmeq(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMDScalar2RegMisc(0, 0, size, 0b01001, rd, rn);
   }
 
   ///< Comparison against 0.0
   void cmlt(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMDScalar2RegMisc(0, 0, size, 0b01010, rd, rn);
   }
   void abs(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMDScalar2RegMisc(0, 0, size, 0b01011, rd, rn);
   }
   ///< size is destination size.
   void sqxtn(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ScalarRegSize::i64Bit, "64-bit destination not supported");
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i64Bit, "64-bit destination not supported");
     ASIMDScalar2RegMisc(0, 0, size, 0b10100, rd, rn);
   }
 
@@ -249,31 +249,31 @@ public:
   }
   ///< Comparison against 0.0
   void cmge(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMDScalar2RegMisc(0, 1, size, 0b01000, rd, rn);
   }
   ///< Comparison against 0.0
   void cmle(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMDScalar2RegMisc(0, 1, size, 0b01001, rd, rn);
   }
   void neg(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMDScalar2RegMisc(0, 1, size, 0b01011, rd, rn);
   }
   ///< size is destination.
   void sqxtun(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ScalarRegSize::i64Bit, "64-bit destination not supported");
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i64Bit, "64-bit destination not supported");
     ASIMDScalar2RegMisc(0, 1, size, 0b10010, rd, rn);
   }
   ///< size is destination.
   void uqxtn(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size != ScalarRegSize::i64Bit, "64-bit destination not supported");
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i64Bit, "64-bit destination not supported");
     ASIMDScalar2RegMisc(0, 1, size, 0b10100, rd, rn);
   }
   ///< size is destination.
   void fcvtxn(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     ASIMDScalar2RegMisc(0, 1, ScalarRegSize::i16Bit, 0b10110, rd, rn);
   }
   void fcvtnu(ScalarRegSize size, VRegister rd, VRegister rn) {
@@ -366,7 +366,7 @@ public:
   }
 
   void fmaxnmp(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
@@ -376,7 +376,7 @@ public:
     ASIMDScalar2RegMisc(1, 1, ConvertedSize, 0b01100, rd, rn);
   }
   void faddp(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
@@ -386,7 +386,7 @@ public:
     ASIMDScalar2RegMisc(1, 1, ConvertedSize, 0b01101, rd, rn);
   }
   void fmaxp(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
@@ -396,17 +396,17 @@ public:
     ASIMDScalar2RegMisc(1, 1, ConvertedSize, 0b01111, rd, rn);
   }
   void fminnmp(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     ASIMDScalar2RegMisc(1, 1, size, 0b01100, rd, rn);
   }
   void fminp(ScalarRegSize size, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     ASIMDScalar2RegMisc(1, 1, size, 0b01111, rd, rn);
   }
 // Advanced SIMD scalar three different
   ///< size is destination.
   void sqdmlal(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
         ScalarRegSize::i32Bit :
@@ -415,7 +415,7 @@ public:
   }
   ///< size is destination.
   void sqdmlsl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
         ScalarRegSize::i32Bit :
@@ -425,7 +425,7 @@ public:
 
   ///< size is destination.
   void sqdmull(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
         ScalarRegSize::i32Bit :
@@ -440,41 +440,41 @@ public:
     ASIMD3RegSame(0, size, 0b00101, rd, rn, rm);
   }
   void cmgt(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(0, size, 0b00110, rd, rn, rm);
   }
   void cmge(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(0, size, 0b00111, rd, rn, rm);
   }
   void sshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(0, size, 0b01000, rd, rn, rm);
   }
   void sqshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     ASIMD3RegSame(0, size, 0b01001, rd, rn, rm);
   }
   void srshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(0, size, 0b01010, rd, rn, rm);
   }
   void sqrshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     ASIMD3RegSame(0, size, 0b01011, rd, rn, rm);
   }
   void add(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(0, size, 0b10000, rd, rn, rm);
   }
   void cmtst(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(0, size, 0b10001, rd, rn, rm);
   }
   void sqdmulh(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i32Bit || size == ScalarRegSize::i16Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i32Bit || size == ScalarRegSize::i16Bit, "Invalid size");
     ASIMD3RegSame(0, size, 0b10110, rd, rn, rm);
   }
   void fmulx(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
@@ -484,7 +484,7 @@ public:
     ASIMD3RegSame(0, ConvertedSize, 0b11011, rd, rn, rm);
   }
   void fcmeq(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
@@ -494,7 +494,7 @@ public:
     ASIMD3RegSame(0, ConvertedSize, 0b11100, rd, rn, rm);
   }
   void frecps(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
@@ -504,7 +504,7 @@ public:
     ASIMD3RegSame(0, ConvertedSize, 0b11111, rd, rn, rm);
   }
   void frsqrts(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     ASIMD3RegSame(0, size, 0b11111, rd, rn, rm);
   }
   void uqadd(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
@@ -514,41 +514,41 @@ public:
     ASIMD3RegSame(1, size, 0b00101, rd, rn, rm);
   }
   void cmhi(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(1, size, 0b00110, rd, rn, rm);
   }
   void cmhs(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(1, size, 0b00111, rd, rn, rm);
   }
   void ushl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(1, size, 0b01000, rd, rn, rm);
   }
   void uqshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     ASIMD3RegSame(1, size, 0b01001, rd, rn, rm);
   }
   void urshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(1, size, 0b01010, rd, rn, rm);
   }
   void uqrshl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
     ASIMD3RegSame(1, size, 0b01011, rd, rn, rm);
   }
   void sub(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(1, size, 0b10000, rd, rn, rm);
   }
   void cmeq(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit, "Only supports 64-bit");
     ASIMD3RegSame(1, size, 0b10001, rd, rn, rm);
   }
   void sqrdmulh(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i32Bit || size == ScalarRegSize::i16Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i32Bit || size == ScalarRegSize::i16Bit, "Invalid size");
     ASIMD3RegSame(1, size, 0b10110, rd, rn, rm);
   }
   void fcmge(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
@@ -558,7 +558,7 @@ public:
     ASIMD3RegSame(1, ConvertedSize, 0b11100, rd, rn, rm);
   }
   void facge(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
 
     const ScalarRegSize ConvertedSize =
       size == ScalarRegSize::i64Bit ?
@@ -568,21 +568,21 @@ public:
     ASIMD3RegSame(1, ConvertedSize, 0b11101, rd, rn, rm);
   }
   void fabd(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     ASIMD3RegSame(1, size, 0b11010, rd, rn, rm);
   }
   void fcmgt(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     ASIMD3RegSame(1, size, 0b11100, rd, rn, rm);
   }
   void facgt(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for float convert");
     ASIMD3RegSame(1, size, 0b11101, rd, rn, rm);
   }
 // Advanced SIMD scalar shift by immediate
   void sshr(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -592,8 +592,8 @@ public:
     ASIMDScalarShiftByImm(0, immh, immb, 0b00000, rd, rn);
   }
   void ssra(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -603,8 +603,8 @@ public:
     ASIMDScalarShiftByImm(0, immh, immb, 0b00010, rd, rn);
   }
   void srshr(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -614,8 +614,8 @@ public:
     ASIMDScalarShiftByImm(0, immh, immb, 0b00100, rd, rn);
   }
   void srsra(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -625,8 +625,8 @@ public:
     ASIMDScalarShiftByImm(0, immh, immb, 0b00110, rd, rn);
   }
   void shl(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     // Shift encoded a bit weirdly.
     // shift = immh:immb - elementsize but immh is /also/ used for element size.
     const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
@@ -644,7 +644,7 @@ public:
   ///< size is destination
   void sqshrn(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrn");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrn");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -655,7 +655,7 @@ public:
   }
   void sqrshrn(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrn");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrn");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -666,8 +666,8 @@ public:
   }
   // TODO: SCVTF, FCVTZS
   void ushr(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -677,8 +677,8 @@ public:
     ASIMDScalarShiftByImm(1, immh, immb, 0b00000, rd, rn);
   }
   void usra(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -688,8 +688,8 @@ public:
     ASIMDScalarShiftByImm(1, immh, immb, 0b00010, rd, rn);
   }
   void urshr(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -699,8 +699,8 @@ public:
     ASIMDScalarShiftByImm(1, immh, immb, 0b00100, rd, rn);
   }
   void ursra(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -710,8 +710,8 @@ public:
     ASIMDScalarShiftByImm(1, immh, immb, 0b00110, rd, rn);
   }
   void sri(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -721,8 +721,8 @@ public:
     ASIMDScalarShiftByImm(1, immh, immb, 0b01000, rd, rn);
   }
   void sli(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
-    LOGMAN_THROW_AA_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
+    LOGMAN_THROW_A_FMT(Shift > 0 && Shift < 64, "Invalid shift for sshr");
+    LOGMAN_THROW_A_FMT(size == ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sshr");
     // Shift encoded a bit weirdly.
     // shift = immh:immb - elementsize but immh is /also/ used for element size.
     const uint32_t immh = 1 << FEXCore::ToUnderlying(size) | (Shift >> 3);
@@ -748,7 +748,7 @@ public:
   ///< size is destination.
   void sqshrun(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrun");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqshrun");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -760,7 +760,7 @@ public:
   ///< size is destination.
   void sqrshrun(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -772,7 +772,7 @@ public:
   ///< size is destination.
   void uqshrn(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -784,7 +784,7 @@ public:
   ///< size is destination.
   void uqrshrn(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Shift) {
     LOGMAN_THROW_A_FMT(Shift > 0 && Shift < ScalarRegSizeInBits(size), "Invalid shift for sshr");
-    LOGMAN_THROW_AA_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
+    LOGMAN_THROW_A_FMT(size != ARMEmitter::ScalarRegSize::i64Bit, "Invalid size selected for sqrshrun");
     const size_t SubregSizeInBits = ScalarRegSizeInBits(size);
     // Shift encoded in immh:immb, but inverted with 128-bit source
     // shift = (esize * 2) - immh:immb
@@ -993,7 +993,7 @@ public:
 
 // Floating-point compare
   void fcmp(ScalarRegSize Size, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(Size != ScalarRegSize::i8Bit, "8-bit destination not supported");
+    LOGMAN_THROW_A_FMT(Size != ScalarRegSize::i8Bit, "8-bit destination not supported");
 
     const auto ConvertedSize =
       Size == ARMEmitter::ScalarRegSize::i64Bit ? 0b01 :
@@ -1225,7 +1225,7 @@ public:
 
   // Floating-point conditional select
   void fcsel(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, Condition Cond) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for {}", __func__);
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for {}", __func__);
 
     const uint32_t ConvertedSize =
       size == ScalarRegSize::i64Bit ? 0b01 :
@@ -1390,7 +1390,7 @@ private:
     dc32(Instr);
   }
   void Float1Source(ScalarRegSize size, uint32_t M, uint32_t S, uint32_t opcode, VRegister rd, VRegister rn) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for {}", __func__);
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for {}", __func__);
 
     const uint32_t ConvertedSize =
       size == ScalarRegSize::i64Bit ? 0b01 :
@@ -1447,7 +1447,7 @@ private:
   }
 
   void Float2Source(ScalarRegSize size, uint32_t M, uint32_t S, uint32_t opcode, VRegister rd, VRegister rn, VRegister rm) {
-    LOGMAN_THROW_AA_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for {}", __func__);
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i64Bit || size == ScalarRegSize::i32Bit, "Invalid size selected for {}", __func__);
 
     const uint32_t ConvertedSize =
       size == ScalarRegSize::i64Bit ? 0b01 :

--- a/CodeEmitter/CodeEmitter/ScalarOps.inl
+++ b/CodeEmitter/CodeEmitter/ScalarOps.inl
@@ -24,7 +24,7 @@ public:
     const uint32_t SizeImm = FEXCore::ToUnderlying(size);
     const uint32_t IndexShift = SizeImm + 1;
     const uint32_t ElementSize = 1U << SizeImm;
-    const uint32_t MaxIndex = 128U / (ElementSize * 8);
+    [[maybe_unused]] const uint32_t MaxIndex = 128U / (ElementSize * 8);
 
     LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 

--- a/CodeEmitter/CodeEmitter/SystemOps.inl
+++ b/CodeEmitter/CodeEmitter/SystemOps.inl
@@ -83,7 +83,7 @@ public:
 
     // Barriers
     void clrex(uint32_t imm = 15) {
-      LOGMAN_THROW_AA_FMT(imm < 16, "Immediate out of range");
+      LOGMAN_THROW_A_FMT(imm < 16, "Immediate out of range");
       Barrier(ARMEmitter::BarrierRegister::CLREX, imm);
     }
     void dsb(ARMEmitter::BarrierScope Scope) {
@@ -117,7 +117,7 @@ private:
 
     // Exception Generation
     void ExceptionGeneration(uint32_t opc, uint32_t op2, uint32_t LL, uint32_t Imm) {
-      LOGMAN_THROW_AA_FMT((Imm & 0xFFFF'0000) == 0, "Imm amount too large");
+      LOGMAN_THROW_A_FMT((Imm & 0xFFFF'0000) == 0, "Imm amount too large");
 
       uint32_t Instr = 0b1101'0100 << 24;
 

--- a/FEXCore/Source/Common/BitSet.h
+++ b/FEXCore/Source/Common/BitSet.h
@@ -21,12 +21,12 @@ struct BitSet final {
   ElementType* Memory;
   void Allocate(size_t Elements) {
     size_t AllocateSize = ToBytes(Elements);
-    LOGMAN_THROW_AA_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
+    LOGMAN_THROW_A_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
     Memory = static_cast<ElementType*>(FEXCore::Allocator::malloc(AllocateSize));
   }
   void Realloc(size_t Elements) {
     size_t AllocateSize = ToBytes(Elements);
-    LOGMAN_THROW_AA_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
+    LOGMAN_THROW_A_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
     Memory = static_cast<ElementType*>(FEXCore::Allocator::realloc(Memory, AllocateSize));
   }
   void Free() {
@@ -68,7 +68,7 @@ struct BitSetView final {
   ElementType* Memory;
 
   void GetView(BitSet<T>& Set, uint64_t ElementOffset) {
-    LOGMAN_THROW_AA_FMT((ElementOffset % MinimumSize) == 0, "Bitset view offset needs to be aligned to size of backing element");
+    LOGMAN_THROW_A_FMT((ElementOffset % MinimumSize) == 0, "Bitset view offset needs to be aligned to size of backing element");
     Memory = &Set.Memory[ElementOffset / MinimumSizeBits];
   }
 

--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -373,7 +373,7 @@ namespace CPU {
     CodeBuffer Buffer;
     Buffer.Size = Size;
     Buffer.Ptr = static_cast<uint8_t*>(FEXCore::Allocator::VirtualAlloc(Buffer.Size, true));
-    LOGMAN_THROW_AA_FMT(!!Buffer.Ptr, "Couldn't allocate code buffer");
+    LOGMAN_THROW_A_FMT(!!Buffer.Ptr, "Couldn't allocate code buffer");
 
     if (static_cast<Context::ContextImpl*>(ThreadState->CTX)->Config.GlobalJITNaming()) {
       static_cast<Context::ContextImpl*>(ThreadState->CTX)->Symbols.RegisterJITSpace(Buffer.Ptr, Buffer.Size);

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -999,11 +999,11 @@ ContextImpl::AddCustomIREntrypoint(uintptr_t Entrypoint, CustomIREntrypointHandl
 }
 
 void ContextImpl::AddThunkTrampolineIRHandler(uintptr_t Entrypoint, uintptr_t GuestThunkEntrypoint) {
-  LOGMAN_THROW_AA_FMT(Entrypoint, "Tried to link null pointer address to guest function");
-  LOGMAN_THROW_AA_FMT(GuestThunkEntrypoint, "Tried to link address to null pointer guest function");
+  LOGMAN_THROW_A_FMT(Entrypoint, "Tried to link null pointer address to guest function");
+  LOGMAN_THROW_A_FMT(GuestThunkEntrypoint, "Tried to link address to null pointer guest function");
   if (!Config.Is64BitMode) {
-    LOGMAN_THROW_AA_FMT((Entrypoint >> 32) == 0, "Tried to link 64-bit address in 32-bit mode");
-    LOGMAN_THROW_AA_FMT((GuestThunkEntrypoint >> 32) == 0, "Tried to link 64-bit address in 32-bit mode");
+    LOGMAN_THROW_A_FMT((Entrypoint >> 32) == 0, "Tried to link 64-bit address in 32-bit mode");
+    LOGMAN_THROW_A_FMT((GuestThunkEntrypoint >> 32) == 0, "Tried to link 64-bit address in 32-bit mode");
   }
 
   LogMan::Msg::DFmt("Thunks: Adding guest trampoline from address {:#x} to guest function {:#x}", Entrypoint, GuestThunkEntrypoint);

--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -283,9 +283,9 @@ bool Decoder::NormalOp(const FEXCore::X86Tables::X86InstInfo* Info, uint16_t Op,
   }
 
   LOGMAN_THROW_A_FMT(!(Info->Type >= FEXCore::X86Tables::TYPE_GROUP_1 && Info->Type <= FEXCore::X86Tables::TYPE_GROUP_P), "Group Ops "
-                                                                                                                           "should have "
-                                                                                                                           "been decoded "
-                                                                                                                           "before this!");
+                                                                                                                          "should have "
+                                                                                                                          "been decoded "
+                                                                                                                          "before this!");
 
   uint8_t DestSize {};
   const bool HasWideningDisplacement =
@@ -546,7 +546,7 @@ bool Decoder::NormalOp(const FEXCore::X86Tables::X86InstInfo* Info, uint16_t Op,
   }
 
   LOGMAN_THROW_A_FMT(Bytes == 0, "Inst at 0x{:x}: 0x{:04x} '{}' Had an instruction of size {} with {} remaining", DecodeInst->PC,
-                      DecodeInst->OP, DecodeInst->TableInfo->Name ?: "UND", InstructionSize, Bytes);
+                     DecodeInst->OP, DecodeInst->TableInfo->Name ?: "UND", InstructionSize, Bytes);
   DecodeInst->InstSize = InstructionSize;
   return true;
 }

--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -75,7 +75,7 @@ Decoder::~Decoder() {
 
 uint8_t Decoder::ReadByte() {
   uint8_t Byte = InstStream[InstructionSize];
-  LOGMAN_THROW_AA_FMT(InstructionSize < MAX_INST_SIZE, "Max instruction size exceeded!");
+  LOGMAN_THROW_A_FMT(InstructionSize < MAX_INST_SIZE, "Max instruction size exceeded!");
   Instruction[InstructionSize] = Byte;
   InstructionSize++;
   return Byte;
@@ -87,7 +87,7 @@ uint8_t Decoder::PeekByte(uint8_t Offset) const {
 }
 
 uint64_t Decoder::ReadData(uint8_t Size) {
-  LOGMAN_THROW_AA_FMT(Size != 0 && Size <= sizeof(uint64_t), "Unknown data size to read");
+  LOGMAN_THROW_A_FMT(Size != 0 && Size <= sizeof(uint64_t), "Unknown data size to read");
 
   uint64_t Res = 0;
   std::memcpy(&Res, &InstStream[InstructionSize], Size);
@@ -235,7 +235,7 @@ void Decoder::DecodeModRM_64(X86Tables::DecodedOperand* Operand, X86Tables::ModR
       Operand->Data.SIB.Base = MapModRMToReg(BaseREX, SIB.base, false, false, false, false, ModRM.mod == 0 ? 0b101 : 16);
     }
 
-    LOGMAN_THROW_AA_FMT(Displacement <= 4, "Number of bytes should be <= 4 for literal src");
+    LOGMAN_THROW_A_FMT(Displacement <= 4, "Number of bytes should be <= 4 for literal src");
 
     if (Displacement) {
       uint64_t Literal = ReadData(Displacement);
@@ -282,7 +282,7 @@ bool Decoder::NormalOp(const FEXCore::X86Tables::X86InstInfo* Info, uint16_t Op,
     return false;
   }
 
-  LOGMAN_THROW_AA_FMT(!(Info->Type >= FEXCore::X86Tables::TYPE_GROUP_1 && Info->Type <= FEXCore::X86Tables::TYPE_GROUP_P), "Group Ops "
+  LOGMAN_THROW_A_FMT(!(Info->Type >= FEXCore::X86Tables::TYPE_GROUP_1 && Info->Type <= FEXCore::X86Tables::TYPE_GROUP_P), "Group Ops "
                                                                                                                            "should have "
                                                                                                                            "been decoded "
                                                                                                                            "before this!");
@@ -404,7 +404,7 @@ bool Decoder::NormalOp(const FEXCore::X86Tables::X86InstInfo* Info, uint16_t Op,
       HAS_NON_XMM_SUBFLAG(Info->Flags, FEXCore::X86Tables::InstFlags::FLAGS_SF_DST_RAX) ? FEXCore::X86State::REG_RAX : FEXCore::X86State::REG_RDX;
     CurrentDest = &DecodeInst->Src[0];
   } else if (HAS_NON_XMM_SUBFLAG(Info->Flags, FEXCore::X86Tables::InstFlags::FLAGS_SF_REX_IN_BYTE)) {
-    LOGMAN_THROW_AA_FMT(!HasMODRM, "This instruction shouldn't have ModRM!");
+    LOGMAN_THROW_A_FMT(!HasMODRM, "This instruction shouldn't have ModRM!");
 
     // If the REX is in the byte that means the lower nibble of the OP contains the destination GPR
     // This also means that the destination is always a GPR on these ones
@@ -522,7 +522,7 @@ bool Decoder::NormalOp(const FEXCore::X86Tables::X86InstInfo* Info, uint16_t Op,
   }
 
   if (Bytes != 0) {
-    LOGMAN_THROW_AA_FMT(Bytes <= 8, "Number of bytes should be <= 8 for literal src");
+    LOGMAN_THROW_A_FMT(Bytes <= 8, "Number of bytes should be <= 8 for literal src");
 
     DecodeInst->Src[CurrentSrc].Data.Literal.Size = Bytes;
 
@@ -545,7 +545,7 @@ bool Decoder::NormalOp(const FEXCore::X86Tables::X86InstInfo* Info, uint16_t Op,
     DecodeInst->Src[CurrentSrc].Data.Literal.Value = Literal;
   }
 
-  LOGMAN_THROW_AA_FMT(Bytes == 0, "Inst at 0x{:x}: 0x{:04x} '{}' Had an instruction of size {} with {} remaining", DecodeInst->PC,
+  LOGMAN_THROW_A_FMT(Bytes == 0, "Inst at 0x{:x}: 0x{:04x} '{}' Had an instruction of size {} with {} remaining", DecodeInst->PC,
                       DecodeInst->OP, DecodeInst->TableInfo->Name ?: "UND", InstructionSize, Bytes);
   DecodeInst->InstSize = InstructionSize;
   return true;
@@ -563,7 +563,7 @@ bool Decoder::NormalOpHeader(const FEXCore::X86Tables::X86InstInfo* Info, uint16
     return false;
   }
 
-  LOGMAN_THROW_AA_FMT(Info->Type != FEXCore::X86Tables::TYPE_REX_PREFIX, "REX PREFIX should have been decoded before this!");
+  LOGMAN_THROW_A_FMT(Info->Type != FEXCore::X86Tables::TYPE_REX_PREFIX, "REX PREFIX should have been decoded before this!");
 
   // A normal instruction is the most likely.
   if (Info->Type == FEXCore::X86Tables::TYPE_INST) [[likely]] {
@@ -613,7 +613,7 @@ bool Decoder::NormalOpHeader(const FEXCore::X86Tables::X86InstInfo* Info, uint16
         255, 0, 1, 2, 255, 255, 255, 3,
       };
       uint8_t Field = RegToField[ModRM.reg];
-      LOGMAN_THROW_AA_FMT(Field != 255, "Invalid field selected!");
+      LOGMAN_THROW_A_FMT(Field != 255, "Invalid field selected!");
 
       LocalOp = (Field << 3) | ModRM.rm;
       return NormalOp(&SecondModRMTableOps[LocalOp], LocalOp);

--- a/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
@@ -92,7 +92,7 @@ DEF_OP(AddNZCV) {
 
   uint64_t Const;
   if (IsInlineConstant(Op->Src2, &Const)) {
-    LOGMAN_THROW_AA_FMT(IROp->Size >= IR::OpSize::i32Bit, "Constant not allowed here");
+    LOGMAN_THROW_A_FMT(IROp->Size >= IR::OpSize::i32Bit, "Constant not allowed here");
     cmn(EmitSize, Src1, Const);
   } else if (IROp->Size < IR::OpSize::i32Bit) {
     unsigned Shift = 32 - IR::OpSizeAsBits(IROp->Size);
@@ -193,7 +193,7 @@ DEF_OP(TestNZ) {
 
 DEF_OP(TestZ) {
   auto Op = IROp->C<IR::IROp_TestZ>();
-  LOGMAN_THROW_AA_FMT(IROp->Size < IR::OpSize::i32Bit, "TestNZ used at higher sizes");
+  LOGMAN_THROW_A_FMT(IROp->Size < IR::OpSize::i32Bit, "TestNZ used at higher sizes");
   const auto EmitSize = ARMEmitter::Size::i32Bit;
 
   uint64_t Const;
@@ -202,7 +202,7 @@ DEF_OP(TestZ) {
 
   if (IsInlineConstant(Op->Src2, &Const)) {
     // We can promote 8/16-bit tests to 32-bit since the constant is masked.
-    LOGMAN_THROW_AA_FMT(!(Const & ~Mask), "constant is already masked");
+    LOGMAN_THROW_A_FMT(!(Const & ~Mask), "constant is already masked");
     tst(EmitSize, Src1, Const);
   } else {
     const auto Src2 = GetReg(Op->Src2.ID());
@@ -228,7 +228,7 @@ DEF_OP(SubNZCV) {
 
   uint64_t Const;
   if (IsInlineConstant(Op->Src2, &Const)) {
-    LOGMAN_THROW_AA_FMT(OpSize >= IR::OpSize::i32Bit, "Constant not allowed here");
+    LOGMAN_THROW_A_FMT(OpSize >= IR::OpSize::i32Bit, "Constant not allowed here");
     cmp(EmitSize, GetReg(Op->Src1.ID()), Const);
   } else {
     unsigned Shift = OpSize < IR::OpSize::i32Bit ? (32 - IR::OpSizeAsBits(OpSize)) : 0;
@@ -287,7 +287,7 @@ DEF_OP(SetSmallNZV) {
   LOGMAN_THROW_A_FMT(CTX->HostFeatures.SupportsFlagM, "Unsupported flagm op");
 
   const auto OpSize = IROp->Size;
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i8Bit || OpSize == IR::OpSize::i16Bit, "Unsupported {} size: {}", __func__, OpSize);
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i8Bit || OpSize == IR::OpSize::i16Bit, "Unsupported {} size: {}", __func__, OpSize);
 
   if (OpSize == IR::OpSize::i8Bit) {
     setf8(GetReg(Op->Src.ID()).W());
@@ -516,7 +516,7 @@ DEF_OP(MulH) {
   auto Op = IROp->C<IR::IROp_MulH>();
   const auto OpSize = IROp->Size;
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit, "Unsupported {} size: {}", __func__, OpSize);
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit, "Unsupported {} size: {}", __func__, OpSize);
 
   const auto Dst = GetReg(Node);
   const auto Src1 = GetReg(Op->Src1.ID());
@@ -536,7 +536,7 @@ DEF_OP(UMulH) {
   auto Op = IROp->C<IR::IROp_UMulH>();
   const auto OpSize = IROp->Size;
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit, "Unsupported {} size: {}", __func__, OpSize);
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit, "Unsupported {} size: {}", __func__, OpSize);
 
   const auto Dst = GetReg(Node);
   const auto Src1 = GetReg(Op->Src1.ID());
@@ -1290,7 +1290,7 @@ DEF_OP(FindMSB) {
   auto Op = IROp->C<IR::IROp_FindMSB>();
   const auto OpSize = IROp->Size;
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
                       "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = ConvertSize(IROp);
 
@@ -1313,7 +1313,7 @@ DEF_OP(FindTrailingZeroes) {
   auto Op = IROp->C<IR::IROp_FindTrailingZeroes>();
   const auto OpSize = IROp->Size;
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
                       "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = ConvertSize(IROp);
 
@@ -1338,7 +1338,7 @@ DEF_OP(CountLeadingZeroes) {
   auto Op = IROp->C<IR::IROp_CountLeadingZeroes>();
   const auto OpSize = IROp->Size;
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
                       "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = ConvertSize(IROp);
 
@@ -1360,7 +1360,7 @@ DEF_OP(Rev) {
   auto Op = IROp->C<IR::IROp_Rev>();
   const auto OpSize = IROp->Size;
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
                       "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = ConvertSize(IROp);
 
@@ -1428,8 +1428,8 @@ DEF_OP(Bfxil) {
 
 DEF_OP(Bfe) {
   auto Op = IROp->C<IR::IROp_Bfe>();
-  LOGMAN_THROW_AA_FMT(IROp->Size <= IR::OpSize::i64Bit, "OpSize is too large for BFE: {}", IROp->Size);
-  LOGMAN_THROW_AA_FMT(Op->Width != 0, "Invalid BFE width of 0");
+  LOGMAN_THROW_A_FMT(IROp->Size <= IR::OpSize::i64Bit, "OpSize is too large for BFE: {}", IROp->Size);
+  LOGMAN_THROW_A_FMT(Op->Width != 0, "Invalid BFE width of 0");
   const auto EmitSize = ConvertSize(IROp);
 
   const auto Dst = GetReg(Node);
@@ -1438,7 +1438,7 @@ DEF_OP(Bfe) {
   if (Op->lsb == 0 && Op->Width == 32) {
     mov(ARMEmitter::Size::i32Bit, Dst, Src);
   } else if (Op->lsb == 0 && Op->Width == 64) {
-    LOGMAN_THROW_AA_FMT(IROp->Size == IR::OpSize::i64Bit, "Must be 64-bit wide register");
+    LOGMAN_THROW_A_FMT(IROp->Size == IR::OpSize::i64Bit, "Must be 64-bit wide register");
     mov(ARMEmitter::Size::i64Bit, Dst, Src);
   } else {
     ubfx(EmitSize, Dst, Src, Op->lsb, Op->Width);
@@ -1576,8 +1576,8 @@ DEF_OP(VExtractToGPR) {
     // when acting on larger register sizes.
     PerformMove(Vector, Op->Index);
   } else {
-    LOGMAN_THROW_AA_FMT(Is256Bit, "Can't perform 256-bit extraction with op side: {}", OpSize);
-    LOGMAN_THROW_AA_FMT(Offset < AVXRegBitSize, "Trying to extract element outside bounds of register. Offset={}, Index={}", Offset, Op->Index);
+    LOGMAN_THROW_A_FMT(Is256Bit, "Can't perform 256-bit extraction with op side: {}", OpSize);
+    LOGMAN_THROW_A_FMT(Offset < AVXRegBitSize, "Trying to extract element outside bounds of register. Offset={}, Index={}", Offset, Op->Index);
 
     // We need to use the upper 128-bit lane, so lets move it down.
     // Inverting our dedicated predicate for 128-bit operations selects

--- a/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
@@ -1291,7 +1291,7 @@ DEF_OP(FindMSB) {
   const auto OpSize = IROp->Size;
 
   LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
-                      "Unsupported {} size: {}", __func__, OpSize);
+                     "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = ConvertSize(IROp);
 
   const auto Dst = GetReg(Node);
@@ -1314,7 +1314,7 @@ DEF_OP(FindTrailingZeroes) {
   const auto OpSize = IROp->Size;
 
   LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
-                      "Unsupported {} size: {}", __func__, OpSize);
+                     "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = ConvertSize(IROp);
 
   const auto Dst = GetReg(Node);
@@ -1339,7 +1339,7 @@ DEF_OP(CountLeadingZeroes) {
   const auto OpSize = IROp->Size;
 
   LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
-                      "Unsupported {} size: {}", __func__, OpSize);
+                     "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = ConvertSize(IROp);
 
   const auto Dst = GetReg(Node);
@@ -1361,7 +1361,7 @@ DEF_OP(Rev) {
   const auto OpSize = IROp->Size;
 
   LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i64Bit,
-                      "Unsupported {} size: {}", __func__, OpSize);
+                     "Unsupported {} size: {}", __func__, OpSize);
   const auto EmitSize = ConvertSize(IROp);
 
   const auto Dst = GetReg(Node);

--- a/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
@@ -1549,12 +1549,12 @@ DEF_OP(VExtractToGPR) {
   const auto Op = IROp->C<IR::IROp_VExtractToGPR>();
   const auto OpSize = IROp->Size;
 
-  constexpr auto AVXRegBitSize = Core::CPUState::XMM_AVX_REG_SIZE * 8;
+  [[maybe_unused]] constexpr auto AVXRegBitSize = Core::CPUState::XMM_AVX_REG_SIZE * 8;
   constexpr auto SSERegBitSize = Core::CPUState::XMM_SSE_REG_SIZE * 8;
   const auto ElementSizeBits = IR::OpSizeAsBits(Op->Header.ElementSize);
 
   const auto Offset = ElementSizeBits * Op->Index;
-  const auto Is256Bit = Offset >= SSERegBitSize;
+  [[maybe_unused]] const auto Is256Bit = Offset >= SSERegBitSize;
   LOGMAN_THROW_A_FMT(!Is256Bit || (Is256Bit && HostSupportsSVE256), "Need SVE256 support in order to use {} with 256-bit operation", __func__);
 
   const auto Dst = GetReg(Node);

--- a/FEXCore/Source/Interface/Core/JIT/Arm64Relocations.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64Relocations.cpp
@@ -86,7 +86,7 @@ bool Arm64JITCore::ApplyRelocations(uint64_t GuestEntry, uint64_t CodeEntry, uin
   size_t DataIndex {};
   for (size_t j = 0; j < NumRelocations; ++j) {
     const FEXCore::CPU::Relocation* Reloc = reinterpret_cast<const FEXCore::CPU::Relocation*>(&EntryRelocations[DataIndex]);
-    LOGMAN_THROW_AA_FMT((DataIndex % alignof(Relocation)) == 0, "Alignment of relocation wasn't adhered to");
+    LOGMAN_THROW_A_FMT((DataIndex % alignof(Relocation)) == 0, "Alignment of relocation wasn't adhered to");
 
     switch (Reloc->Header.Type) {
     case FEXCore::CPU::RelocationTypes::RELOC_NAMED_SYMBOL_LITERAL: {

--- a/FEXCore/Source/Interface/Core/JIT/AtomicOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/AtomicOps.cpp
@@ -13,7 +13,7 @@ namespace FEXCore::CPU {
 #define DEF_OP(x) void Arm64JITCore::Op_##x(IR::IROp_Header const* IROp, IR::NodeID Node)
 DEF_OP(CASPair) {
   auto Op = IROp->C<IR::IROp_CASPair>();
-  LOGMAN_THROW_AA_FMT(IROp->ElementSize == IR::OpSize::i32Bit || IROp->ElementSize == IR::OpSize::i64Bit, "Wrong element size");
+  LOGMAN_THROW_A_FMT(IROp->ElementSize == IR::OpSize::i32Bit || IROp->ElementSize == IR::OpSize::i64Bit, "Wrong element size");
   // Size is the size of each pair element
   auto Dst0 = GetReg(Op->OutLo.ID());
   auto Dst1 = GetReg(Op->OutHi.ID());
@@ -274,7 +274,7 @@ DEF_OP(AtomicNeg) {
 DEF_OP(AtomicSwap) {
   auto Op = IROp->C<IR::IROp_AtomicSwap>();
   const auto OpSize = IROp->Size;
-  LOGMAN_THROW_AA_FMT(
+  LOGMAN_THROW_A_FMT(
     OpSize == IR::OpSize::i64Bit || OpSize == IR::OpSize::i32Bit || OpSize == IR::OpSize::i16Bit || OpSize == IR::OpSize::i8Bit, "Unexpecte"
                                                                                                                                  "d CAS "
                                                                                                                                  "size");

--- a/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
@@ -24,7 +24,7 @@ DEF_OP(VAESEnc) {
   const auto State = GetVReg(Op->State.ID());
   const auto ZeroReg = GetVReg(Op->ZeroReg.ID());
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i128Bit, "Currently only supports 128-bit operations.");
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i128Bit, "Currently only supports 128-bit operations.");
 
   if (Dst == State && Dst != Key) {
     // Optimal case in which Dst already contains the starting state.
@@ -49,7 +49,7 @@ DEF_OP(VAESEncLast) {
   const auto State = GetVReg(Op->State.ID());
   const auto ZeroReg = GetVReg(Op->ZeroReg.ID());
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i128Bit, "Currently only supports 128-bit operations.");
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i128Bit, "Currently only supports 128-bit operations.");
 
   if (Dst == State && Dst != Key) {
     // Optimal case in which Dst already contains the starting state.
@@ -72,7 +72,7 @@ DEF_OP(VAESDec) {
   const auto State = GetVReg(Op->State.ID());
   const auto ZeroReg = GetVReg(Op->ZeroReg.ID());
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i128Bit, "Currently only supports 128-bit operations.");
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i128Bit, "Currently only supports 128-bit operations.");
 
   if (Dst == State && Dst != Key) {
     // Optimal case in which Dst already contains the starting state.
@@ -97,7 +97,7 @@ DEF_OP(VAESDecLast) {
   const auto State = GetVReg(Op->State.ID());
   const auto ZeroReg = GetVReg(Op->ZeroReg.ID());
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i128Bit, "Currently only supports 128-bit operations.");
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i128Bit, "Currently only supports 128-bit operations.");
 
   if (Dst == State && Dst != Key) {
     // Optimal case in which Dst already contains the starting state.
@@ -193,7 +193,7 @@ DEF_OP(PCLMUL) {
   const auto Src1 = GetVReg(Op->Src1.ID());
   const auto Src2 = GetVReg(Op->Src2.ID());
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i128Bit, "Currently only supports 128-bit operations.");
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i128Bit, "Currently only supports 128-bit operations.");
 
   switch (Op->Selector) {
   case 0b00000000: pmull(ARMEmitter::SubRegSize::i128Bit, Dst.D(), Src1.D(), Src2.D()); break;

--- a/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
@@ -17,7 +17,7 @@ DEF_OP(VAESImc) {
 
 DEF_OP(VAESEnc) {
   const auto Op = IROp->C<IR::IROp_VAESEnc>();
-  const auto OpSize = IROp->Size;
+  [[maybe_unused]] const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
   const auto Key = GetVReg(Op->Key.ID());
@@ -42,7 +42,7 @@ DEF_OP(VAESEnc) {
 
 DEF_OP(VAESEncLast) {
   const auto Op = IROp->C<IR::IROp_VAESEncLast>();
-  const auto OpSize = IROp->Size;
+  [[maybe_unused]] const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
   const auto Key = GetVReg(Op->Key.ID());
@@ -65,7 +65,7 @@ DEF_OP(VAESEncLast) {
 
 DEF_OP(VAESDec) {
   const auto Op = IROp->C<IR::IROp_VAESDec>();
-  const auto OpSize = IROp->Size;
+  [[maybe_unused]] const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
   const auto Key = GetVReg(Op->Key.ID());
@@ -90,7 +90,7 @@ DEF_OP(VAESDec) {
 
 DEF_OP(VAESDecLast) {
   const auto Op = IROp->C<IR::IROp_VAESDecLast>();
-  const auto OpSize = IROp->Size;
+  [[maybe_unused]] const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
   const auto Key = GetVReg(Op->Key.ID());
@@ -187,7 +187,7 @@ DEF_OP(VSha256U0) {
 
 DEF_OP(PCLMUL) {
   const auto Op = IROp->C<IR::IROp_PCLMUL>();
-  const auto OpSize = IROp->Size;
+  [[maybe_unused]] const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
   const auto Src1 = GetVReg(Op->Src1.ID());

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -876,8 +876,8 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
     for (size_t i = 0; i < DebugData->GuestOpcodes.size(); i++) {
       const auto& GuestOpcode = DebugData->GuestOpcodes[i];
       auto& RIPEntry = JITRIPEntries[i];
-      uint64_t HostPCOffset = GuestOpcode.HostEntryOffset - CurrentPCOffset;
-      int64_t GuestRIPOffset = GuestOpcode.GuestEntryOffset - CurrentRIPOffset;
+      [[maybe_unused]] uint64_t HostPCOffset = GuestOpcode.HostEntryOffset - CurrentPCOffset;
+      [[maybe_unused]] int64_t GuestRIPOffset = GuestOpcode.GuestEntryOffset - CurrentRIPOffset;
       LOGMAN_THROW_A_FMT(HostPCOffset <= std::numeric_limits<uint16_t>::max(), "PC offset too large");
       LOGMAN_THROW_A_FMT(GuestRIPOffset >= std::numeric_limits<int16_t>::min(), "RIP offset too small");
       LOGMAN_THROW_A_FMT(GuestRIPOffset <= std::numeric_limits<int16_t>::max(), "RIP offset too large");

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -800,7 +800,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
     using namespace FEXCore::IR;
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LOGMAN_THROW_AA_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");
 #endif
 
     auto BlockStartHostCode = GetCursorAddress<uint8_t*>();
@@ -878,9 +878,9 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
       auto& RIPEntry = JITRIPEntries[i];
       uint64_t HostPCOffset = GuestOpcode.HostEntryOffset - CurrentPCOffset;
       int64_t GuestRIPOffset = GuestOpcode.GuestEntryOffset - CurrentRIPOffset;
-      LOGMAN_THROW_AA_FMT(HostPCOffset <= std::numeric_limits<uint16_t>::max(), "PC offset too large");
-      LOGMAN_THROW_AA_FMT(GuestRIPOffset >= std::numeric_limits<int16_t>::min(), "RIP offset too small");
-      LOGMAN_THROW_AA_FMT(GuestRIPOffset <= std::numeric_limits<int16_t>::max(), "RIP offset too large");
+      LOGMAN_THROW_A_FMT(HostPCOffset <= std::numeric_limits<uint16_t>::max(), "PC offset too large");
+      LOGMAN_THROW_A_FMT(GuestRIPOffset >= std::numeric_limits<int16_t>::min(), "RIP offset too small");
+      LOGMAN_THROW_A_FMT(GuestRIPOffset <= std::numeric_limits<int16_t>::max(), "RIP offset too large");
       RIPEntry.HostPCOffset = GuestOpcode.HostEntryOffset - CurrentPCOffset;
       RIPEntry.GuestRIPOffset = GuestOpcode.GuestEntryOffset - CurrentRIPOffset;
       CurrentPCOffset = GuestOpcode.HostEntryOffset;
@@ -899,7 +899,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
 #ifdef VIXL_DISASSEMBLER
   if (Disassemble() & FEXCore::Config::Disassemble::STATS) {
     auto HeaderOp = IR->GetHeader();
-    LOGMAN_THROW_AA_FMT(HeaderOp->Header.Op == IR::OP_IRHEADER, "First op wasn't IRHeader");
+    LOGMAN_THROW_A_FMT(HeaderOp->Header.Op == IR::OP_IRHEADER, "First op wasn't IRHeader");
 
     LogMan::Msg::IFmt("RIP: 0x{:x}", Entry);
     LogMan::Msg::IFmt("Guest Code instructions: {}", HeaderOp->NumHostInstructions);

--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -155,8 +155,8 @@ private:
   [[nodiscard]]
   ARMEmitter::SubRegSize ConvertSubRegSize16(IR::OpSize ElementSize) {
     LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
-                          ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
-                        "Invalid size");
+                         ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
+                       "Invalid size");
     return ElementSize == IR::OpSize::i8Bit  ? ARMEmitter::SubRegSize::i8Bit :
            ElementSize == IR::OpSize::i16Bit ? ARMEmitter::SubRegSize::i16Bit :
            ElementSize == IR::OpSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :

--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -69,7 +69,7 @@ private:
   ARMEmitter::Register GetReg(IR::NodeID Node) const {
     const auto Reg = GetPhys(Node);
 
-    LOGMAN_THROW_AA_FMT(Reg.Class == IR::GPRFixedClass.Val || Reg.Class == IR::GPRClass.Val, "Unexpected Class: {}", Reg.Class);
+    LOGMAN_THROW_A_FMT(Reg.Class == IR::GPRFixedClass.Val || Reg.Class == IR::GPRClass.Val, "Unexpected Class: {}", Reg.Class);
 
     if (Reg.Class == IR::GPRFixedClass.Val) {
       return StaticRegisters[Reg.Reg];
@@ -84,7 +84,7 @@ private:
   ARMEmitter::VRegister GetVReg(IR::NodeID Node) const {
     const auto Reg = GetPhys(Node);
 
-    LOGMAN_THROW_AA_FMT(Reg.Class == IR::FPRFixedClass.Val || Reg.Class == IR::FPRClass.Val, "Unexpected Class: {}", Reg.Class);
+    LOGMAN_THROW_A_FMT(Reg.Class == IR::FPRFixedClass.Val || Reg.Class == IR::FPRClass.Val, "Unexpected Class: {}", Reg.Class);
 
     if (Reg.Class == IR::FPRFixedClass.Val) {
       return StaticFPRegisters[Reg.Reg];
@@ -99,7 +99,7 @@ private:
   ARMEmitter::PRegister GetPReg(IR::NodeID Node) const {
     const auto Reg = GetPhys(Node);
 
-    LOGMAN_THROW_AA_FMT(Reg.Class == IR::PREDClass.Val, "Unexpected Class: {}", Reg.Class);
+    LOGMAN_THROW_A_FMT(Reg.Class == IR::PREDClass.Val, "Unexpected Class: {}", Reg.Class);
 
     if (Reg.Class == IR::PREDClass.Val) {
       return PredicateRegisters[Reg.Reg];
@@ -124,7 +124,7 @@ private:
   ARMEmitter::Register GetZeroableReg(IR::OrderedNodeWrapper Src) const {
     uint64_t Const;
     if (IsInlineConstant(Src, &Const)) {
-      LOGMAN_THROW_AA_FMT(Const == 0, "Only valid constant");
+      LOGMAN_THROW_A_FMT(Const == 0, "Only valid constant");
       return ARMEmitter::Reg::zr;
     } else {
       return GetReg(Src.ID());
@@ -148,13 +148,13 @@ private:
 
   [[nodiscard]]
   ARMEmitter::Size ConvertSize48(const IR::IROp_Header* Op) {
-    LOGMAN_THROW_AA_FMT(Op->Size == IR::OpSize::i32Bit || Op->Size == IR::OpSize::i64Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(Op->Size == IR::OpSize::i32Bit || Op->Size == IR::OpSize::i64Bit, "Invalid size");
     return ConvertSize(Op);
   }
 
   [[nodiscard]]
   ARMEmitter::SubRegSize ConvertSubRegSize16(IR::OpSize ElementSize) {
-    LOGMAN_THROW_AA_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
+    LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
                           ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
                         "Invalid size");
     return ElementSize == IR::OpSize::i8Bit  ? ARMEmitter::SubRegSize::i8Bit :
@@ -171,7 +171,7 @@ private:
 
   [[nodiscard]]
   ARMEmitter::SubRegSize ConvertSubRegSize8(IR::OpSize ElementSize) {
-    LOGMAN_THROW_AA_FMT(ElementSize != IR::OpSize::i128Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(ElementSize != IR::OpSize::i128Bit, "Invalid size");
     return ConvertSubRegSize16(ElementSize);
   }
 
@@ -182,13 +182,13 @@ private:
 
   [[nodiscard]]
   ARMEmitter::SubRegSize ConvertSubRegSize4(const IR::IROp_Header* Op) {
-    LOGMAN_THROW_AA_FMT(Op->ElementSize != IR::OpSize::i64Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(Op->ElementSize != IR::OpSize::i64Bit, "Invalid size");
     return ConvertSubRegSize8(Op);
   }
 
   [[nodiscard]]
   ARMEmitter::SubRegSize ConvertSubRegSize248(const IR::IROp_Header* Op) {
-    LOGMAN_THROW_AA_FMT(Op->ElementSize != IR::OpSize::i8Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(Op->ElementSize != IR::OpSize::i8Bit, "Invalid size");
     return ConvertSubRegSize8(Op);
   }
 
@@ -199,13 +199,13 @@ private:
 
   [[nodiscard]]
   ARMEmitter::VectorRegSizePair ConvertSubRegSizePair8(const IR::IROp_Header* Op) {
-    LOGMAN_THROW_AA_FMT(Op->ElementSize != IR::OpSize::i128Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(Op->ElementSize != IR::OpSize::i128Bit, "Invalid size");
     return ConvertSubRegSizePair16(Op);
   }
 
   [[nodiscard]]
   ARMEmitter::VectorRegSizePair ConvertSubRegSizePair248(const IR::IROp_Header* Op) {
-    LOGMAN_THROW_AA_FMT(Op->ElementSize != IR::OpSize::i8Bit, "Invalid size");
+    LOGMAN_THROW_A_FMT(Op->ElementSize != IR::OpSize::i8Bit, "Invalid size");
     return ConvertSubRegSizePair8(Op);
   }
 

--- a/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
@@ -158,7 +158,7 @@ DEF_OP(LoadRegister) {
       }
     }
   } else {
-    LOGMAN_THROW_AA_FMT(false, "Unhandled Op->Class {}", Op->Class);
+    LOGMAN_THROW_A_FMT(false, "Unhandled Op->Class {}", Op->Class);
   }
 }
 
@@ -210,7 +210,7 @@ DEF_OP(StoreRegister) {
       }
     }
   } else {
-    LOGMAN_THROW_AA_FMT(false, "Unhandled Op->Class {}", Op->Class);
+    LOGMAN_THROW_A_FMT(false, "Unhandled Op->Class {}", Op->Class);
   }
 }
 
@@ -1276,7 +1276,7 @@ DEF_OP(VLoadVectorElement) {
   const auto DstSrc = GetVReg(Op->DstSrc.ID());
   const auto MemReg = GetReg(Op->Addr.ID());
 
-  LOGMAN_THROW_AA_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
                         ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
                       "Invalid element "
                       "size");
@@ -1313,7 +1313,7 @@ DEF_OP(VStoreVectorElement) {
   const auto Value = GetVReg(Op->Value.ID());
   const auto MemReg = GetReg(Op->Addr.ID());
 
-  LOGMAN_THROW_AA_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
                         ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
                       "Invalid element "
                       "size");
@@ -1348,7 +1348,7 @@ DEF_OP(VBroadcastFromMem) {
   const auto Dst = GetVReg(Node);
   const auto MemReg = GetReg(Op->Address.ID());
 
-  LOGMAN_THROW_AA_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
                         ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
                       "Invalid element "
                       "size");
@@ -1894,7 +1894,7 @@ DEF_OP(MemSet) {
   };
 
   if (DirectionIsInline) {
-    LOGMAN_THROW_AA_FMT(DirectionConstant == 1 || DirectionConstant == -1, "unexpected direction");
+    LOGMAN_THROW_A_FMT(DirectionConstant == 1 || DirectionConstant == -1, "unexpected direction");
     EmitMemset(DirectionConstant);
   } else {
     // Emit forward direction memset then backward direction memset.
@@ -2171,7 +2171,7 @@ DEF_OP(MemCpy) {
   };
 
   if (DirectionIsInline) {
-    LOGMAN_THROW_AA_FMT(DirectionConstant == 1 || DirectionConstant == -1, "unexpected direction");
+    LOGMAN_THROW_A_FMT(DirectionConstant == 1 || DirectionConstant == -1, "unexpected direction");
     EmitMemcpy(DirectionConstant);
   } else {
     // Emit forward direction memset then backward direction memset.

--- a/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
@@ -1277,9 +1277,9 @@ DEF_OP(VLoadVectorElement) {
   const auto MemReg = GetReg(Op->Addr.ID());
 
   LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
-                        ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
-                      "Invalid element "
-                      "size");
+                       ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
+                     "Invalid element "
+                     "size");
 
   if (Is256Bit) {
     LOGMAN_MSG_A_FMT("Unsupported 256-bit VLoadVectorElement");
@@ -1314,9 +1314,9 @@ DEF_OP(VStoreVectorElement) {
   const auto MemReg = GetReg(Op->Addr.ID());
 
   LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
-                        ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
-                      "Invalid element "
-                      "size");
+                       ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
+                     "Invalid element "
+                     "size");
 
   // Emit a half-barrier if TSO is enabled.
   if (CTX->IsVectorAtomicTSOEnabled()) {
@@ -1349,9 +1349,9 @@ DEF_OP(VBroadcastFromMem) {
   const auto MemReg = GetReg(Op->Address.ID());
 
   LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit ||
-                        ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
-                      "Invalid element "
-                      "size");
+                       ElementSize == IR::OpSize::i64Bit || ElementSize == IR::OpSize::i128Bit,
+                     "Invalid element "
+                     "size");
 
   if (Is256Bit && HostSupportsSVE256) {
     const auto GoverningPredicate = PRED_TMP_32B.Zeroing();

--- a/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
@@ -148,7 +148,7 @@ DEF_OP(PushRoundingMode) {
   } else if (Op->RoundMode == 0) {
     and_(ARMEmitter::Size::i64Bit, TMP1, Dest, ~(3 << 22));
   } else {
-    LOGMAN_THROW_AA_FMT(Op->RoundMode == 1 || Op->RoundMode == 2, "expect a valid round mode");
+    LOGMAN_THROW_A_FMT(Op->RoundMode == 1 || Op->RoundMode == 2, "expect a valid round mode");
 
     and_(ARMEmitter::Size::i64Bit, TMP1, Dest, ~(Op->RoundMode << 22));
     orr(ARMEmitter::Size::i64Bit, TMP1, TMP1, (Op->RoundMode == 2 ? 1 : 2) << 22);

--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -265,7 +265,7 @@ void Arm64JITCore::VFScalarFMAOperation(IR::OpSize OpSize, IR::OpSize ElementSiz
                                         ARMEmitter::VRegister Addend) {
   LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i128Bit, "256-bit unsupported", __func__);
 
-  LOGMAN_THROW_AA_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid"
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid"
                                                                                                                                    " size");
   const auto SubRegSize = ARMEmitter::ToVectorSizePair(ElementSize == IR::OpSize::i16Bit ? ARMEmitter::SubRegSize::i16Bit :
                                                        ElementSize == IR::OpSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
@@ -299,7 +299,7 @@ void Arm64JITCore::VFScalarOperation(IR::OpSize OpSize, IR::OpSize ElementSize, 
 
   // Bit of a tricky detail.
   // The upper bits of the destination comes from Vector1.
-  LOGMAN_THROW_AA_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid"
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid"
                                                                                                                                    " size");
   const auto SubRegSize = ARMEmitter::ToVectorSizePair(ElementSize == IR::OpSize::i16Bit ? ARMEmitter::SubRegSize::i16Bit :
                                                        ElementSize == IR::OpSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
@@ -371,7 +371,7 @@ void Arm64JITCore::VFScalarUnaryOperation(IR::OpSize OpSize, IR::OpSize ElementS
   LOGMAN_THROW_A_FMT(!Is256Bit || (Is256Bit && HostSupportsSVE256), "Need SVE256 support in order to use {} with 256-bit operation", __func__);
   LOGMAN_THROW_A_FMT(Is256Bit || !ZeroUpperBits, "128-bit operation doesn't support ZeroUpperBits in {}", __func__);
 
-  LOGMAN_THROW_AA_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid"
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid"
                                                                                                                                    " size");
   const auto SubRegSize = ARMEmitter::ToVectorSizePair(ElementSize == IR::OpSize::i16Bit ? ARMEmitter::SubRegSize::i16Bit :
                                                        ElementSize == IR::OpSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
@@ -630,9 +630,9 @@ DEF_OP(VSToFVectorInsert) {
   const auto ElementSize = Op->Header.ElementSize;
   const auto HasTwoElements = Op->HasTwoElements;
 
-  LOGMAN_THROW_AA_FMT(ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid size");
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid size");
   if (HasTwoElements) {
-    LOGMAN_THROW_AA_FMT(ElementSize == IR::OpSize::i32Bit, "Can't have two elements for 8-byte size");
+    LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i32Bit, "Can't have two elements for 8-byte size");
   }
 
   auto ScalarEmit = [this, ElementSize, HasTwoElements](ARMEmitter::VRegister Dst, std::variant<ARMEmitter::VRegister, ARMEmitter::Register> SrcVar) {
@@ -1122,7 +1122,7 @@ DEF_OP(VFAddV) {
   const auto Dst = GetVReg(Node);
   const auto Vector = GetVReg(Op->Vector.ID());
 
-  LOGMAN_THROW_AA_FMT(OpSize == IR::OpSize::i128Bit || OpSize == IR::OpSize::i256Bit, "Only AVX and SSE size "
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i128Bit || OpSize == IR::OpSize::i256Bit, "Only AVX and SSE size "
                                                                                       "supported");
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
@@ -1390,7 +1390,7 @@ DEF_OP(VFMin) {
       mov(Dst.Z(), VTMP1.Z());
     }
   } else {
-    LOGMAN_THROW_AA_FMT(!IsScalar, "should use VFMinScalarInsert instead");
+    LOGMAN_THROW_A_FMT(!IsScalar, "should use VFMinScalarInsert instead");
 
     if (Dst == Vector1) {
       // Destination is already Vector1, need to insert Vector2 on false.
@@ -1442,7 +1442,7 @@ DEF_OP(VFMax) {
       mov(Dst.Z(), VTMP1.Z());
     }
   } else {
-    LOGMAN_THROW_AA_FMT(!IsScalar, "should use VFMaxScalarInsert instead");
+    LOGMAN_THROW_A_FMT(!IsScalar, "should use VFMaxScalarInsert instead");
 
     if (Dst == Vector1) {
       // Destination is already Vector1, need to insert Vector2 on true.
@@ -3912,7 +3912,7 @@ DEF_OP(VTBL1) {
     break;
   }
   case IR::OpSize::i256Bit: {
-    LOGMAN_THROW_AA_FMT(HostSupportsSVE256, "Host does not support SVE. Cannot perform 256-bit table lookup");
+    LOGMAN_THROW_A_FMT(HostSupportsSVE256, "Host does not support SVE. Cannot perform 256-bit table lookup");
 
     tbl(ARMEmitter::SubRegSize::i8Bit, Dst.Z(), VectorTable.Z(), VectorIndices.Z());
     break;
@@ -3956,7 +3956,7 @@ DEF_OP(VTBL2) {
     break;
   }
   case IR::OpSize::i256Bit: {
-    LOGMAN_THROW_AA_FMT(HostSupportsSVE256, "Host does not support SVE. Cannot perform 256-bit table lookup");
+    LOGMAN_THROW_A_FMT(HostSupportsSVE256, "Host does not support SVE. Cannot perform 256-bit table lookup");
 
     tbl(ARMEmitter::SubRegSize::i8Bit, Dst.Z(), VectorTable1.Z(), VectorTable2.Z(), VectorIndices.Z());
     break;
@@ -3989,7 +3989,7 @@ DEF_OP(VTBX1) {
       break;
     }
     case IR::OpSize::i256Bit: {
-      LOGMAN_THROW_AA_FMT(HostSupportsSVE256, "Host does not support SVE. Cannot perform 256-bit table lookup");
+      LOGMAN_THROW_A_FMT(HostSupportsSVE256, "Host does not support SVE. Cannot perform 256-bit table lookup");
       mov(VTMP1.Z(), VectorSrcDst.Z());
       tbx(ARMEmitter::SubRegSize::i8Bit, VTMP1.Z(), VectorTable.Z(), VectorIndices.Z());
       mov(Dst.Z(), VTMP1.Z());
@@ -4008,7 +4008,7 @@ DEF_OP(VTBX1) {
       break;
     }
     case IR::OpSize::i256Bit: {
-      LOGMAN_THROW_AA_FMT(HostSupportsSVE256, "Host does not support SVE. Cannot perform 256-bit table lookup");
+      LOGMAN_THROW_A_FMT(HostSupportsSVE256, "Host does not support SVE. Cannot perform 256-bit table lookup");
 
       tbx(ARMEmitter::SubRegSize::i8Bit, VectorSrcDst.Z(), VectorTable.Z(), VectorIndices.Z());
       break;
@@ -4029,7 +4029,7 @@ DEF_OP(VRev32) {
   const auto Dst = GetVReg(Node);
   const auto Vector = GetVReg(Op->Vector.ID());
 
-  LOGMAN_THROW_AA_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit, "Invalid size");
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i8Bit || ElementSize == IR::OpSize::i16Bit, "Invalid size");
   const auto SubRegSize = ElementSize == IR::OpSize::i8Bit ? ARMEmitter::SubRegSize::i8Bit : ARMEmitter::SubRegSize::i16Bit;
 
   if (HostSupportsSVE256 && Is256Bit) {

--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -265,8 +265,8 @@ void Arm64JITCore::VFScalarFMAOperation(IR::OpSize OpSize, IR::OpSize ElementSiz
                                         ARMEmitter::VRegister Addend) {
   LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i128Bit, "256-bit unsupported", __func__);
 
-  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid"
-                                                                                                                                   " size");
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid "
+                                                                                                                                  "size");
   const auto SubRegSize = ARMEmitter::ToVectorSizePair(ElementSize == IR::OpSize::i16Bit ? ARMEmitter::SubRegSize::i16Bit :
                                                        ElementSize == IR::OpSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
                                                                                            ARMEmitter::SubRegSize::i64Bit);
@@ -299,8 +299,8 @@ void Arm64JITCore::VFScalarOperation(IR::OpSize OpSize, IR::OpSize ElementSize, 
 
   // Bit of a tricky detail.
   // The upper bits of the destination comes from Vector1.
-  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid"
-                                                                                                                                   " size");
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid "
+                                                                                                                                  "size");
   const auto SubRegSize = ARMEmitter::ToVectorSizePair(ElementSize == IR::OpSize::i16Bit ? ARMEmitter::SubRegSize::i16Bit :
                                                        ElementSize == IR::OpSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
                                                                                            ARMEmitter::SubRegSize::i64Bit);
@@ -371,8 +371,8 @@ void Arm64JITCore::VFScalarUnaryOperation(IR::OpSize OpSize, IR::OpSize ElementS
   LOGMAN_THROW_A_FMT(!Is256Bit || (Is256Bit && HostSupportsSVE256), "Need SVE256 support in order to use {} with 256-bit operation", __func__);
   LOGMAN_THROW_A_FMT(Is256Bit || !ZeroUpperBits, "128-bit operation doesn't support ZeroUpperBits in {}", __func__);
 
-  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid"
-                                                                                                                                   " size");
+  LOGMAN_THROW_A_FMT(ElementSize == IR::OpSize::i16Bit || ElementSize == IR::OpSize::i32Bit || ElementSize == IR::OpSize::i64Bit, "Invalid "
+                                                                                                                                  "size");
   const auto SubRegSize = ARMEmitter::ToVectorSizePair(ElementSize == IR::OpSize::i16Bit ? ARMEmitter::SubRegSize::i16Bit :
                                                        ElementSize == IR::OpSize::i32Bit ? ARMEmitter::SubRegSize::i32Bit :
                                                                                            ARMEmitter::SubRegSize::i64Bit);
@@ -1122,8 +1122,7 @@ DEF_OP(VFAddV) {
   const auto Dst = GetVReg(Node);
   const auto Vector = GetVReg(Op->Vector.ID());
 
-  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i128Bit || OpSize == IR::OpSize::i256Bit, "Only AVX and SSE size "
-                                                                                      "supported");
+  LOGMAN_THROW_A_FMT(OpSize == IR::OpSize::i128Bit || OpSize == IR::OpSize::i256Bit, "Only AVX and SSE size supported");
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
     faddv(SubRegSize.Vector, Dst, Pred, Vector.Z());

--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -1348,7 +1348,7 @@ DEF_OP(VFMin) {
 
   const auto ElementSize = Op->Header.ElementSize;
   const auto SubRegSize = ConvertSubRegSize248(IROp);
-  const auto IsScalar = ElementSize == OpSize;
+  [[maybe_unused]] const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == IR::OpSize::i256Bit;
   LOGMAN_THROW_A_FMT(!Is256Bit || (Is256Bit && HostSupportsSVE256), "Need SVE256 support in order to use {} with 256-bit operation", __func__);
 
@@ -1414,7 +1414,7 @@ DEF_OP(VFMax) {
 
   const auto ElementSize = Op->Header.ElementSize;
   const auto SubRegSize = ConvertSubRegSize248(IROp);
-  const auto IsScalar = ElementSize == OpSize;
+  [[maybe_unused]] const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == IR::OpSize::i256Bit;
   LOGMAN_THROW_A_FMT(!Is256Bit || (Is256Bit && HostSupportsSVE256), "Need SVE256 support in order to use {} with 256-bit operation", __func__);
 

--- a/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -44,11 +44,11 @@ LookupCache::LookupCache(FEXCore::Context::ContextImpl* CTX)
   // We currently limit to 128MB of real memory for caching for the total cache size.
   // Can end up being inefficient if we compile a small number of blocks per page
   PageMemory = PagePointer + ctx->Config.VirtualMemSize / 4096 * 8;
-  LOGMAN_THROW_AA_FMT(PageMemory != -1ULL, "Failed to allocate page memory");
+  LOGMAN_THROW_A_FMT(PageMemory != -1ULL, "Failed to allocate page memory");
 
   // L1 Cache
   L1Pointer = PageMemory + CODE_SIZE;
-  LOGMAN_THROW_AA_FMT(L1Pointer != -1ULL, "Failed to allocate L1Pointer");
+  LOGMAN_THROW_A_FMT(L1Pointer != -1ULL, "Failed to allocate L1Pointer");
 
   VirtualMemSize = ctx->Config.VirtualMemSize;
 }

--- a/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/FEXCore/Source/Interface/Core/LookupCache.h
@@ -90,7 +90,7 @@ public:
     std::lock_guard<std::recursive_mutex> lk(WriteLock);
 
     [[maybe_unused]] auto Inserted = BlockList.emplace(Address, (uintptr_t)HostCode).second;
-    LOGMAN_THROW_AA_FMT(Inserted, "Duplicate block mapping added");
+    LOGMAN_THROW_A_FMT(Inserted, "Duplicate block mapping added");
 
     // There is no need to update L1 or L2, they will get updated on first lookup
     // However, adding to L1 here increases performance

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -753,7 +753,7 @@ void OpDispatchBuilder::CondJUMPOp(OpcodeArgs) {
     auto OP = Op->OP & 0xF;
     auto [Complex, SimpleCond] = DecodeNZCVCondition(OP);
     if (Complex) {
-      LOGMAN_THROW_AA_FMT(OP == 0xA || OP == 0xB, "only PF left");
+      LOGMAN_THROW_A_FMT(OP == 0xA || OP == 0xB, "only PF left");
       CondJump_ = CondJumpBit(LoadPFRaw(false, false), 0, OP == 0xB);
     } else {
       CondJump_ = CondJumpNZCV(SimpleCond);
@@ -3924,7 +3924,7 @@ void OpDispatchBuilder::Finalize() {
   Ref RealNode = reinterpret_cast<Ref>(GetNode(1));
 
   [[maybe_unused]] const FEXCore::IR::IROp_Header* IROp = RealNode->Op(DualListData.DataBegin());
-  LOGMAN_THROW_AA_FMT(IROp->Op == OP_IRHEADER, "First op in function must be our header");
+  LOGMAN_THROW_A_FMT(IROp->Op == OP_IRHEADER, "First op in function must be our header");
 
   // Let's walk the jump blocks and see if we have handled every block target
   for (auto& Handler : JumpTargets) {
@@ -3940,13 +3940,13 @@ void OpDispatchBuilder::Finalize() {
 
 uint8_t OpDispatchBuilder::GetDstSize(X86Tables::DecodedOp Op) const {
   const uint32_t DstSizeFlag = X86Tables::DecodeFlags::GetSizeDstFlags(Op->Flags);
-  LOGMAN_THROW_AA_FMT(DstSizeFlag != 0 && DstSizeFlag != X86Tables::DecodeFlags::SIZE_MASK, "Invalid destination size for op");
+  LOGMAN_THROW_A_FMT(DstSizeFlag != 0 && DstSizeFlag != X86Tables::DecodeFlags::SIZE_MASK, "Invalid destination size for op");
   return 1u << (DstSizeFlag - 1);
 }
 
 uint8_t OpDispatchBuilder::GetSrcSize(X86Tables::DecodedOp Op) const {
   const uint32_t SrcSizeFlag = X86Tables::DecodeFlags::GetSizeSrcFlags(Op->Flags);
-  LOGMAN_THROW_AA_FMT(SrcSizeFlag != 0 && SrcSizeFlag != X86Tables::DecodeFlags::SIZE_MASK, "Invalid destination size for op");
+  LOGMAN_THROW_A_FMT(SrcSizeFlag != 0 && SrcSizeFlag != X86Tables::DecodeFlags::SIZE_MASK, "Invalid destination size for op");
   return 1u << (SrcSizeFlag - 1);
 }
 
@@ -4137,7 +4137,7 @@ Ref OpDispatchBuilder::LoadEffectiveAddress(AddressMode A, bool AddSegmentBase, 
 
   if (A.Index) {
     if (A.IndexScale != 1) {
-      LOGMAN_THROW_AA_FMT((A.IndexScale & (A.IndexScale - 1)) == 0, "power of two");
+      LOGMAN_THROW_A_FMT((A.IndexScale & (A.IndexScale - 1)) == 0, "power of two");
       uint32_t Log2 = FEXCore::ilog2(A.IndexScale);
 
       if (Tmp) {
@@ -4424,9 +4424,9 @@ void OpDispatchBuilder::StoreResult_WithOpSize(FEXCore::IR::RegisterClassType Cl
         Ref Value = GetOpSize(Src) == OpSize::i64Bit ? _Bfe(OpSize::i32Bit, 32, 0, Src) : Src;
         StoreGPRRegister(gpr, Value, GPRSize);
 
-        LOGMAN_THROW_AA_FMT(!Operand.Data.GPR.HighBits, "Can't handle 32bit store to high 8bit register");
+        LOGMAN_THROW_A_FMT(!Operand.Data.GPR.HighBits, "Can't handle 32bit store to high 8bit register");
       } else {
-        LOGMAN_THROW_AA_FMT(!(GPRSize == OpSize::i32Bit && OpSize > OpSize::i32Bit), "Oops had a {} GPR load", OpSize);
+        LOGMAN_THROW_A_FMT(!(GPRSize == OpSize::i32Bit && OpSize > OpSize::i32Bit), "Oops had a {} GPR load", OpSize);
 
         if (GPRSize != OpSize) {
           // if the GPR isn't the full size then we need to insert.

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1548,7 +1548,7 @@ private:
 
   [[nodiscard]]
   static uint32_t GPROffset(X86State::X86Reg reg) {
-    LOGMAN_THROW_AA_FMT(reg <= X86State::X86Reg::REG_R15, "Invalid reg used");
+    LOGMAN_THROW_A_FMT(reg <= X86State::X86Reg::REG_R15, "Invalid reg used");
     return static_cast<uint32_t>(offsetof(Core::CPUState, gregs[static_cast<size_t>(reg)]));
   }
 
@@ -1707,7 +1707,7 @@ private:
       CFInverted ^= true;
     }
 
-    LOGMAN_THROW_AA_FMT(CFInverted == RequiredInvert, "post condition");
+    LOGMAN_THROW_A_FMT(CFInverted == RequiredInvert, "post condition");
   }
 
   void CarryInvert() {
@@ -1889,7 +1889,7 @@ private:
   }
 
   Ref LoadRegCache(uint64_t Offset, uint8_t Index, RegisterClassType RegClass, IR::OpSize Size) {
-    LOGMAN_THROW_AA_FMT(Index < 64, "valid index");
+    LOGMAN_THROW_A_FMT(Index < 64, "valid index");
     uint64_t Bit = (1ull << (uint64_t)Index);
 
     if (Size == OpSize::i128Bit && (RegCache.Partial & Bit)) {
@@ -1944,8 +1944,8 @@ private:
   }
 
   RefPair LoadRegCachePair(uint64_t Offset, uint8_t Index, RegisterClassType RegClass, IR::OpSize Size) {
-    LOGMAN_THROW_AA_FMT(Index != DFIndex, "must be pairable");
-    LOGMAN_THROW_AA_FMT(Size != IR::OpSize::iUnsized, "Invalid size!");
+    LOGMAN_THROW_A_FMT(Index != DFIndex, "must be pairable");
+    LOGMAN_THROW_A_FMT(Size != IR::OpSize::iUnsized, "Invalid size!");
 
     // Try to load a pair into the cache
     uint64_t Bits = (3ull << (uint64_t)Index);
@@ -1993,8 +1993,8 @@ private:
   }
 
   void StoreContext(uint8_t Index, Ref Value) {
-    LOGMAN_THROW_AA_FMT(Index < 64, "valid index");
-    LOGMAN_THROW_AA_FMT(Value != InvalidNode, "storing valid");
+    LOGMAN_THROW_A_FMT(Index < 64, "valid index");
+    LOGMAN_THROW_A_FMT(Value != InvalidNode, "storing valid");
 
     uint64_t Bit = (1ull << (uint64_t)Index);
 
@@ -2425,7 +2425,7 @@ private:
   }
 
   AddressMode SelectPairAddressMode(AddressMode A, IR::OpSize Size) {
-    LOGMAN_THROW_AA_FMT(Size != IR::OpSize::iUnsized, "Invalid size!");
+    LOGMAN_THROW_A_FMT(Size != IR::OpSize::iUnsized, "Invalid size!");
     const auto SizeInt = IR::OpSizeToSize(Size);
     AddressMode Out {};
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -486,7 +486,7 @@ OpDispatchBuilder::RefPair OpDispatchBuilder::AVX128_LoadSource_WithOpSize(
 
   if (Operand.IsGPR()) {
     const auto gpr = Operand.Data.GPR.GPR;
-    LOGMAN_THROW_AA_FMT(gpr >= FEXCore::X86State::REG_XMM_0 && gpr <= FEXCore::X86State::REG_XMM_15, "must be AVX reg");
+    LOGMAN_THROW_A_FMT(gpr >= FEXCore::X86State::REG_XMM_0 && gpr <= FEXCore::X86State::REG_XMM_15, "must be AVX reg");
     const auto gprIndex = gpr - X86State::REG_XMM_0;
     return {
       .Low = AVX128_LoadXMMRegister(gprIndex, false),
@@ -502,7 +502,7 @@ OpDispatchBuilder::RefPair OpDispatchBuilder::AVX128_LoadSource_WithOpSize(
 
     if (Operand.IsSIB()) {
       const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
-      LOGMAN_THROW_AA_FMT(!IsVSIB, "VSIB uses LoadVSIB instead");
+      LOGMAN_THROW_A_FMT(!IsVSIB, "VSIB uses LoadVSIB instead");
     }
 
     if (NeedsHigh) {
@@ -523,8 +523,8 @@ OpDispatchBuilder::AVX128_LoadVSIB(const X86Tables::DecodedOp& Op, const X86Tabl
 
   const auto Index_gpr = Operand.Data.SIB.Index;
   const auto Base_gpr = Operand.Data.SIB.Base;
-  LOGMAN_THROW_AA_FMT(Index_gpr >= FEXCore::X86State::REG_XMM_0 && Index_gpr <= FEXCore::X86State::REG_XMM_15, "must be AVX reg");
-  LOGMAN_THROW_AA_FMT(
+  LOGMAN_THROW_A_FMT(Index_gpr >= FEXCore::X86State::REG_XMM_0 && Index_gpr <= FEXCore::X86State::REG_XMM_15, "must be AVX reg");
+  LOGMAN_THROW_A_FMT(
     Base_gpr == FEXCore::X86State::REG_INVALID || (Base_gpr >= FEXCore::X86State::REG_RAX && Base_gpr <= FEXCore::X86State::REG_R15),
     "Base must be a GPR.");
   const auto Index_XMM_gpr = Index_gpr - X86State::REG_XMM_0;
@@ -542,7 +542,7 @@ void OpDispatchBuilder::AVX128_StoreResult_WithOpSize(FEXCore::X86Tables::Decode
                                                       const RefPair Src, MemoryAccessType AccessType) {
   if (Operand.IsGPR()) {
     const auto gpr = Operand.Data.GPR.GPR;
-    LOGMAN_THROW_AA_FMT(gpr >= FEXCore::X86State::REG_XMM_0 && gpr <= FEXCore::X86State::REG_XMM_15, "expected AVX register");
+    LOGMAN_THROW_A_FMT(gpr >= FEXCore::X86State::REG_XMM_0 && gpr <= FEXCore::X86State::REG_XMM_15, "expected AVX register");
     const auto gprIndex = gpr - X86State::REG_XMM_0;
 
     if (Src.Low) {
@@ -1817,7 +1817,7 @@ void OpDispatchBuilder::AVX128_VPERMQ(OpcodeArgs) {
   uint8_t SelectorLow = Selector & 0b1111;
   uint8_t SelectorHigh = (Selector >> 4) & 0b1111;
   auto SelectLane = [this](uint8_t Selector, RefPair Src) -> Ref {
-    LOGMAN_THROW_AA_FMT(Selector < 16, "Selector too large!");
+    LOGMAN_THROW_A_FMT(Selector < 16, "Selector too large!");
 
     switch (Selector) {
     case 0b00'00: return _VDupElement(OpSize::i128Bit, OpSize::i64Bit, Src.Low, 0);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -524,9 +524,8 @@ OpDispatchBuilder::AVX128_LoadVSIB(const X86Tables::DecodedOp& Op, const X86Tabl
   const auto Index_gpr = Operand.Data.SIB.Index;
   const auto Base_gpr = Operand.Data.SIB.Base;
   LOGMAN_THROW_A_FMT(Index_gpr >= FEXCore::X86State::REG_XMM_0 && Index_gpr <= FEXCore::X86State::REG_XMM_15, "must be AVX reg");
-  LOGMAN_THROW_A_FMT(
-    Base_gpr == FEXCore::X86State::REG_INVALID || (Base_gpr >= FEXCore::X86State::REG_RAX && Base_gpr <= FEXCore::X86State::REG_R15),
-    "Base must be a GPR.");
+  LOGMAN_THROW_A_FMT(Base_gpr == FEXCore::X86State::REG_INVALID || (Base_gpr >= FEXCore::X86State::REG_RAX && Base_gpr <= FEXCore::X86State::REG_R15),
+                     "Base must be a GPR.");
   const auto Index_XMM_gpr = Index_gpr - X86State::REG_XMM_0;
 
   return {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -501,7 +501,7 @@ OpDispatchBuilder::RefPair OpDispatchBuilder::AVX128_LoadSource_WithOpSize(
     HighA.Offset += 16;
 
     if (Operand.IsSIB()) {
-      const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
+      [[maybe_unused]] const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
       LOGMAN_THROW_A_FMT(!IsVSIB, "VSIB uses LoadVSIB instead");
     }
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -4956,9 +4956,8 @@ OpDispatchBuilder::RefVSIB OpDispatchBuilder::LoadVSIB(const X86Tables::DecodedO
   const auto Index_gpr = Operand.Data.SIB.Index;
   const auto Base_gpr = Operand.Data.SIB.Base;
   LOGMAN_THROW_A_FMT(Index_gpr >= FEXCore::X86State::REG_XMM_0 && Index_gpr <= FEXCore::X86State::REG_XMM_15, "must be AVX reg");
-  LOGMAN_THROW_A_FMT(
-    Base_gpr == FEXCore::X86State::REG_INVALID || (Base_gpr >= FEXCore::X86State::REG_RAX && Base_gpr <= FEXCore::X86State::REG_R15),
-    "Base must be a GPR.");
+  LOGMAN_THROW_A_FMT(Base_gpr == FEXCore::X86State::REG_INVALID || (Base_gpr >= FEXCore::X86State::REG_RAX && Base_gpr <= FEXCore::X86State::REG_R15),
+                     "Base must be a GPR.");
   const auto Index_XMM_gpr = Index_gpr - X86State::REG_XMM_0;
 
   return {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -4955,8 +4955,8 @@ OpDispatchBuilder::RefVSIB OpDispatchBuilder::LoadVSIB(const X86Tables::DecodedO
 
   const auto Index_gpr = Operand.Data.SIB.Index;
   const auto Base_gpr = Operand.Data.SIB.Base;
-  LOGMAN_THROW_AA_FMT(Index_gpr >= FEXCore::X86State::REG_XMM_0 && Index_gpr <= FEXCore::X86State::REG_XMM_15, "must be AVX reg");
-  LOGMAN_THROW_AA_FMT(
+  LOGMAN_THROW_A_FMT(Index_gpr >= FEXCore::X86State::REG_XMM_0 && Index_gpr <= FEXCore::X86State::REG_XMM_15, "must be AVX reg");
+  LOGMAN_THROW_A_FMT(
     Base_gpr == FEXCore::X86State::REG_INVALID || (Base_gpr >= FEXCore::X86State::REG_RAX && Base_gpr <= FEXCore::X86State::REG_R15),
     "Base must be a GPR.");
   const auto Index_XMM_gpr = Index_gpr - X86State::REG_XMM_0;

--- a/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -138,7 +138,7 @@ static bool LoadAOTIRCache(AOTIRCacheEntry* Entry, int streamfd) {
 
   auto Array = (AOTIRInlineIndex*)((char*)FilePtr + IndexOffset);
 
-  LOGMAN_THROW_AA_FMT(Entry->Array == nullptr && Entry->FilePtr == nullptr, "Entry must not be initialized here");
+  LOGMAN_THROW_A_FMT(Entry->Array == nullptr && Entry->FilePtr == nullptr, "Entry must not be initialized here");
   Entry->Array = Array;
   Entry->FilePtr = FilePtr;
   Entry->Size = Size;
@@ -392,7 +392,7 @@ AOTIRCacheEntry* AOTIRCaptureCache::LoadAOTIRCacheEntry(const fextl::string& fil
     auto Inserted = AOTIRCache.insert({fileid, AOTIRCacheEntry {.FileId = fileid, .Filename = filename}});
     auto Entry = &(Inserted.first->second);
 
-    LOGMAN_THROW_AA_FMT(Entry->Array == nullptr, "Duplicate LoadAOTIRCacheEntry");
+    LOGMAN_THROW_A_FMT(Entry->Array == nullptr, "Duplicate LoadAOTIRCacheEntry");
 
     if (CTX->Config.AOTIRLoad && AOTIRLoader) {
       auto streamfd = AOTIRLoader(fileid);
@@ -409,7 +409,7 @@ AOTIRCacheEntry* AOTIRCaptureCache::LoadAOTIRCacheEntry(const fextl::string& fil
 
 void AOTIRCaptureCache::UnloadAOTIRCacheEntry(AOTIRCacheEntry* Entry) {
 #ifndef _WIN32
-  LOGMAN_THROW_AA_FMT(Entry != nullptr, "Removing not existing entry");
+  LOGMAN_THROW_A_FMT(Entry != nullptr, "Removing not existing entry");
 
   if (Entry->Array) {
     FEXCore::Allocator::munmap(Entry->FilePtr, Entry->Size);

--- a/FEXCore/Source/Interface/IR/IREmitter.cpp
+++ b/FEXCore/Source/Interface/IR/IREmitter.cpp
@@ -160,7 +160,7 @@ IREmitter::IRPair<IROp_CodeBlock> IREmitter::CreateNewCodeBlockAfter(Ref insertA
   if (insertAfter) {
     LinkCodeBlocks(insertAfter, CodeNode);
   } else {
-    LOGMAN_THROW_AA_FMT(CurrentCodeBlock != nullptr, "CurrentCodeBlock must not be null here");
+    LOGMAN_THROW_A_FMT(CurrentCodeBlock != nullptr, "CurrentCodeBlock must not be null here");
 
     // Find last block
     auto LastBlock = CurrentCodeBlock;

--- a/FEXCore/Source/Interface/IR/IREmitter.h
+++ b/FEXCore/Source/Interface/IR/IREmitter.h
@@ -205,7 +205,7 @@ public:
 
     ReplaceAllUsesWithRange(Node, NewNode, Start, AllNodesIterator(DualListData.ListBegin(), DualListData.DataBegin()));
 
-    LOGMAN_THROW_AA_FMT(Node->NumUses == 0, "Node still used");
+    LOGMAN_THROW_A_FMT(Node->NumUses == 0, "Node still used");
 
     auto IROp = Node->Op(DualListData.DataBegin())->CW<FEXCore::IR::IROp_Header>();
     // We can not remove the op if there are side-effects

--- a/FEXCore/Source/Interface/IR/Passes/IRDumperPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/IRDumperPass.cpp
@@ -53,7 +53,7 @@ void IRDumper::Run(IREmitter* IREmit) {
 
   auto IR = IREmit->ViewIR();
   auto HeaderOp = IR.GetHeader();
-  LOGMAN_THROW_AA_FMT(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
+  LOGMAN_THROW_A_FMT(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
 
   // DumpIRStr might be no if not dumping but ShouldDump is set in OpDisp
   if (DumpToFile) {

--- a/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -65,7 +65,7 @@ void IRValidation::Run(IREmitter* IREmit) {
 
   for (auto [BlockNode, BlockHeader] : CurrentIR.GetBlocks()) {
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
-    LOGMAN_THROW_AA_FMT(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
+    LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == OP_CODEBLOCK, "IR type failed to be a code block");
 
     if (!EntryBlock) {
       EntryBlock = BlockNode;

--- a/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
@@ -191,7 +191,7 @@ unsigned DeadFlagCalculationEliminination::FlagsForCondClassType(CondClassType C
   case COND_FLEU:
   case COND_FGT: return FLAG_N | FLAG_Z | FLAG_V;
 
-  default: LOGMAN_THROW_AA_FMT(false, "unknown cond class type"); return FLAG_NZCV;
+  default: LOGMAN_THROW_A_FMT(false, "unknown cond class type"); return FLAG_NZCV;
   }
 }
 
@@ -435,7 +435,7 @@ FlagInfo DeadFlagCalculationEliminination::Classify(IROp_Header* IROp) {
     });
   }
 
-  default: LOGMAN_THROW_AA_FMT(false, "invalid special op"); FEX_UNREACHABLE;
+  default: LOGMAN_THROW_A_FMT(false, "invalid special op"); FEX_UNREACHABLE;
   }
 
   FEX_UNREACHABLE;

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -21,7 +21,7 @@ using namespace FEXCore;
 
 namespace FEXCore::IR {
 namespace {
-  constexpr uint32_t INVALID_REG = IR::InvalidReg;
+  [[maybe_unused]] constexpr uint32_t INVALID_REG = IR::InvalidReg;
   constexpr uint32_t INVALID_CLASS = IR::InvalidClass.Val;
 
   struct RegisterClass {
@@ -289,7 +289,7 @@ private:
     // next-use has the /smallest/ unsigned IP.
     Ref Candidate = nullptr;
     uint32_t BestDistance = UINT32_MAX;
-    uint8_t BestReg = ~0;
+    [[maybe_unused]] uint8_t BestReg = ~0;
     uint32_t Allocated = ((1u << Class->Count) - 1) & ~Class->Available;
 
     foreach_bit(i, Allocated) {

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -160,7 +160,7 @@ private:
 
     // Otherwise fill from stack
     uint32_t SlotPlusOne = SpillSlots[IR->GetID(Old).Value];
-    LOGMAN_THROW_AA_FMT(SlotPlusOne >= 1, "Old must have been spilled");
+    LOGMAN_THROW_A_FMT(SlotPlusOne >= 1, "Old must have been spilled");
 
     RegisterClassType RegClass = GetRegClassFromNode(IR, IROp);
 
@@ -214,7 +214,7 @@ private:
     RegisterClass* Class = GetClass(Reg);
     uint32_t RegBits = GetRegBits(Reg);
 
-    LOGMAN_THROW_AA_FMT(!(Class->Available & RegBits), "Register double-free");
+    LOGMAN_THROW_A_FMT(!(Class->Available & RegBits), "Register double-free");
 
     Class->Available |= RegBits;
   };
@@ -260,7 +260,7 @@ private:
       Class = Op->Class;
       Reg = Op->Reg;
     } else if (IROp->Op == OP_STOREREGISTER) {
-      LOGMAN_THROW_AA_FMT(IROp->Op == OP_STOREREGISTER, "node is SRA");
+      LOGMAN_THROW_A_FMT(IROp->Op == OP_STOREREGISTER, "node is SRA");
       const IROp_StoreRegister* Op = IROp->C<IR::IROp_StoreRegister>();
 
       Class = Op->Class;
@@ -295,7 +295,7 @@ private:
     foreach_bit(i, Allocated) {
       Ref Old = Class->RegToSSA[i];
 
-      LOGMAN_THROW_AA_FMT(Old != nullptr, "Invariant3");
+      LOGMAN_THROW_A_FMT(Old != nullptr, "Invariant3");
       LOGMAN_THROW_A_FMT(SSAToReg[IR->GetID(Map(Old)).Value].Reg == i, "Invariant4");
 
       // Skip any source used by the current instruction, it is unspillable.
@@ -316,11 +316,11 @@ private:
       }
     }
 
-    LOGMAN_THROW_AA_FMT(Candidate != nullptr, "must've found something..");
+    LOGMAN_THROW_A_FMT(Candidate != nullptr, "must've found something..");
     LOGMAN_THROW_A_FMT(IsOld(Candidate), "Invariant5");
 
     PhysicalRegister Reg = SSAToReg[IR->GetID(Map(Candidate)).Value];
-    LOGMAN_THROW_AA_FMT(Reg.Reg == BestReg, "Invariant6");
+    LOGMAN_THROW_A_FMT(Reg.Reg == BestReg, "Invariant6");
 
     IROp_Header* Header = IR->GetOp<IROp_Header>(Candidate);
     uint32_t Value = IR->GetID(Candidate).Value;
@@ -357,7 +357,7 @@ private:
     RegisterClass* Class = GetClass(Reg);
     uint32_t RegBits = GetRegBits(Reg);
 
-    LOGMAN_THROW_AA_FMT((Class->Available & RegBits) == RegBits, "Precondition");
+    LOGMAN_THROW_A_FMT((Class->Available & RegBits) == RegBits, "Precondition");
 
     Class->Available &= ~RegBits;
     Class->RegToSSA[Reg.Reg] = Unmap(Node);
@@ -435,7 +435,7 @@ private:
     }
 
     // Assign a free register in the appropriate class.
-    LOGMAN_THROW_AA_FMT(Class->Available != 0, "Post-condition of spilling");
+    LOGMAN_THROW_A_FMT(Class->Available != 0, "Post-condition of spilling");
     unsigned Reg = std::countr_zero(Class->Available);
     SetReg(CodeNode, PhysicalRegister(ClassType, Reg));
   };
@@ -446,7 +446,7 @@ private:
 };
 
 void ConstrainedRAPass::AddRegisters(IR::RegisterClassType Class, uint32_t RegisterCount) {
-  LOGMAN_THROW_AA_FMT(RegisterCount <= INVALID_REG, "Up to {} regs supported", INVALID_REG);
+  LOGMAN_THROW_A_FMT(RegisterCount <= INVALID_REG, "Up to {} regs supported", INVALID_REG);
 
   Classes[Class].Count = RegisterCount;
 }
@@ -623,7 +623,7 @@ void ConstrainedRAPass::Run(IREmitter* IREmit_) {
         }
 
         SourceIndex--;
-        LOGMAN_THROW_AA_FMT(SourceIndex >= 0, "Consistent source count");
+        LOGMAN_THROW_A_FMT(SourceIndex >= 0, "Consistent source count");
 
         if (!SourcesNextUses[SourceIndex]) {
           Ref Old = IR->GetNode(IROp->Args[s]);
@@ -654,11 +654,11 @@ void ConstrainedRAPass::Run(IREmitter* IREmit_) {
         }
       }
 
-      LOGMAN_THROW_AA_FMT(IP >= 1, "IP relative to end of block, iterating forward");
+      LOGMAN_THROW_A_FMT(IP >= 1, "IP relative to end of block, iterating forward");
       --IP;
     }
 
-    LOGMAN_THROW_AA_FMT(SourceIndex == 0, "Consistent source count in block");
+    LOGMAN_THROW_A_FMT(SourceIndex == 0, "Consistent source count in block");
   }
 
   /* Now that we're done growing things, we can finalize our results.

--- a/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
@@ -541,7 +541,7 @@ void X87StackOptimization::Run(IREmitter* Emit) {
 
   auto CurrentIR = Emit->ViewIR();
   auto* HeaderOp = CurrentIR.GetHeader();
-  LOGMAN_THROW_AA_FMT(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
+  LOGMAN_THROW_A_FMT(HeaderOp->Header.Op == OP_IRHEADER, "First op wasn't IRHeader");
 
   if (!HeaderOp->HasX87) {
     // If there is no x87 in this, just early exit.

--- a/FEXCore/Source/Utils/Allocator/FlexBitSet.h
+++ b/FEXCore/Source/Utils/Allocator/FlexBitSet.h
@@ -72,7 +72,7 @@ struct FlexBitSet final {
     bool FoundHole {};
     for (size_t CurrentPage = BeginningElement; CurrentPage >= (MinimumElement + ElementCount);) {
       size_t Remaining = ElementCount;
-      LOGMAN_THROW_AA_FMT(Remaining <= CurrentPage, "Scanning less than available range");
+      LOGMAN_THROW_A_FMT(Remaining <= CurrentPage, "Scanning less than available range");
 
       while (Remaining) {
         if (this->Get(CurrentPage - Remaining) == WantUnset) {
@@ -112,7 +112,7 @@ struct FlexBitSet final {
       // If we have enough free space, check if we have enough free pages that are contiguous
       size_t Remaining = ElementCount;
 
-      LOGMAN_THROW_AA_FMT((CurrentElement + Remaining - 1) < ElementsInSet, "Scanning less than available range");
+      LOGMAN_THROW_A_FMT((CurrentElement + Remaining - 1) < ElementsInSet, "Scanning less than available range");
 
       while (Remaining) {
         if (this->Get(CurrentElement + Remaining - 1) == WantUnset) {

--- a/FEXCore/Source/Utils/MemberFunctionToPointer.h
+++ b/FEXCore/Source/Utils/MemberFunctionToPointer.h
@@ -25,13 +25,12 @@ public:
     // Low bit of ptr specifies if this Member function pointer is virtual or not
     // Throw an assert if we were trying to cast a virtual member
     LOGMAN_THROW_A_FMT((PMF.ptr & 1) == 0, "C++ Pointer-To-Member representation didn't have low bit set to 0. Are you trying to cast a "
-                                            "virtual member?");
+                                           "virtual member?");
 #elif defined(_M_ARM_64)
     // C++ ABI for the Arm 64-bit Architecture (IHI 0059E)
     // 4.2.1 Representation of pointer to member function
     // Differs from Itanium specification
-    LOGMAN_THROW_A_FMT(PMF.adj == 0, "C++ Pointer-To-Member representation didn't have adj == 0. Are you trying to cast a virtual "
-                                      "member?");
+    LOGMAN_THROW_A_FMT(PMF.adj == 0, "C++ Pointer-To-Member representation didn't have adj == 0. Are you trying to cast a virtual member?");
 #else
 #error Don't know how to cast Member to function here. Likely just Itanium
 #endif
@@ -45,14 +44,14 @@ public:
     // Low bit of ptr specifies if this Member function pointer is virtual or not
     // Throw an assert if we are not loading a virtual member.
     LOGMAN_THROW_A_FMT((PMF.ptr & 1) == 1, "C++ Pointer-To-Member representation didn't have low bit set to 1. This cast only works for "
-                                            "virtual members.");
+                                           "virtual members.");
     return PMF.ptr & ~1ULL;
 #elif defined(_M_ARM_64)
     // C++ ABI for the Arm 64-bit Architecture (IHI 0059E)
     // 4.2.1 Representation of pointer to member function
     // Differs from Itanium specification
     LOGMAN_THROW_A_FMT((PMF.adj & 1) == 1, "C++ Pointer-To-Member representation didn't have adj == 1. This cast only works for virtual "
-                                            "members.");
+                                           "members.");
     return PMF.ptr;
 #else
 #error Don't know how to cast Member to function here. Likely just Itanium

--- a/FEXCore/Source/Utils/MemberFunctionToPointer.h
+++ b/FEXCore/Source/Utils/MemberFunctionToPointer.h
@@ -24,13 +24,13 @@ public:
     // Itanium C++ ABI (https://itanium-cxx-abi.github.io/cxx-abi/abi.html#member-function-pointers)
     // Low bit of ptr specifies if this Member function pointer is virtual or not
     // Throw an assert if we were trying to cast a virtual member
-    LOGMAN_THROW_AA_FMT((PMF.ptr & 1) == 0, "C++ Pointer-To-Member representation didn't have low bit set to 0. Are you trying to cast a "
+    LOGMAN_THROW_A_FMT((PMF.ptr & 1) == 0, "C++ Pointer-To-Member representation didn't have low bit set to 0. Are you trying to cast a "
                                             "virtual member?");
 #elif defined(_M_ARM_64)
     // C++ ABI for the Arm 64-bit Architecture (IHI 0059E)
     // 4.2.1 Representation of pointer to member function
     // Differs from Itanium specification
-    LOGMAN_THROW_AA_FMT(PMF.adj == 0, "C++ Pointer-To-Member representation didn't have adj == 0. Are you trying to cast a virtual "
+    LOGMAN_THROW_A_FMT(PMF.adj == 0, "C++ Pointer-To-Member representation didn't have adj == 0. Are you trying to cast a virtual "
                                       "member?");
 #else
 #error Don't know how to cast Member to function here. Likely just Itanium
@@ -44,14 +44,14 @@ public:
     // Itanium C++ ABI (https://itanium-cxx-abi.github.io/cxx-abi/abi.html#member-function-pointers)
     // Low bit of ptr specifies if this Member function pointer is virtual or not
     // Throw an assert if we are not loading a virtual member.
-    LOGMAN_THROW_AA_FMT((PMF.ptr & 1) == 1, "C++ Pointer-To-Member representation didn't have low bit set to 1. This cast only works for "
+    LOGMAN_THROW_A_FMT((PMF.ptr & 1) == 1, "C++ Pointer-To-Member representation didn't have low bit set to 1. This cast only works for "
                                             "virtual members.");
     return PMF.ptr & ~1ULL;
 #elif defined(_M_ARM_64)
     // C++ ABI for the Arm 64-bit Architecture (IHI 0059E)
     // 4.2.1 Representation of pointer to member function
     // Differs from Itanium specification
-    LOGMAN_THROW_AA_FMT((PMF.adj & 1) == 1, "C++ Pointer-To-Member representation didn't have adj == 1. This cast only works for virtual "
+    LOGMAN_THROW_A_FMT((PMF.adj & 1) == 1, "C++ Pointer-To-Member representation didn't have adj == 1. This cast only works for virtual "
                                             "members.");
     return PMF.ptr;
 #else

--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -170,7 +170,7 @@ public:
   }
 
   void Set(ConfigOption Option, const char* Data) {
-    LOGMAN_THROW_AA_FMT(Data != nullptr, "Data can't be null");
+    LOGMAN_THROW_A_FMT(Data != nullptr, "Data can't be null");
     OptionMap[Option].emplace_back(fextl::string(Data));
   }
 

--- a/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -44,19 +44,9 @@ namespace Throw {
   [[noreturn]]
   void MFmt(const char* fmt, const fmt::format_args& args);
 
-// AA_FMT and AAFmt are assume versions of {AA_FMT, AFmt} which will assert in debug builds if the assumption is incorrect.
-// In a release build these use __builtin_assume so compilers can optimize around the case that these cases always hold true.
-// The assume version should be preferred unless what is being checked has side effects.
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
   template<typename... Args>
   static inline void AFmt(bool Value, const char* fmt, const Args&... args) {
-    if (MSG_LEVEL < ASSERT || Value) {
-      return;
-    }
-    MFmt(fmt, fmt::make_format_args(args...));
-  }
-  template<typename... Args>
-  static inline void AAFmt(bool Value, const char* fmt, const Args&... args) {
     if (MSG_LEVEL < ASSERT || Value) {
       return;
     }
@@ -67,21 +57,10 @@ namespace Throw {
   do {                                      \
     LogMan::Throw::AFmt(pred, __VA_ARGS__); \
   } while (0)
-#define LOGMAN_THROW_AA_FMT(pred, ...)      \
-  do {                                      \
-    LogMan::Throw::AFmt(pred, __VA_ARGS__); \
-  } while (0)
 #else
   static inline void AFmt(bool, const char*, ...) {}
 #define LOGMAN_THROW_A_FMT(pred, ...) \
   do {                                \
-  } while (0)
-  static inline void AAFmt(bool pred, const char*, ...) {
-    __builtin_assume(pred);
-  }
-#define LOGMAN_THROW_AA_FMT(pred, ...) \
-  do {                                 \
-    __builtin_assume(pred);            \
   } while (0)
 #endif
 

--- a/Source/Tools/CommonTools/HarnessHelpers.h
+++ b/Source/Tools/CommonTools/HarnessHelpers.h
@@ -409,7 +409,7 @@ public:
       return reinterpret_cast<uint64_t>(FEXCore::Allocator::VirtualAlloc(StackSize())) + StackSize();
     } else {
       uint64_t Result = reinterpret_cast<uint64_t>(FEXCore::Allocator::VirtualAlloc(reinterpret_cast<void*>(STACK_OFFSET), StackSize()));
-      LOGMAN_THROW_AA_FMT(Result != ~0ULL, "Stack Pointer mmap failed");
+      LOGMAN_THROW_A_FMT(Result != ~0ULL, "Stack Pointer mmap failed");
       return Result + StackSize();
     }
   }
@@ -422,7 +422,7 @@ public:
     bool LimitedSize = true;
     auto DoMMap = [](uint64_t Address, size_t Size) -> void* {
       void* Result = FEXCore::Allocator::VirtualAlloc(reinterpret_cast<void*>(Address), Size, true);
-      LOGMAN_THROW_AA_FMT(Result == reinterpret_cast<void*>(Address), "Map Memory mmap failed");
+      LOGMAN_THROW_A_FMT(Result == reinterpret_cast<void*>(Address), "Map Memory mmap failed");
       return Result;
     };
 

--- a/Source/Tools/CommonTools/Linux/Utils/ELFContainer.cpp
+++ b/Source/Tools/CommonTools/Linux/Utils/ELFContainer.cpp
@@ -147,7 +147,7 @@ ELFContainer::ELFContainer(const fextl::string& Filename, const fextl::string& R
   // PrintInitArray();
   // PrintDynamicTable();
 
-  // LOGMAN_THROW_AA_FMT(InterpreterHeader == nullptr, "Can only handle static programs");
+  // LOGMAN_THROW_A_FMT(InterpreterHeader == nullptr, "Can only handle static programs");
 }
 
 ELFContainer::~ELFContainer() {
@@ -191,8 +191,8 @@ bool ELFContainer::LoadELF_32() {
   Mode = MODE_32BIT;
 
   memcpy(&Header, reinterpret_cast<Elf32_Ehdr*>(&RawFile.at(0)), sizeof(Elf32_Ehdr));
-  LOGMAN_THROW_AA_FMT(Header._32.e_phentsize == sizeof(Elf32_Phdr), "PH Entry size wasn't correct size");
-  LOGMAN_THROW_AA_FMT(Header._32.e_shentsize == sizeof(Elf32_Shdr), "PH Entry size wasn't correct size");
+  LOGMAN_THROW_A_FMT(Header._32.e_phentsize == sizeof(Elf32_Phdr), "PH Entry size wasn't correct size");
+  LOGMAN_THROW_A_FMT(Header._32.e_shentsize == sizeof(Elf32_Shdr), "PH Entry size wasn't correct size");
 
   if (Header._32.e_machine != EM_386) {
     LogMan::Msg::DFmt("32bit ELF wasn't x86 based");
@@ -229,8 +229,8 @@ bool ELFContainer::LoadELF_64() {
   Mode = MODE_64BIT;
 
   memcpy(&Header, reinterpret_cast<Elf64_Ehdr*>(&RawFile.at(0)), sizeof(Elf64_Ehdr));
-  LOGMAN_THROW_AA_FMT(Header._64.e_phentsize == 56, "PH Entry size wasn't 56");
-  LOGMAN_THROW_AA_FMT(Header._64.e_shentsize == 64, "PH Entry size wasn't 64");
+  LOGMAN_THROW_A_FMT(Header._64.e_phentsize == 56, "PH Entry size wasn't 56");
+  LOGMAN_THROW_A_FMT(Header._64.e_shentsize == 64, "PH Entry size wasn't 64");
 
   if (Header._64.e_machine != EM_X86_64) {
     LogMan::Msg::DFmt("64bit ELF wasn't x86-64 based");
@@ -402,7 +402,7 @@ void ELFContainer::CalculateSymbols() {
     uint64_t NumDynSymSymbols = 0;
     if (SymTabHeader) {
       LOGMAN_THROW_A_FMT(SymTabHeader->sh_link < SectionHeaders.size(), "Symbol table string table section is wrong");
-      LOGMAN_THROW_AA_FMT(SymTabHeader->sh_entsize == sizeof(Elf32_Sym), "Entry size doesn't match symbol entry");
+      LOGMAN_THROW_A_FMT(SymTabHeader->sh_entsize == sizeof(Elf32_Sym), "Entry size doesn't match symbol entry");
 
       StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._32;
       StrTab = &RawFile.at(StringTableHeader->sh_offset);
@@ -411,7 +411,7 @@ void ELFContainer::CalculateSymbols() {
 
     if (DynSymTabHeader) {
       LOGMAN_THROW_A_FMT(DynSymTabHeader->sh_link < SectionHeaders.size(), "Symbol table string table section is wrong");
-      LOGMAN_THROW_AA_FMT(DynSymTabHeader->sh_entsize == sizeof(Elf32_Sym), "Entry size doesn't match symbol entry");
+      LOGMAN_THROW_A_FMT(DynSymTabHeader->sh_entsize == sizeof(Elf32_Sym), "Entry size doesn't match symbol entry");
 
       DynStringTableHeader = SectionHeaders.at(DynSymTabHeader->sh_link)._32;
       DynStrTab = &RawFile.at(DynStringTableHeader->sh_offset);
@@ -526,7 +526,7 @@ void ELFContainer::CalculateSymbols() {
     uint64_t NumDynSymSymbols = 0;
     if (SymTabHeader) {
       LOGMAN_THROW_A_FMT(SymTabHeader->sh_link < SectionHeaders.size(), "Symbol table string table section is wrong");
-      LOGMAN_THROW_AA_FMT(SymTabHeader->sh_entsize == sizeof(Elf64_Sym), "Entry size doesn't match symbol entry");
+      LOGMAN_THROW_A_FMT(SymTabHeader->sh_entsize == sizeof(Elf64_Sym), "Entry size doesn't match symbol entry");
 
       StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._64;
       StrTab = &RawFile.at(StringTableHeader->sh_offset);
@@ -535,7 +535,7 @@ void ELFContainer::CalculateSymbols() {
 
     if (DynSymTabHeader) {
       LOGMAN_THROW_A_FMT(DynSymTabHeader->sh_link < SectionHeaders.size(), "Symbol table string table section is wrong");
-      LOGMAN_THROW_AA_FMT(DynSymTabHeader->sh_entsize == sizeof(Elf64_Sym), "Entry size doesn't match symbol entry");
+      LOGMAN_THROW_A_FMT(DynSymTabHeader->sh_entsize == sizeof(Elf64_Sym), "Entry size doesn't match symbol entry");
 
       DynStringTableHeader = SectionHeaders.at(DynSymTabHeader->sh_link)._64;
       DynStrTab = &RawFile.at(DynStringTableHeader->sh_offset);
@@ -795,7 +795,7 @@ void ELFContainer::PrintSymbolTable() const {
     }
 
     LOGMAN_THROW_A_FMT(SymTabHeader->sh_link < SectionHeaders.size(), "Symbol table string table section is wrong");
-    LOGMAN_THROW_AA_FMT(SymTabHeader->sh_entsize == sizeof(Elf32_Sym), "Entry size doesn't match symbol entry");
+    LOGMAN_THROW_A_FMT(SymTabHeader->sh_entsize == sizeof(Elf32_Sym), "Entry size doesn't match symbol entry");
 
     StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._32;
     StrTab = &RawFile.at(StringTableHeader->sh_offset);
@@ -826,7 +826,7 @@ void ELFContainer::PrintSymbolTable() const {
     }
 
     LOGMAN_THROW_A_FMT(SymTabHeader->sh_link < SectionHeaders.size(), "Symbol table string table section is wrong");
-    LOGMAN_THROW_AA_FMT(SymTabHeader->sh_entsize == sizeof(Elf64_Sym), "Entry size doesn't match symbol entry");
+    LOGMAN_THROW_A_FMT(SymTabHeader->sh_entsize == sizeof(Elf64_Sym), "Entry size doesn't match symbol entry");
 
     StringTableHeader = SectionHeaders.at(SymTabHeader->sh_link)._64;
     StrTab = &RawFile.at(StringTableHeader->sh_offset);
@@ -885,7 +885,7 @@ void ELFContainer::PrintRelocationTable() const {
           LogMan::Msg::DFmt("\toffset: 0x{:x}", Entry->r_offset);
           LogMan::Msg::DFmt("\tSym:    0x{:x}", Sym);
           if (DynSymHeader && Sym != 0) {
-            LOGMAN_THROW_AA_FMT(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
+            LOGMAN_THROW_A_FMT(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
 
             const uint64_t offset = DynSymHeader->sh_offset + Sym * DynSymHeader->sh_entsize;
             const auto* Symbol = reinterpret_cast<const Elf64_Sym*>(&RawFile.at(offset));
@@ -957,7 +957,7 @@ void ELFContainer::FixupRelocations(void* ELFBase, uint64_t GuestELFBase, Symbol
           const Elf64_Sym* EntrySymbol {nullptr};
           const char* EntrySymbolName {nullptr};
           if (DynSymHeader && Sym != 0) {
-            LOGMAN_THROW_AA_FMT(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
+            LOGMAN_THROW_A_FMT(DynSymHeader->sh_entsize == sizeof(Elf64_Sym), "Oops, entry size doesn't match");
 
             const uint64_t offset = DynSymHeader->sh_offset + Sym * DynSymHeader->sh_entsize;
             EntrySymbol = reinterpret_cast<const Elf64_Sym*>(&RawFile.at(offset));

--- a/Source/Tools/LinuxEmulation/ArchHelpers/MContext.h
+++ b/Source/Tools/LinuxEmulation/ArchHelpers/MContext.h
@@ -158,7 +158,7 @@ static inline void SetArmReg(void* ucontext, uint32_t id, uint64_t val) {
 static inline __uint128_t GetArmFPR(void* ucontext, uint32_t id) {
   auto MContext = GetMContext(ucontext);
   HostFPRState* HostState = reinterpret_cast<HostFPRState*>(&MContext->__reserved[0]);
-  LOGMAN_THROW_AA_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
+  LOGMAN_THROW_A_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
 
   return HostState->FPRs[id];
 }
@@ -232,7 +232,7 @@ static inline void BackupContext(void* ucontext, T* Backup) {
 
     // Host FPR state starts at _mcontext->reserved[0];
     HostFPRState* HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
-    LOGMAN_THROW_AA_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
+    LOGMAN_THROW_A_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
     Backup->FPSR = HostState->FPSR;
     Backup->FPCR = HostState->FPCR;
     memcpy(&Backup->FPRs[0], &HostState->FPRs[0], 32 * sizeof(__uint128_t));
@@ -258,7 +258,7 @@ static inline void RestoreContext(void* ucontext, T* Backup) {
     auto _mcontext = GetMContext(ucontext);
 
     HostFPRState* HostState = reinterpret_cast<HostFPRState*>(&_mcontext->__reserved[0]);
-    LOGMAN_THROW_AA_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
+    LOGMAN_THROW_A_FMT(HostState->Head.Magic == FPR_MAGIC, "Wrong FPR Magic: 0x{:08x}", HostState->Head.Magic);
     memcpy(&HostState->FPRs[0], &Backup->FPRs[0], 32 * sizeof(__uint128_t));
     HostState->FPCR = Backup->FPCR;
     HostState->FPSR = Backup->FPSR;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -956,7 +956,7 @@ void SignalDelegator::RegisterTLSState(FEX::HLE::ThreadStateObject* Thread) {
   altstack.ss_sp = reinterpret_cast<void*>(reinterpret_cast<uint64_t>(Thread->SignalInfo.AltStackPtr) + 8);
   altstack.ss_size = SIGSTKSZ * 16 - 8;
   altstack.ss_flags = 0;
-  LOGMAN_THROW_AA_FMT(!!altstack.ss_sp, "Couldn't allocate stack pointer");
+  LOGMAN_THROW_A_FMT(!!altstack.ss_sp, "Couldn't allocate stack pointer");
 
   // Copy the thread object to the start of the alt-stack
   memcpy(Thread->SignalInfo.AltStackPtr, &Thread, sizeof(void*));

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator/GuestFramesManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator/GuestFramesManagement.cpp
@@ -577,7 +577,7 @@ uint64_t SignalDelegator::SetupFrame_ia32(FEXCore::Core::InternalThreadState* Th
     guest_uctx->pretcode = (uint32_t)(uint64_t)GuestAction->restorer;
   } else {
     guest_uctx->pretcode = SignalReturn;
-    LOGMAN_THROW_AA_FMT(SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
+    LOGMAN_THROW_A_FMT(SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
   }
 
   // Support regparm=3
@@ -776,7 +776,7 @@ uint64_t SignalDelegator::SetupRTFrame_ia32(FEXCore::Core::InternalThreadState* 
     guest_uctx->pretcode = (uint32_t)(uint64_t)GuestAction->restorer;
   } else {
     guest_uctx->pretcode = SignalReturn;
-    LOGMAN_THROW_AA_FMT(SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
+    LOGMAN_THROW_A_FMT(SignalReturn < 0x1'0000'0000ULL, "This needs to be below 4GB");
   }
 
   // Support regparm=3

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -324,7 +324,7 @@ void SyscallHandler::TrackShmat(FEXCore::Core::InternalThreadState* Thread, int 
 
   shmid_ds stat;
 
-  auto res = shmctl(shmid, IPC_STAT, &stat);
+  [[maybe_unused]] auto res = shmctl(shmid, IPC_STAT, &stat);
   LOGMAN_THROW_A_FMT(res != -1, "shmctl IPC_STAT failed");
 
   uint64_t Length = stat.shm_segsz;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -72,7 +72,7 @@ bool SyscallHandler::HandleSegfault(FEXCore::Core::InternalThreadState* Thread, 
       auto Offset = FaultBase - Entry->first + Entry->second.Offset;
 
       auto VMA = Entry->second.Resource->FirstVMA;
-      LOGMAN_THROW_AA_FMT(VMA, "VMA tracking error");
+      LOGMAN_THROW_A_FMT(VMA, "VMA tracking error");
 
       // Flush all mirrors, remap the page writable as needed
       do {
@@ -83,7 +83,7 @@ bool SyscallHandler::HandleSegfault(FEXCore::Core::InternalThreadState* Thread, 
             _SyscallHandler->TM.InvalidateGuestCodeRange(Thread, FaultBaseMirrored, FEXCore::Utils::FEX_PAGE_SIZE,
                                                          [](uintptr_t Start, uintptr_t Length) {
               auto rv = mprotect((void*)Start, Length, PROT_READ | PROT_WRITE);
-              LogMan::Throw::AAFmt(rv == 0, "mprotect({}, {}) failed", Start, Length);
+              LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", Start, Length);
             });
           } else {
             _SyscallHandler->TM.InvalidateGuestCodeRange(Thread, FaultBaseMirrored, FEXCore::Utils::FEX_PAGE_SIZE);
@@ -93,7 +93,7 @@ bool SyscallHandler::HandleSegfault(FEXCore::Core::InternalThreadState* Thread, 
     } else {
       _SyscallHandler->TM.InvalidateGuestCodeRange(Thread, FaultBase, FEXCore::Utils::FEX_PAGE_SIZE, [](uintptr_t Start, uintptr_t Length) {
         auto rv = mprotect((void*)Start, Length, PROT_READ | PROT_WRITE);
-        LogMan::Throw::AAFmt(rv == 0, "mprotect({}, {}) failed", Start, Length);
+        LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", Start, Length);
       });
     }
 
@@ -136,7 +136,7 @@ void SyscallHandler::MarkGuestExecutableRange(FEXCore::Core::InternalThreadState
           const auto OffsetTop = OffsetBase + ProtectSize;
 
           auto VMA = Mapping->second.Resource->FirstVMA;
-          LOGMAN_THROW_AA_FMT(VMA, "VMA tracking error");
+          LOGMAN_THROW_A_FMT(VMA, "VMA tracking error");
 
           do {
             auto VMAOffsetBase = VMA->Offset;
@@ -149,14 +149,14 @@ void SyscallHandler::MarkGuestExecutableRange(FEXCore::Core::InternalThreadState
               const auto MirroredSize = std::min(OffsetTop, VMAOffsetTop) - MirroredBase;
 
               auto rv = mprotect((void*)(MirroredBase - VMAOffsetBase + VMABase), MirroredSize, PROT_READ);
-              LogMan::Throw::AAFmt(rv == 0, "mprotect({}, {}) failed", MirroredBase, MirroredSize);
+              LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", MirroredBase, MirroredSize);
             }
           } while ((VMA = VMA->ResourceNextVMA));
 
         } else if (Mapping->second.Prot.Writable) {
           int rv = mprotect((void*)ProtectBase, ProtectSize, PROT_READ);
 
-          LogMan::Throw::AAFmt(rv == 0, "mprotect({}, {}) failed", ProtectBase, ProtectSize);
+          LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", ProtectBase, ProtectSize);
         }
       }
     }
@@ -219,7 +219,7 @@ void SyscallHandler::TrackMmap(FEXCore::Core::InternalThreadState* Thread, uintp
       MRID mrid {SpecialDev::Anon, AnonSharedId++};
 
       auto [Iter, Inserted] = VMATracking.MappedResources.emplace(mrid, MappedResource {nullptr, nullptr, 0});
-      LOGMAN_THROW_AA_FMT(Inserted == true, "VMA tracking error");
+      LOGMAN_THROW_A_FMT(Inserted == true, "VMA tracking error");
       Resource = &Iter->second;
       Resource->Iterator = Iter;
     } else {
@@ -286,8 +286,8 @@ void SyscallHandler::TrackMremap(FEXCore::Core::InternalThreadState* Thread, uin
     if (OldSize == 0) {
       // Mirror existing mapping
       // must be a shared mapping
-      LOGMAN_THROW_AA_FMT(OldResource != nullptr, "VMA Tracking error");
-      LOGMAN_THROW_AA_FMT(OldFlags.Shared, "VMA Tracking error");
+      LOGMAN_THROW_A_FMT(OldResource != nullptr, "VMA Tracking error");
+      LOGMAN_THROW_A_FMT(OldFlags.Shared, "VMA Tracking error");
       VMATracking.SetUnsafe(CTX, OldResource, NewAddress, OldOffset, NewSize, OldFlags, OldProt);
     } else {
 
@@ -325,7 +325,7 @@ void SyscallHandler::TrackShmat(FEXCore::Core::InternalThreadState* Thread, int 
   shmid_ds stat;
 
   auto res = shmctl(shmid, IPC_STAT, &stat);
-  LOGMAN_THROW_AA_FMT(res != -1, "shmctl IPC_STAT failed");
+  LOGMAN_THROW_A_FMT(res != -1, "shmctl IPC_STAT failed");
 
   uint64_t Length = stat.shm_segsz;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
@@ -454,7 +454,7 @@ void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
   });
 
   REGISTER_SYSCALL_IMPL_X32(fstatfs64, [](FEXCore::Core::CpuStateFrame* Frame, int fd, size_t sz, struct statfs64_32* buf) -> uint64_t {
-    LOGMAN_THROW_AA_FMT(sz == sizeof(struct statfs64_32), "This needs to match");
+    LOGMAN_THROW_A_FMT(sz == sizeof(struct statfs64_32), "This needs to match");
 
     struct statfs64 host_stat;
     uint64_t Result = ::fstatfs64(fd, &host_stat);
@@ -466,7 +466,7 @@ void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
   });
 
   REGISTER_SYSCALL_IMPL_X32(statfs64, [](FEXCore::Core::CpuStateFrame* Frame, const char* path, size_t sz, struct statfs64_32* buf) -> uint64_t {
-    LOGMAN_THROW_AA_FMT(sz == sizeof(struct statfs64_32), "This needs to match");
+    LOGMAN_THROW_A_FMT(sz == sizeof(struct statfs64_32), "This needs to match");
 
     struct statfs host_stat;
     uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statfs(path, &host_stat);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
@@ -22,11 +22,11 @@ $end_info$
 namespace FEX::HLE::x32 {
 
 void* x32SyscallHandler::GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
-  LOGMAN_THROW_AA_FMT((length >> 32) == 0, "values must fit to 32 bits");
+  LOGMAN_THROW_A_FMT((length >> 32) == 0, "values must fit to 32 bits");
 
   auto Result = (uint64_t)GetAllocator()->Mmap((void*)addr, length, prot, flags, fd, offset);
 
-  LOGMAN_THROW_AA_FMT((Result >> 32) == 0 || (Result >> 32) == 0xFFFFFFFF, "values must fit to 32 bits");
+  LOGMAN_THROW_A_FMT((Result >> 32) == 0 || (Result >> 32) == 0xFFFFFFFF, "values must fit to 32 bits");
 
   if (!FEX::HLE::HasSyscallError(Result)) {
     FEX::HLE::_SyscallHandler->TrackMmap(Thread, Result, length, prot, flags, fd, offset);
@@ -38,8 +38,8 @@ void* x32SyscallHandler::GuestMmap(FEXCore::Core::InternalThreadState* Thread, v
 }
 
 int x32SyscallHandler::GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) {
-  LOGMAN_THROW_AA_FMT((uintptr_t(addr) >> 32) == 0, "values must fit to 32 bits");
-  LOGMAN_THROW_AA_FMT((length >> 32) == 0, "values must fit to 32 bits");
+  LOGMAN_THROW_A_FMT((uintptr_t(addr) >> 32) == 0, "values must fit to 32 bits");
+  LOGMAN_THROW_A_FMT((length >> 32) == 0, "values must fit to 32 bits");
 
   auto Result = GetAllocator()->Munmap(addr, length);
 

--- a/Source/Tools/LinuxEmulation/Thunks.cpp
+++ b/Source/Tools/LinuxEmulation/Thunks.cpp
@@ -283,7 +283,7 @@ void ThunkHandler_impl::LoadLib(std::string_view Name) {
  */
 FEX_DEFAULT_VISIBILITY HostToGuestTrampolinePtr*
 MakeHostTrampolineForGuestFunction(void* HostPacker, uintptr_t GuestTarget, uintptr_t GuestUnpacker) {
-  LOGMAN_THROW_AA_FMT(GuestTarget, "Tried to create host-trampoline to null pointer guest function");
+  LOGMAN_THROW_A_FMT(GuestTarget, "Tried to create host-trampoline to null pointer guest function");
 
   const auto ThunkHandler = reinterpret_cast<ThunkHandler_impl*>(FEX::HLE::_SyscallHandler->GetThunkHandler());
 
@@ -319,7 +319,7 @@ MakeHostTrampolineForGuestFunction(void* HostPacker, uintptr_t GuestTarget, uint
     ThunkHandler->HostTrampolineInstanceDataPtr = (uint8_t*)mmap(0, ThunkHandler->HostTrampolineInstanceDataAvailable,
                                                                  PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
-    LOGMAN_THROW_AA_FMT(ThunkHandler->HostTrampolineInstanceDataPtr != MAP_FAILED, "Failed to mmap HostTrampolineInstanceDataPtr");
+    LOGMAN_THROW_A_FMT(ThunkHandler->HostTrampolineInstanceDataPtr != MAP_FAILED, "Failed to mmap HostTrampolineInstanceDataPtr");
   }
 
   auto HostTrampoline = reinterpret_cast<HostToGuestTrampolinePtr* const>(ThunkHandler->HostTrampolineInstanceDataPtr);


### PR DESCRIPTION
Replacing debug-only assertions with `__builtin_assume` in optimizing builds seems like a free performance-win at first, but it turns out to be a footgun with no practical upside: The binary size reduction I measured is 0.03% (a factor of 0.0003).

One big problem is that these hints interfere with debugging of non-assertion builds. Since the compiler generates code as-if the condition were true, a debugger will print wrong variable values or have erratic source stepping behavior. This can even apply to Debug builds, since FEX uses a dedicated `ASSERTIONS_ENABLED` macro.

Even [debug printfs](https://godbolt.org/z/5oox8jn6h) will print misleading information, which isn't obvious when your assumption is hidden in an innocent-looking macro that's barely distinguished from the non-hinting one.

As a future guideline, optimization hints should instead be placed *intentionally* after identifying bottlenecks in a profiler to communicate where hotspots are located and what invariants their efficient execution relies on.
