### PR TITLE
FEXServer: Fixes FEX_PORTABLE usage

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.cpp
+++ b/FEXCore/Source/Interface/Config/Config.cpp
@@ -334,9 +334,14 @@ void ReloadMetaLayer() {
       FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, ExpandedString);
     } else if (!PathName->empty()) {
       // If the filesystem doesn't exist then let's see if it exists in the fex-emu folder
-      fextl::string NamedRootFS = GetDataDirectory(false) + "RootFS/" + *PathName;
-      if (FHU::Filesystem::Exists(NamedRootFS)) {
-        FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, NamedRootFS);
+      const auto PathNameCopy = *PathName;
+      for (auto Global : {true, false}) {
+        for (auto DirectoryFetchers : {GetDataDirectory, GetConfigDirectory}) {
+          fextl::string NamedRootFS = DirectoryFetchers(Global) + "RootFS/" + PathNameCopy;
+          if (FHU::Filesystem::Exists(NamedRootFS)) {
+            FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, NamedRootFS);
+          }
+        }
       }
     }
   }
@@ -356,9 +361,14 @@ void ReloadMetaLayer() {
       FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_THUNKCONFIG, ExpandedString);
     } else if (!PathName->empty()) {
       // If the filesystem doesn't exist then let's see if it exists in the fex-emu folder
-      fextl::string NamedConfig = GetDataDirectory(false) + "ThunkConfigs/" + *PathName;
-      if (FHU::Filesystem::Exists(NamedConfig)) {
-        FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_THUNKCONFIG, NamedConfig);
+      const auto PathNameCopy = *PathName;
+      for (auto Global : {true, false}) {
+        for (auto DirectoryFetchers : {GetDataDirectory, GetConfigDirectory}) {
+          fextl::string NamedConfig = DirectoryFetchers(Global) + "ThunkConfigs/" + PathNameCopy;
+          if (FHU::Filesystem::Exists(NamedConfig)) {
+            FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_THUNKCONFIG, NamedConfig);
+          }
+        }
       }
     }
   }

--- a/Source/Tools/CommonTools/PortabilityInfo.h
+++ b/Source/Tools/CommonTools/PortabilityInfo.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "Common/Config.h"
+
+namespace FEX {
+static inline FEX::Config::PortableInformation ReadPortabilityInformation() {
+  const FEX::Config::PortableInformation BadResult {false, {}};
+  const char* PortableConfig = getenv("FEX_PORTABLE");
+  if (!PortableConfig) {
+    return BadResult;
+  }
+
+  uint32_t Value {};
+  std::string_view PortableView {PortableConfig};
+
+  if (std::from_chars(PortableView.data(), PortableView.data() + PortableView.size(), Value).ec != std::errc {} || Value == 0) {
+    return BadResult;
+  }
+
+  // Read the FEXInterpreter path from `/proc/self/exe` which is always a symlink to the absolute path of the executable running.
+  // This way we can get the parent path that the application is executing from.
+  char SelfPath[PATH_MAX];
+  auto Result = readlink("/proc/self/exe", SelfPath, PATH_MAX);
+  if (Result == -1) {
+    return BadResult;
+  }
+
+  std::string_view SelfPathView {SelfPath, std::min<size_t>(PATH_MAX, Result)};
+
+  // Extract the absolute path from the FEXInterpreter path
+  return {true, fextl::string {SelfPathView.substr(0, SelfPathView.find_last_of('/') + 1)}};
+}
+} // namespace FEX

--- a/Source/Tools/FEXServer/CMakeLists.txt
+++ b/Source/Tools/FEXServer/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(${NAME} PRIVATE
   ${CMAKE_BINARY_DIR}/generated
   ${CMAKE_SOURCE_DIR}/Source/)
 
-target_link_libraries(${NAME} PRIVATE FEXCore Common JemallocDummy ${PTHREAD_LIB})
+target_link_libraries(${NAME} PRIVATE FEXCore Common CommonTools JemallocDummy ${PTHREAD_LIB})
 
 if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
   target_link_options(${NAME}

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -2,6 +2,7 @@
 #include "ArgumentLoader.h"
 #include "Logger.h"
 #include "PipeScanner.h"
+#include "PortabilityInfo.h"
 #include "ProcessPipe.h"
 #include "SquashFS.h"
 #include "Common/ArgumentLoader.h"
@@ -117,7 +118,7 @@ int main(int argc, char** argv, char** const envp) {
   }
 
   auto ArgsLoader = fextl::make_unique<FEX::ArgLoader::ArgLoader>(FEX::ArgLoader::ArgLoader::LoadType::WITHOUT_FEXLOADER_PARSER, argc, argv);
-  FEX::Config::LoadConfig(std::move(ArgsLoader), {}, envp);
+  FEX::Config::LoadConfig(std::move(ArgsLoader), {}, envp, FEX::ReadPortabilityInformation());
 
   // Reload the meta layer
   FEXCore::Config::ReloadMetaLayer();


### PR DESCRIPTION
This was causing FEXServer to look in to global installed paths and local paths for things when FEXServer was started.

Ensure it listens to FEX_PORTABLE so this doesn't occur. This also requires us to scan both data directories and config directories to find them.