### PR TITLE
Fix warnings about unused objects

### DIFF
--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -378,6 +378,7 @@ static void SetFPCR(uint64_t Value) {
   __asm("msr FPCR, %[Value]" ::[Value] "r"(Value));
 }
 
+#ifndef VIXL_SIMULATOR
 __attribute__((naked)) static uint64_t ReadSVEVectorLengthInBits() {
   ///< Can't use rdvl instruction directly because compilers will complain that sve/sme is required.
   __asm(R"(
@@ -385,6 +386,7 @@ __attribute__((naked)) static uint64_t ReadSVEVectorLengthInBits() {
   ret;
   )");
 }
+#endif
 #else
 [[maybe_unused]]
 static uint32_t GetDCZID() {

--- a/ThunkLibs/Generator/analysis.cpp
+++ b/ThunkLibs/Generator/analysis.cpp
@@ -305,7 +305,7 @@ void AnalysisAction::ParseInterface(clang::ASTContext& context) {
 
         const auto template_arg_loc = GetTemplateArgLocation(decl, 0);
 
-        if (auto emitted_function = llvm::dyn_cast<clang::FunctionDecl>(template_args[0].getAsDecl())) {
+        if (llvm::isa<clang::FunctionDecl>(template_args[0].getAsDecl())) {
           // Process later
         } else if (auto annotated_member = llvm::dyn_cast<clang::FieldDecl>(template_args[0].getAsDecl())) {
           {


### PR DESCRIPTION
These don't show up in the default build configuration and hence were missed before.