### PR TITLE
InstructionCountCI: add blocks using F->I conversion

### DIFF
--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -1309,6 +1309,64 @@
         "ldr x6, [x8], #8",
         "cfinv"
       ]
+    },
+    "Control - random block using cvtss2si 1": {
+      "x86InstructionCount": 7,
+      "ExpectedInstructionCount": 16,
+      "x86Insts": [
+        "mov    rcx,rdx",
+        "cvttss2si rax,xmm1",
+        "add    rax,rcx",
+        "mov    qword [rsp],rax",
+        "mulss  xmm0,dword [rbp]",
+        "xor    ecx,ecx",
+        "comiss xmm0,xmm2"
+      ],
+      "ExpectedArm64ASM": [
+        "mov x7, x5",
+        "fcvtzs x20, s17",
+        "mov x21, #0x8000000000000000",
+        "ldr s2, [x28, #2848]",
+        "fcmp s2, s17",
+        "csel x4, x20, x21, gt",
+        "add x4, x4, x7",
+        "str x4, [x8]",
+        "ldr s2, [x9]",
+        "fmul s0, s16, s2",
+        "mov v16.s[0], v0.s[0]",
+        "mov w7, #0x0",
+        "fcmp s16, s18",
+        "cset w26, vc",
+        "axflag",
+        "mov x27, x7"
+      ]
+    },
+    "Control - random block using cvtss2si 2": {
+      "x86InstructionCount": 6,
+      "ExpectedInstructionCount": 13,
+      "x86Insts": [
+        "movss  xmm1,dword [rbp+0x40]",
+        "roundss xmm1,xmm1,0x1",
+        "cvtss2si eax,xmm1",
+        "mov    dword [r15+0xb4],eax",
+        "mov    dword [rbp+0x48],0x3f800000",
+        "test   r14,r14"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr s17, [x9, #64]",
+        "frintm s0, s17",
+        "mov v17.s[0], v0.s[0]",
+        "frinti s2, s17",
+        "fcvtzs w20, s2",
+        "mov w21, #0x80000000",
+        "ldr s3, [x28, #2816]",
+        "fcmp s3, s2",
+        "csel w4, w20, w21, gt",
+        "str w4, [x29, #180]",
+        "mov w20, #0x3f800000",
+        "str w20, [x9, #72]",
+        "subs x26, x19, #0x0 (0)"
+      ]
     }
   }
 }


### PR DESCRIPTION
to see the impact of Billy's stuff in a real world context since we don't have hot blocks for it yet. random blocks I pulled from Control_DX11.exe which I had handy, with rip relative addressing replaced.