### PR TITLE
ArchHelpers/Arm64: Fix loadstore mask

### DIFF
--- a/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
+++ b/FEXCore/Source/Utils/ArchHelpers/Arm64.cpp
@@ -42,7 +42,8 @@ constexpr uint32_t STLR_INST = 0x08'9F'FC'00;
 constexpr uint32_t STLXR_MASK = 0x3F'E0'FC'00;
 constexpr uint32_t STLXR_INST = 0x08'00'FC'00;
 
-constexpr uint32_t LDSTREGISTER_MASK = 0b0011'1011'0010'0000'0000'1100'0000'0000;
+// Load/store register (register offset) (Rm encoded as xzr)
+constexpr uint32_t LDSTREGISTER_MASK = 0b0011'1111'1111'1111'1111'1100'0000'0000;
 constexpr uint32_t LDR_INST = 0b0011'1000'0111'1111'0110'1000'0000'0000;
 constexpr uint32_t STR_INST = 0b0011'1000'0011'1111'0110'1000'0000'0000;
 


### PR DESCRIPTION
This would become an issue when multiple threads are contending with the SIGBUS handler on the same code.

We were failing to mask the VR, OPC, Rm, and Option bits, resulting in a comparison below always resulting in a false result if another thread managed to backpatch.

This was just unlikely to be seen on LRCPC2 supporting hardware and since we fixed `LDSTUNSCALED_MASK` before, this wasn't really getting seen.