### PR TITLE
ArgumentLoader: Fixes double load

### DIFF
--- a/Source/Common/ArgumentLoader.cpp
+++ b/Source/Common/ArgumentLoader.cpp
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 namespace FEX::ArgLoader {
-void FEX::ArgLoader::ArgLoader::Load() {
+void FEX::ArgLoader::ArgLoader::PreLoad() {
   RemainingArgs.clear();
   ProgramArguments.clear();
   if (Type == LoadType::WITHOUT_FEXLOADER_PARSER) {

--- a/Source/Common/ArgumentLoader.h
+++ b/Source/Common/ArgumentLoader.h
@@ -18,10 +18,13 @@ public:
     , Type {Type}
     , argc {argc}
     , argv {argv} {
-    Load();
+    PreLoad();
   }
 
-  void Load() override;
+  void Load() override {
+    // Intentional no-op.
+  }
+  void PreLoad();
   void LoadWithoutArguments();
   fextl::vector<fextl::string> Get() {
     return RemainingArgs;


### PR DESCRIPTION
The argument loader was loading configuration from the arguments twice.

The use of the argument loader needs to preload the arguments before being handed off to the config system. This way we can pull remaining arguments that get passed to the guest application.

Due to this, `Load` was getting called twice, once in the constructor and once in the Config system. This was causing the backend to allocate twice as much memory since the second load appends the arguments to a fextl::list internally.

Not really any functional change but it was causing some heartburn with some changes I was working on.