### PR TITLE
FileManagement: Throw a warning if `/proc` can't be opened

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.cpp
@@ -325,12 +325,15 @@ FileManager::FileManager(FEXCore::Context::Context* ctx)
 
   // Keep an fd open for /proc, to bypass chroot-style sandboxes
   ProcFD = open("/proc", O_RDONLY | O_CLOEXEC);
-
-  // Track the st_dev of /proc, to check for inode equality
-  struct stat Buffer;
-  auto Result = fstat(ProcFD, &Buffer);
-  if (Result >= 0) {
-    ProcFSDev = Buffer.st_dev;
+  if (ProcFD != -1) {
+    // Track the st_dev of /proc, to check for inode equality
+    struct stat Buffer;
+    auto Result = fstat(ProcFD, &Buffer);
+    if (Result >= 0) {
+      ProcFSDev = Buffer.st_dev;
+    }
+  } else {
+    LogMan::Msg::EFmt("Couldn't open `/proc`. Is ProcFS mounted? FEX won't be able to track FD conflicts");
   }
 
   UpdatePID(::getpid());


### PR DESCRIPTION
We use this for ProcFD collision checking. Give a warning if it can't be opened, also not doing the additional work when it fails.

This isn't likely to occur unless someone messes up their rootfs mounts.