### PR TITLE
CodeEmitter/SVEOps: Add SVE2 crypto operations

### DIFF
--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -2153,7 +2153,12 @@ public:
   }
 
   // SVE2 crypto constructive binary operations
-  // XXX:
+  void sm4ekey(ZRegister zd, ZRegister zn, ZRegister zm) {
+    SVE2CryptoConstructiveBinaryOperation(0, zd, zn, zm);
+  }
+  void rax1(ZRegister zd, ZRegister zn, ZRegister zm) {
+    SVE2CryptoConstructiveBinaryOperation(1, zd, zn, zm);
+  }
 
   // SVE Floating Point Widening Multiply-Add - Indexed
   // SVE BFloat16 floating-point dot product (indexed)
@@ -3924,6 +3929,15 @@ private:
     Instr |= o2 << 10;
     Instr |= zm.Idx() << 5;
     Instr |= zdn.Idx();
+    dc32(Instr);
+  }
+
+  void SVE2CryptoConstructiveBinaryOperation(uint32_t op, ZRegister zd, ZRegister zn, ZRegister zm) {
+    uint32_t Instr = 0b0100'0101'0010'0000'1111'0000'0000'0000;
+    Instr |= zm.Idx() << 16;
+    Instr |= op << 10;
+    Instr |= zn.Idx() << 5;
+    Instr |= zd.Idx();
     dc32(Instr);
   }
 

--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -2134,7 +2134,13 @@ public:
 
   // SVE2 Crypto Extensions
   // SVE2 crypto unary operations
-  // XXX:
+  void aesimc(ZRegister zdn, ZRegister zn) {
+    SVE2CryptoUnaryOperation(1, zdn, zn);
+  }
+  void aesmc(ZRegister zdn, ZRegister zn) {
+    SVE2CryptoUnaryOperation(0, zdn, zn);
+  }
+
   // SVE2 crypto destructive binary operations
   // XXX:
   // SVE2 crypto constructive binary operations
@@ -3889,6 +3895,15 @@ private:
     Instr |= opc << 10;
     Instr |= zn.Idx() << 5;
     Instr |= zd.Idx();
+    dc32(Instr);
+  }
+
+  void SVE2CryptoUnaryOperation(uint32_t op, ZRegister zdn, ZRegister zn) {
+    LOGMAN_THROW_A_FMT(zdn == zn, "zdn and zn must be the same register");
+
+    uint32_t Instr = 0b0100'0101'0010'0000'1110'0000'0000'0000;
+    Instr |= op << 10;
+    Instr |= zdn.Idx();
     dc32(Instr);
   }
 

--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -2142,7 +2142,16 @@ public:
   }
 
   // SVE2 crypto destructive binary operations
-  // XXX:
+  void aese(ZRegister zdn, ZRegister zn, ZRegister zm) {
+    SVE2CryptoDestructiveBinaryOperation(0, 0, zdn, zn, zm);
+  }
+  void aesd(ZRegister zdn, ZRegister zn, ZRegister zm) {
+    SVE2CryptoDestructiveBinaryOperation(0, 1, zdn, zn, zm);
+  }
+  void sm4e(ZRegister zdn, ZRegister zn, ZRegister zm) {
+    SVE2CryptoDestructiveBinaryOperation(1, 0, zdn, zn, zm);
+  }
+
   // SVE2 crypto constructive binary operations
   // XXX:
 
@@ -3903,6 +3912,17 @@ private:
 
     uint32_t Instr = 0b0100'0101'0010'0000'1110'0000'0000'0000;
     Instr |= op << 10;
+    Instr |= zdn.Idx();
+    dc32(Instr);
+  }
+
+  void SVE2CryptoDestructiveBinaryOperation(uint32_t op, uint32_t o2, ZRegister zdn, ZRegister zn, ZRegister zm) {
+    LOGMAN_THROW_A_FMT(zdn == zn, "zdn and zn must be the same register");
+
+    uint32_t Instr = 0b0100'0101'0010'0010'1110'0000'0000'0000;
+    Instr |= op << 16;
+    Instr |= o2 << 10;
+    Instr |= zm.Idx() << 5;
     Instr |= zdn.Idx();
     dc32(Instr);
   }

--- a/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -3377,7 +3377,11 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 Histogram Computation - S
   TEST_SINGLE(histseg(ZReg::z30, ZReg::z29, ZReg::z28), "histseg z30.b, z29.b, z28.b");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto unary operations") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(aesimc(ZReg::z7, ZReg::z7), "aesimc z7.b, z7.b");
+  TEST_SINGLE(aesimc(ZReg::z31, ZReg::z31), "aesimc z31.b, z31.b");
+
+  TEST_SINGLE(aesmc(ZReg::z7, ZReg::z7), "aesmc z7.b, z7.b");
+  TEST_SINGLE(aesmc(ZReg::z31, ZReg::z31), "aesmc z31.b, z31.b");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto destructive binary operations") {
   // TODO: Implement in emitter.

--- a/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -3394,7 +3394,11 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto destructive binary
   TEST_SINGLE(sm4e(ZReg::z30, ZReg::z30, ZReg::z31), "sm4e z30.s, z30.s, z31.s");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto constructive binary operations") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(sm4ekey(ZReg::z0, ZReg::z1, ZReg::z2), "sm4ekey z0.s, z1.s, z2.s");
+  TEST_SINGLE(sm4ekey(ZReg::z29, ZReg::z30, ZReg::z31), "sm4ekey z29.s, z30.s, z31.s");
+
+  TEST_SINGLE(rax1(ZReg::z0, ZReg::z1, ZReg::z2), "rax1 z0.d, z1.d, z2.d");
+  TEST_SINGLE(rax1(ZReg::z29, ZReg::z30, ZReg::z31), "rax1 z29.d, z30.d, z31.d");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE BFloat16 floating-point dot product (indexed)") {
   // TODO: Implement in emitter.

--- a/FEXCore/unittests/Emitter/SVE_Tests.cpp
+++ b/FEXCore/unittests/Emitter/SVE_Tests.cpp
@@ -3384,7 +3384,14 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto unary operations")
   TEST_SINGLE(aesmc(ZReg::z31, ZReg::z31), "aesmc z31.b, z31.b");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto destructive binary operations") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(aesd(ZReg::z7, ZReg::z7, ZReg::z8), "aesd z7.b, z7.b, z8.b");
+  TEST_SINGLE(aesd(ZReg::z30, ZReg::z30, ZReg::z31), "aesd z30.b, z30.b, z31.b");
+
+  TEST_SINGLE(aese(ZReg::z7, ZReg::z7, ZReg::z8), "aese z7.b, z7.b, z8.b");
+  TEST_SINGLE(aese(ZReg::z30, ZReg::z30, ZReg::z31), "aese z30.b, z30.b, z31.b");
+
+  TEST_SINGLE(sm4e(ZReg::z7, ZReg::z7, ZReg::z8), "sm4e z7.s, z7.s, z8.s");
+  TEST_SINGLE(sm4e(ZReg::z30, ZReg::z30, ZReg::z31), "sm4e z30.s, z30.s, z31.s");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: SVE: SVE2 crypto constructive binary operations") {
   // TODO: Implement in emitter.


### PR DESCRIPTION
We couldn't add these before because vixl had a policy of not implementing cryptography ops (which is now not the case), so we can go ahead and drop those into place so we never have to worry about them