### PR TITLE
Pass through FPRs argument

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -1067,7 +1067,7 @@ void Arm64Emitter::FillForPreserveAllABICall(bool FPRs) {
   }
 
   // Fill the static registers.
-  FillStaticRegs(true, PreserveSRAMask, PreserveSRAFPRMask);
+  FillStaticRegs(FPRs, PreserveSRAMask, PreserveSRAFPRMask);
 
   // Pop the vector registers.
   PopVectorRegisters(CanUseSVE256, DynamicFPRs);


### PR DESCRIPTION
At the moment this seems to be NFC since all calls to this function end up passing `true` but it seems that it's a bug waiting to happen if someone ever calls the function with `false`.