### PR TITLE
Profiler/GPUViz: Fixes typo in instant TraceObject

### DIFF
--- a/FEXCore/Source/Utils/Profiler.cpp
+++ b/FEXCore/Source/Utils/Profiler.cpp
@@ -106,7 +106,7 @@ void TraceObject(std::string_view const Format, uint64_t Duration) {
 void TraceObject(std::string_view const Format) {
   if (TraceFD != -1) {
     fextl::string Event = fextl::fmt::format("{}\n", Format);
-    write(TraceFD, Format.data(), Format.size());
+    write(TraceFD, Event.data(), Event.size());
   }
 }
 } // namespace GPUVis


### PR DESCRIPTION
String parsing was adding a newline but then we failed to use it. I don't think it caused any issues considering how infrequent instant profiler objects are used.