### PR TITLE
FEXServerClient: Fix searching for FEXServer

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -220,7 +220,7 @@ int ConnectToServer(ConnectionOption ConnectionOption) {
   return -1;
 }
 
-bool SetupClient(char* InterpreterPath) {
+bool SetupClient(std::string_view InterpreterPath) {
   ServerFD = FEXServerClient::ConnectToAndStartServer(InterpreterPath);
   if (ServerFD == -1) {
     return false;
@@ -238,7 +238,7 @@ bool SetupClient(char* InterpreterPath) {
   return true;
 }
 
-int ConnectToAndStartServer(char* InterpreterPath) {
+int ConnectToAndStartServer(std::string_view InterpreterPath) {
   int ServerFD = ConnectToServer(ConnectionOption::NoPrintConnectionError);
   if (ServerFD == -1) {
     // Couldn't connect to the server. Start one
@@ -250,7 +250,7 @@ int ConnectToAndStartServer(char* InterpreterPath) {
       return -1;
     }
 
-    fextl::string FEXServerPath = FHU::Filesystem::ParentPath(InterpreterPath) + "/FEXServer";
+    fextl::string FEXServerPath = fextl::fmt::format("{}/FEXServer", InterpreterPath);
     // Check if a local FEXServer next to FEXInterpreter exists
     // If it does then it takes priority over the installed one
     if (!FHU::Filesystem::Exists(FEXServerPath)) {

--- a/Source/Common/FEXServerClient.h
+++ b/Source/Common/FEXServerClient.h
@@ -56,14 +56,14 @@ fextl::string GetServerSocketName();
 fextl::string GetServerSocketPath();
 int GetServerFD();
 
-bool SetupClient(char* InterpreterPath);
+bool SetupClient(std::string_view InterpreterPath);
 
 /**
  * @brief Connect to and start a FEXServer instance if required
  *
  * @return socket FD for communicating with server
  */
-int ConnectToAndStartServer(char* InterpreterPath);
+int ConnectToAndStartServer(std::string_view InterpreterPath);
 
 enum class ConnectionOption {
   Default,

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -340,7 +340,8 @@ int main(int argc, char** argv, char** const envp) {
   }
 
   // Ensure FEXServer is setup before config options try to pull CONFIG_ROOTFS
-  if (!FEXServerClient::SetupClient(argv[0])) {
+  auto SelfPath = FEX::GetSelfPath();
+  if (!FEXServerClient::SetupClient(SelfPath.value_or(argv[0]))) {
     LogMan::Msg::EFmt("FEXServerClient: Failure to setup client");
     return -1;
   }


### PR DESCRIPTION
argv[0] is whatever the user passed in and may not directly be FEXLoader/FEXInterpreter's path. Make sure get the full path.