### PR TITLE
FEXCore: Don't copy IR after compilation

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -271,7 +271,8 @@ public:
   void RemoveCustomIREntrypoint(uintptr_t Entrypoint);
 
   struct GenerateIRResult {
-    fextl::unique_ptr<FEXCore::IR::IRStorageBase> IR;
+    std::optional<IR::IRListView> IRView;
+    IR::RegisterAllocationData* RAData;
     uint64_t TotalInstructions;
     uint64_t TotalInstructionsLength;
     uint64_t StartAddr;
@@ -282,9 +283,7 @@ public:
 
   struct CompileCodeResult {
     void* CompiledCode;
-    fextl::unique_ptr<FEXCore::IR::IRStorageBase> IR;
-    FEXCore::Core::DebugData* DebugData;
-    bool GeneratedIR;
+    fextl::unique_ptr<FEXCore::Core::DebugData> DebugData;
     uint64_t StartAddr;
     uint64_t Length;
   };

--- a/FEXCore/Source/Interface/IR/AOTIR.cpp
+++ b/FEXCore/Source/Interface/IR/AOTIR.cpp
@@ -368,10 +368,6 @@ bool AOTIRCaptureCache::PostCompileCode(FEXCore::Core::InternalThreadState* Thre
     }
 
     // Insert to caches if we generated IR
-    if (GeneratedIR) {
-      // If the IR doesn't need to be retained then we can just delete it now
-      delete DebugData;
-    }
   }
 
   return false;

--- a/FEXCore/Source/Interface/IR/IntrusiveIRList.h
+++ b/FEXCore/Source/Interface/IR/IntrusiveIRList.h
@@ -147,7 +147,6 @@ private:
 class IRListView final {
 public:
   IRListView() = delete;
-  IRListView(IRListView&&) = delete;
 
   IRListView(DualIntrusiveAllocator* Data)
     : IRListView(reinterpret_cast<void*>(Data->DataBegin()), reinterpret_cast<void*>(Data->ListBegin()), Data->DataSize(), Data->ListSize()) {}


### PR DESCRIPTION
This wastes a significant amount of compilation time (30%!!) when the copies IR is promptly thrown away after compilation anyway.

Breaks AOTIR - this is already broken and removal is planned so shouldn't be an issue.

Stats (mean over 3*8 runs of nodejs):
With: 2419065553ns
Without:  3307522698ns


