### PR TITLE
FEXLoader/ELFCodeLoader: Be robust against zero length environment variables

### DIFF
--- a/Source/Tools/FEXLoader/ELFCodeLoader.h
+++ b/Source/Tools/FEXLoader/ELFCodeLoader.h
@@ -655,7 +655,7 @@ public:
       }
 
       // Set the null terminator for the string
-      *reinterpret_cast<uint8_t*>(ArgumentBackingBase + CurrentOffset + ArgSize + 1) = 0;
+      *reinterpret_cast<uint8_t*>(ArgumentBackingBase + CurrentOffset + ArgSize) = 0;
 
       CurrentOffset += ArgSize + 1;
     }
@@ -667,10 +667,12 @@ public:
       EnvpPointers[i] = EnvpBackingBaseGuest + CurrentOffset;
 
       // Copy the string in to the final location
-      memcpy(reinterpret_cast<void*>(EnvpBackingBase + CurrentOffset), &EnvironmentVariables[i].at(0), EnvpSize);
+      if (EnvpSize) {
+        memcpy(reinterpret_cast<void*>(EnvpBackingBase + CurrentOffset), &EnvironmentVariables[i].at(0), EnvpSize);
+      }
 
       // Set the null terminator for the string
-      *reinterpret_cast<uint8_t*>(EnvpBackingBase + CurrentOffset + EnvpSize + 1) = 0;
+      *reinterpret_cast<uint8_t*>(EnvpBackingBase + CurrentOffset + EnvpSize) = 0;
 
       CurrentOffset += EnvpSize + 1;
     }


### PR DESCRIPTION
For some reason steamwebhelper is setting a zero length environment variable. This was causing an assert to be raised early as the web helper was starting up.

Just stop trying to memcpy the zero length string, gets steamwebhelper working in the steam beta client again