### PR TITLE
FEXpidof: Fixes searching for wine applications

### DIFF
--- a/FEXHeaderUtils/FEXHeaderUtils/Filesystem.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/Filesystem.h
@@ -125,6 +125,16 @@ inline fextl::string GetFilename(const fextl::string& Path) {
   return Path.substr(LastSeparator + 1);
 }
 
+inline std::string_view GetFilename(std::string_view Path) {
+  auto LastSeparator = Path.rfind('/');
+  if (LastSeparator == fextl::string::npos) {
+    // No separator. Likely relative `.`, `..`, `<Application Name>`, or empty string.
+    return Path;
+  }
+
+  return Path.substr(LastSeparator + 1);
+}
+
 inline fextl::string ParentPath(const fextl::string& Path) {
   auto LastSeparator = Path.rfind('/');
 


### PR DESCRIPTION
I kept finding I needed:
```
./fex_shm_stats_read `FEXpidof Celeste.exe`
```

but FEXpidof wasn't ever wired up to find FEX in the face of emulating
wine and arm64 wine.

This adds two new features basically:
- If x86 wine is being emulated, then walk the argument list just like
  our config options to see what the program executable name is.
- If it is arm64 wine using FEX, then we need to detect that, and walk
  the arguments in a similar fashion

The detection is the main thing here in that the only way to detect FEX
for arm64 wine is checking the applications mapped files and seeing if
it is mapping arm64ecfex.dll or wow64fex.dll.

x86 Wine is easy since that's just skipping the wine{64,}{-preloader,}
arguments to get to the executable name.