### PR TITLE
Library Forwarding/wayland: Fix regression caused by erroneous format

### DIFF
--- a/ThunkLibs/libwayland-client/Guest.cpp
+++ b/ThunkLibs/libwayland-client/Guest.cpp
@@ -337,4 +337,5 @@ void OnInit() {
   fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_callback_interface), "wl_callback_interface");
 }
 
-LOAD_LIB_INIT(libwayland - client, OnInit)
+// clang-format off: Would insert spaces around -
+LOAD_LIB_INIT(libwayland-client, OnInit)

--- a/ThunkLibs/libwayland-client/Guest.cpp
+++ b/ThunkLibs/libwayland-client/Guest.cpp
@@ -337,5 +337,6 @@ void OnInit() {
   fex_wl_exchange_interface_pointer(const_cast<wl_interface*>(&wl_callback_interface), "wl_callback_interface");
 }
 
-// clang-format off: Would insert spaces around -
+// Would insert spaces around -
+// clang-format off
 LOAD_LIB_INIT(libwayland-client, OnInit)


### PR DESCRIPTION
`clang-format` tried a bit too hard to help here.

Before:
```cpp
LOAD_LIB_INIT(libwayland - client, OnInit)
```

After:
```cpp
LOAD_LIB_INIT(libwayland-client, OnInit)
```

This caused FEX to search for a file named `libwayland - client-host.so` instead of `libwayland-client-host.so`, hence failing to map the library to its host equivalent.
