### PR TITLE
FEXServer: Lower close timeout

### DIFF
--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -200,7 +200,7 @@ int main(int argc, char** argv, char** const envp) {
   // This will let FEXInterpreter know we are ready
   PipeScanner::ClosePipes();
 
-  ProcessPipe::SetConfiguration(Options.Foreground, Options.PersistentTimeout ?: 10);
+  ProcessPipe::SetConfiguration(Options.Foreground, Options.PersistentTimeout ?: 1);
 
   // Actually spin up the request thread.
   // Any applications that were waiting for the socket to accept will then go through here.


### PR DESCRIPTION
Certain configuration changes are missed unless FEXServer restarts, so the 10s timeout could make iterative development a bit annoying.

It's quite rare that no FEX process would run for more than 1 second but less than 10 seconds, so this seems like a more reasonable default.
