### PR TITLE
Convert config options once

### DIFF
--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -423,7 +423,7 @@ def print_parse_argloader_options(options):
                 # these need a bit more help
                 output_argloader.write("\tauto Array = Options.all(\"{0}\");\n".format(op_key))
                 output_argloader.write("\tfor (auto iter = Array.begin(); iter != Array.end(); ++iter) {\n")
-                output_argloader.write("\t\tSet(FEXCore::Config::ConfigOption::CONFIG_{0}, *iter);\n".format(op_key.upper()))
+                output_argloader.write("\t\tAppendStrArrayValue(FEXCore::Config::ConfigOption::CONFIG_{0}, *iter);\n".format(op_key.upper()))
                 output_argloader.write("\t}\n")
             else:
                 if (NeedsString):
@@ -466,7 +466,11 @@ def print_parse_jsonloader_options(options):
             value_type = op_vals["Type"]
             if (value_type == "strenum"):
                 output_argloader.write("else if (KeyName == \"{0}\") {{\n".format(op_key))
-                output_argloader.write("Set(KeyOption, FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, Value_View));\n".format(op_key, op_key, op_key))
+                output_argloader.write("\tSet(KeyOption, FEXCore::Config::EnumParser<FEXCore::Config::{}ConfigPair>(FEXCore::Config::{}_EnumPairs, Value_View));\n".format(op_key, op_key, op_key))
+                output_argloader.write("}\n")
+            elif (value_type == "strarray"):
+                output_argloader.write("else if (KeyName == \"{0}\") {{\n".format(op_key))
+                output_argloader.write("\tAppendStrArrayValue(KeyOption, ConfigString);\n")
                 output_argloader.write("}\n")
 
     output_argloader.write("else {{\n".format(op_key))

--- a/FEXCore/Source/Common/StringConv.h
+++ b/FEXCore/Source/Common/StringConv.h
@@ -20,8 +20,20 @@ static bool Conv(std::string_view Value, uint8_t* Result) {
 }
 
 [[maybe_unused]]
+static bool Conv(std::string_view Value, int8_t* Result) {
+  *Result = std::strtol(Value.data(), nullptr, 0);
+  return true;
+}
+
+[[maybe_unused]]
 static bool Conv(std::string_view Value, uint16_t* Result) {
   *Result = std::strtoul(Value.data(), nullptr, 0);
+  return true;
+}
+
+[[maybe_unused]]
+static bool Conv(std::string_view Value, int16_t* Result) {
+  *Result = std::strtol(Value.data(), nullptr, 0);
   return true;
 }
 
@@ -42,6 +54,13 @@ static bool Conv(std::string_view Value, uint64_t* Result) {
   *Result = std::strtoull(Value.data(), nullptr, 0);
   return true;
 }
+
+[[maybe_unused]]
+static bool Conv(std::string_view Value, int64_t* Result) {
+  *Result = std::strtoll(Value.data(), nullptr, 0);
+  return true;
+}
+
 template<typename T, typename = std::enable_if<std::is_enum<T>::value, T>>
 [[maybe_unused]]
 static bool Conv(std::string_view Value, T* Result) {

--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -204,7 +204,7 @@ bool SetupClient(std::string_view InterpreterPath) {
     fextl::string RootFSPath = FEXServerClient::RequestRootFSPath(ServerFD);
 
     //// If everything has passed then we can now update the rootfs path
-    FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_ROOTFS, RootFSPath);
+    FEXCore::Config::Set(FEXCore::Config::CONFIG_ROOTFS, RootFSPath);
   }
 
   return true;

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -447,7 +447,18 @@ public:
 
     for (auto& it : EnvConfigLookup) {
       if (auto Value = GetVar(it.first); Value) {
-        Set(it.second, *Value);
+#define OPT_BASE(type, group, enum, json, default) // Nothing
+#define OPT_STRARRAY(group, enum, json, default)                        \
+  else if (it.second == FEXCore::Config::ConfigOption::CONFIG_##enum) { \
+    AppendStrArrayValue(it.second, *Value);                             \
+  }
+
+        if (false) {
+        }
+#include <FEXCore/Config/ConfigValues.inl>
+        else {
+          Set(it.second, *Value);
+        }
       }
     }
   }
@@ -479,17 +490,17 @@ int main(int argc, char** argv, char** const envp) {
 
   // Setup configurations that this tool needs
   // Maximum one instruction.
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_MAXINST, "1");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_MAXINST, "1");
   // Enable block disassembly.
-  FEXCore::Config::EraseSet(
+  FEXCore::Config::Set(
     FEXCore::Config::CONFIG_DISASSEMBLE,
     fextl::fmt::format("{}", static_cast<uint64_t>(FEXCore::Config::Disassemble::BLOCKS | FEXCore::Config::Disassemble::STATS)));
   // Choose bitness.
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS64BIT_MODE, TestHeaderData->Bitness == 64 ? "1" : "0");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, TestHeaderData->Bitness == 64 ? "1" : "0");
   // Disable telemetry, it can affect instruction counts.
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_DISABLETELEMETRY, "1");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_DISABLETELEMETRY, "1");
   // Disable vixl simulator indirect calls as it can affect instruction counts.
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_DISABLE_VIXL_INDIRECT_RUNTIME_CALLS, "1");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_DISABLE_VIXL_INDIRECT_RUNTIME_CALLS, "1");
 
   // Host feature override. Only supports overriding SVE width.
   enum HostFeatures {
@@ -559,10 +570,10 @@ int main(int argc, char** argv, char** const envp) {
 
   if (TestHeaderData->EnabledHostFeatures & FEATURE_TSO) {
     // Always disable auto migration.
-    FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
-    FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED, "1");
-    FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_VECTORTSOENABLED, "1");
-    FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_MEMCPYSETTSOENABLED, "1");
+    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
+    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED, "1");
+    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_VECTORTSOENABLED, "1");
+    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_MEMCPYSETTSOENABLED, "1");
   }
 
   // Always enable ARMv8.1 LSE atomics.
@@ -610,17 +621,17 @@ int main(int argc, char** argv, char** const envp) {
 
   if (TestHeaderData->DisabledHostFeatures & FEATURE_TSO) {
     // Always disable auto migration.
-    FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
-    FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED, "0");
-    FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_VECTORTSOENABLED, "0");
-    FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_MEMCPYSETTSOENABLED, "0");
+    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
+    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED, "0");
+    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_VECTORTSOENABLED, "0");
+    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_MEMCPYSETTSOENABLED, "0");
   }
 
   // Always enable preserve_all abi.
   HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEPRESERVEALLABI);
 
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_HOSTFEATURES, fextl::fmt::format("{}", HostFeatureControl));
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_FORCESVEWIDTH, fextl::fmt::format("{}", SVEWidth));
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_HOSTFEATURES, fextl::fmt::format("{}", HostFeatureControl));
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_FORCESVEWIDTH, fextl::fmt::format("{}", SVEWidth));
 
   // Initialize static tables.
   FEXCore::Context::InitializeStaticTables(TestHeaderData->Bitness == 64 ? FEXCore::Context::MODE_64BIT : FEXCore::Context::MODE_32BIT);

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -74,7 +74,7 @@ void ConfigModel::Reload() {
 
     const char* OptionType = TypeId.data();
     Item->setData(OptionType, Qt::UserRole + 1);
-    Item->setData(QString::fromStdString(Option.second.front().c_str()), Qt::UserRole + 2);
+    Item->setData(QString::fromStdString(std::get<fextl::string>(Option.second).c_str()), Qt::UserRole + 2);
     appendRow(Item);
   }
   endResetModel();
@@ -99,12 +99,12 @@ bool ConfigModel::getBool(const QString& Name, bool) const {
 }
 
 void ConfigModel::setBool(const QString& Name, bool Value) {
-  LoadedConfig->EraseSet(NameToConfigLookup.at(Name.toStdString()), Value ? "1" : "0");
+  LoadedConfig->Set(NameToConfigLookup.at(Name.toStdString()), Value ? "1" : "0");
   Reload();
 }
 
 void ConfigModel::setString(const QString& Name, const QString& Value) {
-  LoadedConfig->EraseSet(NameToConfigLookup.at(Name.toStdString()), Value.toStdString());
+  LoadedConfig->Set(NameToConfigLookup.at(Name.toStdString()), Value.toStdString());
   Reload();
 }
 
@@ -118,7 +118,7 @@ void ConfigModel::setStringList(const QString& Name, const QStringList& Values) 
 }
 
 void ConfigModel::setInt(const QString& Name, int Value) {
-  LoadedConfig->EraseSet(NameToConfigLookup.at(Name.toStdString()), std::to_string(Value));
+  LoadedConfig->Set(NameToConfigLookup.at(Name.toStdString()), std::to_string(Value));
   Reload();
 }
 
@@ -358,18 +358,18 @@ static bool OpenFile(fextl::string Filename) {
   LoadedConfig->Load();
 
   // Load default options and only overwrite only if the option didn't exist
-#define OPT_BASE(type, group, enum, json, default)                                                 \
-  if (!LoadedConfig->OptionExists(FEXCore::Config::ConfigOption::CONFIG_##enum)) {                 \
-    LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_##enum, std::to_string(default)); \
+#define OPT_BASE(type, group, enum, json, default)                                            \
+  if (!LoadedConfig->OptionExists(FEXCore::Config::ConfigOption::CONFIG_##enum)) {            \
+    LoadedConfig->Set(FEXCore::Config::ConfigOption::CONFIG_##enum, std::to_string(default)); \
   }
 #define OPT_STR(group, enum, json, default)                                        \
   if (!LoadedConfig->OptionExists(FEXCore::Config::ConfigOption::CONFIG_##enum)) { \
-    LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_##enum, default); \
+    LoadedConfig->Set(FEXCore::Config::ConfigOption::CONFIG_##enum, default);      \
   }
 #define OPT_STRARRAY(group, enum, json, default) // Do nothing
-#define OPT_STRENUM(group, enum, json, default)                                                                           \
-  if (!LoadedConfig->OptionExists(FEXCore::Config::ConfigOption::CONFIG_##enum)) {                                        \
-    LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_##enum, std::to_string(FEXCore::ToUnderlying(default))); \
+#define OPT_STRENUM(group, enum, json, default)                                                                      \
+  if (!LoadedConfig->OptionExists(FEXCore::Config::ConfigOption::CONFIG_##enum)) {                                   \
+    LoadedConfig->Set(FEXCore::Config::ConfigOption::CONFIG_##enum, std::to_string(FEXCore::ToUnderlying(default))); \
   }
 #include <FEXCore/Config/ConfigValues.inl>
 

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -324,7 +324,7 @@ int main(int argc, char** argv, char** const envp) {
   FEXCore::Config::Set(FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, InterpreterInstalled ? "1" : "0");
 #ifdef VIXL_SIMULATOR
   // If running under the vixl simulator, ensure that indirect runtime calls are enabled.
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_DISABLE_VIXL_INDIRECT_RUNTIME_CALLS, "0");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_DISABLE_VIXL_INDIRECT_RUNTIME_CALLS, "0");
 #endif
 
   // Early check for process stall
@@ -442,27 +442,27 @@ int main(int argc, char** argv, char** const envp) {
 
   if (ExecutedWithFD) {
     // Don't need to canonicalize Program.ProgramPath, Config loader will have resolved this already.
-    FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_APP_FILENAME, Program.ProgramPath);
-    FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_APP_CONFIG_NAME, Program.ProgramName);
+    FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_FILENAME, Program.ProgramPath);
+    FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_CONFIG_NAME, Program.ProgramName);
   } else if (FEXFD != -1) {
     // Anonymous program.
-    FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_APP_FILENAME, "<Anonymous>");
-    FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_APP_CONFIG_NAME, "<Anonymous>");
+    FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_FILENAME, "<Anonymous>");
+    FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_CONFIG_NAME, "<Anonymous>");
   } else {
     {
       char ExistsTempPath[PATH_MAX];
       char* RealPath = realpath(Program.ProgramPath.c_str(), ExistsTempPath);
       if (RealPath) {
-        FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_APP_FILENAME, fextl::string(RealPath));
+        FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_FILENAME, fextl::string(RealPath));
       }
     }
-    FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_APP_CONFIG_NAME, Program.ProgramName);
+    FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_CONFIG_NAME, Program.ProgramName);
   }
 
   // Setup Thread handlers, so FEXCore can create threads.
   auto StackTracker = FEX::LinuxEmulation::Threads::SetupThreadHandlers();
 
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
 
   fextl::unique_ptr<FEX::HLE::MemAllocator> Allocator;
   fextl::vector<FEXCore::Allocator::MemoryRegion> Base48Bit;

--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -1044,7 +1044,7 @@ void SetRootFSAsDefault(const fextl::string& RootFS) {
   fextl::string Filename = FEXCore::Config::GetConfigFileLocation();
   auto LoadedConfig = FEX::Config::CreateMainLayer(&Filename);
   LoadedConfig->Load();
-  LoadedConfig->EraseSet(FEXCore::Config::ConfigOption::CONFIG_ROOTFS, RootFS);
+  LoadedConfig->Set(FEXCore::Config::ConfigOption::CONFIG_ROOTFS, RootFS);
   FEX::Config::SaveLayerToJSON(Filename, LoadedConfig.get());
 }
 } // namespace ConfigSetter

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -232,7 +232,7 @@ int main(int argc, char** argv, char** const envp) {
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Loader.Is64BitMode() ? "1" : "0");
 #ifdef VIXL_SIMULATOR
   // If running under the vixl simulator, ensure that indirect runtime calls are enabled.
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_DISABLE_VIXL_INDIRECT_RUNTIME_CALLS, "0");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_DISABLE_VIXL_INDIRECT_RUNTIME_CALLS, "0");
 #endif
 
 #ifndef _WIN32

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -534,10 +534,10 @@ NTSTATUS ProcessInit() {
   FEXCore::Config::ReloadMetaLayer();
   FEX::Windows::Logging::Init();
 
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS64BIT_MODE, "1");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, "1");
 
   // Not applicable to Windows
-  FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
+  FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
 
   FEXCore::Profiler::Init("", "");
 

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -454,12 +454,12 @@ void BTCpuProcessInit() {
   FEXCore::Config::ReloadMetaLayer();
   FEX::Windows::Logging::Init();
 
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS_INTERPRETER, "0");
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, "0");
-  FEXCore::Config::EraseSet(FEXCore::Config::CONFIG_IS64BIT_MODE, "0");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_IS_INTERPRETER, "0");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, "0");
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, "0");
 
   // Not applicable to Windows
-  FEXCore::Config::EraseSet(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
+  FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
 
   FEXCore::Profiler::Init("", "");
 


### PR DESCRIPTION
Instead of keeping the vlaue as a string array in the MetaLayer, convert the value to its final type once.

Improves performance in some hotpaths that were doing config based string conversion in a relatively high frequency.