### PR TITLE
LibraryForwarding/vulkan: Add missing vkCmdPushDescriptorSetWithTemplate declaration

### DIFF
--- a/ThunkLibs/libvulkan/libvulkan_interface.cpp
+++ b/ThunkLibs/libvulkan/libvulkan_interface.cpp
@@ -579,6 +579,8 @@ struct fex_gen_config<vkGetImageSubresourceLayout2> {};
 template<>
 struct fex_gen_config<vkCmdPushDescriptorSet> {};
 template<>
+struct fex_gen_config<vkCmdPushDescriptorSetWithTemplate> {};
+template<>
 struct fex_gen_param<vkCmdPushDescriptorSetWithTemplate, 4, const void*> : fexgen::assume_compatible_data_layout {};
 template<>
 struct fex_gen_config<vkCmdSetRenderingAttachmentLocations> {};


### PR DESCRIPTION
This was missed in #4402 since `thunkgen` doesn't error out when annotating parameters of an undeclared entry point.