### PR TITLE
Profiler: Fixes potential crash due to uninitialized variables

### DIFF
--- a/Source/Common/Profiler.h
+++ b/Source/Common/Profiler.h
@@ -46,12 +46,12 @@ protected:
 
   void SaveHeader(FEXCore::Profiler::AppType AppType);
 
-  void* Base;
+  void* Base {};
   uint32_t CurrentSize {};
   FEXCore::Profiler::ThreadStatsHeader* Head {};
-  FEXCore::Profiler::ThreadStats* Stats;
+  FEXCore::Profiler::ThreadStats* Stats {};
   FEXCore::Profiler::ThreadStats* StatTail {};
-  uint32_t RemainingSlots;
+  uint32_t RemainingSlots {};
 
   // Limited to 4MB which should be a few hundred threads of tracking capability.
   // I (Sonicadvance1) wanted to reserve 128MB of VA space because it's cheap, but ran in to a bug when running WINE.


### PR DESCRIPTION
If ProfileStats aren't enabled then `Initialize` early returns, but some of these values weren't being zero initialized which could result in crashes.

Ensure all the values in StatAlloc are zero initialized so this doesn't occur.