### PR TITLE
NFC: Code cleanup

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -18,10 +18,8 @@
 #include <CodeEmitter/Emitter.h>
 #include <CodeEmitter/Registers.h>
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
-#include <utility>
 #include <span>
 
 namespace FEXCore::Context {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -709,32 +709,29 @@ public:
     RES_STI,
   };
 
-  void X87OpHelper(OpcodeArgs, FEXCore::IR::IROps IROp, bool ZeroC2);
   void FADD(OpcodeArgs, IR::OpSize Width, bool Integer, OpResult ResInST0);
-  void FMUL(OpcodeArgs, IR::OpSize Width, bool Integer, OpResult ResInST0);
   void FDIV(OpcodeArgs, IR::OpSize Width, bool Integer, bool Reverse, OpResult ResInST0);
+  void FMUL(OpcodeArgs, IR::OpSize Width, bool Integer, OpResult ResInST0);
+  void FNINIT(OpcodeArgs);
   void FSUB(OpcodeArgs, IR::OpSize Width, bool Integer, bool Reverse, OpResult ResInST0);
   void FTST(OpcodeArgs);
-  void FNINIT(OpcodeArgs);
-
-  void X87ModifySTP(OpcodeArgs, bool Inc);
-  void X87SinCos(OpcodeArgs);
-  void X87FYL2X(OpcodeArgs, bool IsFYL2XP1);
-  void X87LDENV(OpcodeArgs);
+  void FXCH(OpcodeArgs);
+  void X87EMMS(OpcodeArgs);
+  void X87FCMOV(OpcodeArgs);
+  void X87FFREE(OpcodeArgs);
   void X87FLDCW(OpcodeArgs);
-  void X87FNSTENV(OpcodeArgs);
-  void X87FSTCW(OpcodeArgs);
-  void X87LDSW(OpcodeArgs);
-  void X87FNSTSW(OpcodeArgs);
   void X87FNSAVE(OpcodeArgs);
+  void X87FNSTENV(OpcodeArgs);
+  void X87FNSTSW(OpcodeArgs);
   void X87FRSTOR(OpcodeArgs);
+  void X87FSTCW(OpcodeArgs);
   void X87FXAM(OpcodeArgs);
   void X87FXTRACT(OpcodeArgs);
-  void X87FCMOV(OpcodeArgs);
-  void X87EMMS(OpcodeArgs);
-  void X87FFREE(OpcodeArgs);
-
-  void FXCH(OpcodeArgs);
+  void X87FYL2X(OpcodeArgs, bool IsFYL2XP1);
+  void X87LDENV(OpcodeArgs);
+  void X87LDSW(OpcodeArgs);
+  void X87ModifySTP(OpcodeArgs, bool Inc);
+  void X87OpHelper(OpcodeArgs, FEXCore::IR::IROps IROp, bool ZeroC2);
 
   enum class FCOMIFlags {
     FLAGS_X87,
@@ -743,38 +740,22 @@ public:
   void FCOMI(OpcodeArgs, IR::OpSize Width, bool Integer, FCOMIFlags WhichFlags, bool PopTwice);
 
   // F64 X87 Ops
-  void FLDF64(OpcodeArgs, IR::OpSize Width);
-  void FLDF64_Const(OpcodeArgs, uint64_t Num);
-
+  void FADDF64(OpcodeArgs, IR::OpSize Width, bool Integer, OpResult ResInST0);
   void FBLDF64(OpcodeArgs);
   void FBSTPF64(OpcodeArgs);
-
-  void FILDF64(OpcodeArgs);
-
-  void FSTF64(OpcodeArgs, IR::OpSize Width);
-
-  void FISTF64(OpcodeArgs, bool Truncate);
-
-  void FADDF64(OpcodeArgs, IR::OpSize Width, bool Integer, OpResult ResInST0);
-  void FMULF64(OpcodeArgs, IR::OpSize Width, bool Integer, OpResult ResInST0);
+  void FCOMIF64(OpcodeArgs, IR::OpSize width, bool Integer, FCOMIFlags whichflags, bool poptwice);
   void FDIVF64(OpcodeArgs, IR::OpSize Width, bool Integer, bool Reverse, OpResult ResInST0);
+  void FILDF64(OpcodeArgs);
+  void FISTF64(OpcodeArgs, bool Truncate);
+  void FLDF64_Const(OpcodeArgs, uint64_t Num);
+  void FLDF64(OpcodeArgs, IR::OpSize Width);
+  void FMULF64(OpcodeArgs, IR::OpSize Width, bool Integer, OpResult ResInST0);
+  void FSTF64(OpcodeArgs, IR::OpSize Width);
   void FSUBF64(OpcodeArgs, IR::OpSize Width, bool Integer, bool Reverse, OpResult ResInST0);
-  void FCHSF64(OpcodeArgs);
-  void FABSF64(OpcodeArgs);
   void FTSTF64(OpcodeArgs);
-  void FRNDINTF64(OpcodeArgs);
-  void FSQRTF64(OpcodeArgs);
-  void X87UnaryOpF64(OpcodeArgs, FEXCore::IR::IROps IROp);
-  void X87BinaryOpF64(OpcodeArgs, FEXCore::IR::IROps IROp);
-  void X87SinCosF64(OpcodeArgs);
   void X87FLDCWF64(OpcodeArgs);
-  void X87TANF64(OpcodeArgs);
-  void X87ATANF64(OpcodeArgs);
-  void X87FXAMF64(OpcodeArgs);
   void X87FXTRACTF64(OpcodeArgs);
   void X87LDENVF64(OpcodeArgs);
-
-  void FCOMIF64(OpcodeArgs, IR::OpSize width, bool Integer, FCOMIFlags whichflags, bool poptwice);
 
   void FXSaveOp(OpcodeArgs);
   void FXRStoreOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -242,9 +242,9 @@ void OpDispatchBuilder::FMUL(OpcodeArgs, IR::OpSize Width, bool Integer, OpDispa
 
 void OpDispatchBuilder::FDIV(OpcodeArgs, IR::OpSize Width, bool Integer, bool Reverse, OpDispatchBuilder::OpResult ResInST0) {
   if (Op->Src[0].IsNone()) {
-    const auto Offset = Op->OP & 7;
-    const auto St0 = 0;
-    const auto Result = (ResInST0 == OpResult::RES_STI) ? Offset : St0;
+    const uint8_t Offset = Op->OP & 7;
+    const uint8_t St0 = 0;
+    const uint8_t Result = (ResInST0 == OpResult::RES_STI) ? Offset : St0;
 
     if (Reverse ^ (ResInST0 == OpResult::RES_STI)) {
       _F80DivStack(Result, Offset, St0);
@@ -767,13 +767,11 @@ void OpDispatchBuilder::FNINIT(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::X87FFREE(OpcodeArgs) {
-
   _InvalidateStack(Op->OP & 7);
 }
 
 void OpDispatchBuilder::X87EMMS(OpcodeArgs) {
   // Tags all get set to 0b11
-
   _InvalidateStack(0xff);
 }
 


### PR DESCRIPTION
Removing unused declarations.
Cleaning up unused headers and empty lines.
Avoiding static analysis warnings on `const auto` defaulting to int.