### PR TITLE
WINE: Fixes FEX_PORTABLE usage

### DIFF
--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -220,7 +220,11 @@ def print_man_environment_tail():
     print_man_env_option(
     "FEX_PORTABLE",
     [
-    "Allows FEX to run without installation. Global locations for configuration and binfmt_misc are ignored. These files are instead read from <FEXInterpreterPath>/fex-emu/ by default.",
+    "Allows FEX to run without installation. Global locations for configuration and binfmt_misc are ignored.",
+    "For FEXInterpreter on Linux:",
+    "These files are instead read from <FEXInterpreterPath>/fex-emu/ by default.",
+    "For Arm64ec/Wow64 WINE builds:",
+    "These files are instead read from $LOCALAPPDATA/fex-emu/ by default.",
     "For further customization, see FEX_APP_CONFIG_LOCATION and FEX_APP_DATA_LOCATION."
     ],
     "''", True)

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -479,7 +479,7 @@ fextl::string GetDataDirectory(bool Global, const PortableInformation& PortableI
   const char* DataOverride = getenv("FEX_APP_DATA_LOCATION");
 
   if (PortableInfo.IsPortable && (Global || !DataOverride)) {
-    return fextl::fmt::format("{}fex-emu/", PortableInfo.InterpreterPath);
+    return fextl::fmt::format("{}/fex-emu/", PortableInfo.InterpreterPath);
   }
 
   fextl::string DataDir {};
@@ -502,7 +502,7 @@ fextl::string GetDataDirectory(bool Global, const PortableInformation& PortableI
 fextl::string GetConfigDirectory(bool Global, const PortableInformation& PortableInfo) {
   const char* ConfigOverride = getenv("FEX_APP_CONFIG_LOCATION");
   if (PortableInfo.IsPortable && (Global || !ConfigOverride)) {
-    return fextl::fmt::format("{}fex-emu/", PortableInfo.InterpreterPath);
+    return fextl::fmt::format("{}/fex-emu/", PortableInfo.InterpreterPath);
   }
 
   fextl::string ConfigDir;

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -35,6 +35,7 @@ $end_info$
 #include "Common/Logging.h"
 #include "Common/Module.h"
 #include "Common/CRT/CRT.h"
+#include "Common/PortabilityInfo.h"
 #include "DummyHandlers.h"
 #include "BTInterface.h"
 
@@ -525,7 +526,7 @@ NTSTATUS ProcessInit() {
   InitSyscalls();
 
   FEX::Windows::InitCRTProcess();
-  FEX::Config::LoadConfig(nullptr, FEX::Windows::GetExecutableFilePath());
+  FEX::Config::LoadConfig(nullptr, FEX::Windows::GetExecutableFilePath(), nullptr, FEX::ReadPortabilityInformation());
   FEXCore::Config::ReloadMetaLayer();
   FEX::Windows::Logging::Init();
 
@@ -605,7 +606,7 @@ bool ResetToConsistentStateImpl(EXCEPTION_RECORD* Exception, CONTEXT* GuestConte
                           CPUArea.ThreadState()->CurrentFrame->State.rip, FaultAddress);
         NativeContext->Pc = CPUArea.DispatcherLoopTopEnterECFillSRA();
         NativeContext->Sp = CPUArea.EmulatorStackBase();
-        NativeContext->X10 = 1; // Set ENTRY_FILL_SRA_SINGLE_INST_REG to force a single step
+        NativeContext->X10 = 1;                                        // Set ENTRY_FILL_SRA_SINGLE_INST_REG to force a single step
         NativeContext->X17 = reinterpret_cast<uint64_t>(CPUArea.Area); // Set EC_ENTRY_CPUAREA_REG
       } else {
         LogMan::Msg::DFmt("Handled self-modifying code: pc: {:X} fault: {:X}", NativeContext->Pc, FaultAddress);

--- a/Source/Windows/Common/PortabilityInfo.h
+++ b/Source/Windows/Common/PortabilityInfo.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "Common/Config.h"
+
+namespace FEX {
+static inline FEX::Config::PortableInformation ReadPortabilityInformation() {
+  const FEX::Config::PortableInformation BadResult {false, {}};
+  const char* PortableConfig = getenv("FEX_PORTABLE");
+  if (!PortableConfig || strtol(PortableConfig, nullptr, 0) == 0) {
+    return BadResult;
+  }
+
+  return {true, getenv("LOCALAPPDATA")};
+}
+} // namespace FEX

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -36,6 +36,7 @@ $end_info$
 #include "Common/Logging.h"
 #include "Common/Module.h"
 #include "Common/CRT/CRT.h"
+#include "Common/PortabilityInfo.h"
 #include "DummyHandlers.h"
 #include "BTInterface.h"
 
@@ -447,7 +448,7 @@ public:
 
 void BTCpuProcessInit() {
   FEX::Windows::InitCRTProcess();
-  FEX::Config::LoadConfig(nullptr, FEX::Windows::GetExecutableFilePath());
+  FEX::Config::LoadConfig(nullptr, FEX::Windows::GetExecutableFilePath(), nullptr, FEX::ReadPortabilityInformation());
   FEXCore::Config::ReloadMetaLayer();
   FEX::Windows::Logging::Init();
 


### PR DESCRIPTION
Completely didn't listen to FEX_PORTABLE. Necessary otherwise it can read configs from some random locations when portable is enabled.