### PR TITLE
OpcodeDispatcher: Fix potential for uninitialized value use in RCRSmallerOp()

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2177,7 +2177,7 @@ void OpDispatchBuilder::RCRSmallerOp(OpcodeArgs) {
 
     StoreResult(GPRClass, Op, Res, OpSize::iInvalid);
 
-    uint64_t SrcConst;
+    uint64_t SrcConst = 0;
     bool IsSrcConst = IsValueConstant(WrapNode(Src), &SrcConst);
     SrcConst &= 0x1f;
 


### PR DESCRIPTION
If Src isn't a constant, then no value is actually assigned to SrcConst, so this can result in uninitialized arithmetic being performed