### PR TITLE
Improve reciprocal estimate and tests

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -1507,7 +1507,10 @@ DEF_OP(VFRecp) {
         fdiv(Dst.D(), VTMP1.D(), Vector.D());
         break;
       }
-      default: break;
+      default: {
+        LOGMAN_MSG_A_FMT("Unexpected ElementSize for {}", __func__);
+        FEX_UNREACHABLE;
+      }
       }
     } else {
       if (ElementSize == IR::OpSize::i32Bit && HostSupportsRPRES) {
@@ -1523,6 +1526,46 @@ DEF_OP(VFRecp) {
       fmov(SubRegSize.Vector, VTMP1.Q(), 1.0f);
       fdiv(SubRegSize.Vector, Dst.Q(), VTMP1.Q(), Vector.Q());
     }
+  }
+}
+
+DEF_OP(VFRecpPrecision) {
+  const auto Op = IROp->C<IR::IROp_VFRecpPrecision>();
+  const auto OpSize = IROp->Size;
+  const auto ElementSize = Op->Header.ElementSize;
+
+  LOGMAN_THROW_A_FMT((OpSize == IR::OpSize::i64Bit || OpSize == IR::OpSize::i32Bit) && ElementSize == IR::OpSize::i32Bit,
+                     "Unexpected sizes for operation.", __func__);
+
+  const auto SubRegSize = ConvertSubRegSizePair16(IROp);
+  const auto IsScalar = OpSize == ElementSize;
+
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
+
+  if (IsScalar) {
+    if (ElementSize == IR::OpSize::i32Bit && HostSupportsRPRES) {
+      // Not enough precision so we need to improve it with frecps
+      frecpe(SubRegSize.Scalar, VTMP1.S(), Vector.S());
+      frecps(SubRegSize.Scalar, VTMP2.S(), VTMP1.S(), Vector.S());
+      fmul(SubRegSize.Scalar, Dst.S(), VTMP1.S(), VTMP2.S());
+      return;
+    }
+
+    fmov(SubRegSize.Scalar, VTMP1.Q(), 1.0f);
+    // Element size is known to be 32bits
+    fdiv(Dst.S(), VTMP1.S(), Vector.S());
+  } else { // Vector operation - Opsize 64bits, elementsize 32bits
+    if (HostSupportsRPRES) {
+      frecpe(SubRegSize.Vector, VTMP1.D(), Vector.D());
+      frecps(SubRegSize.Vector, VTMP2.D(), VTMP1.D(), Vector.D());
+      fmul(SubRegSize.Vector, Dst.D(), VTMP1.D(), VTMP2.D());
+      return;
+    }
+
+    // No RPRES, so normal division
+    fmov(SubRegSize.Vector, VTMP1.Q(), 1.0f);
+    fdiv(SubRegSize.Vector, Dst.Q(), VTMP1.Q(), Vector.Q());
   }
 }
 
@@ -1592,6 +1635,50 @@ DEF_OP(VFRSqrt) {
       fsqrt(SubRegSize.Vector, VTMP2.Q(), Vector.Q());
       fdiv(SubRegSize.Vector, Dst.Q(), VTMP1.Q(), VTMP2.Q());
     }
+  }
+}
+
+DEF_OP(VFRSqrtPrecision) {
+  const auto Op = IROp->C<IR::IROp_VFRSqrtPrecision>();
+  const auto OpSize = IROp->Size;
+  const auto ElementSize = Op->Header.ElementSize;
+
+
+  LOGMAN_THROW_A_FMT((OpSize == IR::OpSize::i64Bit || OpSize == IR::OpSize::i32Bit) && ElementSize == IR::OpSize::i32Bit,
+                     "Unexpected sizes for operation.", __func__);
+
+  const auto SubRegSize = ConvertSubRegSizePair16(IROp);
+  const auto IsScalar = ElementSize == OpSize;
+
+  const auto Dst = GetVReg(Node);
+  const auto Vector = GetVReg(Op->Vector.ID());
+
+  if (IsScalar) {
+    if (HostSupportsRPRES) {
+      frsqrte(SubRegSize.Scalar, VTMP1.S(), Vector.S());
+      // Improve initial estimate which is not good enough.
+      fmul(SubRegSize.Scalar, VTMP2.S(), VTMP1.S(), VTMP1.S());
+      frsqrts(SubRegSize.Scalar, VTMP2.S(), VTMP2.S(), Vector.S());
+      fmul(SubRegSize.Scalar, Dst.S(), VTMP1.S(), VTMP2.S());
+      return;
+    }
+
+    fmov(SubRegSize.Scalar, VTMP1.Q(), 1.0);
+    // element size is known to be 32bits
+    fsqrt(VTMP2.S(), Vector.S());
+    fdiv(Dst.S(), VTMP1.S(), VTMP2.S());
+  } else {
+    if (HostSupportsRPRES) {
+      frsqrte(SubRegSize.Vector, VTMP1.D(), Vector.D());
+      // Improve initial estimate which is not good enough.
+      fmul(SubRegSize.Vector, VTMP2.D(), VTMP1.D(), VTMP1.D());
+      frsqrts(SubRegSize.Vector, VTMP2.D(), VTMP2.D(), Vector.D());
+      fmul(SubRegSize.Vector, Dst.D(), VTMP1.D(), VTMP2.D());
+      return;
+    }
+    fmov(SubRegSize.Vector, VTMP1.Q(), 1.0);
+    fsqrt(SubRegSize.Vector, VTMP2.Q(), Vector.Q());
+    fdiv(SubRegSize.Vector, Dst.Q(), VTMP1.Q(), VTMP2.Q());
   }
 }
 
@@ -4452,6 +4539,30 @@ DEF_OP(VFNMLS) {
     }
   }
 }
+
+DEF_OP(VFCopySign) {
+  auto Op = IROp->C<IR::IROp_VFCopySign>();
+  const auto OpSize = IROp->Size;
+  const auto SubRegSize = ConvertSubRegSize248(IROp);
+
+  ARMEmitter::VRegister Magnitude = GetVReg(Op->Vector1.ID());
+  ARMEmitter::VRegister Sign = GetVReg(Op->Vector2.ID());
+
+  //  We don't assign explicity to Dst but Dst and Magniture are tied to the same register.
+  //  Similar in semantics to C's copysignf.
+  switch (OpSize) {
+  case IR::OpSize::i64Bit:
+    movi(SubRegSize, VTMP1.D(), 0x80, 24);
+    bit(Magnitude.D(), Sign.D(), VTMP1.D());
+    break;
+  case IR::OpSize::i128Bit:
+    movi(SubRegSize, VTMP1.Q(), 0x80, 24);
+    bit(Magnitude.Q(), Sign.Q(), VTMP1.Q());
+    break;
+  default: LOGMAN_MSG_A_FMT("Unsupported element size for operation {}", __func__); FEX_UNREACHABLE;
+  }
+}
+
 
 #undef DEF_OP
 } // namespace FEXCore::CPU

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -434,6 +434,7 @@ public:
 
   void VectorALUROp(OpcodeArgs, IROps IROp, IR::OpSize ElementSize);
   void VectorUnaryOp(OpcodeArgs, IROps IROp, IR::OpSize ElementSize);
+  void RSqrt3DNowOp(OpcodeArgs, bool Duplicate);
   template<FEXCore::IR::IROps IROp, IR::OpSize ElementSize>
   void VectorUnaryDuplicateOp(OpcodeArgs);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/DDDTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/DDDTables.h
@@ -9,16 +9,16 @@ constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDisp
   {0x1C, 1, &OpDispatchBuilder::PF2IWOp},
   {0x1D, 1, &OpDispatchBuilder::Vector_CVT_Float_To_Int<OpSize::i32Bit, false>},
 
-  {0x86, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorUnaryOp, IR::OP_VFRECP, OpSize::i32Bit>},
-  {0x87, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorUnaryOp, IR::OP_VFRSQRT, OpSize::i32Bit>},
+  {0x86, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorUnaryOp, IR::OP_VFRECPPRECISION, OpSize::i32Bit>},
+  {0x87, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::RSqrt3DNowOp, false>},
 
   {0x8A, 1, &OpDispatchBuilder::PFNACCOp},
   {0x8E, 1, &OpDispatchBuilder::PFPNACCOp},
 
   {0x90, 1, &OpDispatchBuilder::VPFCMPOp<1>},
   {0x94, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorALUOp, IR::OP_VFMIN, OpSize::i32Bit>},
-  {0x96, 1, &OpDispatchBuilder::VectorUnaryDuplicateOp<IR::OP_VFRECP, OpSize::i32Bit>},
-  {0x97, 1, &OpDispatchBuilder::VectorUnaryDuplicateOp<IR::OP_VFRSQRT, OpSize::i32Bit>},
+  {0x96, 1, &OpDispatchBuilder::VectorUnaryDuplicateOp<IR::OP_VFRECPPRECISION, OpSize::i32Bit>},
+  {0x97, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::RSqrt3DNowOp, true>},
 
   {0x9A, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorALUOp, IR::OP_VFSUB, OpSize::i32Bit>},
   {0x9E, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorALUOp, IR::OP_VFADD, OpSize::i32Bit>},

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -1881,6 +1881,12 @@
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize",
         "TiedSource": 0
+      },
+      "FPR = VFCopySign OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector1,  FPR:$Vector2": {
+        "Desc": ["Returns a vector where each element has has the magniture of each corresponding element in vector1 and the sign of vector 2."],
+        "DestSize": "RegisterSize",
+        "ElementSize": "ElementSize",
+        "TiedSource": 0
       }
     },
     "Vector": {
@@ -1967,8 +1973,24 @@
       },
 
       "FPR = VFRecp OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector": {
+        "Desc": [
+          "Reciprocal value - matches the precision required by the x86 spec.",
+          "It has a relative error of at most 1.5 * 2^-12"
+        ],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize"
+      },
+      "FPR = VFRecpPrecision OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector": {
+        "Desc": [
+          "Similar to VFRecp but carrying more precision for 3DNow!",
+          "It provides at least 14 bits precision, with a relative error of at most 2^-14"
+        ],
+        "DestSize": "RegisterSize",
+        "ElementSize": "ElementSize",
+        "EmitValidation": [
+          "RegisterSize == FEXCore::IR::OpSize::i64Bit || RegisterSize == FEXCore::IR::OpSize::i32Bit",
+          "ElementSize == FEXCore::IR::OpSize::i32Bit"
+        ]
       },
 
       "FPR = VFSqrt OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector": {
@@ -1977,9 +1999,26 @@
       },
 
       "FPR = VFRSqrt OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector": {
+        "Desc": [
+          "Reciprocal Square Root - matches the precision required by the x86 spec.",
+          "It has a relative error of at most 1.5 * 2^-12"
+        ],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize"
       },
+      "FPR = VFRSqrtPrecision OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector": {
+        "Desc": [
+          "Similar to VFRSqrt but carrying more precision for 3DNow!",
+          "It provides at least 15 bits precision, with a relative error of at most 2^-15"
+        ],
+        "DestSize": "RegisterSize",
+        "ElementSize": "ElementSize",
+        "EmitValidation": [
+          "RegisterSize == FEXCore::IR::OpSize::i64Bit || RegisterSize == FEXCore::IR::OpSize::i32Bit",
+          "ElementSize == FEXCore::IR::OpSize::i32Bit"
+        ]
+      },
+
       "FPR = VCMPEQZ OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector": {
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize"

--- a/unittests/ASM/3DNow/86.asm
+++ b/unittests/ASM/3DNow/86.asm
@@ -1,20 +1,72 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM0": "0x3f800000bf800000",
-    "MM1": "0x3c000000bc000000",
-    "MM2": "0xbf8000003f800000"
+    "RBX": "1",
+    "MM3": "0xff8000007f800000"
   },
   "HostFeatures": ["3DNOW"]
 }
 %endif
 
+%include "checkprecision.mac"
+
+section .text
+global _start
+
+_start:
 pfrcpv mm0, [rel data1]
 pfrcpv mm1, [rel data2]
 pfrcpv mm2, [rel data3]
+pfrcpv mm3, [rel data4]
+
+; All calculated
+; Now we extract all the values into memory to call check_relerr.
+movd edx, mm0
+mov [rel result11], edx
+
+psrlq mm0, 32
+movd edx, mm0
+mov [rel result12], edx
+
+movd edx, mm1
+mov [rel result21], edx
+
+psrlq mm1, 32
+movd edx, mm1
+mov [rel result22], edx
+
+movd edx, mm2
+mov [rel result31], edx
+
+psrlq mm2, 32
+movd edx, mm2
+mov [rel result32], edx
+
+check_relerr rel eresult11, rel result11, rel tolerance
+mov ebx, eax
+check_relerr rel eresult12, rel result12, rel tolerance
+and ebx, eax
+check_relerr rel eresult21, rel result21, rel tolerance
+and ebx, eax
+check_relerr rel eresult22, rel result22, rel tolerance
+and ebx, eax
+check_relerr rel eresult31, rel result31, rel tolerance
+and ebx, eax
+check_relerr rel eresult32, rel result32, rel tolerance
+and ebx, eax
 
 hlt
 
+section .bss
+align 32
+result11: resd 1
+result12: resd 1
+result21: resd 1
+result22: resd 1
+result31: resd 1
+result32: resd 1
+
+section .data
 align 8
 data1:
 dd -1.0
@@ -27,3 +79,25 @@ dd 128.0
 data3:
 dd 1.0
 dd -1.0
+
+data4:
+dd 0.0
+dd -0.0
+
+eresult11:
+dd -1.0
+eresult12:
+dd 1.0
+eresult21:
+dd 0xbc000000 ; -1/128
+eresult22:
+dd 0x3c000000 ; 1/128
+eresult31:
+dd 1.0
+eresult32:
+dd -1.0
+
+tolerance:
+dd 0x38800000 ; 2^-14 - 14bit accuracy
+
+define_check_data_constants

--- a/unittests/ASM/3DNow/87.asm
+++ b/unittests/ASM/3DNow/87.asm
@@ -1,21 +1,67 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM0": "0x3e8000003f800000",
-    "MM1": "0x3e4ccccd3f000000",
-    "MM2": "0x3f8000003eaaaaab"
+    "RBX": "1"
   },
   "HostFeatures": ["3DNOW"]
 }
 %endif
 
+%include "checkprecision.mac"
+
 pfrsqrtv mm0, [rel data1]
 pfrsqrtv mm1, [rel data2]
 pfrsqrtv mm2, [rel data3]
 
+; All calculated
+; Now we extract all the values into memory to call check_relerr.
+movd edx, mm0
+mov [rel result11], edx
+
+psrlq mm0, 32
+movd edx, mm0
+mov [rel result12], edx
+
+movd edx, mm1
+mov [rel result21], edx
+
+psrlq mm1, 32
+movd edx, mm1
+mov [rel result22], edx
+
+movd edx, mm2
+mov [rel result31], edx
+
+psrlq mm2, 32
+movd edx, mm2
+mov [rel result32], edx
+
+check_relerr rel eresult11, rel result11, rel tolerance
+mov ebx, eax
+check_relerr rel eresult12, rel result12, rel tolerance
+and ebx, eax
+check_relerr rel eresult21, rel result21, rel tolerance
+and ebx, eax
+check_relerr rel eresult22, rel result22, rel tolerance
+and ebx, eax
+check_relerr rel eresult31, rel result31, rel tolerance
+and ebx, eax
+check_relerr rel eresult32, rel result32, rel tolerance
+and ebx, eax
+
 hlt
 
-align 8
+section .bss
+align 32
+result11: resd 1
+result12: resd 1
+result21: resd 1
+result22: resd 1
+result31: resd 1
+result32: resd 1
+
+section .data
+align 32
 data1:
 dd 1.0
 dd 16.0
@@ -27,3 +73,21 @@ dd 25.0
 data3:
 dd 9.0
 dd 1.0
+
+eresult11:
+dd 0x3f800000 ; 1.0
+eresult12:
+dd 0x3e800000 ; 1/4 = 0.25
+eresult21:
+dd 0x3f000000 ; 1/2 = 0.5
+eresult22:
+dd 0x3e4ccccd ; 1/5 = 0.2
+eresult31:
+dd 0x3eaaaaab ; 1/3 = 0.(3)
+eresult32:
+dd 0x3f800000 ; 1.0
+
+tolerance:
+dd 0x38000000 ; 2^-15 - accurate to 15bits
+
+define_check_data_constants

--- a/unittests/ASM/3DNow/96.asm
+++ b/unittests/ASM/3DNow/96.asm
@@ -1,29 +1,109 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM0": "0xbf800000bf800000",
-    "MM1": "0xbc000000bc000000",
-    "MM2": "0x3f8000003f800000"
+    "RCX": "1",
+    "RDX": "1",
+    "MM0":  "0x7f8000007f800000",
+    "MM1":  "0xff800000ff800000"
   },
   "HostFeatures": ["3DNOW"]
 }
 %endif
 
+%include "checkprecision.mac"
+
+; For each operation:
+; * We check precision (except when checking exact values), for 0.0 and -0.0.
+; * Check that top and bottom of register has the same value.
+
+section .text
+global _start
+
+_start:
 pfrcp mm0, [rel data1]
-pfrcp mm1, [rel data2]
-pfrcp mm2, [rel data3]
+
+; Precision
+movd [rel result], mm0
+check_relerr rel eresult1, rel result, rel tolerance
+movzx rdx, al
+; Duplicate top/bottom
+movq mm1, mm0
+psrlq mm1, 32
+pcmpeqd mm0, mm1
+movd eax, mm0
+and al, 1
+movzx rcx, al
+
+pfrcp mm0, [rel data2]
+
+; Precision
+movd [rel result], mm0
+check_relerr rel eresult2, rel result, rel tolerance
+and rdx, rax
+; Duplicate top/bottom
+movq mm1, mm0
+psrlq mm1, 32
+pcmpeqd mm0, mm1
+movd eax, mm0
+and al, 1
+and rcx, rax
+
+pfrcp mm0, [rel data3]
+
+; Precision
+movd [rel result], mm0
+check_relerr rel eresult3, rel result, rel tolerance
+and rdx, rax
+; Duplicate top/bottom
+movq mm1, mm0
+psrlq mm1, 32
+pcmpeqd mm0, mm1
+movd eax, mm0
+and al, 1
+and rcx, rax
+
+; ; Expecting exact results for +inf and -inf
+pfrcp mm0, [rel data4]
+pfrcp mm1, [rel data5]
 
 hlt
 
+section .bss
+align 8
+result resd 1
+
+section .data:
 align 8
 data1:
 dd -1.0
 dd 1.0
 
+eresult1:
+dd -1.0
+
 data2:
 dd -128.0
 dd 128.0
 
+eresult2:
+dd 0xbc000000
+
 data3:
 dd 1.0
 dd -1.0
+
+eresult3:
+dd 1.0
+
+data4:
+dd 0.0
+dd 1.0
+
+data5:
+dd -0.0
+dd 1.0
+
+tolerance:
+dd 0x38800000 ; 2^-14 - 14bit accuracy
+
+define_check_data_constants

--- a/unittests/ASM/3DNow/97.asm
+++ b/unittests/ASM/3DNow/97.asm
@@ -1,29 +1,99 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "MM0":  "0x3f8000003f800000",
-    "MM1":  "0x3f0000003f000000",
-    "MM2":  "0x3eaaaaab3eaaaaab"
+    "RAX":  "1",
+    "RBX":  "1",
+    "RCX":  "1",
+    "RDX":  "1",
+    "MM4":  "0x7f8000007f800000",
+    "MM5":  "0xff800000ff800000"
   },
   "HostFeatures": ["3DNOW"]
 }
 %endif
 
-pfrsqrt mm0, [rel data1]
-pfrsqrt mm1, [rel data2]
-pfrsqrt mm2, [rel data3]
+%include "checkprecision.mac"
 
+section .text
+global _start
+
+; From the isa manual, one thing to consider is that
+; "Negative operands are treated as positive operands for purposes of
+; reciprocal square-root computation, with the sign of the result the
+; same as the sign of the source operand."
+
+_start:
+pfrsqrt mm0, [rel data1]
+movd [rel result1], mm0
+check_relerr rel eresult1, rel result1, rel tolerance
+movzx rdx, al
+
+pfrsqrt mm1, [rel data2]
+movd [rel result2], mm1
+check_relerr rel eresult2, rel result2, rel tolerance
+movzx rcx, al
+
+pfrsqrt mm2, [rel data3]
+movd [rel result3], mm2
+check_relerr rel eresult3, rel result3, rel tolerance
+movzx rbx, al
+
+pfrsqrt mm3, [rel data4] ; pfrsqrt(-1.0) == -1.0
+movd [rel result4], mm3
+check_relerr rel eresult4, rel result4, rel tolerance
+movzx rax, al
+
+; Expecting exact results
+pfrsqrt mm4, [rel data5] ; pfrsqrt(0.0) == inf
+pfrsqrt mm5, [rel data6] ; pfrsqrt(-0.0) == -inf
 hlt
 
+section .bss
 align 8
+result1: resb 32
+result2: resb 32
+result3: resb 32
+result4: resb 32
+
+section .data
+align 32
 data1:
 dd 1.0
 dd 16.0
+
+eresult1: ; expected
+dd 1.0
 
 data2:
 dd 4.0
 dd 25.0
 
+eresult2: ; expected
+dd 0.5
+
 data3:
 dd 9.0
 dd 1.0
+
+eresult3: ; expected
+dd 0x3eaaaaab ; 1/3
+
+data4:
+dd -1.0
+dd -16.0
+
+eresult4: ; expected
+dd -1.0
+
+data5:
+dd 0.0
+dd -9.0
+
+data6:
+dd -0.0
+dd -9.0
+
+tolerance:
+dd 0x38000000 ; 2^-15 - accurate to 15bits
+
+define_check_data_constants

--- a/unittests/ASM/Disabled_Tests
+++ b/unittests/ASM/Disabled_Tests
@@ -1,13 +1,3 @@
-# Needs Precision checking
-Test_REP/F3_52.asm
-Test_REP/F3_53.asm
-Test_TwoByte/0F_52.asm
-Test_TwoByte/0F_53.asm
-Test_VEX/vrcpps.asm
-Test_VEX/vrcpss.asm
-Test_VEX/vrsqrtss.asm
-Test_VEX/vrsqrtps.asm
-
 # Not supported in userspace in all cases
 Test_Primary/Primary_D7.asm
 
@@ -24,9 +14,3 @@ Test_X87/D9_F8.asm
 
 # This is basically a benchmark.
 FEX_bugs/XeSS_quadratic.asm
-
-# 3DNow reciprocal with rpres doesn't offer the same precision as native and fails the tests.
-Test_3DNow/86.asm
-Test_3DNow/87.asm
-Test_3DNow/96.asm
-Test_3DNow/97.asm

--- a/unittests/ASM/H0F3A/66_22_2.asm
+++ b/unittests/ASM/H0F3A/66_22_2.asm
@@ -1,0 +1,32 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x3f800000",
+    "XMM0": ["0x4142434400000000", "0x5152535455565758"]
+  }
+}
+%endif
+
+section .text
+global _start
+
+_start:
+xor esi, esi
+
+movapd xmm0, [rel arg1]
+
+pextrd [rel val], xmm0, 0
+pinsrd xmm0, esi, 0
+
+mov eax, [rel val]
+hlt
+
+section .bss
+align 32
+val resd 1
+
+section .data
+align 128
+arg1: 
+dq 0x414243443f800000
+dq 0x5152535455565758

--- a/unittests/ASM/Includes/checkprecision.mac
+++ b/unittests/ASM/Includes/checkprecision.mac
@@ -1,0 +1,30 @@
+%ifndef CHECK_PRECISION_INC
+%define CHECK_PRECISION_INC
+
+; CheckPrecision.inc - NASM include file containing macro to check precision
+; of single floating-point number.
+
+;; Clobbers xmm12, xmm13, xmm14, xmm15
+;; Returns result in al.
+;; Arguments are in memory locations.
+%macro check_relerr 3; %1=REF %2=X %3=TOLERANCE
+        movss   xmm12, dword [ %1 ] ; xmm12 has REF
+        movss   xmm13, dword [ %2 ] ; xmm13 has X
+        movss   xmm15, dword [rel abs_mask_float] ; xmm15 has the abs float mask
+        movaps  xmm14, xmm12 ; xmm14 has REF
+        subss   xmm14, xmm13 ; xmm14 = REF - X
+        andps   xmm12, xmm15 ; xmm12 = abs(REF)
+        mulss   xmm12, dword [ %3 ] ; xmm12 = abs(REF) * tolerance
+        movaps  xmm13, xmm14 ; xmm13 = REF - X
+        andps   xmm13, xmm15 ; xmm13 = abs(REF - X)
+
+        xor     eax, eax ; clears eax
+        comiss  xmm12, xmm13 ; compares xmm12 and xmm13
+        setnb   al ; stores xmm12 >= xmm13, i.e. abs(REF) * tolerance >= abs(REF - X)
+%endmacro
+
+%macro define_check_data_constants 0
+abs_mask_float:    
+  dd 0x7fffffff   ; Bitmask to get absolute value of a float (single precision)
+%endmacro
+%endif

--- a/unittests/ASM/REP/F3_52.asm
+++ b/unittests/ASM/REP/F3_52.asm
@@ -1,62 +1,126 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "XMM0":  ["0x414243443f800000", "0x5152535455565758"],
-    "XMM1":  ["0x414243443f000000", "0x5152535455565758"],
-    "XMM2":  ["0x414243443eaaaaab", "0x5152535455565758"],
-    "XMM3":  ["0x414243443e800000", "0x5152535455565758"],
-    "XMM4":  ["0x414243443f800000", "0x5152535455565758"],
-    "XMM5":  ["0x414243443f000000", "0x5152535455565758"],
-    "XMM6":  ["0x414243443eaaaaab", "0x5152535455565758"],
-    "XMM7":  ["0x414243443e800000", "0x5152535455565758"]
+    "RAX": "1",
+    "RBX": "1",
+    "RCX": "1",
+    "RDX": "1",
+    "XMM0":  ["0x4142434400000000", "0x5152535455565758"],
+    "XMM1":  ["0x4142434400000000", "0x5152535455565758"],
+    "XMM2":  ["0x4142434400000000", "0x5152535455565758"],
+    "XMM3":  ["0x4142434400000000", "0x5152535455565758"],
+    "XMM4":  ["0x4142434400000000", "0x5152535455565758"],
+    "XMM5":  ["0x4142434400000000", "0x5152535455565758"],
+    "XMM6":  ["0x4142434400000000", "0x5152535455565758"],
+    "XMM7":  ["0x4142434400000000", "0x5152535455565758"]
   }
 }
 %endif
 
-mov rdx, 0xe0000000
 
-mov rax, 0x414243443f800000 ; 1.0
-mov [rdx + 8 * 0], rax
-mov rax, 0x5152535455565758
-mov [rdx + 8 * 1], rax
+section .text
+global _start
 
-mov rax, 0x4142434440800000 ; 4.0
-mov [rdx + 8 * 2], rax
-mov rax, 0x5152535455565758
-mov [rdx + 8 * 3], rax
-
-mov rax, 0x4142434441100000 ; 9.0
-mov [rdx + 8 * 4], rax
-mov rax, 0x5152535455565758
-mov [rdx + 8 * 5], rax
-
-mov rax, 0x4142434441800000 ; 16.0
-mov [rdx + 8 * 6], rax
-mov rax, 0x5152535455565758
-mov [rdx + 8 * 7], rax
-
-mov rax, 0x4142434441c80000 ; 25.0
-mov [rdx + 8 * 8], rax
-mov rax, 0x5152535455565758
-mov [rdx + 8 * 9], rax
-
-movapd xmm0, [rdx + 8 * 0]
-movapd xmm1, [rdx + 8 * 2]
-movapd xmm2, [rdx + 8 * 4]
-movapd xmm3, [rdx + 8 * 6]
-movapd xmm4, [rdx + 8 * 8]
-movapd xmm5, [rdx + 8 * 8]
-movapd xmm6, [rdx + 8 * 8]
-movapd xmm7, [rdx + 8 * 8]
+_start:
+movapd xmm0, [rel arg1]
+movapd xmm1, [rel arg2]
+movapd xmm2, [rel arg3]
+movapd xmm3, [rel arg4]
+movapd xmm4, [rel arg5]
+movapd xmm5, [rel arg5]
+movapd xmm6, [rel arg5]
+movapd xmm7, [rel arg5]
 
 rsqrtss xmm0, xmm0
 rsqrtss xmm1, xmm1
 rsqrtss xmm2, xmm2
 rsqrtss xmm3, xmm3
 
-rsqrtss xmm4, [rdx + 8 * 0]
-rsqrtss xmm5, [rdx + 8 * 2]
-rsqrtss xmm6, [rdx + 8 * 4]
-rsqrtss xmm7, [rdx + 8 * 6]
+rsqrtss xmm4, [rel arg1]
+rsqrtss xmm5, [rel arg2]
+rsqrtss xmm6, [rel arg3]
+rsqrtss xmm7, [rel arg4]
 
+
+; Check precision of the results
+; while ensuring we didn't destroy the rest of the register.
+%include "checkprecision.mac"
+
+;; We will be storing the low 32bits to memory, then zeroing them.
+;; We'll then check precision using checkprecision.mac.
+; Zero rsi:
+xor esi, esi
+
+pextrd [rel result1], xmm0, 0
+pinsrd xmm0, esi, 0
+check_relerr rel eresult1, rel result1, rel tolerance
+mov rbx, rax
+
+pextrd [rel result2], xmm1, 0
+pinsrd xmm1, esi, 0
+check_relerr rel eresult2, rel result2, rel tolerance
+mov rcx, rax
+
+pextrd [rel result3], xmm2, 0
+pinsrd xmm2, esi, 0
+check_relerr rel eresult3, rel result3, rel tolerance
+mov rdx, rax
+
+pextrd [rel result4], xmm3, 0
+pinsrd xmm3, esi, 0
+check_relerr rel eresult4, rel result4, rel tolerance
+
+; no need to test the other results which are the same, 
+; we can just zero them.
+pinsrd xmm4, esi, 0
+pinsrd xmm5, esi, 0
+pinsrd xmm6, esi, 0
+pinsrd xmm7, esi, 0
 hlt
+
+section .bss
+align 32
+result1 resd 1
+result2 resd 1
+result3 resd 1
+result4 resd 1
+
+section .data
+align 16
+
+arg1: 
+dq 0x414243443f800000 ; 1.0
+dq 0x5152535455565758
+
+arg2:
+dq 0x4142434440800000 ; 4.0
+dq 0x5152535455565758
+
+arg3:
+dq 0x4142434441100000 ; 9.0
+dq 0x5152535455565758
+
+arg4:
+dq 0x4142434441800000 ; 16.0
+dq 0x5152535455565758
+
+arg5:
+dq 0x4142434441c80000 ; 25.0
+dq 0x5152535455565758
+
+eresult1: 
+dd 0x3f800000 ; 1.0
+
+eresult2:
+dd 0x3f000000 ; 0.5
+
+eresult3: 
+dd 0x3eaaaaab ; 1/3 = 0.(3)
+
+eresult4:
+dd 0x3e800000 ; 0.25
+
+tolerance:
+dd 0x39c00000
+
+define_check_data_constants

--- a/unittests/ASM/REP/F3_52_2.asm
+++ b/unittests/ASM/REP/F3_52_2.asm
@@ -1,0 +1,44 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "1",
+    "XMM0":  ["0x414243447f800000", "0x5152535455565758"],
+    "XMM1":  ["0x41424344ff800000", "0x5152535455565758"],
+    "XMM2":  ["0x4142434400000000", "0x5152535455565758"]
+  }
+}
+%endif
+
+section .text
+global _start
+
+_start:
+movapd xmm0, [rel arg1]
+movapd xmm1, [rel arg2]
+movapd xmm2, [rel arg3]
+
+rsqrtss xmm0, xmm0
+rsqrtss xmm1, xmm1
+rsqrtss xmm2, xmm2
+
+; The last comparison returns nan so we need to check the 
+; result manually
+ucomiss xmm2, xmm2
+setp al ; sets al to 1 if xmm2 is nan
+xor esi, esi
+pinsrd xmm2, esi, 0 ; inserts 0 in place of nan to test other bits
+hlt
+
+section .data
+align 32
+arg1:
+dq 0x4142434400000000 ; 0.0, result is inf
+dq 0x5152535455565758
+
+arg2:
+dq 0x4142434480000000 ; -0.0, result is -inf
+dq 0x5152535455565758
+
+arg3:
+dq 0x41424344c0800000 ; -4.0, result is nan
+dq 0x5152535455565758

--- a/unittests/ASM/REP/F3_53.asm
+++ b/unittests/ASM/REP/F3_53.asm
@@ -1,28 +1,72 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "XMM0":  ["0x3f8000003f800000", "0x3f8000003f800000"],
-    "XMM1":  ["0x408000003e800000", "0x4080000040800000"]
+    "RAX": "1",
+    "RBX": "1",
+    "XMM0":  ["0x3f80000000000000", "0x3f8000003f800000"],
+    "XMM1":  ["0x4080000000000000", "0x4080000040800000"],
+    "XMM2":  ["0xdeadbeef7f800000", "0xbadc0ffebadc0ffe"]
   }
 }
 %endif
 
-mov rdx, 0xe0000000
+; Check precision of the results
+; while ensuring we didn't destroy the rest of the register.
+%include "checkprecision.mac"
 
-mov rax, 0x3f8000003f800000 ; 1.0
-mov [rdx + 8 * 0], rax
-mov rax, 0x3f8000003f800000
-mov [rdx + 8 * 1], rax
+section .text
+global _start
 
-mov rax, 0x4080000040800000 ; 4.0
-mov [rdx + 8 * 2], rax
-mov rax, 0x4080000040800000
-mov [rdx + 8 * 3], rax
-
-movapd xmm0, [rdx + 8 * 0]
-movapd xmm1, [rdx + 8 * 2]
+_start:
+movapd xmm0, [rel arg1]
+movapd xmm1, [rel arg2]
+movapd xmm2, [rel arg3]
 
 rcpss xmm0, xmm0
-rcpss xmm1, [rdx + 8 * 2]
+rcpss xmm1, [rel arg2]
+rcpss xmm2, xmm2
+
+xor esi, esi
+
+pextrd [rel result1], xmm0, 0
+pinsrd xmm0, esi, 0
+check_relerr rel eresult1, rel result1, rel tolerance
+mov rbx, rax
+
+pextrd [rel result2], xmm1, 0
+pinsrd xmm1, esi, 0
+check_relerr rel eresult2, rel result2, rel tolerance
 
 hlt
+
+
+section .bss
+align 32
+result1 resd 1
+result2 resd 1
+
+section .data
+align 16
+
+arg1: 
+dq 0x3f8000003f800000 ; 1.0
+dq 0x3f8000003f800000
+
+arg2:
+dq 0x4080000040800000 ; 4.0
+dq 0x4080000040800000
+
+arg3:
+dq 0xdeadbeef00000000 ; 0.0
+dq 0xbadc0ffebadc0ffe
+
+eresult1: 
+dd 0x3f800000 ; 1.0
+
+eresult2:
+dd 0x3e800000 ; 0.5
+
+tolerance:
+dd 0x39c00000
+
+define_check_data_constants

--- a/unittests/ASM/TwoByte/0F_52.asm
+++ b/unittests/ASM/TwoByte/0F_52.asm
@@ -1,62 +1,135 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "XMM0":  ["0x3f8000003f800000", "0x3f8000003f800000"],
-    "XMM1":  ["0x3f0000003f000000", "0x3f0000003f000000"],
-    "XMM2":  ["0x3eaaaaab3eaaaaab", "0x3eaaaaab3eaaaaab"],
-    "XMM3":  ["0x3e8000003e800000", "0x3e8000003e800000"],
-    "XMM4":  ["0x3f8000003f800000", "0x3f8000003f800000"],
-    "XMM5":  ["0x3f0000003f000000", "0x3f0000003f000000"],
-    "XMM6":  ["0x3eaaaaab3eaaaaab", "0x3eaaaaab3eaaaaab"],
-    "XMM7":  ["0x3e8000003e800000", "0x3e8000003e800000"]
+    "R8": "1",
+    "R9": "1"
   }
 }
 %endif
 
-mov rdx, 0xe0000000
+%include "checkprecision.mac"
 
-mov rax, 0x3f8000003f800000 ; 1.0
-mov [rdx + 8 * 0], rax
-mov rax, 0x3f8000003f800000
-mov [rdx + 8 * 1], rax
+; clobbers xmm15
+; returns the comparison result in rax
+%macro same_pdwords 1 ; receives the xmms register
+    movd eax, %1
+    movd xmm15, eax
+    pshufd xmm15, xmm15, 0 ; has the lower 32bits of %1 accross all lanes 
+    pcmpeqd xmm15, %1 ; has equalty mask on all lanes
+    movmskps eax, xmm15 ; gets sign bit of each lane into eax
+    cmp eax, 0b1111
+    sete al
+    movzx rax, al
+%endmacro
 
-mov rax, 0x4080000040800000 ; 4.0
-mov [rdx + 8 * 2], rax
-mov rax, 0x4080000040800000
-mov [rdx + 8 * 3], rax
+section .text
+global _start
 
-mov rax, 0x4110000041100000 ; 9.0
-mov [rdx + 8 * 4], rax
-mov rax, 0x4110000041100000
-mov [rdx + 8 * 5], rax
+_start:
 
-mov rax, 0x4180000041800000 ; 16.0
-mov [rdx + 8 * 6], rax
-mov rax, 0x4180000041800000
-mov [rdx + 8 * 7], rax
+;; This test checks that the rsqrtps returns results within the 1.5*2^-12 relative error
+;; margin and that the results are packed as a vector of 4 32bits. Because we pass in
+;; the same argument accross the vector we expect the same result accross the vector
+;; and we check that with macro same_pdwords
 
-mov rax, 0x41c8000041c80000 ; 25.0
-mov [rdx + 8 * 8], rax
-mov rax, 0x41c8000041c80000
-mov [rdx + 8 * 9], rax
-
-movapd xmm0, [rdx + 8 * 0]
-movapd xmm1, [rdx + 8 * 2]
-movapd xmm2, [rdx + 8 * 4]
-movapd xmm3, [rdx + 8 * 6]
-movapd xmm4, [rdx + 8 * 8]
-movapd xmm5, [rdx + 8 * 8]
-movapd xmm6, [rdx + 8 * 8]
-movapd xmm7, [rdx + 8 * 8]
+movapd xmm0, [rel arg1]
+movapd xmm1, [rel arg2]
+movapd xmm2, [rel arg3]
+movapd xmm3, [rel arg4]
+movapd xmm4, [rel arg5]
+movapd xmm5, [rel arg5]
+movapd xmm6, [rel arg5]
+movapd xmm7, [rel arg5]
 
 rsqrtps xmm0, xmm0
 rsqrtps xmm1, xmm1
 rsqrtps xmm2, xmm2
 rsqrtps xmm3, xmm3
 
-rsqrtps xmm4, [rdx + 8 * 0]
-rsqrtps xmm5, [rdx + 8 * 2]
-rsqrtps xmm6, [rdx + 8 * 4]
-rsqrtps xmm7, [rdx + 8 * 6]
+rsqrtps xmm4, [rel arg1]
+rsqrtps xmm5, [rel arg2]
+rsqrtps xmm6, [rel arg3]
+rsqrtps xmm7, [rel arg4]
+
+same_pdwords xmm0
+mov r8, rax
+same_pdwords xmm1
+and r8, rax
+same_pdwords xmm2
+and r8, rax
+same_pdwords xmm3
+and r8, rax
+same_pdwords xmm4
+and r8, rax
+same_pdwords xmm5
+and r8, rax
+same_pdwords xmm6
+and r8, rax
+same_pdwords xmm7
+and r8, rax
+
+pextrd [rel result1], xmm0, 0
+pinsrd xmm0, esi, 0
+check_relerr rel eresult1, rel result1, rel tolerance
+mov r9, rax
+
+pextrd [rel result2], xmm1, 0
+pinsrd xmm1, esi, 0
+check_relerr rel eresult2, rel result2, rel tolerance
+and r9, rax
+
+pextrd [rel result3], xmm2, 0
+pinsrd xmm2, esi, 0
+check_relerr rel eresult3, rel result3, rel tolerance
+and r9, rax
+
+pextrd [rel result4], xmm3, 0
+pinsrd xmm3, esi, 0
+check_relerr rel eresult4, rel result4, rel tolerance
+and r9, rax
 
 hlt
+
+section .bss
+result1: resd 1
+result2: resd 1
+result3: resd 1
+result4: resd 1
+
+section .data
+align 64
+
+arg1: 
+dq 0x3f8000003f800000 ; 1.0
+dq 0x3f8000003f800000
+
+arg2: 
+dq 0x4080000040800000 ; 4.0
+dq 0x4080000040800000
+
+arg3:
+dq 0x4110000041100000 ; 9.0
+dq 0x4110000041100000
+
+arg4: 
+dq 0x4180000041800000 ; 16.0
+dq 0x4180000041800000
+
+arg5:
+dq 0x41c8000041c80000 ; 25.0
+dq 0x41c8000041c80000
+
+align 32
+eresult1:
+dd 0x3f800000 ; 1.0
+eresult2:
+dd 0x3f000000 ; 0.5 
+eresult3:
+dd 0x3eaaaaab ; 1/3 = 0.(3)
+eresult4:
+dd 0x3e800000 ; 0.25
+
+tolerance:
+dd 0x39c00000
+
+define_check_data_constants

--- a/unittests/ASM/TwoByte/0F_53.asm
+++ b/unittests/ASM/TwoByte/0F_53.asm
@@ -1,27 +1,77 @@
 %ifdef CONFIG
 {
   "RegData": {
-    "XMM0":  ["0x3f8000003f800000", "0x3f8000003f800000"],
-    "XMM1":  ["0x3e8000003e800000", "0x3e8000003e800000"]
+    "R8": "1",
+    "R9": "1"
   }
 }
 %endif
 
-mov rdx, 0xe0000000
+%include "checkprecision.mac"
 
-mov rax, 0x3f8000003f800000 ; 1.0
-mov [rdx + 8 * 0], rax
-mov rax, 0x3f8000003f800000
-mov [rdx + 8 * 1], rax
+; clobbers xmm15
+; returns the comparison result in rax
+%macro same_pdwords 1 ; receives the xmms register
+    movd eax, %1
+    movd xmm15, eax
+    pshufd xmm15, xmm15, 0 ; has the lower 32bits of %1 accross all lanes 
+    pcmpeqd xmm15, %1 ; has equalty mask on all lanes
+    movmskps eax, xmm15 ; gets sign bit of each lane into eax
+    cmp eax, 0b1111
+    sete al
+    movzx rax, al
+%endmacro
 
-mov rax, 0x4080000040800000 ; 4.0
-mov [rdx + 8 * 2], rax
-mov rax, 0x4080000040800000
-mov [rdx + 8 * 3], rax
+section .text
+global _start
 
-movapd xmm0, [rdx + 8 * 0]
+_start:
+
+movapd xmm0, [rel arg1]
 
 rcpps xmm0, xmm0
-rcpps xmm1, [rdx + 8 * 2]
+rcpps xmm1, [rel arg2]
+
+same_pdwords xmm0
+mov r8, rax
+same_pdwords xmm1
+and r8, rax
+
+pextrd [rel result1], xmm0, 0
+pinsrd xmm0, esi, 0
+check_relerr rel eresult1, rel result1, rel tolerance
+mov r9, rax
+
+pextrd [rel result2], xmm1, 0
+pinsrd xmm1, esi, 0
+check_relerr rel eresult2, rel result2, rel tolerance
+and r9, rax
 
 hlt
+
+section .bss
+result1: resd 1
+result2: resd 1
+
+section .data
+align 64
+
+arg1: 
+dq 0x3f8000003f800000 ; 1.0
+dq 0x3f8000003f800000
+
+arg2: 
+dq 0x4080000040800000 ; 4.0
+dq 0x4080000040800000
+
+
+align 32
+eresult1:
+dd 0x3f800000 ; 1.0
+eresult2:
+dd 0x3e800000 ; 0.25
+
+tolerance:
+dd 0x39c00000
+
+define_check_data_constants

--- a/unittests/ASM/VEX/vrcpps.asm
+++ b/unittests/ASM/VEX/vrcpps.asm
@@ -2,39 +2,113 @@
 {
   "HostFeatures": ["AVX"],
   "RegData": {
-    "XMM0": ["0x3F8000003F800000", "0x3F8000003F800000", "0x3F8000003F800000", "0x3F8000003F800000"],
-    "XMM1": ["0x4080000040800000", "0x4080000040800000", "0x4080000040800000", "0x4080000040800000"],
-    "XMM2": ["0x3F8000003F800000", "0x3F8000003F800000", "0x3F8000003F800000", "0x3F8000003F800000"],
-    "XMM3": ["0x3F8000003F800000", "0x3F8000003F800000", "0x0000000000000000", "0x0000000000000000"],
-    "XMM4": ["0x3E8000003E800000", "0x3E8000003E800000", "0x3E8000003E800000", "0x3E8000003E800000"],
-    "XMM5": ["0x3E8000003E800000", "0x3E8000003E800000", "0x0000000000000000", "0x0000000000000000"]
+    "R8": "1",
+    "R9": "1"
   }
 }
 %endif
 
-lea rdx, [rel .data]
 
-vmovapd ymm0, [rdx + 32 * 0]
-vmovapd ymm1, [rdx + 32 * 1]
+section .text
+global _start
+
+%include "checkprecision.mac"
+
+; clobbers ymm15
+; returns the comparison result in rax
+%macro same_pdwords 1 ; receives the ymms register
+    vextractf128 xmm15, %1, 0
+    vmovd eax, xmm15
+    vmovd xmm15, eax
+    vbroadcastss ymm15, xmm15  ; broadcast lower 32bits across all 8 lanes
+    vpcmpeqd ymm15, ymm15, %1  ; equality mask on all lanes
+    vmovmskps eax, ymm15       ; gets sign bit of each lane into eax
+    cmp eax, 0b11111111        ; check all 8 lanes
+    sete al
+    movzx rax, al
+%endmacro
+
+; clobbers xmm15
+; returns the comparison result in rax
+%macro same_pdwords_x 1 ; receives the xmms register
+    movd eax, %1
+    movd xmm15, eax
+    pshufd xmm15, xmm15, 0 ; has the lower 32bits of %1 accross all lanes 
+    pcmpeqd xmm15, %1 ; has equalty mask on all lanes
+    movmskps eax, xmm15 ; gets sign bit of each lane into eax
+    cmp eax, 0b1111
+    sete al
+    movzx rax, al
+%endmacro
+
+_start:
+vmovapd ymm0, [rel arg1]
+vmovapd ymm1, [rel arg2]
 
 ; Register only
 vrcpps ymm2, ymm0
 vrcpps xmm3, xmm0
 
 ; Memory operand
-vrcpps ymm4, [rdx + 32 * 1]
-vrcpps xmm5, [rdx + 32 * 1]
+vrcpps ymm4, [rel arg2]
+vrcpps xmm5, [rel arg2]
 
+; Check that each register is properly filled
+same_pdwords ymm2
+mov r8, rax
+
+same_pdwords_x xmm3
+and r8, rax
+
+same_pdwords ymm4
+and r8, rax
+
+same_pdwords_x xmm5
+and r8, rax
+
+; Result checks
+vpextrd [rel result], xmm2, 0
+check_relerr rel eresult1, rel result, rel tolerance
+mov r9, rax
+
+vpextrd [rel result], xmm3, 0
+check_relerr rel eresult1, rel result, rel tolerance
+and r9, rax
+
+vpextrd [rel result], xmm4, 0
+check_relerr rel eresult2, rel result, rel tolerance
+and r9, rax
+
+vpextrd [rel result], xmm5, 0
+check_relerr rel eresult2, rel result, rel tolerance
+and r9, rax
 hlt
 
+section .bss
 align 32
-.data:
+result: resq 4
+
+section .data
+align 32
+arg1:
 dq 0x3F8000003F800000 ; 1.0
 dq 0x3F8000003F800000
 dq 0x3F8000003F800000
 dq 0x3F8000003F800000
 
+arg2:
 dq 0x4080000040800000 ; 4.0
 dq 0x4080000040800000
 dq 0x4080000040800000
 dq 0x4080000040800000
+
+eresult1:
+dd 0x3F800000 ; 1.0
+
+eresult2:
+dd 0x3e800000 ; 0.25
+
+tolerance:
+dd 0x39c00000
+
+define_check_data_constants

--- a/unittests/ASM/VEX/vrcpss.asm
+++ b/unittests/ASM/VEX/vrcpss.asm
@@ -2,35 +2,74 @@
 {
   "HostFeatures": ["AVX"],
   "RegData": {
+    "R9": "1",
     "XMM0": ["0x3F8000003F800000", "0x3F8000003F800000", "0x3F8000003F800000", "0x3F8000003F800000"],
     "XMM1": ["0x4080000040800000", "0x4080000040800000", "0x4080000040800000", "0x4080000040800000"],
-    "XMM2": ["0x408000003F800000", "0x4080000040800000", "0x0000000000000000", "0x0000000000000000"],
-    "XMM3": ["0x3F8000003E800000", "0x3F8000003F800000", "0x0000000000000000", "0x0000000000000000"]
+    "XMM2": ["0x4080000000000000", "0x4080000040800000", "0x0000000000000000", "0x0000000000000000"],
+    "XMM3": ["0x3F80000000000000", "0x3F8000003F800000", "0x0000000000000000", "0x0000000000000000"]
   }
 }
 %endif
 
-lea rdx, [rel .data]
+section .text
+global _start
 
-vmovapd ymm0, [rdx + 32 * 0]
-vmovapd ymm1, [rdx + 32 * 1]
+%include "checkprecision.mac"
+
+; This test checks that:
+; - the results of the reciprocal sqrt is within 1.5*2^-12 error margin.
+; - the top 128 bits of ymms registers are zero.
+; - bits [127:32] are correctly copied from the first argument to vrcpss.
+_start:
+vmovapd ymm0, [rel arg1]
+vmovapd ymm1, [rel arg2]
 
 ; Register only
 vrcpss xmm2, xmm1, xmm0
 
 ; Memory operand
-vrcpss xmm3, xmm0, [rdx + 32 * 1]
+vrcpss xmm3, xmm0, [rel arg2]
 
+; Check precision
+vpextrd [rel result], xmm2, 0
+check_relerr rel eresult1, rel result, rel tolerance
+and r9, rax
+
+vpextrd [rel result], xmm3, 0
+check_relerr rel eresult2, rel result, rel tolerance
+mov r9, rax
+
+; Insert 0s in the bottom 32bits
+xor rax, rax
+vpinsrd xmm2, xmm2, eax, 0
+vpinsrd xmm3, xmm3, eax, 0
 hlt
 
+section .bss
 align 32
-.data:
+result: resq 2
+
+section .data
+align 32
+arg1:
 dq 0x3F8000003F800000 ; 1.0
 dq 0x3F8000003F800000
 dq 0x3F8000003F800000
 dq 0x3F8000003F800000
 
+arg2:
 dq 0x4080000040800000 ; 4.0
 dq 0x4080000040800000
 dq 0x4080000040800000
 dq 0x4080000040800000
+
+eresult1:
+dd 0x3F800000 ; 1.0
+
+eresult2:
+dd 0x3e800000 ; 0.25
+
+tolerance:
+dd 0x39c00000
+
+define_check_data_constants

--- a/unittests/ASM/VEX/vrsqrtps.asm
+++ b/unittests/ASM/VEX/vrsqrtps.asm
@@ -2,28 +2,53 @@
 {
   "HostFeatures": ["AVX"],
   "RegData": {
-    "XMM0":  ["0x3F8000003F800000", "0x3F8000003F800000", "0x3F8000003F800000", "0x3F8000003F800000"],
-    "XMM1":  ["0x3F0000003F000000", "0x3F0000003F000000", "0x3F0000003F000000", "0x3F0000003F000000"],
-    "XMM2":  ["0x3EAAAAAB3EAAAAAB", "0x3EAAAAAB3EAAAAAB", "0x0000000000000000", "0x0000000000000000"],
-    "XMM3":  ["0x3E8000003E800000", "0x3E8000003E800000", "0x0000000000000000", "0x0000000000000000"],
-    "XMM4":  ["0x3F8000003F800000", "0x3F8000003F800000", "0x3F8000003F800000", "0x3F8000003F800000"],
-    "XMM5":  ["0x3F0000003F000000", "0x3F0000003F000000", "0x3F0000003F000000", "0x3F0000003F000000"],
-    "XMM6":  ["0x3EAAAAAB3EAAAAAB", "0x3EAAAAAB3EAAAAAB", "0x0000000000000000", "0x0000000000000000"],
-    "XMM7":  ["0x3E8000003E800000", "0x3E8000003E800000", "0x0000000000000000", "0x0000000000000000"]
+    "R8": "1",
+    "R9": "1"
   }
 }
 %endif
 
-lea rdx, [rel .data]
+section .text
+global _start
 
-vmovapd ymm0, [rdx + 32 * 0]
-vmovapd ymm1, [rdx + 32 * 1]
-vmovapd ymm2, [rdx + 32 * 2]
-vmovapd ymm3, [rdx + 32 * 3]
-vmovapd ymm4, [rdx + 32 * 4]
-vmovapd ymm5, [rdx + 32 * 4]
-vmovapd ymm6, [rdx + 32 * 4]
-vmovapd ymm7, [rdx + 32 * 4]
+%include "checkprecision.mac"
+
+; clobbers ymm15
+; returns the comparison result in rax
+%macro same_pdwords 1 ; receives the ymms register
+    vextractf128 xmm15, %1, 0
+    vmovd eax, xmm15
+    vmovd xmm15, eax
+    vbroadcastss ymm15, xmm15  ; broadcast lower 32bits across all 8 lanes
+    vpcmpeqd ymm15, ymm15, %1  ; equality mask on all lanes
+    vmovmskps eax, ymm15       ; gets sign bit of each lane into eax
+    cmp eax, 0b11111111        ; check all 8 lanes
+    sete al
+    movzx rax, al
+%endmacro
+
+; clobbers xmm15
+; returns the comparison result in rax
+%macro same_pdwords_x 1 ; receives the xmms register
+    movd eax, %1
+    movd xmm15, eax
+    pshufd xmm15, xmm15, 0 ; has the lower 32bits of %1 accross all lanes 
+    pcmpeqd xmm15, %1 ; has equalty mask on all lanes
+    movmskps eax, xmm15 ; gets sign bit of each lane into eax
+    cmp eax, 0b1111
+    sete al
+    movzx rax, al
+%endmacro
+
+_start:
+vmovapd ymm0, [rel arg1]
+vmovapd ymm1, [rel arg2]
+vmovapd ymm2, [rel arg3]
+vmovapd ymm3, [rel arg4]
+vmovapd ymm4, [rel arg5]
+vmovapd ymm5, [rel arg5]
+vmovapd ymm6, [rel arg5]
+vmovapd ymm7, [rel arg5]
 
 ; Register only
 vrsqrtps ymm0, ymm0
@@ -32,36 +57,94 @@ vrsqrtps xmm2, xmm2
 vrsqrtps xmm3, xmm3
 
 ; Memory operand
-vrsqrtps ymm4, [rdx + 32 * 0]
-vrsqrtps ymm5, [rdx + 32 * 1]
-vrsqrtps xmm6, [rdx + 32 * 2]
-vrsqrtps xmm7, [rdx + 32 * 3]
+vrsqrtps ymm4, [rel arg1]
+vrsqrtps ymm5, [rel arg2]
+vrsqrtps xmm6, [rel arg3]
+vrsqrtps xmm7, [rel arg4]
 
+; Check that each register is properly filled
+same_pdwords ymm0
+mov r8, rax
+
+same_pdwords ymm1
+and r8, rax
+
+same_pdwords_x xmm2
+and r8, rax
+
+same_pdwords_x xmm3
+and r8, rax
+
+; Result checks
+vpextrd [rel result1], xmm0, 0
+check_relerr rel eresult1, rel result1, rel tolerance
+mov r9, rax
+
+vpextrd [rel result2], xmm1, 0
+check_relerr rel eresult2, rel result2, rel tolerance
+and r9, rax
+
+vpextrd [rel result3], xmm2, 0
+check_relerr rel eresult3, rel result3, rel tolerance
+and r9, rax
+
+vpextrd [rel result4], xmm3, 0
+check_relerr rel eresult4, rel result4, rel tolerance
+and r9, rax
 hlt
 
+section .bss
 align 32
-.data:
+result1: resq 4
+result2: resq 4
+result3: resq 4
+result4: resq 4
+
+section .data
+align 32
+arg1:
 dq 0x3F8000003F800000 ; 1.0
 dq 0x3F8000003F800000
 dq 0x3F8000003F800000
 dq 0x3F8000003F800000
 
+arg2:
 dq 0x4080000040800000 ; 4.0
 dq 0x4080000040800000
 dq 0x4080000040800000
 dq 0x4080000040800000
 
+arg3:
 dq 0x4110000041100000 ; 9.0
 dq 0x4110000041100000
 dq 0x4110000041100000
 dq 0x4110000041100000
 
+arg4:
 dq 0x4180000041800000 ; 16.0
 dq 0x4180000041800000
 dq 0x4180000041800000
 dq 0x4180000041800000
 
+arg5:
 dq 0x41C8000041C80000 ; 25.0
 dq 0x41C8000041C80000
 dq 0x41C8000041C80000
 dq 0x41C8000041C80000
+
+eresult1:
+dd 0x3F800000 ; 1.0
+
+eresult2:
+dd 0x3f000000 ; 0.5
+
+eresult3:
+dd 0x3eaaaaab ; 1/3 = 0.(3)
+
+eresult4:
+dd 0x3e800000 ; 0.25
+
+tolerance:
+dd 0x39c00000
+
+define_check_data_constants

--- a/unittests/ASM/VEX/vrsqrtss.asm
+++ b/unittests/ASM/VEX/vrsqrtss.asm
@@ -2,32 +2,42 @@
 {
   "HostFeatures": ["AVX"],
   "RegData": {
-    "XMM0":  ["0x414243443F800000", "0xEEEEEEEEEEEEEEEE", "0x0000000000000000", "0x0000000000000000"],
-    "XMM1":  ["0x414243443F000000", "0xDDDDDDDDDDDDDDDD", "0x0000000000000000", "0x0000000000000000"],
-    "XMM2":  ["0x414243443EAAAAAB", "0xCCCCCCCCCCCCCCCC", "0x0000000000000000", "0x0000000000000000"],
-    "XMM3":  ["0x414243443E800000", "0xBBBBBBBBBBBBBBBB", "0x0000000000000000", "0x0000000000000000"],
-    "XMM4":  ["0x414243443F800000", "0xAAAAAAAAAAAAAAAA", "0x0000000000000000", "0x0000000000000000"],
-    "XMM5":  ["0x414243443F000000", "0xAAAAAAAAAAAAAAAA", "0x0000000000000000", "0x0000000000000000"],
-    "XMM6":  ["0x414243443EAAAAAB", "0xAAAAAAAAAAAAAAAA", "0x0000000000000000", "0x0000000000000000"],
-    "XMM7":  ["0x414243443E800000", "0xAAAAAAAAAAAAAAAA", "0x0000000000000000", "0x0000000000000000"],
-    "XMM8":  ["0x414243443F800000", "0xDDDDDDDDDDDDDDDD", "0x0000000000000000", "0x0000000000000000"],
-    "XMM9":  ["0x414243443F000000", "0xCCCCCCCCCCCCCCCC", "0x0000000000000000", "0x0000000000000000"],
-    "XMM10": ["0x414243443EAAAAAB", "0xBBBBBBBBBBBBBBBB", "0x0000000000000000", "0x0000000000000000"],
-    "XMM11": ["0x414243443E800000", "0xAAAAAAAAAAAAAAAA", "0x0000000000000000", "0x0000000000000000"]
+    "R9": "1",
+    "XMM0":  ["0x4142434400000000", "0xEEEEEEEEEEEEEEEE", "0x0000000000000000", "0x0000000000000000"],
+    "XMM1":  ["0x4142434400000000", "0xDDDDDDDDDDDDDDDD", "0x0000000000000000", "0x0000000000000000"],
+    "XMM2":  ["0x4142434400000000", "0xCCCCCCCCCCCCCCCC", "0x0000000000000000", "0x0000000000000000"],
+    "XMM3":  ["0x4142434400000000", "0xBBBBBBBBBBBBBBBB", "0x0000000000000000", "0x0000000000000000"],
+    "XMM4":  ["0x4142434400000000", "0xAAAAAAAAAAAAAAAA", "0x0000000000000000", "0x0000000000000000"],
+    "XMM5":  ["0x4142434400000000", "0xAAAAAAAAAAAAAAAA", "0x0000000000000000", "0x0000000000000000"],
+    "XMM6":  ["0x4142434400000000", "0xAAAAAAAAAAAAAAAA", "0x0000000000000000", "0x0000000000000000"],
+    "XMM7":  ["0x4142434400000000", "0xAAAAAAAAAAAAAAAA", "0x0000000000000000", "0x0000000000000000"],
+    "XMM8":  ["0x4142434400000000", "0xDDDDDDDDDDDDDDDD", "0x0000000000000000", "0x0000000000000000"],
+    "XMM9":  ["0x4142434400000000", "0xCCCCCCCCCCCCCCCC", "0x0000000000000000", "0x0000000000000000"],
+    "XMM10": ["0x4142434400000000", "0xBBBBBBBBBBBBBBBB", "0x0000000000000000", "0x0000000000000000"],
+    "XMM11": ["0x4142434400000000", "0xAAAAAAAAAAAAAAAA", "0x0000000000000000", "0x0000000000000000"]
   }
 }
 %endif
 
-lea rdx, [rel .data]
+section .text
+global _start
 
-vmovapd ymm0, [rdx + 32 * 0]
-vmovapd ymm1, [rdx + 32 * 1]
-vmovapd ymm2, [rdx + 32 * 2]
-vmovapd ymm3, [rdx + 32 * 3]
-vmovapd ymm4, [rdx + 32 * 4]
-vmovapd ymm5, [rdx + 32 * 4]
-vmovapd ymm6, [rdx + 32 * 4]
-vmovapd ymm7, [rdx + 32 * 4]
+%include "checkprecision.mac"
+
+; This test checks that:
+; - the results of the reciprocal sqrt is within 1.5*2^-12 error margin.
+; - the top 128 bits of ymms registers are zero.
+; - bits [127:32] are correctly copied from the first argument to vrsqrtss.
+
+_start:
+vmovapd ymm0, [rel arg1]
+vmovapd ymm1, [rel arg2]
+vmovapd ymm2, [rel arg3]
+vmovapd ymm3, [rel arg4]
+vmovapd ymm4, [rel arg5]
+vmovapd ymm5, [rel arg5]
+vmovapd ymm6, [rel arg5]
+vmovapd ymm7, [rel arg5]
 
 ; Same register
 vrsqrtss xmm0, xmm0, xmm0
@@ -36,42 +46,119 @@ vrsqrtss xmm2, xmm2, xmm2
 vrsqrtss xmm3, xmm3, xmm3
 
 ; Memory operand
-vrsqrtss xmm4, xmm4, [rdx + 32 * 0]
-vrsqrtss xmm5, xmm5, [rdx + 32 * 1]
-vrsqrtss xmm6, xmm6, [rdx + 32 * 2]
-vrsqrtss xmm7, xmm7, [rdx + 32 * 3]
+vrsqrtss xmm4, xmm4, [rel arg1]
+vrsqrtss xmm5, xmm5, [rel arg2]
+vrsqrtss xmm6, xmm6, [rel arg3]
+vrsqrtss xmm7, xmm7, [rel arg4]
 
 ; Memory operand different source register
-vrsqrtss xmm8, xmm1, [rdx + 32 * 0]
-vrsqrtss xmm9, xmm2, [rdx + 32 * 1]
-vrsqrtss xmm10, xmm3, [rdx + 32 * 2]
-vrsqrtss xmm11, xmm4, [rdx + 32 * 3]
+vrsqrtss xmm8, xmm1, [rel arg1]
+vrsqrtss xmm9, xmm2, [rel arg2]
+vrsqrtss xmm10, xmm3, [rel arg3]
+vrsqrtss xmm11, xmm4, [rel arg4]
+
+; Check precision
+vpextrd [rel result1], xmm0, 0
+check_relerr rel eresult1, rel result1, rel tolerance
+mov r9, rax
+
+vpextrd [rel result2], xmm1, 0
+check_relerr rel eresult2, rel result2, rel tolerance
+and r9, rax
+
+vpextrd [rel result3], xmm2, 0
+check_relerr rel eresult3, rel result3, rel tolerance
+and r9, rax
+
+vpextrd [rel result4], xmm3, 0
+check_relerr rel eresult4, rel result4, rel tolerance
+and r9, rax
+
+vpextrd [rel result1], xmm8, 0
+check_relerr rel eresult1, rel result1, rel tolerance
+and r9, rax
+
+vpextrd [rel result2], xmm9, 0
+check_relerr rel eresult2, rel result2, rel tolerance
+and r9, rax
+
+vpextrd [rel result3], xmm10, 0
+check_relerr rel eresult3, rel result3, rel tolerance
+and r9, rax
+
+vpextrd [rel result4], xmm11, 0
+check_relerr rel eresult4, rel result4, rel tolerance
+and r9, rax
+
+; Insert 0s in the bottom 32bits.
+xor rax, rax
+vpinsrd xmm0, xmm0, eax, 0
+vpinsrd xmm1, xmm1, eax, 0
+vpinsrd xmm2, xmm2, eax, 0
+vpinsrd xmm3, xmm3, eax, 0
+vpinsrd xmm4, xmm4, eax, 0
+vpinsrd xmm5, xmm5, eax, 0
+vpinsrd xmm6, xmm6, eax, 0
+vpinsrd xmm7, xmm7, eax, 0
+vpinsrd xmm8, xmm8, eax, 0
+vpinsrd xmm9, xmm9, eax, 0
+vpinsrd xmm10, xmm10, eax, 0
+vpinsrd xmm11, xmm11, eax, 0
 
 hlt
 
+section .bss
 align 32
-.data:
+result1: resq 2
+result2: resq 2
+result3: resq 2
+result4: resq 2
+
+section .data
+align 32
+arg1:
 dq 0x414243443F800000 ; 1.0
 dq 0xEEEEEEEEEEEEEEEE
 dq 0x5152535455565758
 dq 0x5152535455565758
 
+arg2:
 dq 0x4142434440800000 ; 4.0
 dq 0xDDDDDDDDDDDDDDDD
 dq 0x5152535455565758
 dq 0x5152535455565758
 
+arg3:
 dq 0x4142434441100000 ; 9.0
 dq 0xCCCCCCCCCCCCCCCC
 dq 0x5152535455565758
 dq 0x5152535455565758
 
+arg4:
 dq 0x4142434441800000 ; 16.0
 dq 0xBBBBBBBBBBBBBBBB
 dq 0x5152535455565758
 dq 0x5152535455565758
 
+arg5:
 dq 0x4142434441C80000 ; 25.0
 dq 0xAAAAAAAAAAAAAAAA
 dq 0x5152535455565758
 dq 0x5152535455565758
+
+eresult1:
+dd 0x3F800000 ; 1.0
+
+eresult2:
+dd 0x3f000000 ; 0.5 
+
+eresult3:
+dd 0x3eaaaaab ; 1/3 = 0.(3)
+
+eresult4:
+dd 0x3e800000 ; 0.25
+
+tolerance:
+dd 0x39c00000
+
+define_check_data_constants

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -90,16 +90,19 @@
       ]
     },
     "pfrsqrtv mm0, mm1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "0x0f 0x0f 0x87"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #1056]",
+        "fabs v3.4s, v2.4s",
         "fmov v0.4s, #0x70 (1.0000)",
-        "fsqrt v1.4s, v2.4s",
-        "fdiv v2.4s, v0.4s, v1.4s",
-        "str d2, [x28, #1040]",
+        "fsqrt v1.4s, v3.4s",
+        "fdiv v3.4s, v0.4s, v1.4s",
+        "movi v0.2s, #0x80, lsl #24",
+        "bit v3.8b, v2.8b, v0.8b",
+        "str d3, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"
       ]
@@ -174,16 +177,19 @@
       ]
     },
     "pfrsqrt mm0, mm1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 11,
       "Comment": [
         "0x0f 0x0f 0x97"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #1056]",
-        "fmov s0, #0x70 (1.0000)",
-        "fsqrt s1, s2",
-        "fdiv s2, s0, s1",
-        "dup v2.2s, v2.s[0]",
+        "fabs v3.4s, v2.4s",
+        "fmov v0.4s, #0x70 (1.0000)",
+        "fsqrt v1.4s, v3.4s",
+        "fdiv v3.4s, v0.4s, v1.4s",
+        "movi v0.2s, #0x80, lsl #24",
+        "bit v3.8b, v2.8b, v0.8b",
+        "dup v2.2s, v3.s[0]",
         "str d2, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -12,39 +12,49 @@
   },
   "Instructions": {
     "pfrcpv mm0, mm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "0x0f 0x0f 0x86"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #1056]",
-        "frecpe v2.2s, v2.2s",
+        "frecpe v0.2s, v2.2s",
+        "frecps v1.2s, v0.2s, v2.2s",
+        "fmul v2.2s, v0.2s, v1.2s",
         "str d2, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"
       ]
     },
     "pfrsqrtv mm0, mm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 11,
       "Comment": [
         "0x0f 0x0f 0x87"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #1056]",
-        "frsqrte v2.2s, v2.2s",
-        "str d2, [x28, #1040]",
+        "fabs v3.4s, v2.4s",
+        "frsqrte v0.2s, v3.2s",
+        "fmul v1.2s, v0.2s, v0.2s",
+        "frsqrts v1.2s, v1.2s, v3.2s",
+        "fmul v3.2s, v0.2s, v1.2s",
+        "movi v0.2s, #0x80, lsl #24",
+        "bit v3.8b, v2.8b, v0.8b",
+        "str d3, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"
       ]
     },
     "pfrcp mm0, mm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "0x0f 0x0f 0x96"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #1056]",
-        "frecpe s2, s2",
+        "frecpe s0, s2",
+        "frecps s1, s0, s2",
+        "fmul s2, s0, s1",
         "dup v2.2s, v2.s[0]",
         "str d2, [x28, #1040]",
         "mov w20, #0xffff",
@@ -52,14 +62,20 @@
       ]
     },
     "pfrsqrt mm0, mm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0x0f 0x0f 0x97"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #1056]",
-        "frsqrte s2, s2",
-        "dup v2.2s, v2.s[0]",
+        "fabs v3.4s, v2.4s",
+        "frsqrte v0.2s, v3.2s",
+        "fmul v1.2s, v0.2s, v0.2s",
+        "frsqrts v1.2s, v1.2s, v3.2s",
+        "fmul v3.2s, v0.2s, v1.2s",
+        "movi v0.2s, #0x80, lsl #24",
+        "bit v3.8b, v2.8b, v0.8b",
+        "dup v2.2s, v3.s[0]",
         "str d2, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"


### PR DESCRIPTION
Reciprocal estimations did not have enough accuracy. Tests were enabled to check for accurate values of reciprocals.