### PR TITLE
Config: Correctly handle relative paths with portable 

### DIFF
--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -188,7 +188,7 @@ def print_man_environment_tail():
 
     # Additional environment variables that live outside of the normal loop
     print_man_env_option(
-    "FEX_APP_CONFIG_LOCATION",
+    "APP_CONFIG_LOCATION",
     [
     "Allows the user to override where FEX looks for configuration files",
     "By default FEX will look in {$HOME, $XDG_CONFIG_HOME}/.fex-emu/",
@@ -197,7 +197,7 @@ def print_man_environment_tail():
     "''", True)
 
     print_man_env_option(
-    "FEX_APP_CONFIG",
+    "APP_CONFIG",
     [
     "Allows the user to override where FEX looks for only the application config file",
     "By default FEX will look in {$HOME, $XDG_CONFIG_HOME}/.fex-emu/Config.json",
@@ -208,7 +208,7 @@ def print_man_environment_tail():
     "''", True)
 
     print_man_env_option(
-    "FEX_APP_DATA_LOCATION",
+    "APP_DATA_LOCATION",
     [
     "Allows the user to override where FEX looks for data files",
     "By default FEX will look in {$HOME, $XDG_DATA_HOME}/.fex-emu/",
@@ -218,7 +218,7 @@ def print_man_environment_tail():
     "''", True)
 
     print_man_env_option(
-    "FEX_PORTABLE",
+    "PORTABLE",
     [
     "Allows FEX to run without installation. Global locations for configuration and binfmt_misc are ignored.",
     "For FEXInterpreter on Linux:",

--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -193,6 +193,9 @@ def print_man_environment_tail():
     "Allows the user to override where FEX looks for configuration files",
     "By default FEX will look in {$HOME, $XDG_CONFIG_HOME}/.fex-emu/",
     "This will override the full path",
+    "If FEX_PORTABLE is declared then relative paths are also supported",
+    "For FEXInterpreter: Relative to the FEXInterpreter binary",
+    "For WINE: Relative to %LOCALAPPDATA%"
     ],
     "''", True)
 
@@ -204,6 +207,9 @@ def print_man_environment_tail():
     "This will override this file location",
     "One must be careful with this option as it will override any applications that load with execve as well"
     "If you need to support applications that execve then use FEX_APP_CONFIG_LOCATION instead"
+    "If FEX_PORTABLE is declared then relative paths are also supported",
+    "For FEXInterpreter: Relative to the FEXInterpreter binary",
+    "For WINE: Relative to %LOCALAPPDATA%"
     ],
     "''", True)
 

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -76,7 +76,7 @@ fextl::unique_ptr<FEXCore::Config::Layer> CreateGlobalMainLayer();
  * @return unique_ptr for that layer
  */
 fextl::unique_ptr<FEXCore::Config::Layer> CreateMainLayer(const fextl::string* File = nullptr);
-fextl::unique_ptr<FEXCore::Config::Layer> CreateUserOverrideLayer(const char* AppConfig);
+fextl::unique_ptr<FEXCore::Config::Layer> CreateUserOverrideLayer(std::string_view AppConfig);
 
 /**
  * @brief Create an application configuration loader


### PR DESCRIPTION
It is desired that FEX_APP_CONFIG and FEX_APP_CONFIG_LOCATION support
relative paths when portable is used. Support this.