### PR TITLE
Profiler: Drop accidentally included debugging code

### DIFF
--- a/FEXCore/Source/Utils/Profiler.cpp
+++ b/FEXCore/Source/Utils/Profiler.cpp
@@ -200,9 +200,6 @@ bool IsActive() {
   return true;
 #elif FEXCORE_PROFILER_BACKEND == FEXCORE_PROFILER_BACKEND_TRACY
   // Active if previously enabled
-  if (Tracy::Enable) {
-    LogMan::Msg::EFmt("PROFILE ENABLED");
-  }
   return Tracy::Enable;
 #endif
 }


### PR DESCRIPTION
This seems to have slipped in while I had rebased #4300 on latest main.