### PR TITLE
actions: Update to step-security change-files action

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v39
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
         with:
           separator: ","
           skip_initial_fetch: true


### PR DESCRIPTION
This repo is provided by them with the commit prior to when it was compromised. LLVM has switched to the same repo for now.

We probably want to find some better solution to this at some point.