### PR TITLE
Scripts/DefinitionExtract: Make output consistent with clang-format

### DIFF
--- a/Scripts/DefinitionExtract.py
+++ b/Scripts/DefinitionExtract.py
@@ -168,7 +168,7 @@ def HandleFunctionDeclCursor(Arch, Cursor):
 
 def PrintFunctionDecls():
     for Decl in FunctionDecls:
-        print("template<> struct fex_gen_config<{}> {{}};".format(Decl.Name))
+        print("template<>\nstruct fex_gen_config<{}> {{}};".format(Decl.Name))
 
 def FindClangArguments(OriginalArguments):
     AddedArguments = ["clang"]


### PR DESCRIPTION
This makes diff-ing the output with existing Vulkan definitions easier.