### PR TITLE
OpcodeDispatcher: Remove unnecessary 128-bit check in VPGATHER()

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -5071,7 +5071,7 @@ void OpDispatchBuilder::VPGATHER(OpcodeArgs) {
       // Only loads two 32-bit elements in to the lower 64-bits of the first destination.
       // Bits [255:65] all become zero.
       Result = _VMov(OpSize::i64Bit, Result);
-    } else if (Is128Bit) {
+    } else {
       Result = _VMov(OpSize::i128Bit, Result);
     }
   } else {


### PR DESCRIPTION
This is already guaranteed to be true, since it's checked in the outer if, so this can just be a regular else statement