### PR TITLE
Library Forwarding: Add GUI for enabling use of individual host libraries

### DIFF
--- a/Data/ThunksDB.json
+++ b/Data/ThunksDB.json
@@ -9,114 +9,12 @@
         "@PREFIX_LIB@/libGL.so.1.7.0"
       ]
     },
-    "GLESv2": {
-      "Library": "libGLESv2-guest.so",
-      "Depends": [
-        "X11"
-      ],
-      "Overlay": [
-        "@PREFIX_LIB@/libGLESv2.so",
-        "@PREFIX_LIB@/libGLESv2.so.2",
-        "@PREFIX_LIB@/libGLESv2.so.2.0.0"
-      ]
-    },
-    "X11": {
-      "Library": "libX11-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libX11.so",
-        "@PREFIX_LIB@/libX11.so.6",
-        "@PREFIX_LIB@/libX11.so.6.4.0"
-      ]
-    },
     "Vulkan": {
       "Library": "libvulkan-guest.so",
       "Overlay": [
         "@PREFIX_LIB@/libvulkan.so",
         "@PREFIX_LIB@/libvulkan.so.1",
         "@HOME@/.local/share/Steam/ubuntu12_32/steam-runtime/pinned_libs_64/libvulkan.so.1"
-      ]
-    },
-    "xcb": {
-      "Depends": [
-        "X11"
-      ],
-      "Library": "libxcb-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libxcb.so",
-        "@PREFIX_LIB@/libxcb.so.1",
-        "@PREFIX_LIB@/libxcb.so.1.1.0"
-      ]
-    },
-    "xcb-dri2": {
-      "Library": "libxcb-dri2-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libxcb-dri2.so",
-        "@PREFIX_LIB@/libxcb-dri2.so.0",
-        "@PREFIX_LIB@/libxcb-dri2.so.0.0.0"
-      ]
-    },
-    "xcb-dri3": {
-      "Library": "libxcb-dri3-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libxcb-dri3.so",
-        "@PREFIX_LIB@/libxcb-dri3.so.0",
-        "@PREFIX_LIB@/libxcb-dri3.so.0.0.0"
-      ]
-    },
-    "xcb-xfixes": {
-      "Library": "libxcb-xfixes-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libxcb-xfixes.so",
-        "@PREFIX_LIB@/libxcb-xfixes.so.0",
-        "@PREFIX_LIB@/libxcb-xfixes.so.0.0.0"
-      ]
-    },
-    "xcb-shm": {
-      "Library": "libxcb-shm-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libxcb-shm.so",
-        "@PREFIX_LIB@/libxcb-shm.so.0",
-        "@PREFIX_LIB@/libxcb-shm.so.0.0.0"
-      ]
-    },
-    "xcb-sync": {
-      "Library": "libxcb-sync-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libxcb-sync.so",
-        "@PREFIX_LIB@/libxcb-sync.so.1",
-        "@PREFIX_LIB@/libxcb-sync.so.1.0.0"
-      ]
-    },
-    "xcb-randr": {
-      "Library": "libxcb-randr-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libxcb-randr.so",
-        "@PREFIX_LIB@/libxcb-randr.so.0",
-        "@PREFIX_LIB@/libxcb-randr.so.0.1.0"
-      ]
-    },
-    "xcb-present": {
-      "Library": "libxcb-present-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libxcb-present.so",
-        "@PREFIX_LIB@/libxcb-present.so.0",
-        "@PREFIX_LIB@/libxcb-present.so.0.0.0"
-      ]
-    },
-    "xcb-glx": {
-      "Library": "libxcb-glx-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libxcb-glx.so",
-        "@PREFIX_LIB@/libxcb-glx.so.0",
-        "@PREFIX_LIB@/libxcb-glx.so.0.0.0"
-      ]
-    },
-    "xshmfence": {
-      "Library": "libxshmfence-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libxshmfence.so",
-        "@PREFIX_LIB@/libxshmfence.so.1",
-        "@PREFIX_LIB@/libxshmfence.so.1.0.0"
       ]
     },
     "drm": {
@@ -141,38 +39,6 @@
         "@PREFIX_LIB@/libfex_thunk_test.so"
       ]
     },
-    "Xrender": {
-      "Library": "libXrender-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libXrender.so",
-        "@PREFIX_LIB@/libXrender.so.1",
-        "@PREFIX_LIB@/libXrender.so.1.3.0"
-      ]
-    },
-    "Xext": {
-      "Library": "libXext-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libXext.so",
-        "@PREFIX_LIB@/libXext.so.6",
-        "@PREFIX_LIB@/libXext.so.6.4.0"
-      ]
-    },
-    "Xfixes": {
-      "Library": "libXfixes-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libXfixes.so",
-        "@PREFIX_LIB@/libXfixes.so.3",
-        "@PREFIX_LIB@/libXfixes.so.3.1.0"
-      ]
-    },
-    "OpenCL": {
-      "Library" : "libOpenCL-guest.so",
-      "Overlay": [
-        "@PREFIX_LIB@/libOpenCL.so",
-        "@PREFIX_LIB@/libOpenCL.so.1",
-        "@PREFIX_LIB@/libOpenCL.so.1.0.0"
-      ]
-    },
     "WaylandClient": {
       "Library" : "libwayland-client-guest.so",
       "Overlay": [
@@ -180,7 +46,6 @@
         "@PREFIX_LIB@/libwayland-client.so.0",
         "@PREFIX_LIB@/libwayland-client.so.0.20.0"
       ]
-    },
-    "":{}
+    }
   }
 }

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -19,7 +19,8 @@ public:
 protected:
 };
 
-void SaveLayerToJSON(const fextl::string& Filename, FEXCore::Config::Layer* const Layer);
+void SaveLayerToJSON(const fextl::string& Filename, const FEXCore::Config::Layer* Layer);
+void SaveLayerToJSON(const fextl::string& Filename, const FEXCore::Config::Layer* Layer, const fextl::unordered_map<fextl::string, bool>& HostLibs);
 
 struct ApplicationNames {
   // This is the full path to the program (if it exists).

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -335,7 +335,7 @@ ConfigRuntime::ConfigRuntime(const QString& ConfigFilename) {
 
 void ConfigRuntime::onSave(const QUrl& Filename) {
   qInfo() << "Saving to" << Filename.toLocalFile().toStdString().c_str();
-  FEX::Config::SaveLayerToJSON(Filename.toLocalFile().toStdString().c_str(), LoadedConfig.get());
+  FEX::Config::SaveLayerToJSON(Filename.toLocalFile().toStdString().c_str(), LoadedConfig.get(), HostLibs.HostLibsDB);
 }
 
 void ConfigRuntime::onLoad(const QUrl& Filename) {

--- a/Source/Tools/FEXConfig/Main.h
+++ b/Source/Tools/FEXConfig/Main.h
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <Common/Async.h>
+#include <FEXCore/fextl/string.h>
+#include <FEXCore/fextl/unordered_map.h>
 
 #include <QStandardItemModel>
 #include <QQmlApplicationEngine>
@@ -33,6 +35,23 @@ public slots:
   void setInt(const QString&, int value);
 };
 
+class HostLibsModel : public QStandardItemModel {
+  Q_OBJECT
+  QML_ELEMENT
+  QML_SINGLETON
+
+public:
+  fextl::unordered_map<fextl::string, bool> HostLibsDB;
+
+  HostLibsModel();
+
+  QHash<int, QByteArray> roleNames() const override;
+
+  bool setData(const QModelIndex&, const QVariant&, int role) override;
+
+  void Reload(const fextl::string& Filename);
+};
+
 class RootFSModel : public QStandardItemModel {
   Q_OBJECT
   QML_ELEMENT
@@ -62,6 +81,7 @@ class ConfigRuntime : public QObject {
   QQuickWindow* Window = nullptr;
   RootFSModel RootFSList;
   ConfigModel ConfigModelInst;
+  HostLibsModel HostLibs;
 
 public:
   ConfigRuntime(const QString& ConfigFilename);

--- a/Source/Windows/Common/CRT/String.cpp
+++ b/Source/Windows/Common/CRT/String.cpp
@@ -52,6 +52,10 @@ unsigned long long wcstoull(const wchar_t* __restrict__ nptr, wchar_t** __restri
   UNIMPLEMENTED();
 }
 
+long long atoll(const char*) {
+  UNIMPLEMENTED();
+}
+
 long long strtoll(const char* __restrict__, char** __restrict, int) {
   UNIMPLEMENTED();
 }


### PR DESCRIPTION
This will save the list of enabled libraries to the main configuration file. Reading it from there was already supported.

Using a dedicated Thunks.json is considered deprecated and should not be used anymore outside of FEX testing.

Example Config.json:

```json
{
  "Config":{...},
  "ThunksDB": {
    "fex_thunk_test":0,
    "asound":0,
    "drm":0,
    "Vulkan":1,
    "WaylandClient":0,
    "GL":0
  }
}
```
