### PR TITLE
AVX128: Remove old comment from VEXTRACT{F,I}128

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -1670,7 +1670,6 @@ void OpDispatchBuilder::AVX128_VEXTRACT128(OpcodeArgs) {
   const auto DstIsXMM = Op->Dest.IsGPR();
   const auto Selector = Op->Src[1].Literal() & 0b1;
 
-  ///< TODO: Once we support loading only upper-half of the ymm register we can load the half depending on selection literal.
   auto Src = AVX128_LoadSource_WithOpSize(Op, Op->Src[0], Op->Flags, true);
 
   RefPair Result {};


### PR DESCRIPTION
This comment isn't relevant anymore as unused half of ymm loads will get DCE'd