### PR TITLE
Config: Enable multiblock by default

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -3,7 +3,7 @@
     "CPU": {
       "Multiblock": {
         "Type": "bool",
-        "Default": "false",
+        "Default": "true",
         "ShortArg": "m",
         "Desc": [
           "Controls multiblock code compilation",


### PR DESCRIPTION
Dep #4325 #4326 

Before these:
MB on: 3790969649ns
MB off: 3169002331ns
After:
MB on: 2594371996ns
MB off: 2386604655ns

Seems reasonable to take the 10% hit here