### PR TITLE
Addressing: Remove unnecessary assert in LoadEffectiveAddress()

### DIFF
--- a/FEXCore/Source/Interface/Core/Addressing.cpp
+++ b/FEXCore/Source/Interface/Core/Addressing.cpp
@@ -17,7 +17,6 @@ Ref LoadEffectiveAddress(IREmitter* IREmit, AddressMode A, IR::OpSize GPRSize, b
 
   if (A.Index) {
     if (A.IndexScale != 1) {
-      LOGMAN_THROW_A_FMT((A.IndexScale & (A.IndexScale - 1)) == 0, "power of two");
       uint32_t Log2 = FEXCore::ilog2(A.IndexScale);
 
       if (Tmp) {


### PR DESCRIPTION
ilog2 already has an assert for this.