### PR TITLE
FEXCore/Frontend: Changes how VEX operand encoding flags are encoded

### DIFF
--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -471,7 +471,9 @@ bool Decoder::NormalOp(const FEXCore::X86Tables::X86InstInfo* Info, uint16_t Op,
 
   size_t CurrentSrc = 0;
 
-  if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_VEX_1ST_SRC) != 0) {
+  const auto VEXOperand = Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_VEX_SRC_MASK;
+
+  if (VEXOperand == FEXCore::X86Tables::InstFlags::FLAGS_VEX_1ST_SRC) {
     DecodeInst->Src[CurrentSrc].Type = DecodedOperand::OpType::GPR;
     DecodeInst->Src[CurrentSrc].Data.GPR.HighBits = false;
 
@@ -496,7 +498,7 @@ bool Decoder::NormalOp(const FEXCore::X86Tables::X86InstInfo* Info, uint16_t Op,
     ++CurrentSrc;
   }
 
-  if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_VEX_2ND_SRC) != 0) {
+  if (VEXOperand == FEXCore::X86Tables::InstFlags::FLAGS_VEX_2ND_SRC) {
     DecodeInst->Src[CurrentSrc].Type = DecodedOperand::OpType::GPR;
     DecodeInst->Src[CurrentSrc].Data.GPR.HighBits = false;
     DecodeInst->Src[CurrentSrc].Data.GPR.GPR = MapVEXToReg(Options.vvvv, HasXMMSrc);
@@ -515,7 +517,7 @@ bool Decoder::NormalOp(const FEXCore::X86Tables::X86InstInfo* Info, uint16_t Op,
     ++CurrentSrc;
   }
 
-  if ((Info->Flags & FEXCore::X86Tables::InstFlags::FLAGS_VEX_DST) != 0) {
+  if (VEXOperand == FEXCore::X86Tables::InstFlags::FLAGS_VEX_DST) {
     CurrentDest->Type = DecodedOperand::OpType::GPR;
     CurrentDest->Data.GPR.HighBits = false;
     CurrentDest->Data.GPR.GPR = MapVEXToReg(Options.vvvv, HasXMMDst);

--- a/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -343,14 +343,14 @@ constexpr InstFlagType FLAGS_MODRM                 = (1ULL << 16);
 // x87
 constexpr InstFlagType FLAGS_POP                  = (1ULL << 20);
 
-// Whether or not the instruction has a VEX prefix for the first source operand
-constexpr InstFlagType FLAGS_VEX_1ST_SRC          = (1ULL << 21);
-// Whether or not the instruction has a VEX prefix for the second source operand
-constexpr InstFlagType FLAGS_VEX_2ND_SRC          = (1ULL << 22);
-// Whether or not the instruction has a VEX prefix for the destination
-constexpr InstFlagType FLAGS_VEX_DST              = (1ULL << 23);
+// Whether or not the instruction has a VEX prefix for the dest, first, or second source.
+constexpr InstFlagType FLAGS_VEX_SRC_MASK         = (0b11ULL << 21);
+constexpr InstFlagType FLAGS_VEX_NO_OPERAND       = (0b00ULL << 21);
+constexpr InstFlagType FLAGS_VEX_DST              = (0b01ULL << 21);
+constexpr InstFlagType FLAGS_VEX_1ST_SRC          = (0b10ULL << 21);
+constexpr InstFlagType FLAGS_VEX_2ND_SRC          = (0b11ULL << 21);
 // Whether or not the instruction has a VSIB byte
-constexpr InstFlagType FLAGS_VEX_VSIB             = (1ULL << 24);
+constexpr InstFlagType FLAGS_VEX_VSIB             = (1ULL << 23);
 
 constexpr InstFlagType FLAGS_SIZE_DST_OFF = 58;
 constexpr InstFlagType FLAGS_SIZE_SRC_OFF = FLAGS_SIZE_DST_OFF + 3;


### PR DESCRIPTION
These three options are mutually exclusive with each other and could potentially result in invalid encodings of the table on accident.

Change over to a 2-bit bitfield to encode if the operand that consumes the VEX option is none, destination, 1st src, or 2nd src.

This ensures the table can't ever be incorrectly encoded.