### PR TITLE
FEX: Allocate a VMA allocator when running on a 48-bit VA

### DIFF
--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -304,10 +304,10 @@ fextl::vector<MemoryRegion> StealMemoryRegion(uintptr_t Begin, uintptr_t End) {
   return Regions;
 }
 
-void Setup48BitAllocatorIfExists() {
+fextl::vector<MemoryRegion> Setup48BitAllocatorIfExists() {
   size_t Bits = FEXCore::Allocator::DetermineVASize();
   if (Bits < 48) {
-    return;
+    return {};
   }
 
   uintptr_t Begin48BitVA = 0x0'8000'0000'0000ULL;
@@ -316,6 +316,8 @@ void Setup48BitAllocatorIfExists() {
 
   Alloc64 = Alloc::OSAllocator::Create64BitAllocatorWithRegions(Regions);
   AssignHookOverrides();
+
+  return Regions;
 }
 
 void ReclaimMemoryRegion(const fextl::vector<MemoryRegion>& Regions) {

--- a/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -554,8 +554,12 @@ void OSAllocator_64Bit::AllocateMemoryRegions(fextl::vector<FEXCore::Allocator::
   }
 
   for (auto [Ptr, AllocationSize] : Ranges) {
-    // Skip size of zero if ObjectAllocSize matched the size of region.
-    if (AllocationSize == 0) continue;
+    // Skip using any regions that are <= two pages. FEX's VMA allocator requires two pages
+    // for tracking data. So three pages are minimum for a single page VMA allocation.
+    if (AllocationSize <= (FEXCore::Utils::FEX_PAGE_SIZE * 2)) {
+      continue;
+    }
+
     ReservedVMARegion* Region = ObjectAlloc->new_construct<ReservedVMARegion>();
     Region->Base = reinterpret_cast<uint64_t>(Ptr);
     Region->RegionSize = AllocationSize;

--- a/FEXCore/Source/Utils/Allocator/FlexBitSet.h
+++ b/FEXCore/Source/Utils/Allocator/FlexBitSet.h
@@ -145,8 +145,14 @@ struct FlexBitSet final {
     return Get(Element);
   }
 
-  static size_t Size(uint64_t Elements) {
-    return FEXCore::AlignUp(Elements / MinimumSizeBits, MinimumSizeBits);
+  // Returns the number of bits required to hold the number of elements.
+  // Just rounds up to the MinimumSizeInBits.
+  constexpr static size_t SizeInBits(uint64_t Elements) {
+    return FEXCore::AlignUp(Elements, MinimumSizeBits);
+  }
+  // Returns the number of bytes required to hold the number of elements.
+  constexpr static size_t SizeInBytes(uint64_t Elements) {
+    return SizeInBits(Elements) / 8;
   }
 };
 

--- a/FEXCore/Source/Utils/Allocator/HostAllocator.h
+++ b/FEXCore/Source/Utils/Allocator/HostAllocator.h
@@ -2,9 +2,10 @@
 #pragma once
 #include <FEXCore/fextl/allocator.h>
 #include <FEXCore/fextl/memory.h>
+#include <FEXCore/fextl/vector.h>
+#include <FEXCore/Utils/Allocator.h>
 
 #include <cstddef>
-#include <cstdint>
 #include <sys/types.h>
 
 namespace FEXCore::Core {
@@ -49,4 +50,5 @@ public:
 
 namespace Alloc::OSAllocator {
 fextl::unique_ptr<Alloc::HostAllocator> Create64BitAllocator();
+fextl::unique_ptr<Alloc::HostAllocator> Create64BitAllocatorWithRegions(fextl::vector<FEXCore::Allocator::MemoryRegion>& Regions);
 } // namespace Alloc::OSAllocator

--- a/FEXCore/include/FEXCore/Utils/Allocator.h
+++ b/FEXCore/include/FEXCore/Utils/Allocator.h
@@ -86,7 +86,7 @@ FEX_DEFAULT_VISIBILITY void ReclaimMemoryRegion(const fextl::vector<MemoryRegion
 // AArch64 canonical addresses are only up to bits 48/52 with the remainder being other things
 // Use this to reserve the top 128TB of VA so the guest never see it
 // Returns nullptr on host VA < 48bits
-FEX_DEFAULT_VISIBILITY void Setup48BitAllocatorIfExists();
+FEX_DEFAULT_VISIBILITY fextl::vector<MemoryRegion> Setup48BitAllocatorIfExists();
 
 #ifndef _WIN32
 FEX_DEFAULT_VISIBILITY void RegisterTLSData(FEXCore::Core::InternalThreadState* Thread);

--- a/FEXCore/include/FEXCore/Utils/Allocator.h
+++ b/FEXCore/include/FEXCore/Utils/Allocator.h
@@ -86,7 +86,7 @@ FEX_DEFAULT_VISIBILITY void ReclaimMemoryRegion(const fextl::vector<MemoryRegion
 // AArch64 canonical addresses are only up to bits 48/52 with the remainder being other things
 // Use this to reserve the top 128TB of VA so the guest never see it
 // Returns nullptr on host VA < 48bits
-FEX_DEFAULT_VISIBILITY fextl::vector<MemoryRegion> Steal48BitVA();
+FEX_DEFAULT_VISIBILITY void Setup48BitAllocatorIfExists();
 
 #ifndef _WIN32
 FEX_DEFAULT_VISIBILITY void RegisterTLSData(FEXCore::Core::InternalThreadState* Thread);

--- a/FEXCore/unittests/APITests/FlexBitSet.cpp
+++ b/FEXCore/unittests/APITests/FlexBitSet.cpp
@@ -1,0 +1,41 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+#include "Utils/Allocator/FlexBitSet.h"
+
+TEST_CASE("FlexBitSet - Sizing") {
+  // Ensure that FlexBitSet sizing is correct.
+
+  // Size of zero shouldn't take any space.
+  CHECK(FEXCore::FlexBitSet<uint8_t>::SizeInBytes(0) == 0);
+  CHECK(FEXCore::FlexBitSet<uint16_t>::SizeInBytes(0) == 0);
+  CHECK(FEXCore::FlexBitSet<uint32_t>::SizeInBytes(0) == 0);
+  CHECK(FEXCore::FlexBitSet<uint64_t>::SizeInBytes(0) == 0);
+
+  CHECK(FEXCore::FlexBitSet<uint8_t>::SizeInBits(0) == 0);
+  CHECK(FEXCore::FlexBitSet<uint16_t>::SizeInBits(0) == 0);
+  CHECK(FEXCore::FlexBitSet<uint32_t>::SizeInBits(0) == 0);
+  CHECK(FEXCore::FlexBitSet<uint64_t>::SizeInBits(0) == 0);
+
+  // Size of 1 should take one sizeof(ElementSize) size
+  CHECK(FEXCore::FlexBitSet<uint8_t>::SizeInBytes(1) == sizeof(uint8_t));
+  CHECK(FEXCore::FlexBitSet<uint16_t>::SizeInBytes(1) == sizeof(uint16_t));
+  CHECK(FEXCore::FlexBitSet<uint32_t>::SizeInBytes(1) == sizeof(uint32_t));
+  CHECK(FEXCore::FlexBitSet<uint64_t>::SizeInBytes(1) == sizeof(uint64_t));
+
+  CHECK(FEXCore::FlexBitSet<uint8_t>::SizeInBits(1) == sizeof(uint8_t) * 8);
+  CHECK(FEXCore::FlexBitSet<uint16_t>::SizeInBits(1) == sizeof(uint16_t) * 8);
+  CHECK(FEXCore::FlexBitSet<uint32_t>::SizeInBits(1) == sizeof(uint32_t) * 8);
+  CHECK(FEXCore::FlexBitSet<uint64_t>::SizeInBits(1) == sizeof(uint64_t) * 8);
+
+  // Size of `sizeof(ElementSize) * 8` should take one sizeof(ElementSize) size
+  CHECK(FEXCore::FlexBitSet<uint8_t>::SizeInBytes(sizeof(uint8_t) * 8) == sizeof(uint8_t));
+  CHECK(FEXCore::FlexBitSet<uint16_t>::SizeInBytes(sizeof(uint16_t) * 8) == sizeof(uint16_t));
+  CHECK(FEXCore::FlexBitSet<uint32_t>::SizeInBytes(sizeof(uint32_t) * 8) == sizeof(uint32_t));
+  CHECK(FEXCore::FlexBitSet<uint64_t>::SizeInBytes(sizeof(uint64_t) * 8) == sizeof(uint64_t));
+
+  CHECK(FEXCore::FlexBitSet<uint8_t>::SizeInBits(sizeof(uint8_t) * 8) == sizeof(uint8_t) * 8);
+  CHECK(FEXCore::FlexBitSet<uint16_t>::SizeInBits(sizeof(uint16_t) * 8) == sizeof(uint16_t) * 8);
+  CHECK(FEXCore::FlexBitSet<uint32_t>::SizeInBits(sizeof(uint32_t) * 8) == sizeof(uint32_t) * 8);
+  CHECK(FEXCore::FlexBitSet<uint64_t>::SizeInBits(sizeof(uint64_t) * 8) == sizeof(uint64_t) * 8);
+}

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -491,12 +491,11 @@ int main(int argc, char** argv, char** const envp) {
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
 
   fextl::unique_ptr<FEX::HLE::MemAllocator> Allocator;
-  fextl::vector<FEXCore::Allocator::MemoryRegion> Base48Bit;
   fextl::vector<FEXCore::Allocator::MemoryRegion> Low4GB;
 
   if (Loader.Is64BitMode()) {
     // Destroy the 48th bit if it exists
-    Base48Bit = FEXCore::Allocator::Steal48BitVA();
+    FEXCore::Allocator::Setup48BitAllocatorIfExists();
   } else {
     // Reserve [0x1_0000_0000, 0x2_0000_0000).
     // Safety net if 32-bit address calculation overflows in to 64-bit range.
@@ -685,7 +684,6 @@ int main(int argc, char** argv, char** const envp) {
   LogMan::Msg::UnInstallHandler();
 
   FEXCore::Allocator::ClearHooks();
-  FEXCore::Allocator::ReclaimMemoryRegion(Base48Bit);
   FEXCore::Allocator::ReclaimMemoryRegion(Low4GB);
 
   // Allocator is now original system allocator

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -491,11 +491,12 @@ int main(int argc, char** argv, char** const envp) {
   FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
 
   fextl::unique_ptr<FEX::HLE::MemAllocator> Allocator;
+  fextl::vector<FEXCore::Allocator::MemoryRegion> Base48Bit;
   fextl::vector<FEXCore::Allocator::MemoryRegion> Low4GB;
 
   if (Loader.Is64BitMode()) {
     // Destroy the 48th bit if it exists
-    FEXCore::Allocator::Setup48BitAllocatorIfExists();
+    Base48Bit = FEXCore::Allocator::Setup48BitAllocatorIfExists();
   } else {
     // Reserve [0x1_0000_0000, 0x2_0000_0000).
     // Safety net if 32-bit address calculation overflows in to 64-bit range.
@@ -684,6 +685,7 @@ int main(int argc, char** argv, char** const envp) {
   LogMan::Msg::UnInstallHandler();
 
   FEXCore::Allocator::ClearHooks();
+  FEXCore::Allocator::ReclaimMemoryRegion(Base48Bit);
   FEXCore::Allocator::ReclaimMemoryRegion(Low4GB);
 
   // Allocator is now original system allocator


### PR DESCRIPTION
When running on a system with a 48-bit VA, if FEX does any allocations between us reserving the upper 128TB and the application running, then /technically/ we are intersecting with the application's memory region in the lower 47-bits.

This didn't typically result in any problems due to how ASLR works, but if we did any large allocations (like #4291 wants with 128MB VMA region) then these typically get pushed higher in the VA space.

Again not usually a problem, but if you happen to be running an application that is using MAP_FIXED with hardcoded addresses then this can stomp over FEX-Emu memory causing problems.

This is what happens with Wine, it reserves the upper-32MB of its 47-bit VA space, which is /highly/ likely to stomp on FEX memory. In-fact it likely occurs all the time, we just got lucky with whatever it was clobbering wasn't used at the time.

On 39-bit VA systems this isn't a problem because the mmap fails outright with a warning message from WINE.

Because we are already reserving the upper 128TB of VA space, instead just always enable our allocator and use the regions that were reserved. We need to be a little bit careful to ensure we don't accidentally allocate more memory post-reservation but that just requires a small adjustment to our unique_ptr and constructor for the 64BitAllocator.

This means /all/ FEX-Emu allocations will be in the upper 128TB VA space when running 64-bit applications on a 48-bit VA system. Which is kind of nice.

Fixes WINE in #4291 when the allocator stats are bumped to 128MB per process.