### PR TITLE
ConstProp: optimize StoreContext(128-bit zero)

### DIFF
--- a/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/ConstProp.cpp
@@ -603,11 +603,41 @@ void ConstProp::ConstantPropagation(IREmitter* IREmit, const IRListView& Current
 
   case OP_ADC:
   case OP_ADCWITHFLAGS:
-  case OP_STORECONTEXT:
   case OP_RMIFNZCV: {
     InlineIfZero(IREmit, CurrentIR, CodeNode, IROp, 0);
     break;
   }
+  case OP_STORECONTEXT: {
+    // For i128Bit, we won't see a normal Constant to inline, but as a special
+    // case we can replace with a 2x64-bit store which can use inline zeroes.
+    if (IROp->Size == OpSize::i128Bit) {
+      auto Op = IROp->C<IR::IROp_StoreContext>();
+      auto Header = IREmit->GetOpHeader(IROp->Args[0]);
+      const auto MAX_STP_OFFSET = (252 * 4);
+
+      if (Op->Offset <= MAX_STP_OFFSET && Header->Op == OP_LOADNAMEDVECTORCONSTANT) {
+        auto Const = Header->C<IR::IROp_LoadNamedVectorConstant>();
+
+        if (Const->Constant == IR::NamedVectorConstant::NAMED_VECTOR_ZERO) {
+          IREmit->SetWriteCursor(CodeNode);
+          Ref Zero = IREmit->_Constant(0);
+          Ref STP = IREmit->_StoreContextPair(IR::OpSize::i64Bit, GPRClass, Zero, Zero, Op->Offset);
+          IREmit->Remove(CodeNode);
+
+          // XXX: This works around InlineConstant not having an associated
+          // register class, else we'd just do InlineConstant above.
+          Ref InlineZero = IREmit->_InlineConstant(0);
+          IREmit->ReplaceNodeArgument(STP, 0, InlineZero);
+          IREmit->ReplaceNodeArgument(STP, 1, InlineZero);
+        }
+      }
+    } else {
+      InlineIfZero(IREmit, CurrentIR, CodeNode, IROp, 0);
+    }
+
+    break;
+  }
+
   case OP_CONDADDNZCV:
   case OP_CONDSUBNZCV: {
     InlineIfZero(IREmit, CurrentIR, CodeNode, IROp, 0);

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -14,24 +14,22 @@
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "Map 1 0b00 0x10 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "stp xzr, xzr, [x28, #16]"
+      ]
+    },
+    "vmovups xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
-      ]
-    },
-    "vmovups xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
-      "Comment": [
-        "Map 1 0b00 0x10 128-bit"
-      ],
-      "ExpectedArm64ASM": [
         "ldr q16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovups ymm0, ymm0": {
@@ -56,24 +54,22 @@
       ]
     },
     "vmovupd xmm0, xmm0": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "Map 1 0b01 0x10 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "stp xzr, xzr, [x28, #16]"
+      ]
+    },
+    "vmovupd xmm0, [rax]": {
       "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
-      ]
-    },
-    "vmovupd xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
-      "Comment": [
-        "Map 1 0b01 0x10 128-bit"
-      ],
-      "ExpectedArm64ASM": [
         "ldr q16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovupd ymm0, ymm0": {
@@ -98,41 +94,38 @@
       ]
     },
     "vmovss xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr s16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b10 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.s[0], v18.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovsd xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0x10 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr d16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b11 0x10 128-bit"
@@ -140,8 +133,7 @@
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.d[0], v18.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovups [rax], xmm0": {
@@ -192,7 +184,7 @@
       ]
     },
     "db 0xc5, 0xf2, 0x11, 0xc2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "vmovss xmm2, xmm1, xmm0",
         "Need to manually encode since nasm won't encode this",
@@ -201,8 +193,7 @@
       "ExpectedArm64ASM": [
         "mov v18.16b, v17.16b",
         "mov v18.s[0], v16.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #48]"
+        "stp xzr, xzr, [x28, #48]"
       ]
     },
     "vmovsd [rax], xmm0": {
@@ -215,7 +206,7 @@
       ]
     },
     "db 0xc5, 0xf3, 0x11, 0xc2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "vmovsd xmm2, xmm1, xmm0",
         "Need to manually encode since nasm won't encode this",
@@ -225,12 +216,11 @@
       "ExpectedArm64ASM": [
         "mov v18.16b, v17.16b",
         "mov v18.d[0], v16.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #48]"
+        "stp xzr, xzr, [x28, #48]"
       ]
     },
     "vmovlps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b00 0x12 128-bit"
@@ -238,12 +228,11 @@
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "ld1 {v16.d}[0], [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovlpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Insert in to first element could be more optimal, which is the common case.",
         "Map 1 0b01 0x12 128-bit"
@@ -251,20 +240,18 @@
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "ld1 {v16.d}[0], [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovsldup xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b10 0x12 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
         "trn1 v16.4s, v2.4s, v2.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovsldup ymm0, [rax]": {
@@ -280,15 +267,14 @@
       ]
     },
     "vmovddup xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b11 0x12 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
         "dup v16.2d, v2.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovddup ymm0, [rax]": {
@@ -322,15 +308,14 @@
       ]
     },
     "vunpcklps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b00 0x14 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
         "zip1 v16.4s, v17.4s, v2.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vunpcklps ymm0, ymm1, [rax]": {
@@ -347,15 +332,14 @@
       ]
     },
     "vunpcklpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0x14 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
         "zip1 v16.2d, v17.2d, v2.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vunpcklpd ymm0, ymm1, [rax]": {
@@ -372,15 +356,14 @@
       ]
     },
     "vunpckhps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b00 0x15 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
         "zip2 v16.4s, v17.4s, v2.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vunpckhps ymm0, ymm1, [rax]": {
@@ -397,15 +380,14 @@
       ]
     },
     "vunpckhpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0x15 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
         "zip2 v16.2d, v17.2d, v2.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vunpckhpd ymm0, ymm1, [rax]": {
@@ -422,50 +404,46 @@
       ]
     },
     "vmovhps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b00 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "ld1 {v16.d}[1], [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovhpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "ld1 {v16.d}[1], [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovlhps xmm0, xmm1, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
         "zip1 v16.2d, v17.2d, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovshdup xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b10 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
         "trn2 v16.4s, v2.4s, v2.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovshdup ymm0, [rax]": {
@@ -561,14 +539,13 @@
       ]
     },
     "vsqrtps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x51 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fsqrt v16.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vsqrtps ymm0, ymm1": {
@@ -584,14 +561,13 @@
       ]
     },
     "vsqrtpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x51 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fsqrt v16.2d, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vsqrtpd ymm0, ymm1": {
@@ -607,7 +583,7 @@
       ]
     },
     "vsqrtss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x51 128-bit"
       ],
@@ -615,12 +591,11 @@
         "mov v16.16b, v17.16b",
         "fsqrt s0, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vsqrtsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x51 128-bit"
       ],
@@ -628,12 +603,11 @@
         "mov v16.16b, v17.16b",
         "fsqrt d0, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vrsqrtps xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b00 0x52 128-bit"
       ],
@@ -641,8 +615,7 @@
         "fmov v0.4s, #0x70 (1.0000)",
         "fsqrt v1.4s, v17.4s",
         "fdiv v16.4s, v0.4s, v1.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vrsqrtps ymm0, ymm1": {
@@ -662,7 +635,7 @@
       ]
     },
     "vrsqrtss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b10 0x52 128-bit"
       ],
@@ -672,20 +645,18 @@
         "fsqrt s1, s18",
         "fdiv s0, s0, s1",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vrcpps xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b00 0x53 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmov v0.4s, #0x70 (1.0000)",
         "fdiv v16.4s, v0.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vrcpps ymm0, ymm1": {
@@ -703,7 +674,7 @@
       ]
     },
     "vrcpss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b10 0x53 128-bit"
       ],
@@ -712,19 +683,17 @@
         "fmov s0, #0x70 (1.0000)",
         "fdiv s0, s0, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vandps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x54 128-bit"
       ],
       "ExpectedArm64ASM": [
         "and v16.16b, v16.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vandps ymm0, ymm1": {
@@ -741,14 +710,13 @@
       ]
     },
     "vandpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x54 128-bit"
       ],
       "ExpectedArm64ASM": [
         "and v16.16b, v16.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vandpd ymm0, ymm1": {
@@ -765,14 +733,13 @@
       ]
     },
     "vandnps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x55 128-bit"
       ],
       "ExpectedArm64ASM": [
         "bic v16.16b, v17.16b, v16.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vandnps ymm0, ymm1": {
@@ -789,14 +756,13 @@
       ]
     },
     "vandnpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x55 128-bit"
       ],
       "ExpectedArm64ASM": [
         "bic v16.16b, v17.16b, v16.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vandnpd ymm0, ymm1": {
@@ -813,14 +779,13 @@
       ]
     },
     "vorps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x56 128-bit"
       ],
       "ExpectedArm64ASM": [
         "orr v16.16b, v16.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vorps ymm0, ymm1": {
@@ -837,14 +802,13 @@
       ]
     },
     "vorpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x56 128-bit"
       ],
       "ExpectedArm64ASM": [
         "orr v16.16b, v16.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vorpd ymm0, ymm1": {
@@ -861,14 +825,13 @@
       ]
     },
     "vxorps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x57 128-bit"
       ],
       "ExpectedArm64ASM": [
         "eor v16.16b, v16.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vxorps ymm0, ymm1": {
@@ -885,14 +848,13 @@
       ]
     },
     "vxorpd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x57 128-bit"
       ],
       "ExpectedArm64ASM": [
         "eor v16.16b, v16.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vxorpd ymm0, ymm1": {
@@ -916,7 +878,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vxorps ymm0, ymm1, ymm1": {
@@ -927,7 +889,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vxorpd xmm0, xmm1, xmm1": {
@@ -938,7 +900,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vxorpd ymm0, ymm1, ymm1": {
@@ -949,18 +911,17 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpunpcklbw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x60 128-bit"
       ],
       "ExpectedArm64ASM": [
         "zip1 v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpunpcklbw ymm0, ymm1, ymm2": {
@@ -977,14 +938,13 @@
       ]
     },
     "vpunpcklwd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x61 128-bit"
       ],
       "ExpectedArm64ASM": [
         "zip1 v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpunpcklwd ymm0, ymm1, ymm2": {
@@ -1001,14 +961,13 @@
       ]
     },
     "vpunpckldq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x62 128-bit"
       ],
       "ExpectedArm64ASM": [
         "zip1 v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpunpckldq ymm0, ymm1, ymm2": {
@@ -1025,15 +984,14 @@
       ]
     },
     "vpacksswb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0x63 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqxtn v16.8b, v17.8h",
         "sqxtn2 v16.16b, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpacksswb ymm0, ymm1, ymm2": {
@@ -1052,14 +1010,13 @@
       ]
     },
     "vpcmpgtb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x64 128-bit"
       ],
       "ExpectedArm64ASM": [
         "cmgt v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpcmpgtb ymm0, ymm1, ymm2": {
@@ -1076,14 +1033,13 @@
       ]
     },
     "vpcmpgtw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x65 128-bit"
       ],
       "ExpectedArm64ASM": [
         "cmgt v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpcmpgtw ymm0, ymm1, ymm2": {
@@ -1100,14 +1056,13 @@
       ]
     },
     "vpcmpgtd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x66 128-bit"
       ],
       "ExpectedArm64ASM": [
         "cmgt v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpcmpgtd ymm0, ymm1, ymm2": {
@@ -1124,15 +1079,14 @@
       ]
     },
     "vpackuswb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0x67 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqxtun v16.8b, v17.8h",
         "sqxtun2 v16.16b, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpackuswb ymm0, ymm1, ymm2": {
@@ -1151,53 +1105,49 @@
       ]
     },
     "vpshufd xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "dup v16.4s, v17.s[0]",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshufd xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "ldr x0, [x28, #2096]",
-        "ldr q3, [x0, #16]",
-        "tbl v16.16b, {v17.16b}, v3.16b",
-        "str q2, [x28, #16]"
+        "ldr q2, [x0, #16]",
+        "tbl v16.16b, {v17.16b}, v2.16b",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshufd xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "ldr x0, [x28, #2096]",
-        "ldr q3, [x0, #32]",
-        "tbl v16.16b, {v17.16b}, v3.16b",
-        "str q2, [x28, #16]"
+        "ldr q2, [x0, #32]",
+        "tbl v16.16b, {v17.16b}, v2.16b",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshufd xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "ldr x0, [x28, #2096]",
-        "ldr q3, [x0, #48]",
-        "tbl v16.16b, {v17.16b}, v3.16b",
-        "str q2, [x28, #16]"
+        "ldr q2, [x0, #48]",
+        "tbl v16.16b, {v17.16b}, v2.16b",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshufd ymm0, ymm1, 00b": {
@@ -1255,19 +1205,18 @@
       ]
     },
     "vpshufhw xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "dup v2.8h, v17.h[4]",
         "trn1 v16.2d, v17.2d, v2.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshufhw xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
@@ -1275,12 +1224,11 @@
         "ldr x0, [x28, #2088]",
         "ldr q2, [x0, #16]",
         "tbl v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshufhw xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
@@ -1288,12 +1236,11 @@
         "ldr x0, [x28, #2088]",
         "ldr q2, [x0, #32]",
         "tbl v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshufhw xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x70 128-bit"
       ],
@@ -1301,8 +1248,7 @@
         "ldr x0, [x28, #2088]",
         "ldr q2, [x0, #48]",
         "tbl v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshufhw ymm0, ymm1, 00b": {
@@ -1362,19 +1308,18 @@
       ]
     },
     "vpshuflw xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
       "ExpectedArm64ASM": [
         "dup v2.8h, v17.h[0]",
         "trn2 v16.2d, v2.2d, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshuflw xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
@@ -1382,12 +1327,11 @@
         "ldr x0, [x28, #2080]",
         "ldr q2, [x0, #16]",
         "tbl v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshuflw xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
@@ -1395,12 +1339,11 @@
         "ldr x0, [x28, #2080]",
         "ldr q2, [x0, #32]",
         "tbl v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshuflw xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x70 128-bit"
       ],
@@ -1408,8 +1351,7 @@
         "ldr x0, [x28, #2080]",
         "ldr q2, [x0, #48]",
         "tbl v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshuflw ymm0, ymm1, 00b": {
@@ -1469,14 +1411,13 @@
       ]
     },
     "vpcmpeqb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x74 128-bit"
       ],
       "ExpectedArm64ASM": [
         "cmeq v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpcmpeqb ymm0, ymm1, ymm2": {
@@ -1493,14 +1434,13 @@
       ]
     },
     "vpcmpeqw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x75 128-bit"
       ],
       "ExpectedArm64ASM": [
         "cmeq v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpcmpeqw ymm0, ymm1, ymm2": {
@@ -1517,14 +1457,13 @@
       ]
     },
     "vpcmpeqd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x76 128-bit"
       ],
       "ExpectedArm64ASM": [
         "cmeq v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpcmpeqd ymm0, ymm1, ymm2": {
@@ -1592,14 +1531,13 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmeq v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x00": {
@@ -1616,14 +1554,13 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmgt v16.4s, v18.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x01": {
@@ -1640,14 +1577,13 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmge v16.4s, v18.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x02": {
@@ -1664,7 +1600,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
@@ -1673,8 +1609,7 @@
         "fcmgt v1.4s, v18.4s, v17.4s",
         "orr v16.16b, v0.16b, v1.16b",
         "mvn v16.16b, v16.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x03": {
@@ -1697,15 +1632,14 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmeq v16.4s, v17.4s, v18.4s",
         "mvn v16.16b, v16.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x04": {
@@ -1724,15 +1658,14 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmgt v2.4s, v18.4s, v17.4s",
         "mvn v16.16b, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x05": {
@@ -1751,15 +1684,14 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmge v2.4s, v18.4s, v17.4s",
         "mvn v16.16b, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x06": {
@@ -1778,7 +1710,7 @@
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b00 0xC2 128-bit"
       ],
@@ -1786,8 +1718,7 @@
         "fcmge v0.4s, v17.4s, v18.4s",
         "fcmgt v1.4s, v18.4s, v17.4s",
         "orr v16.16b, v0.16b, v1.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpps ymm0, ymm1, ymm2, 0x07": {
@@ -1808,14 +1739,13 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmeq v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x00": {
@@ -1832,14 +1762,13 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmgt v16.2d, v18.2d, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x01": {
@@ -1856,14 +1785,13 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmge v16.2d, v18.2d, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x02": {
@@ -1880,7 +1808,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
@@ -1889,8 +1817,7 @@
         "fcmgt v1.2d, v18.2d, v17.2d",
         "orr v16.16b, v0.16b, v1.16b",
         "mvn v16.16b, v16.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x03": {
@@ -1913,15 +1840,14 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmeq v16.2d, v17.2d, v18.2d",
         "mvn v16.16b, v16.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x04": {
@@ -1940,15 +1866,14 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmgt v2.2d, v18.2d, v17.2d",
         "mvn v16.16b, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x05": {
@@ -1967,15 +1892,14 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcmge v2.2d, v18.2d, v17.2d",
         "mvn v16.16b, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x06": {
@@ -1994,7 +1918,7 @@
       ]
     },
     "vcmppd xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0xC2 128-bit"
       ],
@@ -2002,8 +1926,7 @@
         "fcmge v0.2d, v17.2d, v18.2d",
         "fcmgt v1.2d, v18.2d, v17.2d",
         "orr v16.16b, v0.16b, v1.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmppd ymm0, ymm1, ymm2, 0x07": {
@@ -2024,7 +1947,7 @@
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2032,12 +1955,11 @@
         "mov v16.16b, v17.16b",
         "fcmeq s0, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2045,12 +1967,11 @@
         "mov v16.16b, v17.16b",
         "fcmgt s0, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2058,12 +1979,11 @@
         "mov v16.16b, v17.16b",
         "fcmge s0, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2074,12 +1994,11 @@
         "orr v0.8b, v0.8b, v1.8b",
         "mvn v0.8b, v0.8b",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2088,12 +2007,11 @@
         "fcmeq s0, s18, s17",
         "mvn v0.8b, v0.8b",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2102,12 +2020,11 @@
         "mvn v2.16b, v2.16b",
         "mov v16.16b, v17.16b",
         "mov v16.s[0], v2.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2116,12 +2033,11 @@
         "mvn v2.16b, v2.16b",
         "mov v16.16b, v17.16b",
         "mov v16.s[0], v2.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpss xmm0, xmm1, xmm2, 0x07": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b10 0xC2 128-bit"
       ],
@@ -2131,12 +2047,11 @@
         "fcmgt s1, s18, s17",
         "orr v0.8b, v0.8b, v1.8b",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x00": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2144,12 +2059,11 @@
         "mov v16.16b, v17.16b",
         "fcmeq d0, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x01": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2157,12 +2071,11 @@
         "mov v16.16b, v17.16b",
         "fcmgt d0, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x02": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
       ],
@@ -2170,69 +2083,10 @@
         "mov v16.16b, v17.16b",
         "fcmge d0, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcmpsd xmm0, xmm1, xmm2, 0x03": {
-      "ExpectedInstructionCount": 8,
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov v16.16b, v17.16b",
-        "fcmge d0, d17, d18",
-        "fcmgt d1, d18, d17",
-        "orr v0.8b, v0.8b, v1.8b",
-        "mvn v0.8b, v0.8b",
-        "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x04": {
-      "ExpectedInstructionCount": 6,
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov v16.16b, v17.16b",
-        "fcmeq d0, d18, d17",
-        "mvn v0.8b, v0.8b",
-        "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x05": {
-      "ExpectedInstructionCount": 6,
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "fcmgt d2, d18, d17",
-        "mvn v2.16b, v2.16b",
-        "mov v16.16b, v17.16b",
-        "mov v16.d[0], v2.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x06": {
-      "ExpectedInstructionCount": 6,
-      "Comment": [
-        "Map 1 0b11 0xC2 128-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "fcmge d2, d18, d17",
-        "mvn v2.16b, v2.16b",
-        "mov v16.16b, v17.16b",
-        "mov v16.d[0], v2.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
-      ]
-    },
-    "vcmpsd xmm0, xmm1, xmm2, 0x07": {
       "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 1 0b11 0xC2 128-bit"
@@ -2242,56 +2096,105 @@
         "fcmge d0, d17, d18",
         "fcmgt d1, d18, d17",
         "orr v0.8b, v0.8b, v1.8b",
+        "mvn v0.8b, v0.8b",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x04": {
+      "ExpectedInstructionCount": 5,
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov v16.16b, v17.16b",
+        "fcmeq d0, d18, d17",
+        "mvn v0.8b, v0.8b",
+        "mov v16.d[0], v0.d[0]",
+        "stp xzr, xzr, [x28, #16]"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x05": {
+      "ExpectedInstructionCount": 5,
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcmgt d2, d18, d17",
+        "mvn v2.16b, v2.16b",
+        "mov v16.16b, v17.16b",
+        "mov v16.d[0], v2.d[0]",
+        "stp xzr, xzr, [x28, #16]"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x06": {
+      "ExpectedInstructionCount": 5,
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcmge d2, d18, d17",
+        "mvn v2.16b, v2.16b",
+        "mov v16.16b, v17.16b",
+        "mov v16.d[0], v2.d[0]",
+        "stp xzr, xzr, [x28, #16]"
+      ]
+    },
+    "vcmpsd xmm0, xmm1, xmm2, 0x07": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "Map 1 0b11 0xC2 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov v16.16b, v17.16b",
+        "fcmge d0, d17, d18",
+        "fcmgt d1, d18, d17",
+        "orr v0.8b, v0.8b, v1.8b",
+        "mov v16.d[0], v0.d[0]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrw xmm0, xmm0, eax, 000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.h[0], w4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.h[0], w4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.h[1], w4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 111b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.h[7], w4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpextrw eax, xmm0, 000b": {
@@ -2349,7 +2252,7 @@
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 00b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
@@ -2357,8 +2260,7 @@
         "dup v2.4s, v17.s[0]",
         "dup v3.4s, v18.s[0]",
         "zip1 v16.2d, v2.2d, v3.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 00b": {
@@ -2379,7 +2281,7 @@
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 01b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
@@ -2387,8 +2289,7 @@
         "ldr x0, [x28, #2104]",
         "ldr q2, [x0, #16]",
         "tbl v16.16b, {v17.16b, v18.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 01b": {
@@ -2407,7 +2308,7 @@
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 10b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
@@ -2415,8 +2316,7 @@
         "ldr x0, [x28, #2104]",
         "ldr q2, [x0, #32]",
         "tbl v16.16b, {v17.16b, v18.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 10b": {
@@ -2435,7 +2335,7 @@
       ]
     },
     "vshufps xmm0, xmm1, xmm2, 11b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b00 0xC6 128-bit"
       ],
@@ -2443,8 +2343,7 @@
         "ldr x0, [x28, #2104]",
         "ldr q2, [x0, #48]",
         "tbl v16.16b, {v17.16b, v18.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vshufps ymm0, ymm1, ymm2, 11b": {
@@ -2463,14 +2362,13 @@
       ]
     },
     "vshufpd xmm0, xmm1, xmm2, 0b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xC6 128-bit"
       ],
       "ExpectedArm64ASM": [
         "zip1 v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vshufpd ymm0, ymm1, ymm2, 0b": {
@@ -2487,14 +2385,13 @@
       ]
     },
     "vshufpd xmm0, xmm1, xmm2, 1b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xC6 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ext v16.16b, v17.16b, v18.16b, #8",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vshufpd ymm0, ymm1, ymm2, 1b": {
@@ -2511,14 +2408,13 @@
       ]
     },
     "vmovaps xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x28 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovaps ymm0, [rax]": {
@@ -2532,13 +2428,12 @@
       ]
     },
     "vmovaps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x29 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
@@ -2554,14 +2449,13 @@
       ]
     },
     "vmovapd xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x28 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovapd ymm0, [rax]": {
@@ -2575,13 +2469,12 @@
       ]
     },
     "vmovapd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x29 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
@@ -2635,7 +2528,7 @@
       ]
     },
     "vcvtsi2ss xmm0, xmm1, eax": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x2A 128-bit"
       ],
@@ -2643,12 +2536,11 @@
         "mov v16.16b, v17.16b",
         "scvtf s0, w4",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtsi2ss xmm0, xmm1, rax": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x2A 128-bit"
       ],
@@ -2656,12 +2548,11 @@
         "mov v16.16b, v17.16b",
         "scvtf s0, x4",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtsi2sd xmm0, xmm1, eax": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x2A 128-bit"
       ],
@@ -2669,12 +2560,11 @@
         "mov v16.16b, v17.16b",
         "scvtf d0, w4",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtsi2sd xmm0, xmm1, rax": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x2A 128-bit"
       ],
@@ -2682,8 +2572,7 @@
         "mov v16.16b, v17.16b",
         "scvtf d0, x4",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovntps [rax], xmm0": {
@@ -2901,14 +2790,13 @@
       ]
     },
     "vaddps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fadd v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaddps ymm0, ymm1, ymm2": {
@@ -2925,14 +2813,13 @@
       ]
     },
     "vaddpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fadd v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaddpd ymm0, ymm1, ymm2": {
@@ -2949,7 +2836,7 @@
       ]
     },
     "vaddss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x58 128-bit"
       ],
@@ -2957,12 +2844,11 @@
         "mov v16.16b, v17.16b",
         "fadd s0, s17, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaddsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x58 128-bit"
       ],
@@ -2970,19 +2856,17 @@
         "mov v16.16b, v17.16b",
         "fadd d0, d17, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmulps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmul v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmulps ymm0, ymm1, ymm2": {
@@ -2999,14 +2883,13 @@
       ]
     },
     "vmulpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmul v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmulpd ymm0, ymm1, ymm2": {
@@ -3023,7 +2906,7 @@
       ]
     },
     "vmulss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x59 128-bit"
       ],
@@ -3031,12 +2914,11 @@
         "mov v16.16b, v17.16b",
         "fmul s0, s17, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmulsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x59 128-bit"
       ],
@@ -3044,35 +2926,32 @@
         "mov v16.16b, v17.16b",
         "fmul d0, d17, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtps2pd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x5a 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcvtl v16.2d, v17.2s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtpd2ps xmm0, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0x5a 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
         "fcvtn v16.2s, v2.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtpd2ps xmm0, yword [rax]": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b01 0x5a 128-bit"
       ],
@@ -3082,23 +2961,21 @@
         "fcvtn v3.2s, v3.2d",
         "mov v16.16b, v2.16b",
         "mov v16.d[1], v3.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtpd2ps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x5a 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcvtn v16.2s, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtss2sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x5a 128-bit"
       ],
@@ -3106,12 +2983,11 @@
         "mov v16.16b, v17.16b",
         "fcvt d0, s18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtsd2ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x5a 128-bit"
       ],
@@ -3119,19 +2995,17 @@
         "mov v16.16b, v17.16b",
         "fcvt s0, d18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtdq2ps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
         "scvtf v16.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtdq2ps ymm0, ymm1": {
@@ -3147,7 +3021,7 @@
       ]
     },
     "vcvtps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 1 0b01 0x5b 128-bit"
       ],
@@ -3159,8 +3033,7 @@
         "fcmgt v2.4s, v4.4s, v2.4s",
         "mov v16.16b, v2.16b",
         "bsl v16.16b, v5.16b, v3.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtps2dq ymm0, ymm1": {
@@ -3185,7 +3058,7 @@
       ]
     },
     "vcvttps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 1 0b10 0x5b 128-bit"
       ],
@@ -3196,8 +3069,7 @@
         "fcmgt v3.4s, v3.4s, v17.4s",
         "mov v16.16b, v3.16b",
         "bsl v16.16b, v4.16b, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvttps2dq ymm0, ymm1": {
@@ -3220,14 +3092,13 @@
       ]
     },
     "vsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x5c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fsub v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vsubps ymm0, ymm1, ymm2": {
@@ -3244,14 +3115,13 @@
       ]
     },
     "vsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x5c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fsub v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vsubpd ymm0, ymm1, ymm2": {
@@ -3268,7 +3138,7 @@
       ]
     },
     "vsubss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x5c 128-bit"
       ],
@@ -3276,12 +3146,11 @@
         "mov v16.16b, v17.16b",
         "fsub s0, s17, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vsubsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x5c 128-bit"
       ],
@@ -3289,12 +3158,11 @@
         "mov v16.16b, v17.16b",
         "fsub d0, d17, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vminps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b00 0x5d 128-bit"
       ],
@@ -3302,8 +3170,7 @@
         "fcmgt v0.4s, v18.4s, v17.4s",
         "mov v16.16b, v17.16b",
         "bif v16.16b, v18.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vminps ymm0, ymm1, ymm2": {
@@ -3323,7 +3190,7 @@
       ]
     },
     "vminpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0x5d 128-bit"
       ],
@@ -3331,8 +3198,7 @@
         "fcmgt v0.2d, v18.2d, v17.2d",
         "mov v16.16b, v17.16b",
         "bif v16.16b, v18.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vminpd ymm0, ymm1, ymm2": {
@@ -3352,7 +3218,7 @@
       ]
     },
     "vminss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 1 0b10 0x5d 128-bit"
       ],
@@ -3362,13 +3228,12 @@
         "fcmp s17, s18",
         "fcsel s0, s17, s18, mi",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
         "msr nzcv, x20",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vminsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 1 0b11 0x5d 128-bit"
       ],
@@ -3378,20 +3243,18 @@
         "fcmp d17, d18",
         "fcsel d0, d17, d18, mi",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
         "msr nzcv, x20",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdivps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x5e 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fdiv v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdivps ymm0, ymm0, ymm2": {
@@ -3436,14 +3299,13 @@
       ]
     },
     "vdivpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x5e 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fdiv v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdivpd ymm0, ymm1, ymm0": {
@@ -3488,7 +3350,7 @@
       ]
     },
     "vdivss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b10 0x5e 128-bit"
       ],
@@ -3496,12 +3358,11 @@
         "mov v16.16b, v17.16b",
         "fdiv s0, s17, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdivsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x5e 128-bit"
       ],
@@ -3509,12 +3370,11 @@
         "mov v16.16b, v17.16b",
         "fdiv d0, d17, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmaxps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b00 0x5f 128-bit"
       ],
@@ -3522,8 +3382,7 @@
         "fcmgt v0.4s, v18.4s, v17.4s",
         "mov v16.16b, v17.16b",
         "bit v16.16b, v18.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmaxps ymm0, ymm1, ymm2": {
@@ -3543,7 +3402,7 @@
       ]
     },
     "vmaxpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0x5f 128-bit"
       ],
@@ -3551,8 +3410,7 @@
         "fcmgt v0.2d, v18.2d, v17.2d",
         "mov v16.16b, v17.16b",
         "bit v16.16b, v18.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmaxpd ymm0, ymm1, ymm2": {
@@ -3572,7 +3430,7 @@
       ]
     },
     "vmaxss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 1 0b10 0x5f 128-bit"
       ],
@@ -3582,13 +3440,12 @@
         "fcmp s17, s18",
         "fcsel s0, s17, s18, gt",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
         "msr nzcv, x20",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmaxsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 1 0b11 0x5f 128-bit"
       ],
@@ -3598,20 +3455,18 @@
         "fcmp d17, d18",
         "fcsel d0, d17, d18, gt",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
         "msr nzcv, x20",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpunpckhbw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x68 128-bit"
       ],
       "ExpectedArm64ASM": [
         "zip2 v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpunpckhbw ymm0, ymm1, ymm2": {
@@ -3628,14 +3483,13 @@
       ]
     },
     "vpunpckhwd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x69 128-bit"
       ],
       "ExpectedArm64ASM": [
         "zip2 v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpunpckhwd ymm0, ymm1, ymm2": {
@@ -3652,14 +3506,13 @@
       ]
     },
     "vpunpckhdq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x6a 128-bit"
       ],
       "ExpectedArm64ASM": [
         "zip2 v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpunpckhdq ymm0, ymm1, ymm2": {
@@ -3676,15 +3529,14 @@
       ]
     },
     "vpackssdw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0x6b 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqxtn v16.4h, v17.4s",
         "sqxtn2 v16.8h, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpackssdw ymm0, ymm1, ymm2": {
@@ -3703,14 +3555,13 @@
       ]
     },
     "vpunpcklqdq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x6c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "zip1 v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpunpcklqdq ymm0, ymm1, ymm2": {
@@ -3727,14 +3578,13 @@
       ]
     },
     "vpunpckhqdq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x6d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "zip2 v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpunpckhqdq ymm0, ymm1, ymm2": {
@@ -3751,36 +3601,33 @@
       ]
     },
     "vmovd xmm0, dword [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x6e 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr s16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovq xmm0, qword [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x6e 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr d16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovdqa xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x6f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovdqa [rax], xmm0": {
@@ -3793,14 +3640,13 @@
       ]
     },
     "vmovdqu xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x6f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovdqu [rax], xmm0": {
@@ -3813,14 +3659,13 @@
       ]
     },
     "vhaddpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x7c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "faddp v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vhaddpd ymm0, ymm1, ymm2": {
@@ -3837,14 +3682,13 @@
       ]
     },
     "vhaddps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0x7c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "faddp v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vhaddps ymm0, ymm1, ymm2": {
@@ -3861,7 +3705,7 @@
       ]
     },
     "vhsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0x7d 128-bit"
       ],
@@ -3869,8 +3713,7 @@
         "uzp1 v2.2d, v17.2d, v18.2d",
         "uzp2 v3.2d, v17.2d, v18.2d",
         "fsub v16.2d, v2.2d, v3.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vhsubpd ymm0, ymm1, ymm2": {
@@ -3891,7 +3734,7 @@
       ]
     },
     "vhsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0x7d 128-bit"
       ],
@@ -3899,8 +3742,7 @@
         "uzp1 v2.4s, v17.4s, v18.4s",
         "uzp2 v3.4s, v17.4s, v18.4s",
         "fsub v16.4s, v2.4s, v3.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vhsubps ymm0, ymm1, ymm2": {
@@ -3979,7 +3821,7 @@
       ]
     },
     "vaddsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0xd0 128-bit"
       ],
@@ -3987,8 +3829,7 @@
         "ldr q2, [x28, #2464]",
         "eor v2.16b, v18.16b, v2.16b",
         "fadd v16.2d, v17.2d, v2.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaddsubpd ymm0, ymm1, ymm2": {
@@ -4008,7 +3849,7 @@
       ]
     },
     "vaddsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0xd0 128-bit"
       ],
@@ -4016,8 +3857,7 @@
         "ldr q2, [x28, #2432]",
         "eor v2.16b, v18.16b, v2.16b",
         "fadd v16.4s, v17.4s, v2.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaddsubps ymm0, ymm1, ymm2": {
@@ -4037,7 +3877,7 @@
       ]
     },
     "vpsrlw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b01 0xd1 128-bit"
       ],
@@ -4047,8 +3887,7 @@
         "dup v0.8h, v0.h[0]",
         "neg v0.8h, v0.8h",
         "ushl v16.8h, v17.8h, v0.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrlw ymm0, ymm1, xmm2": {
@@ -4072,7 +3911,7 @@
       ]
     },
     "vpsrld xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b01 0xd2 128-bit"
       ],
@@ -4082,8 +3921,7 @@
         "dup v0.4s, v0.s[0]",
         "neg v0.4s, v0.4s",
         "ushl v16.4s, v17.4s, v0.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrld ymm0, ymm1, xmm2": {
@@ -4107,7 +3945,7 @@
       ]
     },
     "vpsrlq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b01 0xd3 128-bit"
       ],
@@ -4117,8 +3955,7 @@
         "dup v0.2d, v0.d[0]",
         "neg v0.2d, v0.2d",
         "ushl v16.2d, v17.2d, v0.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrlq ymm0, ymm1, xmm2": {
@@ -4142,14 +3979,13 @@
       ]
     },
     "vpaddq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xd4 128-bit"
       ],
       "ExpectedArm64ASM": [
         "add v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpaddq ymm0, ymm1, ymm2": {
@@ -4166,14 +4002,13 @@
       ]
     },
     "vpmullw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xd5 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mul v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmullw ymm0, ymm1, ymm2": {
@@ -4238,14 +4073,13 @@
       ]
     },
     "vpsubusb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xd8 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uqsub v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsubusb ymm0, ymm1, ymm2": {
@@ -4262,14 +4096,13 @@
       ]
     },
     "vpsubusw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xd9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uqsub v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsubusw ymm0, ymm1, ymm2": {
@@ -4286,14 +4119,13 @@
       ]
     },
     "vpminub xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xda 128-bit"
       ],
       "ExpectedArm64ASM": [
         "umin v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpminub ymm0, ymm1, ymm0": {
@@ -4338,14 +4170,13 @@
       ]
     },
     "vpand xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xdb 128-bit"
       ],
       "ExpectedArm64ASM": [
         "and v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpand ymm0, ymm1, ymm2": {
@@ -4362,14 +4193,13 @@
       ]
     },
     "vpaddusb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xdc 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uqadd v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpaddusb ymm0, ymm1, ymm2": {
@@ -4386,14 +4216,13 @@
       ]
     },
     "vpaddusw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xdd 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uqadd v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpaddusw ymm0, ymm1, ymm2": {
@@ -4410,15 +4239,14 @@
       ]
     },
     "vpmaxub xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Aliasing source and destination",
         "Map 1 0b01 0xdd 128-bit"
       ],
       "ExpectedArm64ASM": [
         "umax v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaxub ymm0, ymm0, ymm2": {
@@ -4463,14 +4291,13 @@
       ]
     },
     "vpandn xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xdf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "bic v16.16b, v18.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpandn ymm0, ymm1, ymm2": {
@@ -4487,14 +4314,13 @@
       ]
     },
     "vpavgb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xe0 128-bit"
       ],
       "ExpectedArm64ASM": [
         "urhadd v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpavgb ymm0, ymm1, ymm0": {
@@ -4539,7 +4365,7 @@
       ]
     },
     "vpsraw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b01 0xe1 128-bit"
       ],
@@ -4549,8 +4375,7 @@
         "dup v0.8h, v0.h[0]",
         "neg v0.8h, v0.8h",
         "sshl v16.8h, v17.8h, v0.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsraw ymm0, ymm1, xmm2": {
@@ -4574,7 +4399,7 @@
       ]
     },
     "vpsrad xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b01 0xe2 128-bit"
       ],
@@ -4584,8 +4409,7 @@
         "dup v0.4s, v0.s[0]",
         "neg v0.4s, v0.4s",
         "sshl v16.4s, v17.4s, v0.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrad ymm0, ymm1, xmm2": {
@@ -4609,14 +4433,13 @@
       ]
     },
     "vpavgw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xe3 128-bit"
       ],
       "ExpectedArm64ASM": [
         "urhadd v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpavgw ymm0, ymm1, ymm0": {
@@ -4661,7 +4484,7 @@
       ]
     },
     "vpmulhuw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0xe4 128-bit"
       ],
@@ -4669,8 +4492,7 @@
         "umull2 v0.4s, v17.8h, v18.8h",
         "umull v16.4s, v17.4h, v18.4h",
         "uzp2 v16.8h, v16.8h, v0.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmulhuw ymm0, ymm1, ymm2": {
@@ -4691,7 +4513,7 @@
       ]
     },
     "vpmulhw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0xe5 128-bit"
       ],
@@ -4699,8 +4521,7 @@
         "smull2 v0.4s, v17.8h, v18.8h",
         "smull v16.4s, v17.4h, v18.4h",
         "uzp2 v16.8h, v16.8h, v0.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmulhw ymm0, ymm1, ymm2": {
@@ -4721,7 +4542,7 @@
       ]
     },
     "vcvttpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 1 0b01 0xe6 128-bit"
       ],
@@ -4735,12 +4556,11 @@
         "shrn v3.2s, v3.2d, #32",
         "mov v16.16b, v3.16b",
         "bsl v16.16b, v4.16b, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvttpd2dq xmm0, ymm1": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "Map 1 0b01 0xe6 256-bit"
       ],
@@ -4761,20 +4581,18 @@
         "shrn v2.2s, v2.2d, #32",
         "bsl v2.16b, v6.16b, v3.16b",
         "zip1 v16.2d, v5.2d, v2.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtdq2pd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b10 0xe6 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sxtl v2.2d, v17.2s",
         "scvtf v16.2d, v2.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtdq2pd ymm0, xmm1": {
@@ -4791,7 +4609,7 @@
       ]
     },
     "vcvtpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Comment": [
         "Map 1 0b11 0xe6 128-bit"
       ],
@@ -4806,12 +4624,11 @@
         "shrn v2.2s, v2.2d, #32",
         "mov v16.16b, v2.16b",
         "bsl v16.16b, v5.16b, v3.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtpd2dq xmm0, ymm1": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 19,
       "Comment": [
         "Map 1 0b11 0xe6 256-bit"
       ],
@@ -4834,8 +4651,7 @@
         "shrn v2.2s, v2.2d, #32",
         "bsl v2.16b, v6.16b, v4.16b",
         "zip1 v16.2d, v3.2d, v2.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovntdq [rax], xmm0": {
@@ -4858,14 +4674,13 @@
       ]
     },
     "vpsubsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xe8 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqsub v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsubsb ymm0, ymm1, ymm2": {
@@ -4882,14 +4697,13 @@
       ]
     },
     "vpsubsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xe9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqsub v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsubsw ymm0, ymm1, ymm2": {
@@ -4906,14 +4720,13 @@
       ]
     },
     "vpminsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xea 128-bit"
       ],
       "ExpectedArm64ASM": [
         "smin v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpminsw ymm0, ymm1, ymm0": {
@@ -4958,14 +4771,13 @@
       ]
     },
     "vpor xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xeb 128-bit"
       ],
       "ExpectedArm64ASM": [
         "orr v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpor ymm0, ymm1, ymm2": {
@@ -4982,14 +4794,13 @@
       ]
     },
     "vpaddsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xec 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqadd v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpaddsb ymm0, ymm1, ymm2": {
@@ -5006,14 +4817,13 @@
       ]
     },
     "vpaddsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xed 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqadd v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpaddsw ymm0, ymm1, ymm2": {
@@ -5030,14 +4840,13 @@
       ]
     },
     "vpmaxsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xee 128-bit"
       ],
       "ExpectedArm64ASM": [
         "smax v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaxsw ymm0, ymm1, ymm0": {
@@ -5082,14 +4891,13 @@
       ]
     },
     "vpxor xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xef 128-bit"
       ],
       "ExpectedArm64ASM": [
         "eor v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpxor ymm0, ymm1, ymm2": {
@@ -5113,7 +4921,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpxor ymm0, ymm1, ymm1": {
@@ -5124,18 +4932,17 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vlddqu xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0xf0 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vlddqu ymm0, [rax]": {
@@ -5149,7 +4956,7 @@
       ]
     },
     "vpsllw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b01 0xf1 128-bit"
       ],
@@ -5158,8 +4965,7 @@
         "ushr d0, d0, #57",
         "dup v0.8h, v0.h[0]",
         "ushl v16.8h, v17.8h, v0.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsllw ymm0, ymm1, xmm2": {
@@ -5181,7 +4987,7 @@
       ]
     },
     "vpslld xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b01 0xf2 128-bit"
       ],
@@ -5190,8 +4996,7 @@
         "ushr d0, d0, #57",
         "dup v0.4s, v0.s[0]",
         "ushl v16.4s, v17.4s, v0.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpslld ymm0, ymm1, xmm2": {
@@ -5213,7 +5018,7 @@
       ]
     },
     "vpsllq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 1 0b01 0xf3 128-bit"
       ],
@@ -5222,8 +5027,7 @@
         "ushr d0, d0, #57",
         "dup v0.2d, v0.d[0]",
         "ushl v16.2d, v17.2d, v0.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsllq ymm0, ymm1, xmm2": {
@@ -5245,7 +5049,7 @@
       ]
     },
     "vpmuludq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0xf4 128-bit"
       ],
@@ -5253,8 +5057,7 @@
         "uzp1 v2.4s, v17.4s, v17.4s",
         "uzp1 v3.4s, v18.4s, v18.4s",
         "umull v16.2d, v2.2s, v3.2s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmuludq ymm0, ymm1, ymm2": {
@@ -5275,7 +5078,7 @@
       ]
     },
     "vpmaddwd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0xf5 128-bit"
       ],
@@ -5283,8 +5086,7 @@
         "smull v2.4s, v17.4h, v18.4h",
         "smull2 v3.4s, v17.8h, v18.8h",
         "addp v16.4s, v2.4s, v3.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaddwd ymm0, ymm1, ymm2": {
@@ -5305,7 +5107,7 @@
       ]
     },
     "vpsadbw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b01 0xf6 128-bit"
       ],
@@ -5315,8 +5117,7 @@
         "addv h2, v2.8h",
         "addv h3, v3.8h",
         "zip1 v16.2d, v2.2d, v3.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsadbw ymm0, ymm1, ymm2": {
@@ -5353,14 +5154,13 @@
       ]
     },
     "vpsubb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xf8 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sub v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsubb ymm0, ymm1, ymm2": {
@@ -5377,14 +5177,13 @@
       ]
     },
     "vpsubw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xf9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sub v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsubw ymm0, ymm1, ymm2": {
@@ -5401,14 +5200,13 @@
       ]
     },
     "vpsubd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xfa 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sub v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsubd ymm0, ymm1, ymm2": {
@@ -5425,14 +5223,13 @@
       ]
     },
     "vpsubq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xfb 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sub v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsubq ymm0, ymm1, ymm2": {
@@ -5449,14 +5246,13 @@
       ]
     },
     "vpaddb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xfc 128-bit"
       ],
       "ExpectedArm64ASM": [
         "add v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpaddb ymm0, ymm1, ymm2": {
@@ -5473,14 +5269,13 @@
       ]
     },
     "vpaddw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xfd 128-bit"
       ],
       "ExpectedArm64ASM": [
         "add v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpaddw ymm0, ymm1, ymm2": {
@@ -5497,14 +5292,13 @@
       ]
     },
     "vpaddd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xfe 128-bit"
       ],
       "ExpectedArm64ASM": [
         "add v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpaddd ymm0, ymm1, ymm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
@@ -12,15 +12,14 @@
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0xd0 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ext v2.16b, v18.16b, v18.16b, #8",
         "fcadd v16.2d, v17.2d, v2.2d, #90",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaddsubpd ymm0, ymm0, ymm2": {
@@ -71,15 +70,14 @@
       ]
     },
     "vaddsubps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b11 0xd0 128-bit"
       ],
       "ExpectedArm64ASM": [
         "rev64 v2.4s, v18.4s",
         "fcadd v16.4s, v17.4s, v2.4s, #90",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaddsubps ymm0, ymm1, ymm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -12,7 +12,7 @@
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x00 128-bit"
       ],
@@ -20,8 +20,7 @@
         "movi v2.16b, #0x8f",
         "and v2.16b, v18.16b, v2.16b",
         "tbl v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpshufb ymm0, ymm1, ymm2": {
@@ -41,14 +40,13 @@
       ]
     },
     "vphaddw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x01 128-bit"
       ],
       "ExpectedArm64ASM": [
         "addp v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vphaddw ymm0, ymm1, ymm2": {
@@ -65,14 +63,13 @@
       ]
     },
     "vphaddd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "addp v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vphaddd ymm0, ymm1, ymm2": {
@@ -89,7 +86,7 @@
       ]
     },
     "vphaddsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x03 128-bit"
       ],
@@ -97,8 +94,7 @@
         "uzp1 v2.8h, v17.8h, v18.8h",
         "uzp2 v3.8h, v17.8h, v18.8h",
         "sqadd v16.8h, v2.8h, v3.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vphaddsw ymm0, ymm1, ymm2": {
@@ -119,7 +115,7 @@
       ]
     },
     "vpmaddubsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0x04 128-bit"
       ],
@@ -133,8 +129,7 @@
         "uzp1 v4.8h, v2.8h, v3.8h",
         "uzp2 v2.8h, v2.8h, v3.8h",
         "sqadd v16.8h, v4.8h, v2.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaddubsw ymm0, ymm1, ymm2": {
@@ -167,7 +162,7 @@
       ]
     },
     "vphsubw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x05 128-bit"
       ],
@@ -175,8 +170,7 @@
         "uzp1 v2.8h, v17.8h, v18.8h",
         "uzp2 v3.8h, v17.8h, v18.8h",
         "sub v16.8h, v2.8h, v3.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vphsubw ymm0, ymm1, ymm2": {
@@ -197,7 +191,7 @@
       ]
     },
     "vphsubd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x06 128-bit"
       ],
@@ -205,8 +199,7 @@
         "uzp1 v2.4s, v17.4s, v18.4s",
         "uzp2 v3.4s, v17.4s, v18.4s",
         "sub v16.4s, v2.4s, v3.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vphsubd ymm0, ymm1, ymm2": {
@@ -227,7 +220,7 @@
       ]
     },
     "vphsubsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x07 128-bit"
       ],
@@ -235,8 +228,7 @@
         "uzp1 v2.8h, v17.8h, v18.8h",
         "uzp2 v3.8h, v17.8h, v18.8h",
         "sqsub v16.8h, v2.8h, v3.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vphsubsw ymm0, ymm1, ymm2": {
@@ -257,7 +249,7 @@
       ]
     },
     "vpsignb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x08 128-bit"
       ],
@@ -265,8 +257,7 @@
         "sqshl v2.16b, v18.16b, #7",
         "srshr v2.16b, v2.16b, #7",
         "mul v16.16b, v17.16b, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsignb ymm0, ymm1, ymm2": {
@@ -287,7 +278,7 @@
       ]
     },
     "vpsignw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x09 128-bit"
       ],
@@ -295,8 +286,7 @@
         "sqshl v2.8h, v18.8h, #15",
         "srshr v2.8h, v2.8h, #15",
         "mul v16.8h, v17.8h, v2.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsignw ymm0, ymm1, ymm2": {
@@ -317,7 +307,7 @@
       ]
     },
     "vpsignd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x0a 128-bit"
       ],
@@ -325,8 +315,7 @@
         "sqshl v2.4s, v18.4s, #31",
         "srshr v2.4s, v2.4s, #31",
         "mul v16.4s, v17.4s, v2.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsignd ymm0, ymm1, ymm2": {
@@ -347,7 +336,7 @@
       ]
     },
     "vpmulhrsw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "Map 2 0b01 0x0b 128-bit"
       ],
@@ -363,8 +352,7 @@
         "mov v0.16b, v2.16b",
         "shrn2 v0.8h, v3.4s, #1",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmulhrsw ymm0, ymm1, ymm2": {
@@ -399,7 +387,7 @@
       ]
     },
     "vpermilps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Comment": [
         "Map 2 0b01 0x0c 128-bit"
       ],
@@ -414,8 +402,7 @@
         "dup v3.4s, w20",
         "add v2.16b, v3.16b, v2.16b",
         "tbl v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpermilps ymm0, ymm1, ymm2": {
@@ -448,7 +435,7 @@
       ]
     },
     "vpermilpd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 16,
       "Comment": [
         "Map 2 0b01 0x0d 128-bit"
       ],
@@ -468,8 +455,7 @@
         "dup v3.2d, x20",
         "add v2.16b, v3.16b, v2.16b",
         "tbl v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpermilpd ymm0, ymm1, ymm2": {
@@ -626,14 +612,13 @@
       ]
     },
     "vcvtph2ps xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x13 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fcvtl v16.4s, v17.4h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtph2ps ymm0, xmm1": {
@@ -729,14 +714,13 @@
       ]
     },
     "vbroadcastss xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x18 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1r {v16.4s}, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vbroadcastss ymm0, [rax]": {
@@ -770,14 +754,13 @@
       ]
     },
     "vpabsb xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x1c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "abs v16.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpabsb ymm0, ymm1": {
@@ -793,14 +776,13 @@
       ]
     },
     "vpabsw xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x1d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "abs v16.8h, v17.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpabsw ymm0, ymm1": {
@@ -816,14 +798,13 @@
       ]
     },
     "vpabsd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x1e 128-bit"
       ],
       "ExpectedArm64ASM": [
         "abs v16.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpabsd ymm0, ymm1": {
@@ -839,14 +820,13 @@
       ]
     },
     "vpmovsxbw xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sxtl v16.8h, v17.8b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovsxbw ymm0, xmm1": {
@@ -862,15 +842,14 @@
       ]
     },
     "vpmovsxbd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sxtl v2.8h, v17.8b",
         "sxtl v16.4s, v2.4h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovsxbd ymm0, xmm1": {
@@ -888,7 +867,7 @@
       ]
     },
     "vpmovsxbq xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x22 128-bit"
       ],
@@ -896,8 +875,7 @@
         "sxtl v2.8h, v17.8b",
         "sxtl v2.4s, v2.4h",
         "sxtl v16.2d, v2.2s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovsxbq ymm0, xmm1": {
@@ -917,14 +895,13 @@
       ]
     },
     "vpmovsxwd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x23 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sxtl v16.4s, v17.4h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovsxwd ymm0, xmm1": {
@@ -940,15 +917,14 @@
       ]
     },
     "vpmovsxwq xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x24 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sxtl v2.4s, v17.4h",
         "sxtl v16.2d, v2.2s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovsxwq ymm0, xmm1": {
@@ -966,14 +942,13 @@
       ]
     },
     "vpmovsxdq xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x25 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sxtl v16.2d, v17.2s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovsxdq ymm0, xmm1": {
@@ -989,7 +964,7 @@
       ]
     },
     "vpmuldq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x28 128-bit"
       ],
@@ -997,8 +972,7 @@
         "uzp1 v2.4s, v17.4s, v17.4s",
         "uzp1 v3.4s, v18.4s, v18.4s",
         "smull v16.2d, v2.2s, v3.2s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmuldq ymm0, ymm1, ymm2": {
@@ -1019,14 +993,13 @@
       ]
     },
     "vpcmpeqq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x29 128-bit"
       ],
       "ExpectedArm64ASM": [
         "cmeq v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpcmpeqq ymm0, ymm1, ymm2": {
@@ -1043,14 +1016,13 @@
       ]
     },
     "vmovntdqa xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x2a 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovntdqa ymm0, [rax]": {
@@ -1065,15 +1037,14 @@
       ]
     },
     "vpackusdw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x2b 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sqxtun v16.4h, v17.4s",
         "sqxtun2 v16.8h, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpackusdw ymm0, ymm1, ymm2": {
@@ -1092,7 +1063,7 @@
       ]
     },
     "vmaskmovps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 18,
       "Comment": [
         "Map 2 0b01 0x2c 128-bit"
       ],
@@ -1114,8 +1085,7 @@
         "tbz w0, #31, #+0x8",
         "ld1 {v0.s}[3], [x1]",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmaskmovps ymm0, ymm1, [rax]": {
@@ -1164,7 +1134,7 @@
       ]
     },
     "vmaskmovpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0x2d 128-bit"
       ],
@@ -1178,8 +1148,7 @@
         "tbz x0, #63, #+0x8",
         "ld1 {v0.d}[1], [x1]",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmaskmovpd ymm0, ymm1, [rax]": {
@@ -1316,14 +1285,13 @@
       ]
     },
     "vpmovzxbw xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x30 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uxtl v16.8h, v17.8b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovzxbw ymm0, xmm1": {
@@ -1339,15 +1307,14 @@
       ]
     },
     "vpmovzxbd xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x31 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uxtl v2.8h, v17.8b",
         "uxtl v16.4s, v2.4h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovzxbd ymm0, xmm1": {
@@ -1365,7 +1332,7 @@
       ]
     },
     "vpmovzxbq xmm0, xmm1": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x32 128-bit"
       ],
@@ -1373,8 +1340,7 @@
         "uxtl v2.8h, v17.8b",
         "uxtl v2.4s, v2.4h",
         "uxtl v16.2d, v2.2s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovzxbq ymm0, xmm1": {
@@ -1394,14 +1360,13 @@
       ]
     },
     "vpmovzxwd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x33 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uxtl v16.4s, v17.4h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovzxwd ymm0, xmm1": {
@@ -1417,15 +1382,14 @@
       ]
     },
     "vpmovzxwq xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x34 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uxtl v2.4s, v17.4h",
         "uxtl v16.2d, v2.2s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovzxwq ymm0, xmm1": {
@@ -1443,14 +1407,13 @@
       ]
     },
     "vpmovzxdq xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x35 128-bit"
       ],
       "ExpectedArm64ASM": [
         "uxtl v16.2d, v17.2s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmovzxdq ymm0, xmm1": {
@@ -1497,14 +1460,13 @@
       ]
     },
     "vpcmpgtq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x37 128-bit"
       ],
       "ExpectedArm64ASM": [
         "cmgt v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpcmpgtq ymm0, ymm1, ymm2": {
@@ -1521,14 +1483,13 @@
       ]
     },
     "vpminsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x38 128-bit"
       ],
       "ExpectedArm64ASM": [
         "smin v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpminsb ymm0, ymm1, ymm0": {
@@ -1573,14 +1534,13 @@
       ]
     },
     "vpminsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x39 128-bit"
       ],
       "ExpectedArm64ASM": [
         "smin v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpminsd ymm0, ymm1, ymm0": {
@@ -1625,14 +1585,13 @@
       ]
     },
     "vpminuw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x3a 128-bit"
       ],
       "ExpectedArm64ASM": [
         "umin v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpminuw ymm0, ymm1, ymm0": {
@@ -1677,14 +1636,13 @@
       ]
     },
     "vpminud xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x3b 128-bit"
       ],
       "ExpectedArm64ASM": [
         "umin v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpminud ymm0, ymm1, ymm0": {
@@ -1729,14 +1687,13 @@
       ]
     },
     "vpmaxsb xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x3c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "smax v16.16b, v17.16b, v18.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaxsb ymm0, ymm0, ymm2": {
@@ -1780,14 +1737,13 @@
       ]
     },
     "vpmaxsd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x3d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "smax v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaxsd ymm0, ymm1, ymm0": {
@@ -1832,14 +1788,13 @@
       ]
     },
     "vpmaxuw xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x3e 128-bit"
       ],
       "ExpectedArm64ASM": [
         "umax v16.8h, v17.8h, v18.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaxuw ymm0, ymm1, ymm0": {
@@ -1884,14 +1839,13 @@
       ]
     },
     "vpmaxud xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x3f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "umax v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaxud ymm0, ymm0, ymm2": {
@@ -1935,14 +1889,13 @@
       ]
     },
     "vpmulld xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mul v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmulld ymm0, ymm1, ymm2": {
@@ -1959,7 +1912,7 @@
       ]
     },
     "vphminposuw xmm0, xmm1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 2 0b01 0x41 256-bit"
       ],
@@ -1970,12 +1923,11 @@
         "umin v2.4s, v3.4s, v2.4s",
         "uminv s2, v2.4s",
         "rev32 v16.8h, v2.8h",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrlvd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0x45 128-bit"
       ],
@@ -1984,8 +1936,7 @@
         "umin v0.4s, v0.4s, v18.4s",
         "neg v0.4s, v0.4s",
         "ushl v16.4s, v17.4s, v0.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrlvd ymm0, ymm1, ymm2": {
@@ -2008,7 +1959,7 @@
       ]
     },
     "vpsrlvq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 2 0b01 0x45 128-bit"
       ],
@@ -2019,8 +1970,7 @@
         "bif v0.16b, v18.16b, v1.16b",
         "neg v0.2d, v0.2d",
         "ushl v16.2d, v17.2d, v0.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrlvq ymm0, ymm1, ymm2": {
@@ -2047,7 +1997,7 @@
       ]
     },
     "vpsravd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0x46 128-bit"
       ],
@@ -2056,8 +2006,7 @@
         "umin v0.4s, v0.4s, v18.4s",
         "neg v0.4s, v0.4s",
         "sshl v16.4s, v17.4s, v0.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsravd ymm0, ymm1, ymm2": {
@@ -2080,7 +2029,7 @@
       ]
     },
     "vpsllvd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x47 128-bit"
       ],
@@ -2088,8 +2037,7 @@
         "movi v0.4s, #0x20, lsl #0",
         "umin v0.4s, v0.4s, v18.4s",
         "ushl v16.4s, v17.4s, v0.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsllvd ymm0, ymm1, ymm2": {
@@ -2110,7 +2058,7 @@
       ]
     },
     "vpsllvq xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x47 128-bit"
       ],
@@ -2120,8 +2068,7 @@
         "cmhi v1.2d, v18.2d, v0.2d",
         "bif v0.16b, v18.16b, v1.16b",
         "ushl v16.2d, v17.2d, v0.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsllvq ymm0, ymm1, ymm2": {
@@ -2146,25 +2093,23 @@
       ]
     },
     "vpbroadcastd xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
         "dup v16.4s, v17.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpbroadcastd xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x58 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1r {v16.4s}, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpbroadcastd ymm0, xmm1": {
@@ -2188,25 +2133,23 @@
       ]
     },
     "vpbroadcastq xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
         "dup v16.2d, v17.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpbroadcastq xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x59 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1r {v16.2d}, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpbroadcastq ymm0, xmm1": {
@@ -2241,25 +2184,23 @@
       ]
     },
     "vpbroadcastb xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
       ],
       "ExpectedArm64ASM": [
         "dup v16.16b, v17.b[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpbroadcastb xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x78 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1r {v16.16b}, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpbroadcastb ymm0, xmm1": {
@@ -2284,25 +2225,23 @@
       ]
     },
     "vpbroadcastw xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
       ],
       "ExpectedArm64ASM": [
         "dup v16.8h, v17.h[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpbroadcastw xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x79 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ld1r {v16.8h}, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpbroadcastw ymm0, xmm1": {
@@ -2327,7 +2266,7 @@
       ]
     },
     "vpmaskmovd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 18,
       "Comment": [
         "Map 2 0b01 0x8c 128-bit"
       ],
@@ -2349,8 +2288,7 @@
         "tbz w0, #31, #+0x8",
         "ld1 {v0.s}[3], [x1]",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaskmovd ymm0, ymm1, [rax]": {
@@ -2399,7 +2337,7 @@
       ]
     },
     "vpmaskmovq xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0x8c 128-bit"
       ],
@@ -2413,8 +2351,7 @@
         "tbz x0, #63, #+0x8",
         "ld1 {v0.d}[1], [x1]",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaskmovq ymm0, ymm1, [rax]": {
@@ -2577,8 +2514,8 @@
         "add x1, x4, w0, sxtw",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd xmm0, [xmm1*2 + rax], xmm2": {
@@ -2608,8 +2545,8 @@
         "add x1, x4, w0, sxtw #1",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd xmm0, [xmm1*4 + rax], xmm2": {
@@ -2639,8 +2576,8 @@
         "add x1, x4, w0, sxtw #2",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd xmm0, [xmm1*8 + rax], xmm2": {
@@ -2670,8 +2607,8 @@
         "add x1, x4, w0, sxtw #3",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd ymm0, [ymm1*1 + rax], ymm2": {
@@ -2724,7 +2661,7 @@
         "add x1, x4, w0, sxtw",
         "ld1 {v2.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2778,7 +2715,7 @@
         "add x1, x4, w0, sxtw #1",
         "ld1 {v2.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2832,7 +2769,7 @@
         "add x1, x4, w0, sxtw #2",
         "ld1 {v2.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2886,7 +2823,7 @@
         "add x1, x4, w0, sxtw #3",
         "ld1 {v2.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2907,8 +2844,8 @@
         "add x1, x4, w0, sxtw",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq xmm0, [xmm1*2 + rax], xmm2": {
@@ -2928,8 +2865,8 @@
         "add x1, x4, w0, sxtw #1",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq xmm0, [xmm1*4 + rax], xmm2": {
@@ -2949,8 +2886,8 @@
         "add x1, x4, w0, sxtw #2",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq xmm0, [xmm1*8 + rax], xmm2": {
@@ -2970,8 +2907,8 @@
         "add x1, x4, w0, sxtw #3",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq ymm0, [xmm1*1 + rax], ymm2": {
@@ -3003,7 +2940,7 @@
         "add x1, x4, w0, sxtw",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3036,7 +2973,7 @@
         "add x1, x4, w0, sxtw #1",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3069,7 +3006,7 @@
         "add x1, x4, w0, sxtw #2",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3102,7 +3039,7 @@
         "add x1, x4, w0, sxtw #3",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3125,8 +3062,8 @@
         "ld1 {v2.s}[1], [x1]",
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [xmm1*2 + rax], xmm2": {
@@ -3148,8 +3085,8 @@
         "ld1 {v2.s}[1], [x1]",
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [xmm1*4 + rax], xmm2": {
@@ -3171,8 +3108,8 @@
         "ld1 {v2.s}[1], [x1]",
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [xmm1*8 + rax], xmm2": {
@@ -3194,8 +3131,8 @@
         "ld1 {v2.s}[1], [x1]",
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*1 + rax], xmm2": {
@@ -3226,8 +3163,8 @@
         "add x1, x4, x0",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*2 + rax], xmm2": {
@@ -3258,8 +3195,8 @@
         "add x1, x4, x0, lsl #1",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*4 + rax], xmm2": {
@@ -3290,8 +3227,8 @@
         "add x1, x4, x0, lsl #2",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*8 + rax], xmm2": {
@@ -3322,8 +3259,8 @@
         "add x1, x4, x0, lsl #3",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*1 + rax], xmm2": {
@@ -3343,8 +3280,8 @@
         "add x1, x4, x0",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*2 + rax], xmm2": {
@@ -3364,8 +3301,8 @@
         "add x1, x4, x0, lsl #1",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*4 + rax], xmm2": {
@@ -3385,8 +3322,8 @@
         "add x1, x4, x0, lsl #2",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*8 + rax], xmm2": {
@@ -3406,8 +3343,8 @@
         "add x1, x4, x0, lsl #3",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq ymm0, [ymm1*1 + rax], ymm2": {
@@ -3440,7 +3377,7 @@
         "add x1, x4, x0",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3474,7 +3411,7 @@
         "add x1, x4, x0, lsl #1",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3508,7 +3445,7 @@
         "add x1, x4, x0, lsl #2",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3542,7 +3479,7 @@
         "add x1, x4, x0, lsl #3",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3573,8 +3510,8 @@
         "add x1, x4, w0, sxtw",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps xmm0, [xmm1*2 + rax], xmm2": {
@@ -3604,8 +3541,8 @@
         "add x1, x4, w0, sxtw #1",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps xmm0, [xmm1*4 + rax], xmm2": {
@@ -3635,8 +3572,8 @@
         "add x1, x4, w0, sxtw #2",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps xmm0, [xmm1*8 + rax], xmm2": {
@@ -3666,8 +3603,8 @@
         "add x1, x4, w0, sxtw #3",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps ymm0, [ymm1*1 + rax], ymm2": {
@@ -3720,7 +3657,7 @@
         "add x1, x4, w0, sxtw",
         "ld1 {v2.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3774,7 +3711,7 @@
         "add x1, x4, w0, sxtw #1",
         "ld1 {v2.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3828,7 +3765,7 @@
         "add x1, x4, w0, sxtw #2",
         "ld1 {v2.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3882,7 +3819,7 @@
         "add x1, x4, w0, sxtw #3",
         "ld1 {v2.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -3903,8 +3840,8 @@
         "add x1, x4, w0, sxtw",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd xmm0, [xmm1*2 + rax], xmm2": {
@@ -3924,8 +3861,8 @@
         "add x1, x4, w0, sxtw #1",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd xmm0, [xmm1*4 + rax], xmm2": {
@@ -3945,8 +3882,8 @@
         "add x1, x4, w0, sxtw #2",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd xmm0, [xmm1*8 + rax], xmm2": {
@@ -3966,8 +3903,8 @@
         "add x1, x4, w0, sxtw #3",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd ymm0, [xmm1*1 + rax], ymm2": {
@@ -3999,7 +3936,7 @@
         "add x1, x4, w0, sxtw",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -4032,7 +3969,7 @@
         "add x1, x4, w0, sxtw #1",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -4065,7 +4002,7 @@
         "add x1, x4, w0, sxtw #2",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -4098,7 +4035,7 @@
         "add x1, x4, w0, sxtw #3",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -4121,8 +4058,8 @@
         "ld1 {v2.s}[1], [x1]",
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [xmm1*2 + rax], xmm2": {
@@ -4144,8 +4081,8 @@
         "ld1 {v2.s}[1], [x1]",
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [xmm1*4 + rax], xmm2": {
@@ -4167,8 +4104,8 @@
         "ld1 {v2.s}[1], [x1]",
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [xmm1*8 + rax], xmm2": {
@@ -4190,8 +4127,8 @@
         "ld1 {v2.s}[1], [x1]",
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*1 + rax], xmm2": {
@@ -4222,8 +4159,8 @@
         "add x1, x4, x0",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*2 + rax], xmm2": {
@@ -4254,8 +4191,8 @@
         "add x1, x4, x0, lsl #1",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*4 + rax], xmm2": {
@@ -4286,8 +4223,8 @@
         "add x1, x4, x0, lsl #2",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*8 + rax], xmm2": {
@@ -4318,8 +4255,8 @@
         "add x1, x4, x0, lsl #3",
         "ld1 {v16.s}[3], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*1 + rax], xmm2": {
@@ -4339,8 +4276,8 @@
         "add x1, x4, x0",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*2 + rax], xmm2": {
@@ -4360,8 +4297,8 @@
         "add x1, x4, x0, lsl #1",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*4 + rax], xmm2": {
@@ -4381,8 +4318,8 @@
         "add x1, x4, x0, lsl #2",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*8 + rax], xmm2": {
@@ -4402,8 +4339,8 @@
         "add x1, x4, x0, lsl #3",
         "ld1 {v16.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd ymm0, [ymm1*1 + rax], ymm2": {
@@ -4436,7 +4373,7 @@
         "add x1, x4, x0",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -4470,7 +4407,7 @@
         "add x1, x4, x0, lsl #1",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -4504,7 +4441,7 @@
         "add x1, x4, x0, lsl #2",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -4538,12 +4475,12 @@
         "add x1, x4, x0, lsl #3",
         "ld1 {v2.d}[1], [x1]",
         "movi v18.2d, #0x0",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
     "vfmaddsub132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x96 128-bit"
       ],
@@ -4553,8 +4490,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub132ps ymm0, ymm1, ymm2": {
@@ -4577,7 +4513,7 @@
       ]
     },
     "vfmaddsub132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x96 128-bit"
       ],
@@ -4587,8 +4523,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub132pd ymm0, ymm1, ymm2": {
@@ -4611,7 +4546,7 @@
       ]
     },
     "vfmsubadd132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x97 128-bit"
       ],
@@ -4621,8 +4556,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd132ps ymm0, ymm1, ymm2": {
@@ -4645,7 +4579,7 @@
       ]
     },
     "vfmsubadd132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x97 128-bit"
       ],
@@ -4655,8 +4589,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd132pd ymm0, ymm1, ymm2": {
@@ -4679,7 +4612,7 @@
       ]
     },
     "vfmadd132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x98 128-bit"
       ],
@@ -4687,8 +4620,7 @@
         "mov v0.16b, v17.16b",
         "fmla v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd132ps ymm0, ymm1, ymm2": {
@@ -4708,7 +4640,7 @@
       ]
     },
     "vfmadd132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x98 128-bit"
       ],
@@ -4716,8 +4648,7 @@
         "mov v0.16b, v17.16b",
         "fmla v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd132pd ymm0, ymm1, ymm2": {
@@ -4737,31 +4668,29 @@
       ]
     },
     "vfmadd132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x99 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x99 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9a 128-bit"
       ],
@@ -4769,8 +4698,7 @@
         "fneg v0.4s, v17.4s",
         "fmla v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub132ps ymm0, ymm1, ymm2": {
@@ -4791,7 +4719,7 @@
       ]
     },
     "vfmsub132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9a 128-bit"
       ],
@@ -4799,8 +4727,7 @@
         "fneg v0.2d, v17.2d",
         "fmla v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub132pd ymm0, ymm1, ymm2": {
@@ -4821,31 +4748,29 @@
       ]
     },
     "vfmsub132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9b 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9b 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9c 128-bit"
       ],
@@ -4853,8 +4778,7 @@
         "mov v0.16b, v17.16b",
         "fmls v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd132ps ymm0, ymm1, ymm2": {
@@ -4874,7 +4798,7 @@
       ]
     },
     "vfnmadd132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9c 128-bit"
       ],
@@ -4882,8 +4806,7 @@
         "mov v0.16b, v17.16b",
         "fmls v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd132pd ymm0, ymm1, ymm2": {
@@ -4903,31 +4826,29 @@
       ]
     },
     "vfnmadd132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9e 128-bit"
       ],
@@ -4935,8 +4856,7 @@
         "fneg v0.4s, v17.4s",
         "fmls v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub132ps ymm0, ymm1, ymm2": {
@@ -4957,7 +4877,7 @@
       ]
     },
     "vfnmsub132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9e 128-bit"
       ],
@@ -4965,8 +4885,7 @@
         "fneg v0.2d, v17.2d",
         "fmls v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub132pd ymm0, ymm1, ymm2": {
@@ -4987,31 +4906,29 @@
       ]
     },
     "vfnmsub132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xa8 128-bit"
       ],
@@ -5019,8 +4936,7 @@
         "mov v0.16b, v18.16b",
         "fmla v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd213ps ymm0, ymm1, ymm2": {
@@ -5040,7 +4956,7 @@
       ]
     },
     "vfmadd213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xa8 128-bit"
       ],
@@ -5048,8 +4964,7 @@
         "mov v0.16b, v18.16b",
         "fmla v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd213pd ymm0, ymm1, ymm2": {
@@ -5069,31 +4984,29 @@
       ]
     },
     "vfmadd213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xa9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xa9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xaa 128-bit"
       ],
@@ -5101,8 +5014,7 @@
         "fneg v0.4s, v18.4s",
         "fmla v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub213ps ymm0, ymm1, ymm2": {
@@ -5123,7 +5035,7 @@
       ]
     },
     "vfmsub213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xaa 128-bit"
       ],
@@ -5131,8 +5043,7 @@
         "fneg v0.2d, v18.2d",
         "fmla v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub213pd ymm0, ymm1, ymm2": {
@@ -5153,31 +5064,29 @@
       ]
     },
     "vfmsub213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xab 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xab 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xac 128-bit"
       ],
@@ -5185,8 +5094,7 @@
         "mov v0.16b, v18.16b",
         "fmls v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd213ps ymm0, ymm1, ymm2": {
@@ -5206,7 +5114,7 @@
       ]
     },
     "vfnmadd213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xac 128-bit"
       ],
@@ -5214,8 +5122,7 @@
         "mov v0.16b, v18.16b",
         "fmls v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd213pd ymm0, ymm1, ymm2": {
@@ -5235,31 +5142,29 @@
       ]
     },
     "vfnmadd213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xad 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xad 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xae 128-bit"
       ],
@@ -5267,8 +5172,7 @@
         "fneg v0.4s, v18.4s",
         "fmls v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub213ps ymm0, ymm1, ymm2": {
@@ -5289,7 +5193,7 @@
       ]
     },
     "vfnmsub213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xae 128-bit"
       ],
@@ -5297,8 +5201,7 @@
         "fneg v0.2d, v18.2d",
         "fmls v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub213pd ymm0, ymm1, ymm2": {
@@ -5319,38 +5222,35 @@
       ]
     },
     "vfnmsub213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xaf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xaf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xb8 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmla v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd231ps ymm0, ymm1, ymm2": {
@@ -5368,14 +5268,13 @@
       ]
     },
     "vfmadd231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xb8 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmla v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd231pd ymm0, ymm1, ymm2": {
@@ -5393,39 +5292,36 @@
       ]
     },
     "vfmadd231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xb9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd s0, s17, s18, s16",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xb9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd d0, d17, d18, d16",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xba 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fneg v16.4s, v16.4s",
         "fmla v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub231ps ymm0, ymm1, ymm2": {
@@ -5445,15 +5341,14 @@
       ]
     },
     "vfmsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xba 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fneg v16.2d, v16.2d",
         "fmla v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub231pd ymm0, ymm1, ymm2": {
@@ -5473,38 +5368,35 @@
       ]
     },
     "vfmsub231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbb 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub s0, s17, s18, s16",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbb 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub d0, d17, d18, d16",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbc 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmls v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd231ps ymm0, ymm1, ymm2": {
@@ -5522,14 +5414,13 @@
       ]
     },
     "vfnmadd231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbc 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmls v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd231pd ymm0, ymm1, ymm2": {
@@ -5547,39 +5438,36 @@
       ]
     },
     "vfnmadd231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbd 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub s0, s17, s18, s16",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbd 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub d0, d17, d18, d16",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbe 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fneg v16.4s, v16.4s",
         "fmls v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub231ps ymm0, ymm1, ymm2": {
@@ -5599,15 +5487,14 @@
       ]
     },
     "vfnmsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbe 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fneg v16.2d, v16.2d",
         "fmls v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub231pd ymm0, ymm1, ymm2": {
@@ -5627,31 +5514,29 @@
       ]
     },
     "vfnmsub231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd s0, s17, s18, s16",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd d0, d17, d18, d16",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xa6 128-bit"
       ],
@@ -5661,8 +5546,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub213ps ymm0, ymm1, ymm2": {
@@ -5685,7 +5569,7 @@
       ]
     },
     "vfmaddsub213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xa6 128-bit"
       ],
@@ -5695,8 +5579,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub213pd ymm0, ymm1, ymm2": {
@@ -5719,7 +5602,7 @@
       ]
     },
     "vfmsubadd213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xa7 128-bit"
       ],
@@ -5729,8 +5612,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd213ps ymm0, ymm1, ymm2": {
@@ -5753,7 +5635,7 @@
       ]
     },
     "vfmsubadd213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xa7 128-bit"
       ],
@@ -5763,8 +5645,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd213pd ymm0, ymm1, ymm2": {
@@ -5787,7 +5668,7 @@
       ]
     },
     "vfmaddsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb6 128-bit"
       ],
@@ -5796,8 +5677,7 @@
         "eor v2.16b, v16.16b, v2.16b",
         "mov v16.16b, v2.16b",
         "fmla v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub231ps ymm0, ymm1, ymm2": {
@@ -5819,7 +5699,7 @@
       ]
     },
     "vfmaddsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb6 128-bit"
       ],
@@ -5828,8 +5708,7 @@
         "eor v2.16b, v16.16b, v2.16b",
         "mov v16.16b, v2.16b",
         "fmla v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub231pd ymm0, ymm1, ymm2": {
@@ -5851,7 +5730,7 @@
       ]
     },
     "vfmsubadd231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb7 128-bit"
       ],
@@ -5860,8 +5739,7 @@
         "eor v2.16b, v16.16b, v2.16b",
         "mov v16.16b, v2.16b",
         "fmla v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd231ps ymm0, ymm1, ymm2": {
@@ -5883,7 +5761,7 @@
       ]
     },
     "vfmsubadd231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb7 128-bit"
       ],
@@ -5892,8 +5770,7 @@
         "eor v2.16b, v16.16b, v2.16b",
         "mov v16.16b, v2.16b",
         "fmla v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd231pd ymm0, ymm1, ymm2": {
@@ -5915,14 +5792,13 @@
       ]
     },
     "vaesimc xmm0, xmm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xdb 128-bit"
       ],
       "ExpectedArm64ASM": [
         "aesimc v16.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaesenc xmm0, xmm1, xmm2": {
@@ -5936,7 +5812,7 @@
         "aese v0.16b, v2.16b",
         "aesmc v0.16b, v0.16b",
         "eor v16.16b, v0.16b, v18.16b",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaesenc ymm0, ymm1, ymm2": {
@@ -5969,7 +5845,7 @@
         "mov v0.16b, v17.16b",
         "aese v0.16b, v2.16b",
         "eor v16.16b, v0.16b, v18.16b",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaesenclast ymm0, ymm1, ymm2": {
@@ -6001,7 +5877,7 @@
         "aesd v0.16b, v2.16b",
         "aesimc v0.16b, v0.16b",
         "eor v16.16b, v0.16b, v18.16b",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaesdec ymm0, ymm1, ymm2": {
@@ -6034,7 +5910,7 @@
         "mov v0.16b, v17.16b",
         "aesd v0.16b, v2.16b",
         "eor v16.16b, v0.16b, v18.16b",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaesdeclast ymm0, ymm1, ymm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
@@ -11,283 +11,259 @@
   },
   "Instructions": {
     "vfmadd132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x99 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x99 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9b 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9b 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xa9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xa9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xab 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xab 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xad 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xad 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xaf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xaf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xb9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd s16, s17, s18, s16",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xb9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd d16, d17, d18, d16",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbb 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub s16, s17, s18, s16",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbb 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub d16, d17, d18, d16",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbd 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub s16, s17, s18, s16",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbd 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub d16, d17, d18, d16",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd s16, s17, s18, s16",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd d16, d17, d18, d16",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     }
   }

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -13,14 +13,13 @@
   },
   "Instructions": {
     "vmovntdqa xmm0, [rax]": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0x2a 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldnt1b {z16.b}, p6/z, [x4]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmovntdqa ymm0, [rax]": {
@@ -35,7 +34,7 @@
       ]
     },
     "vmaskmovps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0x2c 128-bit"
       ],
@@ -43,9 +42,8 @@
         "mrs x20, nzcv",
         "cmplt p0.s, p6/z, z17.s, #0",
         "ld1w {z16.s}, p0/z, [x4]",
-        "movi v2.2d, #0x0",
         "msr nzcv, x20",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmaskmovps ymm0, ymm1, [rax]": {
@@ -65,7 +63,7 @@
       ]
     },
     "vmaskmovpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0x2d 128-bit"
       ],
@@ -73,9 +71,8 @@
         "mrs x20, nzcv",
         "cmplt p0.d, p6/z, z17.d, #0",
         "ld1d {z16.d}, p0/z, [x4]",
-        "movi v2.2d, #0x0",
         "msr nzcv, x20",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmaskmovpd ymm0, ymm1, [rax]": {
@@ -162,8 +159,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd xmm0, [xmm1*2 + rax], xmm2": {
@@ -184,8 +181,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd xmm0, [xmm1*4 + rax], xmm2": {
@@ -200,8 +197,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd xmm0, [xmm1*8 + rax], xmm2": {
@@ -222,8 +219,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd ymm0, [ymm1*1 + rax], ymm2": {
@@ -244,7 +241,7 @@
         "mov z2.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -278,7 +275,7 @@
         "uzp1 v0.4s, v0.4s, v1.4s",
         "mov z2.s, p0/m, z0.s",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -300,7 +297,7 @@
         "mov z2.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -334,7 +331,7 @@
         "uzp1 v0.4s, v0.4s, v1.4s",
         "mov z2.s, p0/m, z0.s",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -351,8 +348,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq xmm0, [xmm1*2 + rax], xmm2": {
@@ -368,8 +365,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq xmm0, [xmm1*4 + rax], xmm2": {
@@ -385,8 +382,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq xmm0, [xmm1*8 + rax], xmm2": {
@@ -402,8 +399,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq ymm0, [xmm1*1 + rax], ymm2": {
@@ -425,7 +422,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -448,7 +445,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -471,7 +468,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -494,7 +491,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -513,8 +510,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [xmm1*2 + rax], xmm2": {
@@ -533,8 +530,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [xmm1*4 + rax], xmm2": {
@@ -552,8 +549,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [xmm1*8 + rax], xmm2": {
@@ -572,8 +569,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*1 + rax], xmm2": {
@@ -593,8 +590,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*2 + rax], xmm2": {
@@ -616,8 +613,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*4 + rax], xmm2": {
@@ -637,8 +634,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*8 + rax], xmm2": {
@@ -660,8 +657,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*1 + rax], xmm2": {
@@ -676,8 +673,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*2 + rax], xmm2": {
@@ -693,8 +690,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*4 + rax], xmm2": {
@@ -710,8 +707,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*8 + rax], xmm2": {
@@ -726,8 +723,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq ymm0, [ymm1*1 + rax], ymm2": {
@@ -748,7 +745,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -772,7 +769,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -796,7 +793,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -818,7 +815,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -834,8 +831,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps xmm0, [xmm1*2 + rax], xmm2": {
@@ -856,8 +853,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps xmm0, [xmm1*4 + rax], xmm2": {
@@ -872,8 +869,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps xmm0, [xmm1*8 + rax], xmm2": {
@@ -894,8 +891,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps ymm0, [ymm1*1 + rax], ymm2": {
@@ -916,7 +913,7 @@
         "mov z2.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -950,7 +947,7 @@
         "uzp1 v0.4s, v0.4s, v1.4s",
         "mov z2.s, p0/m, z0.s",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -972,7 +969,7 @@
         "mov z2.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1006,7 +1003,7 @@
         "uzp1 v0.4s, v0.4s, v1.4s",
         "mov z2.s, p0/m, z0.s",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1023,8 +1020,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd xmm0, [xmm1*2 + rax], xmm2": {
@@ -1040,8 +1037,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd xmm0, [xmm1*4 + rax], xmm2": {
@@ -1057,8 +1054,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd xmm0, [xmm1*8 + rax], xmm2": {
@@ -1074,8 +1071,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd ymm0, [xmm1*1 + rax], ymm2": {
@@ -1097,7 +1094,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1120,7 +1117,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1143,7 +1140,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1166,7 +1163,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1185,8 +1182,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [xmm1*2 + rax], xmm2": {
@@ -1205,8 +1202,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [xmm1*4 + rax], xmm2": {
@@ -1224,8 +1221,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [xmm1*8 + rax], xmm2": {
@@ -1244,8 +1241,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*1 + rax], xmm2": {
@@ -1265,8 +1262,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*2 + rax], xmm2": {
@@ -1288,8 +1285,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*4 + rax], xmm2": {
@@ -1309,8 +1306,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*8 + rax], xmm2": {
@@ -1332,8 +1329,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*1 + rax], xmm2": {
@@ -1348,8 +1345,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*2 + rax], xmm2": {
@@ -1365,8 +1362,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*4 + rax], xmm2": {
@@ -1382,8 +1379,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*8 + rax], xmm2": {
@@ -1398,8 +1395,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd ymm0, [ymm1*1 + rax], ymm2": {
@@ -1420,7 +1417,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1444,7 +1441,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1468,7 +1465,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1490,7 +1487,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1512,8 +1509,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd xmm0, [xmm1*4], xmm2": {
@@ -1529,8 +1526,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd xmm0, [xmm1*8], xmm2": {
@@ -1551,8 +1548,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdd ymm0, [ymm1*1], ymm2": {
@@ -1573,7 +1570,7 @@
         "mov z2.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1607,7 +1604,7 @@
         "uzp1 v0.4s, v0.4s, v1.4s",
         "mov z2.s, p0/m, z0.s",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1631,7 +1628,7 @@
         "mov z2.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1665,7 +1662,7 @@
         "uzp1 v0.4s, v0.4s, v1.4s",
         "mov z2.s, p0/m, z0.s",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1682,8 +1679,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq xmm0, [xmm1*2], xmm2": {
@@ -1699,8 +1696,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq xmm0, [xmm1*4], xmm2": {
@@ -1716,8 +1713,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq xmm0, [xmm1*8], xmm2": {
@@ -1733,8 +1730,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherdq ymm0, [xmm1*1], ymm2": {
@@ -1756,7 +1753,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1779,7 +1776,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1802,7 +1799,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1825,7 +1822,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -1844,8 +1841,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [xmm1*2], xmm2": {
@@ -1864,8 +1861,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [xmm1*4], xmm2": {
@@ -1884,8 +1881,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [xmm1*8], xmm2": {
@@ -1904,8 +1901,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*1], xmm2": {
@@ -1925,8 +1922,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*2], xmm2": {
@@ -1948,8 +1945,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*4], xmm2": {
@@ -1971,8 +1968,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqd xmm0, [ymm1*8], xmm2": {
@@ -1994,8 +1991,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*1], xmm2": {
@@ -2010,8 +2007,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*2], xmm2": {
@@ -2027,8 +2024,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*4], xmm2": {
@@ -2044,8 +2041,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq xmm0, [xmm1*8], xmm2": {
@@ -2061,8 +2058,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpgatherqq ymm0, [ymm1*1], ymm2": {
@@ -2083,7 +2080,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2107,7 +2104,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2131,7 +2128,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2155,7 +2152,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2171,8 +2168,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps xmm0, [xmm1*2], xmm2": {
@@ -2193,8 +2190,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps xmm0, [xmm1*4], xmm2": {
@@ -2210,8 +2207,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps xmm0, [xmm1*8], xmm2": {
@@ -2232,8 +2229,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdps ymm0, [ymm1*1], ymm2": {
@@ -2254,7 +2251,7 @@
         "mov z2.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2288,7 +2285,7 @@
         "uzp1 v0.4s, v0.4s, v1.4s",
         "mov z2.s, p0/m, z0.s",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2312,7 +2309,7 @@
         "mov z2.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2346,7 +2343,7 @@
         "uzp1 v0.4s, v0.4s, v1.4s",
         "mov z2.s, p0/m, z0.s",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2363,8 +2360,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd xmm0, [xmm1*2], xmm2": {
@@ -2380,8 +2377,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd xmm0, [xmm1*4], xmm2": {
@@ -2397,8 +2394,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd xmm0, [xmm1*8], xmm2": {
@@ -2414,8 +2411,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherdpd ymm0, [xmm1*1], ymm2": {
@@ -2437,7 +2434,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2460,7 +2457,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2483,7 +2480,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2506,7 +2503,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2525,8 +2522,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [xmm1*2], xmm2": {
@@ -2545,8 +2542,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [xmm1*4], xmm2": {
@@ -2565,8 +2562,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [xmm1*8], xmm2": {
@@ -2585,8 +2582,8 @@
         "movi v18.2d, #0x0",
         "zip1 v16.2d, v2.2d, v18.2d",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*1], xmm2": {
@@ -2606,8 +2603,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*2], xmm2": {
@@ -2629,8 +2626,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*4], xmm2": {
@@ -2652,8 +2649,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqps xmm0, [ymm1*8], xmm2": {
@@ -2675,8 +2672,8 @@
         "mov z16.s, p0/m, z0.s",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*1], xmm2": {
@@ -2691,8 +2688,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*2], xmm2": {
@@ -2708,8 +2705,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*4], xmm2": {
@@ -2725,8 +2722,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd xmm0, [xmm1*8], xmm2": {
@@ -2742,8 +2739,8 @@
         "mov z16.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
-        "str q18, [x28, #16]"
+        "stp xzr, xzr, [x28, #48]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vgatherqpd ymm0, [ymm1*1], ymm2": {
@@ -2764,7 +2761,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2788,7 +2785,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2812,7 +2809,7 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
@@ -2836,12 +2833,12 @@
         "mov z2.d, p0/m, z0.d",
         "movi v18.2d, #0x0",
         "msr nzcv, x20",
-        "str q18, [x28, #48]",
+        "stp xzr, xzr, [x28, #48]",
         "str q2, [x28, #16]"
       ]
     },
     "vfmaddsub132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x96 128-bit"
       ],
@@ -2851,8 +2848,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub132ps ymm0, ymm1, ymm2": {
@@ -2875,7 +2871,7 @@
       ]
     },
     "vfmaddsub132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x96 128-bit"
       ],
@@ -2885,8 +2881,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub132pd ymm0, ymm1, ymm2": {
@@ -2909,7 +2904,7 @@
       ]
     },
     "vfmsubadd132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x97 128-bit"
       ],
@@ -2919,8 +2914,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd132ps ymm0, ymm1, ymm2": {
@@ -2943,7 +2937,7 @@
       ]
     },
     "vfmsubadd132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0x97 128-bit"
       ],
@@ -2953,8 +2947,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd132pd ymm0, ymm1, ymm2": {
@@ -2977,7 +2970,7 @@
       ]
     },
     "vfmadd132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x98 128-bit"
       ],
@@ -2985,8 +2978,7 @@
         "mov v0.16b, v17.16b",
         "fmla v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd132ps ymm0, ymm1, ymm2": {
@@ -3006,7 +2998,7 @@
       ]
     },
     "vfmadd132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x98 128-bit"
       ],
@@ -3014,8 +3006,7 @@
         "mov v0.16b, v17.16b",
         "fmla v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd132pd ymm0, ymm1, ymm2": {
@@ -3035,31 +3026,29 @@
       ]
     },
     "vfmadd132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x99 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x99 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9a 128-bit"
       ],
@@ -3067,8 +3056,7 @@
         "mov z0.d, z17.d",
         "fnmls z0.s, p6/m, z16.s, z18.s",
         "mov z16.d, z0.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub132ps ymm0, ymm1, ymm2": {
@@ -3088,7 +3076,7 @@
       ]
     },
     "vfmsub132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9a 128-bit"
       ],
@@ -3096,8 +3084,7 @@
         "mov z0.d, z17.d",
         "fnmls z0.d, p6/m, z16.d, z18.d",
         "mov z16.d, z0.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub132pd ymm0, ymm1, ymm2": {
@@ -3117,31 +3104,29 @@
       ]
     },
     "vfmsub132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9b 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9b 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9c 128-bit"
       ],
@@ -3149,8 +3134,7 @@
         "mov v0.16b, v17.16b",
         "fmls v0.4s, v16.4s, v18.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd132ps ymm0, ymm1, ymm2": {
@@ -3170,7 +3154,7 @@
       ]
     },
     "vfnmadd132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9c 128-bit"
       ],
@@ -3178,8 +3162,7 @@
         "mov v0.16b, v17.16b",
         "fmls v0.2d, v16.2d, v18.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd132pd ymm0, ymm1, ymm2": {
@@ -3199,31 +3182,29 @@
       ]
     },
     "vfnmadd132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub132ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9e 128-bit"
       ],
@@ -3231,8 +3212,7 @@
         "mov z0.d, z17.d",
         "fnmla z0.s, p6/m, z16.s, z18.s",
         "mov z16.d, z0.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub132ps ymm0, ymm1, ymm2": {
@@ -3252,7 +3232,7 @@
       ]
     },
     "vfnmsub132pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0x9e 128-bit"
       ],
@@ -3260,8 +3240,7 @@
         "mov z0.d, z17.d",
         "fnmla z0.d, p6/m, z16.d, z18.d",
         "mov z16.d, z0.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub132pd ymm0, ymm1, ymm2": {
@@ -3281,31 +3260,29 @@
       ]
     },
     "vfnmsub132ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd s0, s16, s18, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub132sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0x9f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd d0, d16, d18, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xa8 128-bit"
       ],
@@ -3313,8 +3290,7 @@
         "mov v0.16b, v18.16b",
         "fmla v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd213ps ymm0, ymm1, ymm2": {
@@ -3334,7 +3310,7 @@
       ]
     },
     "vfmadd213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xa8 128-bit"
       ],
@@ -3342,8 +3318,7 @@
         "mov v0.16b, v18.16b",
         "fmla v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd213pd ymm0, ymm1, ymm2": {
@@ -3363,31 +3338,29 @@
       ]
     },
     "vfmadd213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xa9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xa9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xaa 128-bit"
       ],
@@ -3395,8 +3368,7 @@
         "mov z0.d, z18.d",
         "fnmls z0.s, p6/m, z17.s, z16.s",
         "mov z16.d, z0.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub213ps ymm0, ymm1, ymm2": {
@@ -3416,7 +3388,7 @@
       ]
     },
     "vfmsub213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xaa 128-bit"
       ],
@@ -3424,8 +3396,7 @@
         "mov z0.d, z18.d",
         "fnmls z0.d, p6/m, z17.d, z16.d",
         "mov z16.d, z0.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub213pd ymm0, ymm1, ymm2": {
@@ -3445,31 +3416,29 @@
       ]
     },
     "vfmsub213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xab 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xab 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xac 128-bit"
       ],
@@ -3477,8 +3446,7 @@
         "mov v0.16b, v18.16b",
         "fmls v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd213ps ymm0, ymm1, ymm2": {
@@ -3498,7 +3466,7 @@
       ]
     },
     "vfnmadd213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xac 128-bit"
       ],
@@ -3506,8 +3474,7 @@
         "mov v0.16b, v18.16b",
         "fmls v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd213pd ymm0, ymm1, ymm2": {
@@ -3527,31 +3494,29 @@
       ]
     },
     "vfnmadd213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xad 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xad 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xae 128-bit"
       ],
@@ -3559,8 +3524,7 @@
         "mov z0.d, z18.d",
         "fnmla z0.s, p6/m, z17.s, z16.s",
         "mov z16.d, z0.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub213ps ymm0, ymm1, ymm2": {
@@ -3580,7 +3544,7 @@
       ]
     },
     "vfnmsub213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 2 0b01 0xae 128-bit"
       ],
@@ -3588,8 +3552,7 @@
         "mov z0.d, z18.d",
         "fnmla z0.d, p6/m, z17.d, z16.d",
         "mov z16.d, z0.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub213pd ymm0, ymm1, ymm2": {
@@ -3609,38 +3572,35 @@
       ]
     },
     "vfnmsub213ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xaf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd s0, s17, s16, s18",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub213sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xaf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd d0, d17, d16, d18",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xb8 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmla v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd231ps ymm0, ymm1, ymm2": {
@@ -3658,14 +3618,13 @@
       ]
     },
     "vfmadd231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xb8 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmla v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd231pd ymm0, ymm1, ymm2": {
@@ -3683,38 +3642,35 @@
       ]
     },
     "vfmadd231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xb9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd s0, s17, s18, s16",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmadd231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xb9 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmadd d0, d17, d18, d16",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xba 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmls z16.s, p6/m, z17.s, z18.s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub231ps ymm0, ymm1, ymm2": {
@@ -3732,14 +3688,13 @@
       ]
     },
     "vfmsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xba 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmls z16.d, p6/m, z17.d, z18.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub231pd ymm0, ymm1, ymm2": {
@@ -3757,38 +3712,35 @@
       ]
     },
     "vfmsub231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbb 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub s0, s17, s18, s16",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsub231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbb 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmsub d0, d17, d18, d16",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbc 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmls v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd231ps ymm0, ymm1, ymm2": {
@@ -3806,14 +3758,13 @@
       ]
     },
     "vfnmadd231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbc 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmls v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd231pd ymm0, ymm1, ymm2": {
@@ -3831,38 +3782,35 @@
       ]
     },
     "vfnmadd231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbd 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub s0, s17, s18, s16",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmadd231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbd 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fmsub d0, d17, d18, d16",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbe 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmla z16.s, p6/m, z17.s, z18.s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub231ps ymm0, ymm1, ymm2": {
@@ -3880,14 +3828,13 @@
       ]
     },
     "vfnmsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 2 0b01 0xbe 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmla z16.d, p6/m, z17.d, z18.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub231pd ymm0, ymm1, ymm2": {
@@ -3905,31 +3852,29 @@
       ]
     },
     "vfnmsub231ss xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd s0, s17, s18, s16",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfnmsub231sd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 2 0b01 0xbf 128-bit"
       ],
       "ExpectedArm64ASM": [
         "fnmadd d0, d17, d18, d16",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xa6 128-bit"
       ],
@@ -3939,8 +3884,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub213ps ymm0, ymm1, ymm2": {
@@ -3963,7 +3907,7 @@
       ]
     },
     "vfmaddsub213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xa6 128-bit"
       ],
@@ -3973,8 +3917,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub213pd ymm0, ymm1, ymm2": {
@@ -3997,7 +3940,7 @@
       ]
     },
     "vfmsubadd213ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xa7 128-bit"
       ],
@@ -4007,8 +3950,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.4s, v17.4s, v16.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd213ps ymm0, ymm1, ymm2": {
@@ -4031,7 +3973,7 @@
       ]
     },
     "vfmsubadd213pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 2 0b01 0xa7 128-bit"
       ],
@@ -4041,8 +3983,7 @@
         "mov v0.16b, v2.16b",
         "fmla v0.2d, v17.2d, v16.2d",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd213pd ymm0, ymm1, ymm2": {
@@ -4065,7 +4006,7 @@
       ]
     },
     "vfmaddsub231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb6 128-bit"
       ],
@@ -4074,8 +4015,7 @@
         "eor v2.16b, v16.16b, v2.16b",
         "mov v16.16b, v2.16b",
         "fmla v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub231ps ymm0, ymm1, ymm2": {
@@ -4097,7 +4037,7 @@
       ]
     },
     "vfmaddsub231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb6 128-bit"
       ],
@@ -4106,8 +4046,7 @@
         "eor v2.16b, v16.16b, v2.16b",
         "mov v16.16b, v2.16b",
         "fmla v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmaddsub231pd ymm0, ymm1, ymm2": {
@@ -4129,7 +4068,7 @@
       ]
     },
     "vfmsubadd231ps xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb7 128-bit"
       ],
@@ -4138,8 +4077,7 @@
         "eor v2.16b, v16.16b, v2.16b",
         "mov v16.16b, v2.16b",
         "fmla v16.4s, v17.4s, v18.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd231ps ymm0, ymm1, ymm2": {
@@ -4161,7 +4099,7 @@
       ]
     },
     "vfmsubadd231pd xmm0, xmm1, xmm2": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 2 0b01 0xb7 128-bit"
       ],
@@ -4170,8 +4108,7 @@
         "eor v2.16b, v16.16b, v2.16b",
         "mov v16.16b, v2.16b",
         "fmla v16.2d, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vfmsubadd231pd ymm0, ymm1, ymm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -168,7 +168,7 @@
       ]
     },
     "vmaskmovps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 18,
       "Comment": [
         "Map 2 0b01 0x2c 128-bit"
       ],
@@ -190,8 +190,7 @@
         "tbz w0, #31, #+0x8",
         "ld1 {v0.s}[3], [x1]",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmaskmovps ymm0, ymm1, [rax]": {
@@ -240,7 +239,7 @@
       ]
     },
     "vmaskmovpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0x2d 128-bit"
       ],
@@ -254,8 +253,7 @@
         "tbz x0, #63, #+0x8",
         "ld1 {v0.d}[1], [x1]",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmaskmovpd ymm0, ymm1, [rax]": {
@@ -392,7 +390,7 @@
       ]
     },
     "vpmaskmovd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 18,
       "Comment": [
         "Map 2 0b01 0x8c 128-bit"
       ],
@@ -414,8 +412,7 @@
         "tbz w0, #31, #+0x8",
         "ld1 {v0.s}[3], [x1]",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaskmovd ymm0, ymm1, [rax]": {
@@ -464,7 +461,7 @@
       ]
     },
     "vpmaskmovq xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 2 0b01 0x8c 128-bit"
       ],
@@ -478,8 +475,7 @@
         "tbz x0, #63, #+0x8",
         "ld1 {v0.d}[1], [x1]",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpmaskmovq ymm0, ymm1, [rax]": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -272,185 +272,169 @@
       ]
     },
     "vpblendd xmm0, xmm1, 0000b": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "Map 3 0b01 0x02 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "stp xzr, xzr, [x28, #16]"
+      ]
+    },
+    "vpblendd xmm0, xmm1, 0001b": {
       "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
-      ]
-    },
-    "vpblendd xmm0, xmm1, 0001b": {
-      "ExpectedInstructionCount": 3,
-      "Comment": [
-        "Map 3 0b01 0x02 128-bit"
-      ],
-      "ExpectedArm64ASM": [
         "mov v16.s[0], v17.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 0010b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.s[1], v17.s[1]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 0011b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.d[0], v17.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 0100b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.s[2], v17.s[2]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 0101b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "rev64 v2.4s, v17.4s",
         "trn2 v16.4s, v2.4s, v16.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 0110b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2592]",
         "tbx v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 0111b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2608]",
         "tbx v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 1000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.s[3], v17.s[3]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 1001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2624]",
         "tbx v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 1010b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "rev64 v2.4s, v16.4s",
         "trn2 v16.4s, v2.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 1011b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2640]",
         "tbx v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 1100b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.d[1], v17.d[1]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 1101b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2656]",
         "tbx v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 1110b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #2672]",
         "tbx v16.16b, {v17.16b}, v2.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendd xmm0, xmm1, 1111b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x02 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
@@ -506,47 +490,43 @@
       ]
     },
     "vpermilps xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "dup v16.4s, v17.s[0]",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpermilps xmm0, xmm1, 01010101b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "dup v16.4s, v17.s[1]",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpermilps xmm0, xmm1, 10101010b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "dup v16.4s, v17.s[2]",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpermilps xmm0, xmm1, 11111111b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x03 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "dup v16.4s, v17.s[3]",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpermilps ymm0, ymm1, 00000000b": {
@@ -598,47 +578,43 @@
       ]
     },
     "vpermilpd xmm0, xmm1, 00b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "dup v16.2d, v17.d[0]",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpermilpd xmm0, xmm1, 01b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "ext v16.16b, v17.16b, v17.16b, #8",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpermilpd xmm0, xmm1, 10b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vpermilpd xmm0, xmm1, 11b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x05 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "dup v16.2d, v17.d[1]",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpermilpd ymm0, ymm1, 0000b": {
@@ -1044,111 +1020,102 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000001b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x28, #32]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000010b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v18.16b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000011b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x28, #48]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundps xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
         "frintn v16.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundps xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
         "frintm v16.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundps xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
         "frintp v16.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundps xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
         "frintz v16.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundps xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x08 128-bit"
       ],
       "ExpectedArm64ASM": [
         "frinti v16.4s, v17.4s",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundps ymm0, ymm1, 00000000b": {
@@ -1217,63 +1184,58 @@
       ]
     },
     "vroundpd xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
         "frintn v16.2d, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundpd xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
         "frintm v16.2d, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundpd xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
         "frintp v16.2d, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundpd xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
         "frintz v16.2d, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundpd xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x09 128-bit"
       ],
       "ExpectedArm64ASM": [
         "frinti v16.2d, v17.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundpd ymm0, ymm1, 00000000b": {
@@ -1342,7 +1304,7 @@
       ]
     },
     "vroundss xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1350,12 +1312,11 @@
       "ExpectedArm64ASM": [
         "frintn s0, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundss xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1363,12 +1324,11 @@
       "ExpectedArm64ASM": [
         "frintm s0, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundss xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1376,12 +1336,11 @@
       "ExpectedArm64ASM": [
         "frintp s0, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundss xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1389,12 +1348,11 @@
       "ExpectedArm64ASM": [
         "frintz s0, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundss xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x0a 128-bit"
@@ -1402,12 +1360,11 @@
       "ExpectedArm64ASM": [
         "frinti s0, s17",
         "mov v16.s[0], v0.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundsd xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -1415,12 +1372,11 @@
       "ExpectedArm64ASM": [
         "frintn d0, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundsd xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -1428,12 +1384,11 @@
       "ExpectedArm64ASM": [
         "frintm d0, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundsd xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -1441,12 +1396,11 @@
       "ExpectedArm64ASM": [
         "frintp d0, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundsd xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -1454,12 +1408,11 @@
       "ExpectedArm64ASM": [
         "frintz d0, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vroundsd xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x0b 128-bit"
@@ -1467,41 +1420,37 @@
       "ExpectedArm64ASM": [
         "frinti d0, d17",
         "mov v16.d[0], v0.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vblendps xmm0, xmm1, xmm2, 0000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vblendps xmm0, xmm1, xmm2, 0001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.s[0], v18.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vblendps xmm0, xmm1, xmm2, 1111b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x0c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v18.16b"
       ]
     },
@@ -1542,48 +1491,44 @@
       ]
     },
     "vblendpd xmm0, xmm1, xmm2, 00b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vblendpd xmm0, xmm1, xmm2, 01b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.d[0], v18.d[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vblendpd xmm0, xmm1, xmm2, 10b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.d[1], v18.d[1]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vblendpd xmm0, xmm1, xmm2, 11b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x0d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v18.16b"
       ]
     },
@@ -1788,36 +1733,33 @@
       ]
     },
     "vpblendw xmm0, xmm1, xmm2, 00000000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vpblendw xmm0, xmm1, xmm2, 00000001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.h[0], v18.h[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendw xmm0, xmm1, xmm2, 11111111b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x0e 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v18.16b"
       ]
     },
@@ -1858,46 +1800,42 @@
       ]
     },
     "vpalignr xmm0, xmm1, xmm2, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v18.16b"
       ]
     },
     "vpalignr xmm0, xmm1, xmm2, 1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ext v16.16b, v18.16b, v17.16b, #1",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpalignr xmm0, xmm1, xmm2, 15": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ext v16.16b, v18.16b, v17.16b, #15",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpalignr xmm0, xmm1, xmm2, 16": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x0f 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
@@ -1909,7 +1847,7 @@
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
         "ext v16.16b, v17.16b, v2.16b, #1",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpalignr ymm0, ymm1, ymm2, 0": {
@@ -2121,25 +2059,23 @@
       ]
     },
     "vextractf128 xmm0, ymm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x19 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vextractf128 xmm0, ymm1, 1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x19 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x28, #32]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtps2ph xmm0, xmm1, 00000000b": {
@@ -2211,7 +2147,7 @@
       ]
     },
     "vcvtps2ph xmm0, ymm1, 00000000b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x1D 256-bit"
@@ -2226,12 +2162,11 @@
         "fcvtn2 v0.8h, v2.4s",
         "mov v16.16b, v0.16b",
         "msr fpcr, x20",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtps2ph xmm0, ymm1, 00000001b": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x1D 256-bit"
@@ -2247,12 +2182,11 @@
         "fcvtn2 v0.8h, v2.4s",
         "mov v16.16b, v0.16b",
         "msr fpcr, x20",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtps2ph xmm0, ymm1, 00000010b": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 11,
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x1D 256-bit"
@@ -2268,12 +2202,11 @@
         "fcvtn2 v0.8h, v2.4s",
         "mov v16.16b, v0.16b",
         "msr fpcr, x20",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtps2ph xmm0, ymm1, 00000011b": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x1D 256-bit"
@@ -2288,12 +2221,11 @@
         "fcvtn2 v0.8h, v2.4s",
         "mov v16.16b, v0.16b",
         "msr fpcr, x20",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vcvtps2ph xmm0, ymm1, 00000100b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x1D 256-bit"
@@ -2304,55 +2236,50 @@
         "mov v0.16b, v3.16b",
         "fcvtn2 v0.8h, v2.4s",
         "mov v16.16b, v0.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrb xmm0, xmm0, eax, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.b[0], w4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.b[0], w4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 15": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.b[15], w4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b00 << 6) | (0b00 << 4) | (0b0000))": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.s[0], v18.s[0]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b00 << 6) | (0b00 << 4) | (0b1111))": {
@@ -2362,89 +2289,82 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vinsertps xmm0, xmm1, xmm2, ((0b11 << 6) | (0b11 << 4) | (0b0000))": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x21 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.s[3], v18.s[3]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrd xmm0, xmm0, eax, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.s[0], w4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.s[0], w4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 3": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.s[3], w4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrq xmm0, xmm0, rax, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.d[0], x4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrq xmm0, xmm1, rax, 0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.d[0], x4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpinsrq xmm0, xmm1, rax, 1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
         "mov v16.16b, v17.16b",
         "mov v16.d[1], x4",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vinserti128 ymm0, ymm1, xmm2, 0": {
@@ -2469,25 +2389,23 @@
       ]
     },
     "vextracti128 xmm0, ymm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x39 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vextracti128 xmm0, ymm1, 1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x39 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x28, #32]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 00000000b": {
@@ -2497,7 +2415,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 00001111b": {
@@ -2507,7 +2425,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 11110000b": {
@@ -2517,21 +2435,20 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdpps xmm0, xmm1, xmm2, 11111111b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "fmul v3.4s, v17.4s, v18.4s",
-        "faddp v3.4s, v3.4s, v3.4s",
-        "faddp s3, v3.2s",
-        "dup v16.4s, v3.s[0]",
-        "str q2, [x28, #16]"
+        "fmul v2.4s, v17.4s, v18.4s",
+        "faddp v2.4s, v2.4s, v2.4s",
+        "faddp s2, v2.2s",
+        "dup v16.4s, v2.s[0]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdpps ymm0, ymm1, ymm2, 00000000b": {
@@ -2541,7 +2458,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdpps ymm0, ymm1, ymm2, 00001111b": {
@@ -2551,7 +2468,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdpps ymm0, ymm1, ymm2, 11110000b": {
@@ -2561,7 +2478,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdpps ymm0, ymm1, ymm2, 11111111b": {
@@ -2590,7 +2507,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 00001111b": {
@@ -2600,7 +2517,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 11110000b": {
@@ -2610,212 +2527,203 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vdppd xmm0, xmm1, xmm2, 11111111b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x41 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "fmul v3.2d, v17.2d, v18.2d",
-        "faddp d3, v3.2d",
-        "dup v16.2d, v3.d[0]",
-        "str q2, [x28, #16]"
+        "fmul v2.2d, v17.2d, v18.2d",
+        "faddp d2, v2.2d",
+        "dup v16.2d, v2.d[0]",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 000b": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "dup v3.4s, v18.s[0]",
-        "ext v4.16b, v17.16b, v17.16b, #0",
-        "ext v5.16b, v17.16b, v17.16b, #1",
-        "ext v6.16b, v17.16b, v17.16b, #2",
-        "ext v7.16b, v17.16b, v17.16b, #3",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v3.8h, v7.8b, v3.8b",
-        "addp v4.8h, v4.8h, v6.8h",
-        "addp v3.8h, v5.8h, v3.8h",
-        "trn1 v5.4s, v4.4s, v3.4s",
-        "trn2 v3.4s, v4.4s, v3.4s",
-        "addp v16.8h, v5.8h, v3.8h",
-        "str q2, [x28, #16]"
+        "dup v2.4s, v18.s[0]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v16.8h, v4.8h, v2.8h",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 001b": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "dup v3.4s, v18.s[1]",
-        "ext v4.16b, v17.16b, v17.16b, #0",
-        "ext v5.16b, v17.16b, v17.16b, #1",
-        "ext v6.16b, v17.16b, v17.16b, #2",
-        "ext v7.16b, v17.16b, v17.16b, #3",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v3.8h, v7.8b, v3.8b",
-        "addp v4.8h, v4.8h, v6.8h",
-        "addp v3.8h, v5.8h, v3.8h",
-        "trn1 v5.4s, v4.4s, v3.4s",
-        "trn2 v3.4s, v4.4s, v3.4s",
-        "addp v16.8h, v5.8h, v3.8h",
-        "str q2, [x28, #16]"
+        "dup v2.4s, v18.s[1]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v16.8h, v4.8h, v2.8h",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 010b": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "dup v3.4s, v18.s[2]",
-        "ext v4.16b, v17.16b, v17.16b, #0",
-        "ext v5.16b, v17.16b, v17.16b, #1",
-        "ext v6.16b, v17.16b, v17.16b, #2",
-        "ext v7.16b, v17.16b, v17.16b, #3",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v3.8h, v7.8b, v3.8b",
-        "addp v4.8h, v4.8h, v6.8h",
-        "addp v3.8h, v5.8h, v3.8h",
-        "trn1 v5.4s, v4.4s, v3.4s",
-        "trn2 v3.4s, v4.4s, v3.4s",
-        "addp v16.8h, v5.8h, v3.8h",
-        "str q2, [x28, #16]"
+        "dup v2.4s, v18.s[2]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v16.8h, v4.8h, v2.8h",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 011b": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "dup v3.4s, v18.s[3]",
-        "ext v4.16b, v17.16b, v17.16b, #0",
-        "ext v5.16b, v17.16b, v17.16b, #1",
-        "ext v6.16b, v17.16b, v17.16b, #2",
-        "ext v7.16b, v17.16b, v17.16b, #3",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v3.8h, v7.8b, v3.8b",
-        "addp v4.8h, v4.8h, v6.8h",
-        "addp v3.8h, v5.8h, v3.8h",
-        "trn1 v5.4s, v4.4s, v3.4s",
-        "trn2 v3.4s, v4.4s, v3.4s",
-        "addp v16.8h, v5.8h, v3.8h",
-        "str q2, [x28, #16]"
+        "dup v2.4s, v18.s[3]",
+        "ext v3.16b, v17.16b, v17.16b, #0",
+        "ext v4.16b, v17.16b, v17.16b, #1",
+        "ext v5.16b, v17.16b, v17.16b, #2",
+        "ext v6.16b, v17.16b, v17.16b, #3",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v16.8h, v4.8h, v2.8h",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 100b": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "dup v3.4s, v18.s[0]",
-        "ext v4.16b, v17.16b, v17.16b, #4",
-        "ext v5.16b, v17.16b, v17.16b, #5",
-        "ext v6.16b, v17.16b, v17.16b, #6",
-        "ext v7.16b, v17.16b, v17.16b, #7",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v3.8h, v7.8b, v3.8b",
-        "addp v4.8h, v4.8h, v6.8h",
-        "addp v3.8h, v5.8h, v3.8h",
-        "trn1 v5.4s, v4.4s, v3.4s",
-        "trn2 v3.4s, v4.4s, v3.4s",
-        "addp v16.8h, v5.8h, v3.8h",
-        "str q2, [x28, #16]"
+        "dup v2.4s, v18.s[0]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v16.8h, v4.8h, v2.8h",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 101b": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "dup v3.4s, v18.s[1]",
-        "ext v4.16b, v17.16b, v17.16b, #4",
-        "ext v5.16b, v17.16b, v17.16b, #5",
-        "ext v6.16b, v17.16b, v17.16b, #6",
-        "ext v7.16b, v17.16b, v17.16b, #7",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v3.8h, v7.8b, v3.8b",
-        "addp v4.8h, v4.8h, v6.8h",
-        "addp v3.8h, v5.8h, v3.8h",
-        "trn1 v5.4s, v4.4s, v3.4s",
-        "trn2 v3.4s, v4.4s, v3.4s",
-        "addp v16.8h, v5.8h, v3.8h",
-        "str q2, [x28, #16]"
+        "dup v2.4s, v18.s[1]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v16.8h, v4.8h, v2.8h",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 110b": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "dup v3.4s, v18.s[2]",
-        "ext v4.16b, v17.16b, v17.16b, #4",
-        "ext v5.16b, v17.16b, v17.16b, #5",
-        "ext v6.16b, v17.16b, v17.16b, #6",
-        "ext v7.16b, v17.16b, v17.16b, #7",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v3.8h, v7.8b, v3.8b",
-        "addp v4.8h, v4.8h, v6.8h",
-        "addp v3.8h, v5.8h, v3.8h",
-        "trn1 v5.4s, v4.4s, v3.4s",
-        "trn2 v3.4s, v4.4s, v3.4s",
-        "addp v16.8h, v5.8h, v3.8h",
-        "str q2, [x28, #16]"
+        "dup v2.4s, v18.s[2]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v16.8h, v4.8h, v2.8h",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmpsadbw xmm0, xmm1, xmm2, 111b": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 15,
       "Comment": [
         "Map 3 0b01 0x42 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "dup v3.4s, v18.s[3]",
-        "ext v4.16b, v17.16b, v17.16b, #4",
-        "ext v5.16b, v17.16b, v17.16b, #5",
-        "ext v6.16b, v17.16b, v17.16b, #6",
-        "ext v7.16b, v17.16b, v17.16b, #7",
-        "uabdl v4.8h, v4.8b, v3.8b",
-        "uabdl v5.8h, v5.8b, v3.8b",
-        "uabdl v6.8h, v6.8b, v3.8b",
-        "uabdl v3.8h, v7.8b, v3.8b",
-        "addp v4.8h, v4.8h, v6.8h",
-        "addp v3.8h, v5.8h, v3.8h",
-        "trn1 v5.4s, v4.4s, v3.4s",
-        "trn2 v3.4s, v4.4s, v3.4s",
-        "addp v16.8h, v5.8h, v3.8h",
-        "str q2, [x28, #16]"
+        "dup v2.4s, v18.s[3]",
+        "ext v3.16b, v17.16b, v17.16b, #4",
+        "ext v4.16b, v17.16b, v17.16b, #5",
+        "ext v5.16b, v17.16b, v17.16b, #6",
+        "ext v6.16b, v17.16b, v17.16b, #7",
+        "uabdl v3.8h, v3.8b, v2.8b",
+        "uabdl v4.8h, v4.8b, v2.8b",
+        "uabdl v5.8h, v5.8b, v2.8b",
+        "uabdl v2.8h, v6.8b, v2.8b",
+        "addp v3.8h, v3.8h, v5.8h",
+        "addp v2.8h, v4.8h, v2.8h",
+        "trn1 v4.4s, v3.4s, v2.4s",
+        "trn2 v2.4s, v3.4s, v2.4s",
+        "addp v16.8h, v4.8h, v2.8h",
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vmpsadbw ymm0, ymm1, ymm2, 000b": {
@@ -3131,49 +3039,45 @@
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 00000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
         "pmull v16.1q, v17.1d, v18.1d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 00001b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
         "dup v0.2d, v17.d[1]",
         "pmull v16.1q, v0.1d, v18.1d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 10000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
         "dup v0.2d, v18.d[1]",
         "pmull v16.1q, v0.1d, v17.1d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpclmulqdq xmm0, xmm1, xmm2, 10001b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x44 128-bit"
       ],
       "ExpectedArm64ASM": [
         "pmull2 v16.1q, v17.2d, v18.2d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpclmulqdq ymm0, ymm1, ymm2, 00000b": {
@@ -3447,55 +3351,51 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000001b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x28, #32]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000010b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v18.16b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000011b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q16, [x28, #48]",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vblendvps xmm0, xmm1, xmm2, xmm3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x4a 128-bit"
       ],
@@ -3503,8 +3403,7 @@
         "sshr v2.4s, v19.4s, #31",
         "mov v16.16b, v2.16b",
         "bsl v16.16b, v18.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vblendvps ymm0, ymm1, ymm2, ymm3": {
@@ -3525,7 +3424,7 @@
       ]
     },
     "vblendvpd xmm0, xmm1, xmm2, xmm3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x4b 128-bit"
       ],
@@ -3533,8 +3432,7 @@
         "sshr v2.2d, v19.2d, #63",
         "mov v16.16b, v2.16b",
         "bsl v16.16b, v18.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vblendvpd ymm0, ymm1, ymm2, ymm3": {
@@ -3555,7 +3453,7 @@
       ]
     },
     "vpblendvb xmm0, xmm1, xmm2, xmm3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x4c 128-bit"
       ],
@@ -3563,8 +3461,7 @@
         "sshr v2.16b, v19.16b, #7",
         "mov v16.16b, v2.16b",
         "bsl v16.16b, v18.16b, v17.16b",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendvb ymm0, ymm1, ymm2, ymm3": {
@@ -3595,7 +3492,7 @@
         "mov v16.16b, v17.16b",
         "aese v16.16b, v2.16b",
         "tbl v16.16b, {v16.16b}, v3.16b",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vaeskeygenassist xmm0, xmm1, 0xFF": {
@@ -3612,7 +3509,7 @@
         "mov x0, #0xff00000000",
         "dup v1.2d, x0",
         "eor v16.16b, v16.16b, v1.16b",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     }
   }

--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -11,7 +11,7 @@
   },
   "Instructions": {
     "vblendvps xmm0, xmm1, xmm2, xmm3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x4a 128-bit"
       ],
@@ -19,8 +19,7 @@
         "sshr v2.4s, v19.4s, #31",
         "movprfx z16, z18",
         "bsl z16.d, z16.d, z17.d, z2.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vblendvps ymm0, ymm1, ymm2, ymm3": {
@@ -41,7 +40,7 @@
       ]
     },
     "vblendvpd xmm0, xmm1, xmm2, xmm3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x4b 128-bit"
       ],
@@ -49,8 +48,7 @@
         "sshr v2.2d, v19.2d, #63",
         "movprfx z16, z18",
         "bsl z16.d, z16.d, z17.d, z2.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vblendvpd ymm0, ymm1, ymm2, ymm3": {
@@ -71,7 +69,7 @@
       ]
     },
     "vpblendvb xmm0, xmm1, xmm2, xmm3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x4c 128-bit"
       ],
@@ -79,8 +77,7 @@
         "sshr v2.16b, v19.16b, #7",
         "movprfx z16, z18",
         "bsl z16.d, z16.d, z17.d, z2.d",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpblendvb ymm0, ymm1, ymm2, ymm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -12,36 +12,33 @@
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vpsrlw xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ushr v16.8h, v17.8h, #15",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrlw xmm0, xmm1, 16": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 12 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrlw ymm0, ymm1, 0": {
@@ -80,36 +77,33 @@
       ]
     },
     "vpsraw xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vpsraw xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sshr v16.8h, v17.8h, #15",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsraw xmm0, xmm1, 16": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 12 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sshr v16.8h, v17.8h, #15",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsraw ymm0, ymm1, 0": {
@@ -148,36 +142,33 @@
       ]
     },
     "vpsllw xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vpsllw xmm0, xmm1, 15": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
         "shl v16.8h, v17.8h, #15",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsllw xmm0, xmm1, 16": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 12 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsllw ymm0, ymm1, 0": {
@@ -216,36 +207,33 @@
       ]
     },
     "vpsrld xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vpsrld xmm0, xmm1, 31": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ushr v16.4s, v17.4s, #31",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrld xmm0, xmm1, 32": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 13 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrld ymm0, ymm1, 0": {
@@ -284,36 +272,33 @@
       ]
     },
     "vpsrad xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vpsrad xmm0, xmm1, 31": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sshr v16.4s, v17.4s, #31",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrad xmm0, xmm1, 32": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 13 0b100 128-bit"
       ],
       "ExpectedArm64ASM": [
         "sshr v16.4s, v17.4s, #31",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrad ymm0, ymm1, 0": {
@@ -352,36 +337,33 @@
       ]
     },
     "vpslld xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vpslld xmm0, xmm1, 31": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
         "shl v16.4s, v17.4s, #31",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpslld xmm0, xmm1, 32": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 13 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpslld ymm0, ymm1, 0": {
@@ -420,36 +402,33 @@
       ]
     },
     "vpsrlq xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vpsrlq xmm0, xmm1, 63": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
         "ushr v16.2d, v17.2d, #63",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrlq xmm0, xmm1, 64": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 14 0b010 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrlq ymm0, ymm1, 0": {
@@ -488,13 +467,12 @@
       ]
     },
     "vpsrldq xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 14 0b011 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
@@ -506,7 +484,7 @@
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
         "ext v16.16b, v17.16b, v2.16b, #15",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrldq xmm0, xmm1, 16": {
@@ -516,7 +494,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsrldq ymm0, ymm1, 0": {
@@ -550,40 +528,37 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsllq xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
     "vpsllq xmm0, xmm1, 63": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
         "shl v16.2d, v17.2d, #63",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsllq xmm0, xmm1, 64": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 14 0b110 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpsllq ymm0, ymm1, 0": {
@@ -622,13 +597,12 @@
       ]
     },
     "vpslldq xmm0, xmm1, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map group 14 0b111 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "str q2, [x28, #16]",
+        "stp xzr, xzr, [x28, #16]",
         "mov v16.16b, v17.16b"
       ]
     },
@@ -640,7 +614,7 @@
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
         "ext v16.16b, v2.16b, v17.16b, #1",
-        "str q2, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpslldq xmm0, xmm1, 16": {
@@ -650,7 +624,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     },
     "vpslldq ymm0, ymm1, 0": {
@@ -684,7 +658,7 @@
       ],
       "ExpectedArm64ASM": [
         "movi v16.2d, #0x0",
-        "str q16, [x28, #16]"
+        "stp xzr, xzr, [x28, #16]"
       ]
     }
   }


### PR DESCRIPTION
    Turn this into stp to save a move in a /ton/ of AVX-128 code. It's pretty
    annoying to optimize this at the dispatcher level because of the SRA cache, so
    doing it in the ConstProp is a nice compromise solution.