### PR TITLE
Fix slight inaccuracy in test 3_F7_05_2

### DIFF
--- a/unittests/ASM/PrimaryGroup/3_F7_05_2.asm
+++ b/unittests/ASM/PrimaryGroup/3_F7_05_2.asm
@@ -44,40 +44,49 @@ mov [r8 + 8 * 5], rax
 
 ; Negative * Negative
 mov ax, -128
+cwd
 imul word [r8 + 8 * 0 + 0]
 ofcfmerge
 
 mov eax, -128
+cdq
 imul dword [r8 + 8 * 1 + 0]
 ofcfmerge
 
 mov rax, -128
+cqo
 imul qword [r8 + 8 * 2 + 0]
 ofcfmerge
 
 ; Negative * Positive
 mov ax, -128
+cwd
 imul word [r8 + 8 * 3 + 0]
 ofcfmerge
 
 mov eax, -128
+cdq
 imul dword [r8 + 8 * 4 + 0]
 ofcfmerge
 
 mov rax, -128
+cqo
 imul qword [r8 + 8 * 5 + 0]
 ofcfmerge
 
 ; Positive * Positive
 mov ax, 128
+cwd
 imul word [r8 + 8 * 3 + 0]
 ofcfmerge
 
 mov eax, 128
+cdq
 imul dword [r8 + 8 * 4 + 0]
 ofcfmerge
 
 mov rax, 128
+cqo
 imul qword [r8 + 8 * 5 + 0]
 ofcfmerge
 


### PR DESCRIPTION
Needs cwd/cdq/cqo to sign extend into RDX/EAX/AX for imul to do what is described, for example in
```
; Negative * Negative
mov ax, -128
imul word [r8 + 8 * 0 + 0]
ofcfmerge
```

dx:ax is not negative, unless if we do `cwd`