### PR TITLE
Addressing: Amend binary AND into logical AND in SelectAddressMode()

### DIFF
--- a/FEXCore/Source/Interface/Core/Addressing.cpp
+++ b/FEXCore/Source/Interface/Core/Addressing.cpp
@@ -127,7 +127,7 @@ AddressMode SelectAddressMode(IREmitter* IREmit, AddressMode A, IR::OpSize GPRSi
   } else {
     if (OffsetIsSIMM9 || OffsetIsUnsignedScaled) {
       return InlineImmOffsetLoadstore(A);
-    } else if (!Is32Bit && A.Base && (A.Index || A.Segment) & !A.Offset && (A.IndexScale == 1 || A.IndexScale == AccessSizeAsImm)) {
+    } else if (!Is32Bit && A.Base && (A.Index || A.Segment) && !A.Offset && (A.IndexScale == 1 || A.IndexScale == AccessSizeAsImm)) {
       return ScaledRegisterLoadstore(A);
     }
   }


### PR DESCRIPTION
Bitwise AND here is a little odd and was likely intended to be a logical AND.