### PR TITLE
LinuxSyscalls: Emulate futimesat syscalls

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Time.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Time.cpp
@@ -186,18 +186,7 @@ void RegisterTime(FEX::HLE::SyscallHandler* Handler) {
   });
 
   REGISTER_SYSCALL_IMPL_X32(futimesat, [](FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, const timeval32 times[2]) -> uint64_t {
-    // TODO: This will always return ENOSYS on Arm64 since `futimesat` doesn't exist on that platform.
-    uint64_t Result = 0;
-    if (times) {
-      FaultSafeUserMemAccess::VerifyIsReadable(times, sizeof(timeval32) * 2);
-      struct timeval times64[2] {};
-      times64[0] = times[0];
-      times64[1] = times[1];
-      Result = ::syscall(SYSCALL_DEF(futimesat), dirfd, pathname, times64);
-    } else {
-      Result = ::syscall(SYSCALL_DEF(futimesat), dirfd, pathname, nullptr);
-    }
-    SYSCALL_ERRNO();
+    return FEX::HLE::futimesat_compat<timeval32>(dirfd, pathname, times);
   });
 
   REGISTER_SYSCALL_IMPL_X32(

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/FD.cpp
@@ -59,9 +59,7 @@ void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
 
   REGISTER_SYSCALL_IMPL_X64(
     futimesat, [](FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, const struct timeval times[2]) -> uint64_t {
-      // TODO: This will always return ENOSYS on Arm64 since `futimesat` doesn't exist on that platform.
-      uint64_t Result = ::syscall(SYSCALL_DEF(futimesat), dirfd, pathname, times);
-      SYSCALL_ERRNO();
+      return FEX::HLE::futimesat_compat<timeval>(dirfd, pathname, times);
     });
 
   REGISTER_SYSCALL_IMPL_X64(stat, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname, FEX::HLE::x64::guest_stat* buf) -> uint64_t {

--- a/unittests/FEXLinuxTests/tests/syscalls/futimesat.cpp
+++ b/unittests/FEXLinuxTests/tests/syscalls/futimesat.cpp
@@ -1,0 +1,129 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+
+struct compat_timeval {
+  long tv_sec;
+  long tv_usec;
+};
+
+uint64_t compat_futimesat(int dirfd, const char* pathname, const struct compat_timeval times[2]) {
+  return ::syscall(SYS_futimesat, dirfd, pathname, times);
+}
+
+TEST_CASE("futimesat - invalid - minimum") {
+  compat_timeval tvs[2] {};
+  tvs[0].tv_sec = 0;
+  tvs[0].tv_usec = -1;
+
+  tvs[1].tv_sec = 0;
+  tvs[1].tv_usec = -1;
+
+  char file[] = "futimesat-tests.XXXXXXXX";
+  int fd = mkstemp(file);
+  REQUIRE(fd != -1);
+
+  REQUIRE(compat_futimesat(fd, nullptr, tvs) == -1);
+  CHECK(errno == EINVAL);
+  REQUIRE(unlinkat(AT_FDCWD, file, 0) != -1);
+  REQUIRE(close(fd) != -1);
+}
+
+TEST_CASE("futimesat - invalid - maximum") {
+  compat_timeval tvs[2] {};
+  tvs[0].tv_sec = 0;
+  tvs[0].tv_usec = 1000000;
+
+  tvs[1].tv_sec = 0;
+  tvs[1].tv_usec = 1000000;
+
+  char file[] = "futimesat-tests.XXXXXXXX";
+  int fd = mkstemp(file);
+  REQUIRE(fd != -1);
+
+  REQUIRE(compat_futimesat(fd, nullptr, tvs) == -1);
+  CHECK(errno == EINVAL);
+  REQUIRE(unlinkat(AT_FDCWD, file, 0) != -1);
+  REQUIRE(close(fd) != -1);
+}
+
+TEST_CASE("futimesat - valid - null") {
+  char file[] = "futimesat-tests.XXXXXXXX";
+  int fd = mkstemp(file);
+  REQUIRE(fd != -1);
+
+  timespec time {};
+  REQUIRE(clock_gettime(CLOCK_REALTIME, &time) == 0);
+
+  // Sets the time to "Now".
+  REQUIRE(compat_futimesat(fd, nullptr, nullptr) == 0);
+  REQUIRE(unlinkat(AT_FDCWD, file, 0) != -1);
+
+  // Get the stat information of the file.
+  struct stat sb {};
+  REQUIRE(fstat(fd, &sb) == 0);
+  CHECK(sb.st_atim.tv_sec >= time.tv_sec);
+  CHECK(sb.st_mtim.tv_sec >= time.tv_sec);
+
+  REQUIRE(close(fd) != -1);
+}
+
+TEST_CASE("futimesat - valid - future") {
+  char file[] = "futimesat-tests.XXXXXXXX";
+  int fd = mkstemp(file);
+  REQUIRE(fd != -1);
+
+  timespec time {};
+  REQUIRE(clock_gettime(CLOCK_REALTIME, &time) == 0);
+
+  compat_timeval tvs[2] {};
+  tvs[0].tv_sec = time.tv_sec + 60;
+  tvs[0].tv_usec = 0;
+
+  tvs[1].tv_sec = time.tv_sec + 60;
+  tvs[1].tv_usec = 0;
+
+  // Sets the time to "Now".
+  REQUIRE(compat_futimesat(fd, nullptr, tvs) == 0);
+  REQUIRE(unlinkat(AT_FDCWD, file, 0) != -1);
+
+  // Get the stat information of the file.
+  struct stat sb {};
+  REQUIRE(fstat(fd, &sb) == 0);
+  CHECK(sb.st_atim.tv_sec == tvs[0].tv_sec);
+  CHECK(sb.st_mtim.tv_sec == tvs[1].tv_sec);
+
+  REQUIRE(close(fd) != -1);
+}
+
+TEST_CASE("futimesat - valid - past") {
+  char file[] = "futimesat-tests.XXXXXXXX";
+  int fd = mkstemp(file);
+  REQUIRE(fd != -1);
+
+  timespec time {};
+  REQUIRE(clock_gettime(CLOCK_REALTIME, &time) == 0);
+
+  compat_timeval tvs[2] {};
+  tvs[0].tv_sec = time.tv_sec - 60;
+  tvs[0].tv_usec = 0;
+
+  tvs[1].tv_sec = time.tv_sec - 60;
+  tvs[1].tv_usec = 0;
+
+  // Sets the time to "Now".
+  REQUIRE(compat_futimesat(fd, nullptr, tvs) == 0);
+  REQUIRE(unlinkat(AT_FDCWD, file, 0) != -1);
+
+  // Get the stat information of the file.
+  struct stat sb {};
+  REQUIRE(fstat(fd, &sb) == 0);
+  CHECK(sb.st_atim.tv_sec == tvs[0].tv_sec);
+  CHECK(sb.st_mtim.tv_sec == tvs[1].tv_sec);
+
+  REQUIRE(close(fd) != -1);
+}


### PR DESCRIPTION
Since this syscall doesn't exist, we need to convert it to the
equivalent utimensat like the kernel does internally.

This is fairly trivial but there are some safety nets in place.