### PR TITLE
Linux: Fixes PAGESIZE checks that could return <= 0

### DIFF
--- a/Source/Tools/CommonTools/HarnessHelpers.h
+++ b/Source/Tools/CommonTools/HarnessHelpers.h
@@ -401,7 +401,8 @@ public:
   }
 
   uint64_t StackSize() const override {
-    return sysconf(_SC_PAGESIZE);
+    const auto Page = sysconf(_SC_PAGESIZE);
+    return Page > 0 ? Page : FEXCore::Utils::FEX_PAGE_SIZE;
   }
 
   uint64_t GetStackPointer() override {
@@ -426,7 +427,11 @@ public:
       return Result;
     };
 
-    const auto AllocPageSize = sysconf(_SC_PAGESIZE);
+    auto AllocPageSize = sysconf(_SC_PAGESIZE);
+    if (AllocPageSize <= 0) {
+      AllocPageSize = FEXCore::Utils::FEX_PAGE_SIZE;
+    }
+
     if (LimitedSize) {
       DoMMap(0xe000'0000, AllocPageSize * 10);
 

--- a/Source/Tools/FEXLoader/ELFCodeLoader.h
+++ b/Source/Tools/FEXLoader/ELFCodeLoader.h
@@ -564,21 +564,21 @@ public:
     // All done
 
     // Setup AuxVars
-    AuxVariables.emplace_back(auxv_t {11, getauxval(AT_UID)});          // AT_UID
-    AuxVariables.emplace_back(auxv_t {12, getauxval(AT_EUID)});         // AT_EUID
-    AuxVariables.emplace_back(auxv_t {13, getauxval(AT_GID)});          // AT_GID
-    AuxVariables.emplace_back(auxv_t {14, getauxval(AT_EGID)});         // AT_EGID
-    AuxVariables.emplace_back(auxv_t {17, getauxval(AT_CLKTCK)});       // AT_CLKTIK
-    AuxVariables.emplace_back(auxv_t {6, 0x1000});                      // AT_PAGESIZE
-    AuxRandom = &AuxVariables.emplace_back(auxv_t {25, ~0ULL});         // AT_RANDOM
-    AuxVariables.emplace_back(auxv_t {23, getauxval(AT_SECURE)});       // AT_SECURE
-    AuxVariables.emplace_back(auxv_t {8, 0});                           // AT_FLAGS
-    AuxVariables.emplace_back(auxv_t {5, MainElf.phdrs.size()});        // AT_PHNUM
-    AuxVariables.emplace_back(auxv_t {16, HWCap});                      // AT_HWCAP
-    AuxVariables.emplace_back(auxv_t {26, HWCap2});                     // AT_HWCAP2
-    AuxVariables.emplace_back(auxv_t {51, CalculateSignalStackSize()}); // AT_MINSIGSTKSZ
-    AuxPlatform = &AuxVariables.emplace_back(auxv_t {24, ~0ULL});       // AT_PLATFORM
-    AuxExecFN = &AuxVariables.emplace_back(auxv_t {AT_EXECFN, ~0ULL});  // AT_EXECFN
+    AuxVariables.emplace_back(auxv_t {11, getauxval(AT_UID)});            // AT_UID
+    AuxVariables.emplace_back(auxv_t {12, getauxval(AT_EUID)});           // AT_EUID
+    AuxVariables.emplace_back(auxv_t {13, getauxval(AT_GID)});            // AT_GID
+    AuxVariables.emplace_back(auxv_t {14, getauxval(AT_EGID)});           // AT_EGID
+    AuxVariables.emplace_back(auxv_t {17, getauxval(AT_CLKTCK)});         // AT_CLKTIK
+    AuxVariables.emplace_back(auxv_t {6, FEXCore::Utils::FEX_PAGE_SIZE}); // AT_PAGESIZE
+    AuxRandom = &AuxVariables.emplace_back(auxv_t {25, ~0ULL});           // AT_RANDOM
+    AuxVariables.emplace_back(auxv_t {23, getauxval(AT_SECURE)});         // AT_SECURE
+    AuxVariables.emplace_back(auxv_t {8, 0});                             // AT_FLAGS
+    AuxVariables.emplace_back(auxv_t {5, MainElf.phdrs.size()});          // AT_PHNUM
+    AuxVariables.emplace_back(auxv_t {16, HWCap});                        // AT_HWCAP
+    AuxVariables.emplace_back(auxv_t {26, HWCap2});                       // AT_HWCAP2
+    AuxVariables.emplace_back(auxv_t {51, CalculateSignalStackSize()});   // AT_MINSIGSTKSZ
+    AuxPlatform = &AuxVariables.emplace_back(auxv_t {24, ~0ULL});         // AT_PLATFORM
+    AuxExecFN = &AuxVariables.emplace_back(auxv_t {AT_EXECFN, ~0ULL});    // AT_EXECFN
 
     if (Is64BitMode()) {
       AuxVariables.emplace_back(auxv_t {4, 0x38}); // AT_PHENT

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -29,9 +29,7 @@ void ThreadManager::StatAlloc::Initialize() {
     return;
   }
   CurrentSize = sysconf(_SC_PAGESIZE);
-  if (CurrentSize == 0) {
-    CurrentSize = 4096;
-  }
+  CurrentSize = CurrentSize > 0 ? CurrentSize : FEXCore::Utils::FEX_PAGE_SIZE;
 
   if (ftruncate(fd, CurrentSize) == -1) {
     LogMan::Msg::EFmt("[StatAlloc] ftruncate failed");

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
@@ -652,7 +652,7 @@ void LoadGuestVDSOSymbols(bool Is64Bit, char* VDSOBase) {
 void LoadUnique32BitSigreturn(VDSOMapping* Mapping) {
   // Hardcoded to one page for now
   const auto PageSize = sysconf(_SC_PAGESIZE);
-  Mapping->OptionalMappingSize = PageSize;
+  Mapping->OptionalMappingSize = PageSize > 0 ? PageSize : FEXCore::Utils::FEX_PAGE_SIZE;
 
   // First 64bit page
   constexpr uintptr_t LOCATION_MAX = 0x1'0000'0000;


### PR DESCRIPTION
If any `sysconf(_SC_PAGESIZE);` errors then we can get bad values, make sure to at minimum use the x86 page size.

Also changes a hardcoded page size to use the FEX pagesize define.