### PR TITLE
FEXServer: Fixes background startup

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -270,10 +270,13 @@ int ConnectToAndStartServer(char* InterpreterPath) {
       // Child
       close(fds[0]); // Close read end of pipe
 
-      const char* argv[2];
+      const char* argv[4];
 
+      auto pipe_string = fextl::fmt::format("{}", fds[1]);
       argv[0] = FEXServerPath.c_str();
-      argv[1] = nullptr;
+      argv[1] = "--wait_pipe";
+      argv[2] = pipe_string.c_str();
+      argv[3] = nullptr;
 
       if (execvp(argv[0], (char* const*)argv) == -1) {
         // Let the parent know that we couldn't execute for some reason

--- a/Source/Tools/FEXServer/ArgumentLoader.cpp
+++ b/Source/Tools/FEXServer/ArgumentLoader.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include "ArgumentLoader.h"
 #include "Common/cpp-optparse/OptionParser.h"
+#include "PipeScanner.h"
 
 #include "git_version.h"
 
@@ -20,6 +21,7 @@ FEXServerOptions Load(int argc, char** argv) {
   Parser.add_option("-p", "--persistent").action("store").type("int").set_default(0).set_optional_value(true).metavar("n").help("Make FEXServer persistent. Optional number of seconds");
 
   Parser.add_option("-w", "--wait").action("store_true").set_default(false).help("Wait for the FEXServer to shutdown");
+  Parser.add_option("--wait_pipe").action("store").type("int").set_default(-1).set_optional_value(true);
 
   Parser.add_option("-v").action("version").help("Version string");
 
@@ -33,6 +35,10 @@ FEXServerOptions Load(int argc, char** argv) {
   }
   FEXOptions.PersistentTimeout = Options.get("persistent");
 
+  int WaitPipe = Options.get("wait_pipe");
+  if (WaitPipe != -1) {
+    PipeScanner::SetWaitPipe(WaitPipe);
+  }
   return FEXOptions;
 }
 } // namespace FEXServer::Config

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -109,10 +109,6 @@ int main(int argc, char** argv, char** const envp) {
     LogMan::Msg::InstallHandler(Logging::MsgHandler);
   }
 
-  // Scan for any incoming pipes
-  // We will close these later
-  PipeScanner::ScanForPipes();
-
   if (!Options.Foreground) {
     DeparentSelf();
   }

--- a/Source/Tools/FEXServer/PipeScanner.cpp
+++ b/Source/Tools/FEXServer/PipeScanner.cpp
@@ -1,42 +1,18 @@
 // SPDX-License-Identifier: MIT
-#include <cstdlib>
 #include <dirent.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <vector>
+#include <fcntl.h>
 
 namespace PipeScanner {
 std::vector<int> IncomingPipes {};
-
-// Scan and store any pipe files.
-// This will capture all pipe files so needs to be executed early.
-// This ensures we find any pipe files from execve for waiting FEXInterpreters.
-void ScanForPipes() {
-  DIR* fd = opendir("/proc/self/fd");
-  if (fd) {
-    struct dirent* dir {};
-    do {
-      dir = readdir(fd);
-      if (dir) {
-        char* end {};
-        int open_fd = std::strtol(dir->d_name, &end, 8);
-        if (end != dir->d_name) {
-          struct stat stat {};
-          int result = fstat(open_fd, &stat);
-          if (result == -1) {
-            continue;
-          }
-          if (stat.st_mode & S_IFIFO) {
-            // Close any incoming pipes
-            IncomingPipes.emplace_back(open_fd);
-          }
-        }
-      }
-    } while (dir);
-
-    closedir(fd);
-  }
+void SetWaitPipe(int FD) {
+  int flags = fcntl(FD, F_GETFD);
+  flags |= FD_CLOEXEC;
+  fcntl(FD, F_SETFD, flags);
+  IncomingPipes.emplace_back(FD);
 }
 
 void ClosePipes() {

--- a/Source/Tools/FEXServer/PipeScanner.h
+++ b/Source/Tools/FEXServer/PipeScanner.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 namespace PipeScanner {
-void ScanForPipes();
+void SetWaitPipe(int FD);
 void ClosePipes();
 } // namespace PipeScanner


### PR DESCRIPTION
The problem here is that the pipe we used for telling FEXInterpreter that the FEXServer is ready to accept connections was inherited by erofsfuse or squashfuse. So the closing of the pipe from the FEXServer side would leave a reference open in squashfuse or erofsfuse.

Fix this by setting FD_CLOEXEC on the pipe, but also pass the pipe FD through an argument instead of scanning for all pipes.

Then once we execve the squashfuse/erofsfuse application, the FD isn't inherited.

Fixes #4329