### PR TITLE
Scripts: Fix indentation of changelog items

### DIFF
--- a/Scripts/changelog_generator.py
+++ b/Scripts/changelog_generator.py
@@ -47,10 +47,10 @@ for item in sorted(Meta.items()):
     if Tag != tag and tag != category:
         Tag = tag
         print("")
-        print(" - " + tag.split("/")[1])
-    
+        print("  - " + tag.split("/")[1])
+
     for change in item[1]:
         if Tag == "":
-            print(" - " + change)
-        else:
             print("  - " + change)
+        else:
+            print("    - " + change)


### PR DESCRIPTION
Looking e.g. over the [2405 release notes](https://github.com/FEX-Emu/FEX/releases/tag/FEX-2405), I noticed categories and descriptions are placed on separate lines:

> - Allocator
>  - Fixes compiling on Fedora 40 (https://github.com/FEX-Emu/FEX/commit/7b88b0f2711b1ee9f2f47f7547b6ee3d2a184d90)
> - AllocatorHooks
>  - Mark JIT code memory as EC code on ARM64EC (https://github.com/FEX-Emu/FEX/commit/bb24e1419c5ef07ee9d93b2d77fa08c8253902cf)
> - AppConfig
>  - Disable libGL forwarding for steamwebhelper (https://github.com/FEX-Emu/FEX/commit/02ebb6e32074ca26d60727b998d39fe04a2a2465)

Instead, the descriptions were meant to be placed in sublists (since there might be multiple per category):

> - Allocator
>   - Fixes compiling on Fedora 40 (https://github.com/FEX-Emu/FEX/commit/7b88b0f2711b1ee9f2f47f7547b6ee3d2a184d90)
> - AllocatorHooks
>   - Mark JIT code memory as EC code on ARM64EC (https://github.com/FEX-Emu/FEX/commit/bb24e1419c5ef07ee9d93b2d77fa08c8253902cf)
> - AppConfig
>   - Disable libGL forwarding for steamwebhelper (https://github.com/FEX-Emu/FEX/commit/02ebb6e32074ca26d60727b998d39fe04a2a2465)

The source of the issue is that GitHub's markdown parser requires at least 2 spaces to open a new level of indentation, but we only used 1.
