### PR TITLE
OpcodeDispatcher: drop useless mask in trivial cmpxchg

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3793,7 +3793,7 @@ void OpDispatchBuilder::CMPXCHGOp(OpcodeArgs) {
 
     if (GPRSize == OpSize::i64Bit && Size == OpSize::i32Bit) {
       Src1 = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, GPRSize, Op->Flags, {.AllowUpperGarbage = true});
-      Src1Lower = _Bfe(GPRSize, IR::OpSizeAsBits(Size), 0, Src1);
+      Src1Lower = Trivial ? Src1 : _Bfe(GPRSize, IR::OpSizeAsBits(Size), 0, Src1);
     } else {
       Src1 = LoadSource_WithOpSize(GPRClass, Op, Op->Dest, Size, Op->Flags, {.AllowUpperGarbage = true});
       Src1Lower = Src1;

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -1140,12 +1140,11 @@
       ]
     },
     "cmpxchg eax, ebx": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "eor x27, x4, x20",
-        "subs w26, w4, w20",
+        "mov w27, #0x0",
+        "subs w26, w4, w4",
         "mov x4, x6"
       ]
     },

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -2034,12 +2034,11 @@
       ]
     },
     "cmpxchg eax, ebx": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x0f 0xb1",
       "ExpectedArm64ASM": [
-        "mov w20, w4",
-        "eor x27, x4, x20",
-        "subs w26, w4, w20",
+        "mov w27, #0x0",
+        "subs w26, w4, w4",
         "mov x4, x6"
       ]
     },


### PR DESCRIPTION
    hit by upcoming opt pass, but we don't want to depend on that pass for that.