### PR TITLE
SignalDelegator: Protect first page of the altstack

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -961,6 +961,9 @@ void SignalDelegator::RegisterTLSState(FEX::HLE::ThreadStateObject* Thread) {
   // Copy the thread object to the start of the alt-stack
   memcpy(Thread->SignalInfo.AltStackPtr, &Thread, sizeof(void*));
 
+  // Protect the first page of the alt-stack for overflow protection.
+  mprotect(Thread->SignalInfo.AltStackPtr, 4096, PROT_READ);
+
   // Register the alt stack
   const int Result = sigaltstack(&altstack, nullptr);
   if (Result == -1) {


### PR DESCRIPTION
When the alt-stack gets overflown then it is hard to see what went wrong since the TLS variable is no longer accessible.

Protect the first page that contains the TLS variable.

Fixes #4320