### PR TITLE
Various: Removes warnings about uninitialized variables

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1589,7 +1589,7 @@ void OpDispatchBuilder::RotateOp(OpcodeArgs, bool Left, bool IsImmediate, bool I
 
   const uint32_t Size = GetSrcBitSize(Op);
   const auto OpSize = Size == 64 ? OpSize::i64Bit : OpSize::i32Bit;
-  uint64_t UnmaskedConst;
+  uint64_t UnmaskedConst {};
 
   // x86 masks the shift by 0x3F or 0x1F depending on size of op. But it's
   // equivalent to mask to the actual size of the op, that way we can bound
@@ -2658,7 +2658,7 @@ void OpDispatchBuilder::MULOp(OpcodeArgs) {
 
   Ref Src1 = LoadSource(GPRClass, Op, Op->Dest, Op->Flags, {.AllowUpperGarbage = true});
   Ref Src2 = LoadGPRRegister(X86State::REG_RAX);
-  Ref Result;
+  Ref Result {};
 
   if (Size != OpSize::i64Bit) {
     Src1 = _Bfe(OpSize::i64Bit, SizeBits, 0, Src1);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -783,7 +783,7 @@ void OpDispatchBuilder::AVX128_VZERO(OpcodeArgs) {
   if (IsVZEROALL) {
     // NOTE: Despite the name being VZEROALL, this will still only ever
     //       zero out up to the first 16 registers (even on AVX-512, where we have 32 registers)
-    Ref ZeroVector;
+    Ref ZeroVector {};
 
     for (uint32_t i = 0; i < NumRegs; i++) {
       // Explicitly not caching named vector zero. This ensures that every register gets movi #0.0 directly.

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -40,7 +40,7 @@ Ref OpDispatchBuilder::GetX87Tag(Ref Value, Ref AbridgedFTW) {
 
 void OpDispatchBuilder::SetX87FTW(Ref FTW) {
   Ref X87Empty = _Constant(static_cast<uint8_t>(FPState::X87Tag::Empty));
-  Ref NewAbridgedFTW;
+  Ref NewAbridgedFTW {};
 
   for (int i = 0; i < 8; i++) {
     Ref RegTag = _Bfe(OpSize::i32Bit, 2, i * 2, FTW);

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -250,7 +250,7 @@ private:
 
   PhysicalRegister DecodeSRAReg(const IROp_Header* IROp, Ref Node) {
     RegisterClassType Class;
-    uint8_t Reg;
+    uint8_t Reg {};
 
     uint8_t FlagOffset = Classes[GPRFixedClass.Val].Count - 2;
 


### PR DESCRIPTION
NFC. These wouldn't even occur in practice.