### PR TITLE
Initialize OutputFS to -1

### DIFF
--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -529,7 +529,7 @@ int main(int argc, char** argv, char** const envp) {
   auto VDSOMapping = FEX::VDSO::LoadVDSOThunks(Loader.Is64BitMode(), SyscallHandler.get());
 
   // Now that we have the syscall handler. Track some FDs that are FEX owned.
-  if (OutputFD != -1) {
+  if (OutputFD > 2) {
     SyscallHandler->FM.TrackFEXFD(OutputFD);
   }
   SyscallHandler->FM.TrackFEXFD(FEXServerClient::GetServerFD());


### PR DESCRIPTION
Avoids the non-fatal error: "[ERROR] Close closing FEX FD 2" that happens when the guest program executes a syscall to close fd 2, and it's not in fex tracked set.