### PR TITLE
CMake: Check for compatible Catch2 versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,7 @@ add_definitions(-Wno-trigraphs)
 add_definitions(-DGLOBAL_DATA_DIRECTORY="${DATA_DIRECTORY}/")
 
 if (BUILD_TESTS)
-  find_package(Catch2 QUIET)
+  find_package(Catch2 3 QUIET)
   if (NOT Catch2_FOUND)
     add_subdirectory(External/Catch2/)
 


### PR DESCRIPTION
Our unittests don't compile with Catch2 2.x, so make sure to fall back to the submodule if the system library is not a 3.x version.
