### PR TITLE
X87: Minor optimization in how GPRs are moved in to vector registers

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ConversionOps.cpp
@@ -104,6 +104,16 @@ DEF_OP(VCastFromGPR) {
   }
 }
 
+DEF_OP(VLoadTwoGPRs) {
+  const auto Op = IROp->C<IR::IROp_VLoadTwoGPRs>();
+
+  const auto Dst = GetVReg(Node);
+  const auto SrcLower = GetReg(Op->Lower.ID());
+  const auto SrcUpper = GetReg(Op->Upper.ID());
+  fmov(ARMEmitter::Size::i64Bit, Dst.D(), SrcLower);
+  fmov(ARMEmitter::Size::i64Bit, Dst.D(), SrcUpper, true);
+}
+
 DEF_OP(VDupFromGPR) {
   const auto Op = IROp->C<IR::IROp_VDupFromGPR>();
   const auto OpSize = IROp->Size;

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -124,8 +124,7 @@ void OpDispatchBuilder::FILD(OpcodeArgs) {
   auto zeroed_exponent = _Select(COND_EQ, absolute, zero, zero, adjusted_exponent);
   auto upper = _Or(OpSize::i64Bit, sign, zeroed_exponent);
 
-  Ref ConvertedData = _VCastFromGPR(OpSize::i64Bit, OpSize::i64Bit, shifted);
-  ConvertedData = _VInsElement(OpSize::i128Bit, OpSize::i64Bit, 1, 0, ConvertedData, _VCastFromGPR(OpSize::i128Bit, OpSize::i64Bit, upper));
+  Ref ConvertedData = _VLoadTwoGPRs(shifted, upper);
   _PushStack(ConvertedData, Data, ReadWidth, false);
 }
 
@@ -550,8 +549,7 @@ void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
 
   auto low = _Constant(~0ULL);
   auto high = _Constant(0xFFFF);
-  Ref Mask = _VCastFromGPR(OpSize::i128Bit, OpSize::i64Bit, low);
-  Mask = _VInsGPR(OpSize::i128Bit, OpSize::i64Bit, 1, Mask, high);
+  Ref Mask = _VLoadTwoGPRs(low, high);
   const auto StoreSize = ReducedPrecisionMode ? OpSize::i64Bit : OpSize::i128Bit;
   for (int i = 0; i < 7; ++i) {
     Ref Reg = _LoadMem(FPRClass, OpSize::i128Bit, Mem, _Constant((IR::OpSizeToSize(Size) * 7) + (10 * i)), OpSize::i8Bit, MEM_OFFSET_SXTX, 1);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -2590,6 +2590,12 @@
         "ElementSize": "ElementSize"
       },
 
+      "FPR = VLoadTwoGPRs GPR:$Lower, GPR:$Upper": {
+        "Desc": ["Moves two 64-bit registers to a vector register optimally"],
+        "DestSize": "OpSize::i128Bit",
+        "ElementSize": "OpSize::i64Bit"
+      },
+
       "FPR = Float_FromGPR_S OpSize:#DstElementSize, OpSize:$SrcElementSize, GPR:$Src": {
         "Desc": ["Scalar op: Converts signed GPR to Scalar float",
                  "Zeroes the upper bits of the vector register"

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -55094,7 +55094,7 @@
     },
     "Block5": {
       "x86InstructionCount": 368,
-      "ExpectedInstructionCount": 270,
+      "ExpectedInstructionCount": 268,
       "x86Insts": [
         "mov ebx,dword [eax + 0x68]",
         "fld dword [esi + 0x2c]",
@@ -55552,8 +55552,7 @@
         "csel x20, x22, x12, eq",
         "orr x20, x24, x20",
         "fmov d2, x13",
-        "fmov d3, x20",
-        "mov v2.d[1], v3.d[0]",
+        "fmov v2.D[1], x20",
         "msr nzcv, x21",
         "str w4, [x8, #64]",
         "mov w20, #0xddd8",
@@ -55659,8 +55658,7 @@
         "csel x20, x22, x24, eq",
         "orr x20, x23, x20",
         "fmov d2, x25",
-        "fmov d4, x20",
-        "mov v2.d[1], v4.d[0]",
+        "fmov v2.D[1], x20",
         "msr nzcv, x21",
         "mrs x0, nzcv",
         "str w0, [x28, #1000]",

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -6431,7 +6431,7 @@
       ]
     },
     "fild dword [rax]": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdf !11b /5"
       ],
@@ -6456,8 +6456,7 @@
         "csel x20, x22, x24, eq",
         "orr x20, x23, x20",
         "fmov d2, x25",
-        "fmov d3, x20",
-        "mov v2.d[1], v3.d[0]",
+        "fmov v2.D[1], x20",
         "msr nzcv, x21",
         "ldrb w20, [x28, #1019]",
         "mov w21, #0x1",
@@ -11038,7 +11037,7 @@
         "mov x22, #0xffffffffffffffff",
         "mov w24, #0xffff",
         "fmov d2, x22",
-        "mov v2.d[1], x24",
+        "fmov v2.D[1], x24",
         "ldur q3, [x4, #28]",
         "and v3.16b, v3.16b, v2.16b",
         "add x0, x28, x21, lsl #4",
@@ -15871,7 +15870,7 @@
       ]
     },
     "fild word [rax]": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdf !11b /0"
       ],
@@ -15896,8 +15895,7 @@
         "csel x20, x22, x24, eq",
         "orr x20, x23, x20",
         "fmov d2, x25",
-        "fmov d3, x20",
-        "mov v2.d[1], v3.d[0]",
+        "fmov v2.D[1], x20",
         "msr nzcv, x21",
         "ldrb w20, [x28, #1019]",
         "mov w21, #0x1",

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -6321,7 +6321,7 @@
         "mov x22, #0xffffffffffffffff",
         "mov w24, #0xffff",
         "fmov d2, x22",
-        "mov v2.d[1], x24",
+        "fmov v2.D[1], x24",
         "ldur q3, [x4, #28]",
         "and v3.16b, v3.16b, v2.16b",
         "mrs x0, nzcv",

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -6430,7 +6430,7 @@
       ]
     },
     "fild dword [rax]": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdf !11b /5"
       ],
@@ -6455,8 +6455,7 @@
         "csel x20, x22, x24, eq",
         "orr x20, x23, x20",
         "fmov d2, x25",
-        "fmov d3, x20",
-        "mov v2.d[1], v3.d[0]",
+        "fmov v2.D[1], x20",
         "msr nzcv, x21",
         "ldrb w20, [x28, #1019]",
         "mov w21, #0x1",
@@ -11069,7 +11068,7 @@
         "mov x22, #0xffffffffffffffff",
         "mov w24, #0xffff",
         "fmov d2, x22",
-        "mov v2.d[1], x24",
+        "fmov v2.D[1], x24",
         "ldur q3, [x4, #28]",
         "and v3.16b, v3.16b, v2.16b",
         "add x0, x28, x21, lsl #4",
@@ -15733,7 +15732,7 @@
       ]
     },
     "fild word [rax]": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdf !11b /0"
       ],
@@ -15758,8 +15757,7 @@
         "csel x20, x22, x24, eq",
         "orr x20, x23, x20",
         "fmov d2, x25",
-        "fmov d3, x20",
-        "mov v2.d[1], v3.d[0]",
+        "fmov v2.D[1], x20",
         "msr nzcv, x21",
         "ldrb w20, [x28, #1019]",
         "mov w21, #0x1",

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -6360,7 +6360,7 @@
         "mov x22, #0xffffffffffffffff",
         "mov w24, #0xffff",
         "fmov d2, x22",
-        "mov v2.d[1], x24",
+        "fmov v2.D[1], x24",
         "ldur q3, [x4, #28]",
         "and v3.16b, v3.16b, v2.16b",
         "mrs x0, nzcv",


### PR DESCRIPTION
We weren't optimally moving two GPRs in to a vector register because we had no way to describe this operation easily.

Shaves an instruction off of each FILD and FRSTOR instruction. Should fall within noise but makes the asm a bit easier to read.