### PR TITLE
Profiler: Add Tracy backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,6 @@
 [submodule "External/jemalloc_glibc"]
 	path = External/jemalloc_glibc
 	url = https://github.com/FEX-Emu/jemalloc.git
+[submodule "External/tracy"]
+	path = External/tracy
+	url = https://github.com/wolfpld/tracy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ option(ENABLE_VIXL_SIMULATOR "Enable use of VIXL simulator for emulation (only u
 option(ENABLE_VIXL_DISASSEMBLER "Enables debug disassembler output with VIXL" FALSE)
 option(USE_LEGACY_BINFMTMISC "Uses legacy method of setting up binfmt_misc" FALSE)
 option(ENABLE_FEXCORE_PROFILER "Enables use of the FEXCore timeline profiling capabilities" FALSE)
-set (FEXCORE_PROFILER_BACKEND "gpuvis" CACHE STRING "Set which backend you want to use for the FEXCore profiler")
+set (FEXCORE_PROFILER_BACKEND "gpuvis" CACHE STRING "Set which backend to use for the FEXCore profiler (gpuvis, tracy)")
 option(ENABLE_GLIBC_ALLOCATOR_HOOK_FAULT "Enables glibc memory allocation hooking with fault for CI testing")
 option(USE_PDB_DEBUGINFO "Builds debug info in PDB format" FALSE)
 
@@ -61,6 +61,22 @@ if (ENABLE_FEXCORE_PROFILER)
 
   if (FEXCORE_PROFILER_BACKEND STREQUAL "GPUVIS")
     add_definitions(-DFEXCORE_PROFILER_BACKEND=1)
+  elseif (FEXCORE_PROFILER_BACKEND STREQUAL "TRACY")
+    add_definitions(-DFEXCORE_PROFILER_BACKEND=2)
+    add_definitions(-DTRACY_ENABLE=1)
+    # Required so that Tracy will only start in the selected guest application
+    add_definitions(-DTRACY_MANUAL_LIFETIME=1)
+    add_definitions(-DTRACY_DELAYED_INIT=1)
+    # This interferes with FEX's signal handling
+    add_definitions(-DTRACY_NO_CRASH_HANDLER=1)
+    # Tracy can gather call stack samples in regular intervals, but this
+    # isn't useful for us since it would usually sample opaque JIT code
+    add_definitions(-DTRACY_NO_SAMPLING=1)
+    # This pulls in libbacktrace which allocators in global constructors (before FEX can set up its allocator hooks)
+    add_definitions(-DTRACY_NO_CALLSTACK=1)
+    if (MINGW_BUILD)
+      message(FATAL_ERROR "Tracy profiler not supported")
+    endif()
   else()
     message(FATAL_ERROR "Unknown FEXCore profiler backend ${FEXCORE_PROFILER_BACKEND}")
   endif()
@@ -268,6 +284,10 @@ include_directories(External/robin-map/include/)
 if (BUILD_TESTS OR ENABLE_VIXL_DISASSEMBLER OR ENABLE_VIXL_SIMULATOR)
   add_subdirectory(External/vixl/)
   include_directories(SYSTEM External/vixl/src/)
+endif()
+
+if (ENABLE_FEXCORE_PROFILER AND FEXCORE_PROFILER_BACKEND STREQUAL "TRACY")
+  add_subdirectory(External/tracy)
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/FEXCore/Source/CMakeLists.txt
+++ b/FEXCore/Source/CMakeLists.txt
@@ -338,6 +338,10 @@ add_library(FEXCore_Base STATIC ${FEXCORE_BASE_SRCS})
 target_link_libraries(FEXCore_Base ${LIBS})
 AddDefaultOptionsToTarget(FEXCore_Base)
 
+if (ENABLE_FEXCORE_PROFILER AND FEXCORE_PROFILER_BACKEND STREQUAL "TRACY")
+  target_link_libraries(FEXCore_Base TracyClient)
+endif()
+
 function(AddObject Name Type)
   add_library(${Name} ${Type} ${SRCS})
 

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -473,6 +473,7 @@ void ContextImpl::DestroyThread(FEXCore::Core::InternalThreadState* Thread) {
 void ContextImpl::UnlockAfterFork(FEXCore::Core::InternalThreadState* LiveThread, bool Child) {
   Allocator::UnlockAfterFork(LiveThread, Child);
 
+  Profiler::PostForkAction(Child);
   if (Child) {
     CodeInvalidationMutex.StealAndDropActiveLocks();
     if (Config.StrictInProcessSplitLocks) {

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -389,7 +389,6 @@ int main(int argc, char** argv, char** const envp) {
     std::this_thread::sleep_for(std::chrono::seconds(StartupSleep()));
   }
 
-  FEXCore::Profiler::Init();
   FEXCore::Telemetry::Initialize();
 
   if (!LDPath().empty() && Program.ProgramPath.starts_with(LDPath())) {
@@ -492,6 +491,8 @@ int main(int argc, char** argv, char** const envp) {
     } while (reinterpret_cast<uintptr_t>(data) >> 32 != 0);
     free(data);
   }
+
+  FEXCore::Profiler::Init(Program.ProgramName, Program.ProgramPath);
 
   // System allocator is now system allocator or FEX
   FEXCore::Context::InitializeStaticTables(Loader.Is64BitMode() ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -539,7 +539,7 @@ NTSTATUS ProcessInit() {
   // Not applicable to Windows
   FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
 
-  FEXCore::Profiler::Init();
+  FEXCore::Profiler::Init("", "");
 
   FEXCore::Context::InitializeStaticTables(FEXCore::Context::MODE_64BIT);
 

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -461,7 +461,7 @@ void BTCpuProcessInit() {
   // Not applicable to Windows
   FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
 
-  FEXCore::Profiler::Init();
+  FEXCore::Profiler::Init("", "");
 
   FEXCore::Context::InitializeStaticTables(FEXCore::Context::MODE_32BIT);
 


### PR DESCRIPTION
## Overview

The existing GPUVis backend isn't suitable for live-profiling and carries heavy overhead per traced event (a memory allocation and a system call). This makes gathering accurate data for quantitative analysis impossible.

This PR adds a new backend for FEX's profiler interface based on Tracy, a nanosecond resolution profiler with support for live tracing and a rich feature set. Notably, statistics and histograms are generated from profiled zones out-of-the-box.

To use this backend, one of the environment variables `FEX_PROFILE_TARGET_NAME`
or `FEX_PROFILE_TARGET_PATH` must be defined to select the application under
profile by name or by path suffix.

Here's an example screenshot of the profiler view while running God of War (a very JIT-time heavy title). I'll post more screenshots as comments below.

![20250123_fex_tracy_general](https://github.com/user-attachments/assets/addbc8df-5963-45d7-9f4c-823604023823)

## Usage

0. Build FEX with `ENABLE_FEXCORE_PROFILER=ON` and `FEXCORE_PROFILER_BACKEND=tracy`
1. Build the Tracy profiler in `External/tracy/profiler` using CMake and run using `tracy-profiler -a ::`
2. Launch a game using `FEX_PROFILE_TARGET_NAME=Celeste.bin.x86_64` (matches app name) or `FEX_PROFILE_TARGET_PATH=amd64/SuperMeatBoy` (matches a path suffix)
   * Using a game's Steam launch options for these is a good way to automatically profile when using a profile-enabled FEX build
   * Additionally setting `FEX_PROFILE_WAIT_FOR_FORK=1` will fix games that `fork()` on startup (this is rarely needed though)

## Future work

### Plotting data

Tracy supports plotting data and creating pretty graphs out of it, which is easy to implement but will need new Profiler interfaces.

### Frame markers

Integration with GL/Vulkan library forwarding allows us to detect where frames end, which is useful to recognize stuttering in a recorded profile.
