### PR TITLE
CPUBackend: Move bool to end of JITCodeTail

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -87,9 +87,6 @@ namespace CPU {
       // The length of the guest code for this block.
       size_t GuestSize;
 
-      // If this block represents a single guest instruction.
-      bool SingleInst;
-
       // Number of RIP entries for this JIT Code section.
       uint32_t NumberOfRIPEntries;
 
@@ -99,7 +96,10 @@ namespace CPU {
       // Shared-code modification spin-loop futex.
       uint32_t SpinLockFutex;
 
-      uint32_t _Pad;
+      // If this block represents a single guest instruction.
+      bool SingleInst;
+
+      uint8_t _Pad[3];
     };
 
     /**


### PR DESCRIPTION
Reduces the size by 8 bytes from 48 to 40.