### PR TITLE
CMake: Prefer static libraries over shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,15 @@ if (NOT MINGW_BUILD)
   endif()
 endif()
 
+# Setup library search paths to prefer static libraries if available.
+# Helps for when package maintainers try to replace our static libraries with system libraries.
+# See https://github.com/FEX-Emu/FEX/issues/4301 why we don't want dynamic libraries.
+if (MINGW_BUILD)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib;.dll")
+else()
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.so")
+endif()
+
 if (ENABLE_FEXCORE_PROFILER)
   add_definitions(-DENABLE_FEXCORE_PROFILER=1)
   string(TOUPPER "${FEXCORE_PROFILER_BACKEND}" FEXCORE_PROFILER_BACKEND)


### PR DESCRIPTION
This option allows us to give cmake a priority when searching for libraries. Invert the order of library suffixes to be static first then shared.

This doesn't fully remove the problems of shared library linking but at least mitigates the problem that #4301 brought up.

As a test I have the system libxxhash installed on my system and cmake now prefers the static library from that package instead of the shared library.

Still more work to go, but this at least removes a bit of the headache.