### PR TITLE
OpcodeDispatcher: Implement support for SHA1MSG2 using SHA instructions 

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
@@ -169,6 +169,25 @@ DEF_OP(VSha1H) {
   sha1h(Dst.S(), Src.S());
 }
 
+DEF_OP(VSha1SU1) {
+  auto Op = IROp->C<IR::IROp_VSha1SU1>();
+
+  const auto Dst = GetVReg(Node);
+  const auto Src1 = GetVReg(Op->Src1.ID());
+  const auto Src2 = GetVReg(Op->Src2.ID());
+
+  if (Dst == Src1) {
+    sha1su1(Dst, Src2);
+  } else if (Dst != Src2) {
+    mov(Dst.Q(), Src1.Q());
+    sha1su1(Dst, Src2);
+  } else {
+    mov(VTMP1.Q(), Src1.Q());
+    sha1su1(VTMP1, Src2);
+    mov(Dst.Q(), VTMP1.Q());
+  }
+}
+
 DEF_OP(VSha256U0) {
   auto Op = IROp->C<IR::IROp_VSha256U0>();
 

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -2656,6 +2656,11 @@
         "Desc": "Does vector scalar SHA1H instruction",
         "DestSize": "FEXCore::IR::OpSize::i32Bit"
       },
+      "FPR = VSha1SU1 FPR:$Src1, FPR:$Src2": {
+        "Desc": "Does vector scalar SHA1H instruction",
+        "DestSize": "FEXCore::IR::OpSize::i128Bit",
+        "TiedSource": 0
+      },
       "FPR = VSha256U0 FPR:$Src1, FPR:$Src2": {
         "Desc": "Does vector scalar VSha256U0 instruction",
         "DestSize": "FEXCore::IR::OpSize::i128Bit",

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -25,6 +25,21 @@
         "mov v16.s[3], v2.s[3]"
       ]
     },
+    "sha1msg2 xmm0, xmm1": {
+      "ExpectedInstructionCount": 7,
+      "Comment": [
+        "0x66 0x0f 0x38 0xca"
+      ],
+      "ExpectedArm64ASM": [
+        "rev64 v2.4s, v16.4s",
+        "ext v2.16b, v2.16b, v2.16b, #8",
+        "rev64 v3.4s, v17.4s",
+        "ext v3.16b, v3.16b, v3.16b, #8",
+        "unimplemented (Unimplemented)",
+        "rev64 v2.4s, v2.4s",
+        "ext v16.16b, v2.16b, v2.16b, #8"
+      ]
+    },
     "sha256msg1 xmm0, xmm1": {
       "ExpectedInstructionCount": 1,
       "Comment": [


### PR DESCRIPTION
Only saves a handful of instructions, but still an improvement.

```diff
   "sha1msg2 xmm0, xmm1": {
     -      "ExpectedInstructionCount": 11,
     +      "ExpectedInstructionCount": 7,
```