### PR TITLE
Optimize float->integer conversions with Feat_FRINTTS

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -59,6 +59,8 @@
           "DISABLEFLAGM": "disableflagm",
           "ENABLEFLAGM2": "enableflagm2",
           "DISABLEFLAGM2": "disableflagm2",
+          "ENABLEFRINTTS": "enablefrintts",
+          "DISABLEFRINTTS": "disablefrintts",
           "ENABLECRYPTO": "enablecrypto",
           "DISABLECRYPTO": "disablecrypto",
           "ENABLERPRES": "enablerpres",

--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -3274,7 +3274,11 @@ DEF_OP(VUShrNI) {
     shrnb(SubRegSize, Dst.Z(), Vector.Z(), BitShift);
     uzp1(SubRegSize, Dst.Z(), Dst.Z(), Dst.Z());
   } else {
-    shrn(SubRegSize, Dst.D(), Vector.D(), BitShift);
+    if (BitShift == 0) {
+      xtn(SubRegSize, Dst.D(), Vector.D());
+    } else {
+      shrn(SubRegSize, Dst.D(), Vector.D(), BitShift);
+    }
   }
 }
 

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -2697,6 +2697,14 @@
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize"
       },
+      "FPR = Vector_FToISized OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector, i1:$HostRound, OpSize:$IntSize": {
+        "Desc": ["Vector op: Rounds float to sized integral",
+                 "Either host rounding or round-to-zero",
+                 "Rounding mode determined by argument"
+                ],
+        "DestSize": "RegisterSize",
+        "ElementSize": "ElementSize"
+      },
       "FPR = Vector_F64ToI32 OpSize:#RegisterSize, FPR:$Vector, RoundType:$Round, i1:$EnsureZeroUpperHalf": {
         "Desc": ["Vector op: Rounds 64-bit float to 32-bit integral with round mode",
                  "Matches CVTPD2DQ/CVTTPD2DQ behaviour"

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -2092,7 +2092,7 @@
         "ElementSize": "ElementSize >> 1",
         "EmitValidation": [
           "ElementSize >= FEXCore::IR::OpSize::i16Bit && ElementSize <= FEXCore::IR::OpSize::i64Bit",
-          "BitShift > 0 && BitShift <= IR::OpSizeAsBits(ElementSize)"
+          "BitShift <= IR::OpSizeAsBits(ElementSize)"
         ]
       },
 

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -36,6 +36,7 @@ struct HostFeatures {
   bool SupportsAES256 {};
   bool SupportsSVEBitPerm {};
   bool SupportsCPUIndexInTPIDRRO {};
+  bool SupportsFRINTTS {};
 
   // Float exception behaviour
   bool SupportsAFP {};

--- a/Scripts/InstructionCountParser.py
+++ b/Scripts/InstructionCountParser.py
@@ -58,6 +58,7 @@ class HostFeatures(Flag) :
     FEATURE_TSO    = (1 << 13)
     FEATURE_LRCPC  = (1 << 14)
     FEATURE_LRCPC2 = (1 << 15)
+    FEATURE_FRINTTS = (1 << 16)
 
 HostFeaturesLookup = {
     "SVE128"  : HostFeatures.FEATURE_SVE128,
@@ -76,6 +77,7 @@ HostFeaturesLookup = {
     "TSO" : HostFeatures.FEATURE_TSO,
     "LRCPC" : HostFeatures.FEATURE_LRCPC,
     "LRCPC2" : HostFeatures.FEATURE_LRCPC2,
+    "FRINTTS" : HostFeatures.FEATURE_FRINTTS,
 }
 
 def GetHostFeatures(data):

--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -430,6 +430,7 @@ static void OverrideFeatures(FEXCore::HostFeatures* Features, uint64_t ForceSVEW
   ENABLE_DISABLE_OPTION(SupportsFCMA, FCMA, FCMA);
   ENABLE_DISABLE_OPTION(SupportsFlagM, FlagM, FLAGM);
   ENABLE_DISABLE_OPTION(SupportsFlagM2, FlagM2, FLAGM2);
+  ENABLE_DISABLE_OPTION(SupportsFRINTTS, FRINTTS, FRINTTS);
   ENABLE_DISABLE_OPTION(SupportsRPRES, RPRES, RPRES);
   ENABLE_DISABLE_OPTION(SupportsSVEBitPerm, SVEBITPERM, SVEBITPERM);
   ENABLE_DISABLE_OPTION(SupportsPreserveAllABI, PRESERVEALLABI, PRESERVEALLABI);
@@ -479,6 +480,7 @@ FEXCore::HostFeatures FetchHostFeatures(FEX::CPUFeatures& Features, bool Support
   HostFeatures.SupportsFCMA = Features.Supports(CPUFeatures::Feature::FCMA);
   HostFeatures.SupportsFlagM = Features.Supports(CPUFeatures::Feature::FlagM);
   HostFeatures.SupportsFlagM2 = Features.Supports(CPUFeatures::Feature::FlagM2);
+  HostFeatures.SupportsFRINTTS = Features.Supports(CPUFeatures::Feature::FRINTTS);
   HostFeatures.SupportsRPRES = Features.Supports(CPUFeatures::Feature::RPRES);
   HostFeatures.SupportsSVEBitPerm = Features.Supports(CPUFeatures::Feature::SVE_BitPerm);
 

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -520,6 +520,7 @@ int main(int argc, char** argv, char** const envp) {
     FEATURE_TSO = (1U << 13),
     FEATURE_LRCPC = (1U << 14),
     FEATURE_LRCPC2 = (1U << 15),
+    FEATURE_FRINTTS = (1U << 16),
   };
 
   uint64_t SVEWidth = 0;
@@ -566,6 +567,9 @@ int main(int argc, char** argv, char** const envp) {
   }
   if (TestHeaderData->EnabledHostFeatures & FEATURE_LRCPC2) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLELRCPC2);
+  }
+  if (TestHeaderData->EnabledHostFeatures & FEATURE_FRINTTS) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::ENABLEFRINTTS);
   }
 
   if (TestHeaderData->EnabledHostFeatures & FEATURE_TSO) {
@@ -617,6 +621,9 @@ int main(int argc, char** argv, char** const envp) {
   }
   if (TestHeaderData->DisabledHostFeatures & FEATURE_LRCPC2) {
     HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLELRCPC2);
+  }
+  if (TestHeaderData->DisabledHostFeatures & FEATURE_FRINTTS) {
+    HostFeatureControl |= static_cast<uint64_t>(FEXCore::Config::HostFeatures::DISABLEFRINTTS);
   }
 
   if (TestHeaderData->DisabledHostFeatures & FEATURE_TSO) {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -2616,127 +2616,83 @@
       ]
     },
     "vcvttss2si eax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtzs w20, s16",
-        "mov w21, #0x80000000",
-        "ldr s2, [x28, #2816]",
-        "mrs x22, nzcv",
-        "fcmp s2, s16",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32z s2, s16",
+        "fcvtzs w4, s2"
       ]
     },
     "vcvttss2si rax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtzs x20, s16",
-        "mov x21, #0x8000000000000000",
-        "ldr s2, [x28, #2848]",
-        "mrs x22, nzcv",
-        "fcmp s2, s16",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64z s2, s16",
+        "fcvtzs x4, s2"
       ]
     },
     "vcvttsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtzs w20, d16",
-        "mov w21, #0x80000000",
-        "ldr d2, [x28, #2864]",
-        "mrs x22, nzcv",
-        "fcmp d2, d16",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32z d2, d16",
+        "fcvtzs w4, d2"
       ]
     },
     "vcvttsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtzs x20, d16",
-        "mov x21, #0x8000000000000000",
-        "ldr d2, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d2, d16",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64z d2, d16",
+        "fcvtzs x4, d2"
       ]
     },
     "vcvtss2si eax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti s2, s16",
-        "fcvtzs w20, s2",
-        "mov w21, #0x80000000",
-        "ldr s3, [x28, #2816]",
-        "mrs x22, nzcv",
-        "fcmp s3, s2",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32x s2, s16",
+        "fcvtzs w4, s2"
       ]
     },
     "vcvtss2si rax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti s2, s16",
-        "fcvtzs x20, s2",
-        "mov x21, #0x8000000000000000",
-        "ldr s3, [x28, #2848]",
-        "mrs x22, nzcv",
-        "fcmp s3, s2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x s2, s16",
+        "fcvtzs x4, s2"
       ]
     },
     "vcvtsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti d2, d16",
-        "fcvtzs x20, d2",
-        "mov x21, #0x8000000000000000",
-        "ldr d3, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d3, d2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x d2, d16",
+        "fcvtzs x4, d2"
       ]
     },
     "vcvtsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti d2, d16",
-        "fcvtzs x20, d2",
-        "mov x21, #0x8000000000000000",
-        "ldr d3, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d3, d2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x d2, d16",
+        "fcvtzs x4, d2"
       ]
     },
     "vucomiss xmm0, xmm1": {
@@ -3023,73 +2979,52 @@
       ]
     },
     "vcvtps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti v2.4s, v17.4s",
-        "ldr q3, [x28, #2912]",
-        "ldr q4, [x28, #2816]",
-        "fcvtzs v5.4s, v2.4s",
-        "fcmgt v2.4s, v4.4s, v2.4s",
-        "mov v16.16b, v2.16b",
-        "bsl v16.16b, v5.16b, v3.16b",
+        "frint32x v2.4s, v17.4s",
+        "fcvtzs v16.4s, v2.4s",
         "stp xzr, xzr, [x28, #32]"
       ]
     },
     "vcvtps2dq ymm0, ymm1": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b01 0x5b 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #48]",
-        "frinti v3.4s, v17.4s",
-        "ldr q4, [x28, #2912]",
-        "ldr q5, [x28, #2816]",
-        "fcvtzs v6.4s, v3.4s",
-        "fcmgt v3.4s, v5.4s, v3.4s",
-        "mov v16.16b, v3.16b",
-        "bsl v16.16b, v6.16b, v4.16b",
-        "frinti v2.4s, v2.4s",
-        "fcvtzs v3.4s, v2.4s",
-        "fcmgt v2.4s, v5.4s, v2.4s",
-        "bsl v2.16b, v3.16b, v4.16b",
+        "frint32x v3.4s, v17.4s",
+        "fcvtzs v16.4s, v3.4s",
+        "frint32x v2.4s, v2.4s",
+        "fcvtzs v2.4s, v2.4s",
         "str q2, [x28, #32]"
       ]
     },
     "vcvttps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b10 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x28, #2912]",
-        "ldr q3, [x28, #2816]",
-        "fcvtzs v4.4s, v17.4s",
-        "fcmgt v3.4s, v3.4s, v17.4s",
-        "mov v16.16b, v3.16b",
-        "bsl v16.16b, v4.16b, v2.16b",
+        "frint32z v2.4s, v17.4s",
+        "fcvtzs v16.4s, v2.4s",
         "stp xzr, xzr, [x28, #32]"
       ]
     },
     "vcvttps2dq ymm0, ymm1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 1 0b10 0x5b 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #48]",
-        "ldr q3, [x28, #2912]",
-        "ldr q4, [x28, #2816]",
-        "fcvtzs v5.4s, v17.4s",
-        "fcmgt v6.4s, v4.4s, v17.4s",
-        "mov v16.16b, v6.16b",
-        "bsl v16.16b, v5.16b, v3.16b",
-        "fcvtzs v5.4s, v2.4s",
-        "fcmgt v2.4s, v4.4s, v2.4s",
-        "bsl v2.16b, v5.16b, v3.16b",
+        "frint32z v3.4s, v17.4s",
+        "fcvtzs v16.4s, v3.4s",
+        "frint32z v2.4s, v2.4s",
+        "fcvtzs v2.4s, v2.4s",
         "str q2, [x28, #32]"
       ]
     },
@@ -4544,45 +4479,31 @@
       ]
     },
     "vcvttpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b01 0xe6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr d2, [x28, #2912]",
-        "ldr q3, [x28, #2864]",
-        "frintz v4.2d, v17.2d",
-        "fcvtn v4.2s, v4.2d",
-        "fcvtzs v4.2s, v4.2s",
-        "fcmgt v3.2d, v3.2d, v17.2d",
-        "shrn v3.2s, v3.2d, #32",
-        "mov v16.16b, v3.16b",
-        "bsl v16.16b, v4.16b, v2.16b",
+        "frint32z v2.2d, v17.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v16.2s, v2.2d",
         "stp xzr, xzr, [x28, #32]"
       ]
     },
     "vcvttpd2dq xmm0, ymm1": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Map 1 0b01 0xe6 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #48]",
-        "ldr q3, [x28, #2912]",
-        "ldr q4, [x28, #2864]",
-        "frintz v5.2d, v17.2d",
-        "fcvtn v5.2s, v5.2d",
-        "fcvtzs v5.2s, v5.2s",
-        "fcmgt v6.2d, v4.2d, v17.2d",
-        "shrn v6.2s, v6.2d, #32",
-        "bsl v6.16b, v5.16b, v3.16b",
-        "frintz v5.2d, v2.2d",
-        "fcvtn v5.2s, v5.2d",
-        "fcvtzs v5.2s, v5.2s",
-        "fcmgt v2.2d, v4.2d, v2.2d",
-        "shrn v2.2s, v2.2d, #32",
-        "bsl v2.16b, v5.16b, v3.16b",
-        "zip1 v16.2d, v6.2d, v2.2d",
+        "frint32z v3.2d, v17.2d",
+        "fcvtzs v3.2d, v3.2d",
+        "xtn v3.2s, v3.2d",
+        "frint32z v2.2d, v2.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v2.2s, v2.2d",
+        "zip1 v16.2d, v3.2d, v2.2d",
         "stp xzr, xzr, [x28, #32]"
       ]
     },
@@ -4611,47 +4532,30 @@
       ]
     },
     "vcvtpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 1 0b11 0xe6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti v2.2d, v17.2d",
-        "ldr d3, [x28, #2912]",
-        "ldr q4, [x28, #2864]",
-        "frintz v5.2d, v2.2d",
-        "fcvtn v5.2s, v5.2d",
-        "fcvtzs v5.2s, v5.2s",
-        "fcmgt v2.2d, v4.2d, v2.2d",
-        "shrn v2.2s, v2.2d, #32",
-        "mov v16.16b, v2.16b",
-        "bsl v16.16b, v5.16b, v3.16b",
+        "frint32x v2.2d, v17.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v16.2s, v2.2d",
         "stp xzr, xzr, [x28, #32]"
       ]
     },
     "vcvtpd2dq xmm0, ymm1": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Map 1 0b11 0xe6 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #48]",
-        "frinti v3.2d, v17.2d",
-        "ldr q4, [x28, #2912]",
-        "ldr q5, [x28, #2864]",
-        "frintz v6.2d, v3.2d",
-        "fcvtn v6.2s, v6.2d",
-        "fcvtzs v6.2s, v6.2s",
-        "fcmgt v3.2d, v5.2d, v3.2d",
-        "shrn v3.2s, v3.2d, #32",
-        "bsl v3.16b, v6.16b, v4.16b",
-        "frinti v2.2d, v2.2d",
-        "frintz v6.2d, v2.2d",
-        "fcvtn v6.2s, v6.2d",
-        "fcvtzs v6.2s, v6.2s",
-        "fcmgt v2.2d, v5.2d, v2.2d",
-        "shrn v2.2s, v2.2d, #32",
-        "bsl v2.16b, v6.16b, v4.16b",
+        "frint32x v3.2d, v17.2d",
+        "fcvtzs v3.2d, v3.2d",
+        "xtn v3.2s, v3.2d",
+        "frint32x v2.2d, v2.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v2.2s, v2.2d",
         "zip1 v16.2d, v3.2d, v2.2d",
         "stp xzr, xzr, [x28, #32]"
       ]

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -1,7 +1,9 @@
 {
   "Features": {
     "Bitness": 64,
-    "EnabledHostFeatures": [],
+    "EnabledHostFeatures": [
+      "FRINTTS"
+    ],
     "DisabledHostFeatures": [
       "FCMA",
       "RPRES",

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -1,7 +1,9 @@
 {
   "Features": {
     "Bitness": 64,
-    "EnabledHostFeatures": [],
+    "EnabledHostFeatures": [
+      "FRINTTS"
+    ],
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256",

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -61,17 +61,14 @@
       ]
     },
     "pf2id mm0, mm1": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "0x0f 0x0f 0x1d"
       ],
       "ExpectedArm64ASM": [
         "ldr d2, [x28, #1056]",
-        "ldr d3, [x28, #2912]",
-        "ldr d4, [x28, #2816]",
-        "fcvtzs v5.2s, v2.2s",
-        "fcmgt v2.4s, v4.4s, v2.4s",
-        "bsl v2.8b, v5.8b, v3.8b",
+        "frint32z v2.4s, v2.4s",
+        "fcvtzs v2.2s, v2.2s",
         "str d2, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -1313,7 +1313,7 @@
     },
     "Control - random block using cvtss2si 1": {
       "x86InstructionCount": 7,
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 13,
       "x86Insts": [
         "mov    rcx,rdx",
         "cvttss2si rax,xmm1",
@@ -1325,11 +1325,8 @@
       ],
       "ExpectedArm64ASM": [
         "mov x7, x5",
-        "fcvtzs x20, s17",
-        "mov x21, #0x8000000000000000",
-        "ldr s2, [x28, #2848]",
-        "fcmp s2, s17",
-        "csel x4, x20, x21, gt",
+        "frint64z s2, s17",
+        "fcvtzs x4, s2",
         "add x4, x4, x7",
         "str x4, [x8]",
         "ldr s2, [x9]",
@@ -1344,7 +1341,7 @@
     },
     "Control - random block using cvtss2si 2": {
       "x86InstructionCount": 6,
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 9,
       "x86Insts": [
         "movss  xmm1,dword [rbp+0x40]",
         "roundss xmm1,xmm1,0x1",
@@ -1357,12 +1354,8 @@
         "ldr s17, [x9, #64]",
         "frintm s0, s17",
         "mov v17.s[0], v0.s[0]",
-        "frinti s2, s17",
-        "fcvtzs w20, s2",
-        "mov w21, #0x80000000",
-        "ldr s3, [x28, #2816]",
-        "fcmp s3, s2",
-        "csel w4, w20, w21, gt",
+        "frint32x s2, s17",
+        "fcvtzs w4, s2",
         "str w4, [x29, #180]",
         "mov w20, #0x3f800000",
         "str w20, [x9, #72]",

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -3,7 +3,8 @@
     "Bitness": 64,
     "EnabledHostFeatures": [
       "FLAGM",
-      "FLAGM2"
+      "FLAGM2",
+      "FRINTTS"
     ],
     "DisabledHostFeatures": [
       "SVE128",

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -1,7 +1,9 @@
 {
   "Features": {
     "Bitness": 64,
-    "EnabledHostFeatures": [],
+    "EnabledHostFeatures": [
+      "FRINTTS"
+    ],
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256",

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -170,62 +170,48 @@
       ]
     },
     "cvttps2pi mm0, [rax]": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 8,
       "Comment": "0x0f 0x2c",
       "ExpectedArm64ASM": [
         "strb wzr, [x28, #1019]",
         "mov w20, #0xffff",
         "ldr d2, [x4]",
-        "ldr d3, [x28, #2912]",
-        "ldr d4, [x28, #2816]",
-        "fcvtzs v5.2s, v2.2s",
-        "fcmgt v2.4s, v4.4s, v2.4s",
-        "bsl v2.8b, v5.8b, v3.8b",
+        "frint32z v2.4s, v2.4s",
+        "fcvtzs v2.2s, v2.2s",
         "strb w20, [x28, #1298]",
         "str d2, [x28, #1040]",
         "strh w20, [x28, #1048]"
       ]
     },
     "cvttps2pi mm0, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 5,
       "Comment": "0x0f 0x2c",
       "ExpectedArm64ASM": [
-        "ldr d2, [x28, #2912]",
-        "ldr d3, [x28, #2816]",
-        "fcvtzs v4.2s, v16.2s",
-        "fcmgt v3.4s, v3.4s, v16.4s",
-        "bsl v3.8b, v4.8b, v2.8b",
-        "str d3, [x28, #1040]",
+        "frint32z v2.4s, v16.4s",
+        "fcvtzs v2.4s, v2.4s",
+        "str d2, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"
       ]
     },
     "cvtps2pi mm0, [rax]": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 6,
       "Comment": "0x0f 0x2d",
       "ExpectedArm64ASM": [
         "ldr d2, [x4]",
-        "frinti v2.4s, v2.4s",
-        "ldr d3, [x28, #2912]",
-        "ldr d4, [x28, #2816]",
-        "fcvtzs v5.2s, v2.2s",
-        "fcmgt v2.4s, v4.4s, v2.4s",
-        "bsl v2.8b, v5.8b, v3.8b",
+        "frint32x v2.4s, v2.4s",
+        "fcvtzs v2.2s, v2.2s",
         "str d2, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"
       ]
     },
     "cvtps2pi mm0, xmm0": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 5,
       "Comment": "0x0f 0x2d",
       "ExpectedArm64ASM": [
-        "frinti v2.4s, v16.4s",
-        "ldr d3, [x28, #2912]",
-        "ldr d4, [x28, #2816]",
-        "fcvtzs v5.2s, v2.2s",
-        "fcmgt v2.4s, v4.4s, v2.4s",
-        "bsl v2.8b, v5.8b, v3.8b",
+        "frint32x v2.4s, v16.4s",
+        "fcvtzs v2.4s, v2.4s",
         "str d2, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -1,7 +1,9 @@
 {
   "Features": {
     "Bitness": 64,
-    "EnabledHostFeatures": [],
+    "EnabledHostFeatures": [
+      "FRINTTS"
+    ],
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256",

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -125,35 +125,24 @@
       ]
     },
     "cvttpd2pi mm0, xmm0": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 6,
       "Comment": "0x66 0x0f 0x2c",
       "ExpectedArm64ASM": [
-        "ldr d2, [x28, #2912]",
-        "ldr q3, [x28, #2864]",
-        "frintz v4.2d, v16.2d",
-        "fcvtn v4.2s, v4.2d",
-        "fcvtzs v4.2s, v4.2s",
-        "fcmgt v3.2d, v3.2d, v16.2d",
-        "shrn v3.2s, v3.2d, #32",
-        "bsl v3.8b, v4.8b, v2.8b",
-        "str d3, [x28, #1040]",
+        "frint32z v2.2d, v16.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v2.2s, v2.2d",
+        "str d2, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"
       ]
     },
     "cvtpd2pi mm0, xmm0": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 6,
       "Comment": "0x66 0x0f 0x2d",
       "ExpectedArm64ASM": [
-        "frinti v2.2d, v16.2d",
-        "ldr d3, [x28, #2912]",
-        "ldr q4, [x28, #2864]",
-        "frintz v5.2d, v2.2d",
-        "fcvtn v5.2s, v5.2d",
-        "fcvtzs v5.2s, v5.2s",
-        "fcmgt v2.2d, v4.2d, v2.2d",
-        "shrn v2.2s, v2.2d, #32",
-        "bsl v2.8b, v5.8b, v3.8b",
+        "frint32x v2.2d, v16.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v2.2s, v2.2d",
         "str d2, [x28, #1040]",
         "mov w20, #0xffff",
         "strh w20, [x28, #1048]"
@@ -228,30 +217,20 @@
       ]
     },
     "cvtps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": "0x66 0x0f 0x5b",
       "ExpectedArm64ASM": [
-        "frinti v2.4s, v17.4s",
-        "ldr q3, [x28, #2912]",
-        "ldr q4, [x28, #2816]",
-        "fcvtzs v5.4s, v2.4s",
-        "fcmgt v2.4s, v4.4s, v2.4s",
-        "mov v16.16b, v2.16b",
-        "bsl v16.16b, v5.16b, v3.16b"
+        "frint32x v2.4s, v17.4s",
+        "fcvtzs v16.4s, v2.4s"
       ]
     },
     "cvtps2dq xmm0, [rax]": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf2 0x0f 0x5b",
       "ExpectedArm64ASM": [
         "ldr q2, [x4]",
-        "frinti v2.4s, v2.4s",
-        "ldr q3, [x28, #2912]",
-        "ldr q4, [x28, #2816]",
-        "fcvtzs v5.4s, v2.4s",
-        "fcmgt v2.4s, v4.4s, v2.4s",
-        "mov v16.16b, v2.16b",
-        "bsl v16.16b, v5.16b, v3.16b"
+        "frint32x v2.4s, v2.4s",
+        "fcvtzs v16.4s, v2.4s"
       ]
     },
     "subpd xmm0, xmm1": {
@@ -1419,18 +1398,12 @@
       ]
     },
     "cvttpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 3,
       "Comment": "0x66 0x0f 0xe6",
       "ExpectedArm64ASM": [
-        "ldr d2, [x28, #2912]",
-        "ldr q3, [x28, #2864]",
-        "frintz v4.2d, v17.2d",
-        "fcvtn v4.2s, v4.2d",
-        "fcvtzs v4.2s, v4.2s",
-        "fcmgt v3.2d, v3.2d, v17.2d",
-        "shrn v3.2s, v3.2d, #32",
-        "mov v16.16b, v3.16b",
-        "bsl v16.16b, v4.16b, v2.16b"
+        "frint32z v2.2d, v17.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v16.2s, v2.2d"
       ]
     },
     "movntdq [rax], xmm0": {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -8,7 +8,8 @@
       "RPRES",
       "AFP",
       "FLAGM",
-      "FLAGM2"
+      "FLAGM2",
+      "FRINTTS"
     ]
   },
   "Instructions": {

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -1,7 +1,9 @@
 {
   "Features": {
     "Bitness": 64,
-    "EnabledHostFeatures": [],
+    "EnabledHostFeatures": [
+      "FRINTTS"
+    ],
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256",

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -98,115 +98,71 @@
       ]
     },
     "cvttsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
-        "fcvtzs w20, d16",
-        "mov w21, #0x80000000",
-        "ldr d2, [x28, #2864]",
-        "mrs x22, nzcv",
-        "fcmp d2, d16",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32z d2, d16",
+        "fcvtzs w4, d2"
       ]
     },
     "cvttsd2si eax, qword [rbx]": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "ldr d2, [x6]",
-        "fcvtzs w20, d2",
-        "mov w21, #0x80000000",
-        "ldr d3, [x28, #2864]",
-        "mrs x22, nzcv",
-        "fcmp d3, d2",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32z d2, d2",
+        "fcvtzs w4, d2"
       ]
     },
     "cvttsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
-        "fcvtzs x20, d16",
-        "mov x21, #0x8000000000000000",
-        "ldr d2, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d2, d16",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64z d2, d16",
+        "fcvtzs x4, d2"
       ]
     },
     "cvttsd2si rax, qword [rbx]": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf2 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "ldr d2, [x6]",
-        "fcvtzs x20, d2",
-        "mov x21, #0x8000000000000000",
-        "ldr d3, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d3, d2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64z d2, d2",
+        "fcvtzs x4, d2"
       ]
     },
     "cvtsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": "0xf2 0x0f 0x2d",
       "ExpectedArm64ASM": [
-        "frinti d2, d16",
-        "fcvtzs x20, d2",
-        "mov x21, #0x8000000000000000",
-        "ldr d3, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d3, d2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x d2, d16",
+        "fcvtzs x4, d2"
       ]
     },
     "cvtsd2si eax, qword [rbx]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf2 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "ldr d2, [x6]",
-        "frinti d2, d2",
-        "fcvtzs x20, d2",
-        "mov x21, #0x8000000000000000",
-        "ldr d3, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d3, d2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x d2, d2",
+        "fcvtzs x4, d2"
       ]
     },
     "cvtsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": "0xf2 0x0f 0x2d",
       "ExpectedArm64ASM": [
-        "frinti d2, d16",
-        "fcvtzs x20, d2",
-        "mov x21, #0x8000000000000000",
-        "ldr d3, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d3, d2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x d2, d16",
+        "fcvtzs x4, d2"
       ]
     },
     "cvtsd2si rax, qword [rbx]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf2 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "ldr d2, [x6]",
-        "frinti d2, d2",
-        "fcvtzs x20, d2",
-        "mov x21, #0x8000000000000000",
-        "ldr d3, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d3, d2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x d2, d2",
+        "fcvtzs x4, d2"
       ]
     },
     "sqrtsd xmm0, xmm1": {
@@ -518,19 +474,12 @@
       ]
     },
     "cvtpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf2 0x0f 0xe6",
       "ExpectedArm64ASM": [
-        "frinti v2.2d, v17.2d",
-        "ldr d3, [x28, #2912]",
-        "ldr q4, [x28, #2864]",
-        "frintz v5.2d, v2.2d",
-        "fcvtn v5.2s, v5.2d",
-        "fcvtzs v5.2s, v5.2s",
-        "fcmgt v2.2d, v4.2d, v2.2d",
-        "shrn v2.2s, v2.2d, #32",
-        "mov v16.16b, v2.16b",
-        "bsl v16.16b, v5.16b, v3.16b"
+        "frint32x v2.2d, v17.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v16.2s, v2.2d"
       ]
     },
     "lddqu xmm0, [rax]": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -2,7 +2,8 @@
   "Features": {
     "Bitness": 64,
     "EnabledHostFeatures": [
-      "SVE128"
+      "SVE128",
+      "FRINTTS"
     ],
     "DisabledHostFeatures": [
       "SVE256",

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -13,19 +13,12 @@
   },
   "Instructions": {
     "cvtpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf2 0x0f 0xe6",
       "ExpectedArm64ASM": [
-        "frinti v2.2d, v17.2d",
-        "ldr d3, [x28, #2912]",
-        "ldr q4, [x28, #2864]",
-        "fcvtzs z5.s, p6/m, z2.d",
-        "uzp1 z5.s, z5.s, z5.s",
-        "mov v5.8b, v5.8b",
-        "fcmgt v2.2d, v4.2d, v2.2d",
-        "shrn v2.2s, v2.2d, #32",
-        "movprfx z16, z5",
-        "bsl z16.d, z16.d, z3.d, z2.d"
+        "frint32x v2.2d, v17.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v16.2s, v2.2d"
       ]
     }
   }

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -1,0 +1,142 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "FRINTTS"
+    ],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256",
+      "RPRES",
+      "AFP",
+      "FLAGM",
+      "FLAGM2"
+    ]
+  },
+  "Instructions": {
+    "cvttss2si eax, xmm0": {
+      "ExpectedInstructionCount": 7,
+      "Comment": "0xf3 0x0f 0x2c",
+      "ExpectedArm64ASM": [
+        "fcvtzs w20, s16",
+        "mov w21, #0x80000000",
+        "ldr s2, [x28, #2816]",
+        "mrs x22, nzcv",
+        "fcmp s2, s16",
+        "csel w4, w20, w21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "cvttss2si eax, dword [rbx]": {
+      "ExpectedInstructionCount": 8,
+      "Comment": "0xf3 0x0f 0x2c",
+      "ExpectedArm64ASM": [
+        "ldr s2, [x6]",
+        "fcvtzs w20, s2",
+        "mov w21, #0x80000000",
+        "ldr s3, [x28, #2816]",
+        "mrs x22, nzcv",
+        "fcmp s3, s2",
+        "csel w4, w20, w21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "cvttss2si rax, xmm0": {
+      "ExpectedInstructionCount": 7,
+      "Comment": "0xf3 0x0f 0x2c",
+      "ExpectedArm64ASM": [
+        "fcvtzs x20, s16",
+        "mov x21, #0x8000000000000000",
+        "ldr s2, [x28, #2848]",
+        "mrs x22, nzcv",
+        "fcmp s2, s16",
+        "csel x4, x20, x21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "cvttss2si rax, dword [rbx]": {
+      "ExpectedInstructionCount": 8,
+      "Comment": "0xf3 0x0f 0x2c",
+      "ExpectedArm64ASM": [
+        "ldr d2, [x6]",
+        "fcvtzs x20, s2",
+        "mov x21, #0x8000000000000000",
+        "ldr s3, [x28, #2848]",
+        "mrs x22, nzcv",
+        "fcmp s3, s2",
+        "csel x4, x20, x21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "cvtss2si eax, xmm0": {
+      "ExpectedInstructionCount": 8,
+      "Comment": "0xf3 0x0f 0x2d",
+      "ExpectedArm64ASM": [
+        "frinti s2, s16",
+        "fcvtzs w20, s2",
+        "mov w21, #0x80000000",
+        "ldr s3, [x28, #2816]",
+        "mrs x22, nzcv",
+        "fcmp s3, s2",
+        "csel w4, w20, w21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "cvtss2si eax, dword [rbx]": {
+      "ExpectedInstructionCount": 9,
+      "Comment": "0xf3 0x0f 0x2d",
+      "ExpectedArm64ASM": [
+        "ldr s2, [x6]",
+        "frinti s2, s2",
+        "fcvtzs w20, s2",
+        "mov w21, #0x80000000",
+        "ldr s3, [x28, #2816]",
+        "mrs x22, nzcv",
+        "fcmp s3, s2",
+        "csel w4, w20, w21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "cvtss2si rax, xmm0": {
+      "ExpectedInstructionCount": 8,
+      "Comment": "0xf3 0x0f 0x2d",
+      "ExpectedArm64ASM": [
+        "frinti s2, s16",
+        "fcvtzs x20, s2",
+        "mov x21, #0x8000000000000000",
+        "ldr s3, [x28, #2848]",
+        "mrs x22, nzcv",
+        "fcmp s3, s2",
+        "csel x4, x20, x21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "cvtss2si rax, dword [rbx]": {
+      "ExpectedInstructionCount": 9,
+      "Comment": "0xf3 0x0f 0x2d",
+      "ExpectedArm64ASM": [
+        "ldr d2, [x6]",
+        "frinti s2, s2",
+        "fcvtzs x20, s2",
+        "mov x21, #0x8000000000000000",
+        "ldr s3, [x28, #2848]",
+        "mrs x22, nzcv",
+        "fcmp s3, s2",
+        "csel x4, x20, x21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "cvttps2dq xmm0, xmm1": {
+      "ExpectedInstructionCount": 6,
+      "Comment": "0xf3 0x0f 0x5b",
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #2912]",
+        "ldr q3, [x28, #2816]",
+        "fcvtzs v4.4s, v17.4s",
+        "fcmgt v3.4s, v3.4s, v17.4s",
+        "mov v16.16b, v3.16b",
+        "bsl v16.16b, v4.16b, v2.16b"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -15,127 +15,79 @@
   },
   "Instructions": {
     "cvttss2si eax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": "0xf3 0x0f 0x2c",
       "ExpectedArm64ASM": [
-        "fcvtzs w20, s16",
-        "mov w21, #0x80000000",
-        "ldr s2, [x28, #2816]",
-        "mrs x22, nzcv",
-        "fcmp s2, s16",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32z s2, s16",
+        "fcvtzs w4, s2"
       ]
     },
     "cvttss2si eax, dword [rbx]": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf3 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "ldr s2, [x6]",
-        "fcvtzs w20, s2",
-        "mov w21, #0x80000000",
-        "ldr s3, [x28, #2816]",
-        "mrs x22, nzcv",
-        "fcmp s3, s2",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32z s2, s2",
+        "fcvtzs w4, s2"
       ]
     },
     "cvttss2si rax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": "0xf3 0x0f 0x2c",
       "ExpectedArm64ASM": [
-        "fcvtzs x20, s16",
-        "mov x21, #0x8000000000000000",
-        "ldr s2, [x28, #2848]",
-        "mrs x22, nzcv",
-        "fcmp s2, s16",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64z s2, s16",
+        "fcvtzs x4, s2"
       ]
     },
     "cvttss2si rax, dword [rbx]": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf3 0x0f 0x2c",
       "ExpectedArm64ASM": [
         "ldr d2, [x6]",
-        "fcvtzs x20, s2",
-        "mov x21, #0x8000000000000000",
-        "ldr s3, [x28, #2848]",
-        "mrs x22, nzcv",
-        "fcmp s3, s2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64z s2, s2",
+        "fcvtzs x4, s2"
       ]
     },
     "cvtss2si eax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": "0xf3 0x0f 0x2d",
       "ExpectedArm64ASM": [
-        "frinti s2, s16",
-        "fcvtzs w20, s2",
-        "mov w21, #0x80000000",
-        "ldr s3, [x28, #2816]",
-        "mrs x22, nzcv",
-        "fcmp s3, s2",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32x s2, s16",
+        "fcvtzs w4, s2"
       ]
     },
     "cvtss2si eax, dword [rbx]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf3 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "ldr s2, [x6]",
-        "frinti s2, s2",
-        "fcvtzs w20, s2",
-        "mov w21, #0x80000000",
-        "ldr s3, [x28, #2816]",
-        "mrs x22, nzcv",
-        "fcmp s3, s2",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32x s2, s2",
+        "fcvtzs w4, s2"
       ]
     },
     "cvtss2si rax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": "0xf3 0x0f 0x2d",
       "ExpectedArm64ASM": [
-        "frinti s2, s16",
-        "fcvtzs x20, s2",
-        "mov x21, #0x8000000000000000",
-        "ldr s3, [x28, #2848]",
-        "mrs x22, nzcv",
-        "fcmp s3, s2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x s2, s16",
+        "fcvtzs x4, s2"
       ]
     },
     "cvtss2si rax, dword [rbx]": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 3,
       "Comment": "0xf3 0x0f 0x2d",
       "ExpectedArm64ASM": [
         "ldr d2, [x6]",
-        "frinti s2, s2",
-        "fcvtzs x20, s2",
-        "mov x21, #0x8000000000000000",
-        "ldr s3, [x28, #2848]",
-        "mrs x22, nzcv",
-        "fcmp s3, s2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x s2, s2",
+        "fcvtzs x4, s2"
       ]
     },
     "cvttps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 2,
       "Comment": "0xf3 0x0f 0x5b",
       "ExpectedArm64ASM": [
-        "ldr q2, [x28, #2912]",
-        "ldr q3, [x28, #2816]",
-        "fcvtzs v4.4s, v17.4s",
-        "fcmgt v3.4s, v3.4s, v17.4s",
-        "mov v16.16b, v3.16b",
-        "bsl v16.16b, v4.16b, v2.16b"
+        "frint32z v2.4s, v17.4s",
+        "fcvtzs v16.4s, v2.4s"
       ]
     }
   }

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -10,7 +10,8 @@
       "RPRES",
       "AFP",
       "FLAGM",
-      "FLAGM2"
+      "FLAGM2",
+      "FRINTTS"
     ]
   },
   "Instructions": {

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -1,0 +1,295 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "SVE128",
+      "SVE256",
+      "FRINTTS"
+    ],
+    "DisabledHostFeatures": [
+      "FCMA",
+      "RPRES",
+      "AFP",
+      "FLAGM",
+      "FLAGM2"
+    ]
+  },
+  "Instructions": {
+    "vcvttss2si eax, xmm0": {
+      "ExpectedInstructionCount": 7,
+      "Comment": [
+        "Map 1 0b10 0x2c 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcvtzs w20, s16",
+        "mov w21, #0x80000000",
+        "ldr s2, [x28, #2816]",
+        "mrs x22, nzcv",
+        "fcmp s2, s16",
+        "csel w4, w20, w21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "vcvttss2si rax, xmm0": {
+      "ExpectedInstructionCount": 7,
+      "Comment": [
+        "Map 1 0b10 0x2c 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcvtzs x20, s16",
+        "mov x21, #0x8000000000000000",
+        "ldr s2, [x28, #2848]",
+        "mrs x22, nzcv",
+        "fcmp s2, s16",
+        "csel x4, x20, x21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "vcvttsd2si eax, xmm0": {
+      "ExpectedInstructionCount": 7,
+      "Comment": [
+        "Map 1 0b11 0x2c 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcvtzs w20, d16",
+        "mov w21, #0x80000000",
+        "ldr d2, [x28, #2864]",
+        "mrs x22, nzcv",
+        "fcmp d2, d16",
+        "csel w4, w20, w21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "vcvttsd2si rax, xmm0": {
+      "ExpectedInstructionCount": 7,
+      "Comment": [
+        "Map 1 0b11 0x2c 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "fcvtzs x20, d16",
+        "mov x21, #0x8000000000000000",
+        "ldr d2, [x28, #2896]",
+        "mrs x22, nzcv",
+        "fcmp d2, d16",
+        "csel x4, x20, x21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "vcvtss2si eax, xmm0": {
+      "ExpectedInstructionCount": 8,
+      "Comment": [
+        "Map 1 0b10 0x2d 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frinti s2, s16",
+        "fcvtzs w20, s2",
+        "mov w21, #0x80000000",
+        "ldr s3, [x28, #2816]",
+        "mrs x22, nzcv",
+        "fcmp s3, s2",
+        "csel w4, w20, w21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "vcvtss2si rax, xmm0": {
+      "ExpectedInstructionCount": 8,
+      "Comment": [
+        "Map 1 0b10 0x2d 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frinti s2, s16",
+        "fcvtzs x20, s2",
+        "mov x21, #0x8000000000000000",
+        "ldr s3, [x28, #2848]",
+        "mrs x22, nzcv",
+        "fcmp s3, s2",
+        "csel x4, x20, x21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "vcvtsd2si eax, xmm0": {
+      "ExpectedInstructionCount": 8,
+      "Comment": [
+        "Map 1 0b11 0x2d 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frinti d2, d16",
+        "fcvtzs x20, d2",
+        "mov x21, #0x8000000000000000",
+        "ldr d3, [x28, #2896]",
+        "mrs x22, nzcv",
+        "fcmp d3, d2",
+        "csel x4, x20, x21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "vcvtsd2si rax, xmm0": {
+      "ExpectedInstructionCount": 8,
+      "Comment": [
+        "Map 1 0b11 0x2d 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frinti d2, d16",
+        "fcvtzs x20, d2",
+        "mov x21, #0x8000000000000000",
+        "ldr d3, [x28, #2896]",
+        "mrs x22, nzcv",
+        "fcmp d3, d2",
+        "csel x4, x20, x21, gt",
+        "msr nzcv, x22"
+      ]
+    },
+    "vcvtps2dq xmm0, xmm1": {
+      "ExpectedInstructionCount": 7,
+      "Comment": [
+        "Map 1 0b01 0x5b 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frinti v2.4s, v17.4s",
+        "ldr q3, [x28, #2912]",
+        "ldr q4, [x28, #2816]",
+        "fcvtzs v5.4s, v2.4s",
+        "fcmgt v2.4s, v4.4s, v2.4s",
+        "mov v16.16b, v2.16b",
+        "bsl v16.16b, v5.16b, v3.16b"
+      ]
+    },
+    "vcvtps2dq ymm0, ymm1": {
+      "ExpectedInstructionCount": 13,
+      "Comment": [
+        "Map 1 0b01 0x5b 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frinti z2.s, p7/m, z17.s",
+        "ldr x0, [x28, #2024]",
+        "ld1b {z3.b}, p7/z, [x0]",
+        "ldr x0, [x28, #1976]",
+        "ld1b {z4.b}, p7/z, [x0]",
+        "fcvtzs z5.s, p7/m, z2.s",
+        "fcmgt p0.s, p7/z, z4.s, z2.s",
+        "not z0.s, p0/m, z4.s",
+        "movprfx z2.s, p0/z, z4.s",
+        "orr z2.s, p0/m, z2.s, z0.s",
+        "movprfx z0, z5",
+        "bsl z0.d, z0.d, z3.d, z2.d",
+        "mov z16.d, z0.d"
+      ]
+    },
+    "vcvttps2dq xmm0, xmm1": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "Map 1 0b10 0x5b 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #2912]",
+        "ldr q3, [x28, #2816]",
+        "fcvtzs v4.4s, v17.4s",
+        "fcmgt v3.4s, v3.4s, v17.4s",
+        "mov v16.16b, v3.16b",
+        "bsl v16.16b, v4.16b, v2.16b"
+      ]
+    },
+    "vcvttps2dq ymm0, ymm1": {
+      "ExpectedInstructionCount": 12,
+      "Comment": [
+        "Map 1 0b10 0x5b 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr x0, [x28, #2024]",
+        "ld1b {z2.b}, p7/z, [x0]",
+        "ldr x0, [x28, #1976]",
+        "ld1b {z3.b}, p7/z, [x0]",
+        "fcvtzs z4.s, p7/m, z17.s",
+        "fcmgt p0.s, p7/z, z3.s, z17.s",
+        "not z0.s, p0/m, z3.s",
+        "movprfx z3.s, p0/z, z3.s",
+        "orr z3.s, p0/m, z3.s, z0.s",
+        "movprfx z0, z4",
+        "bsl z0.d, z0.d, z2.d, z3.d",
+        "mov z16.d, z0.d"
+      ]
+    },
+    "vcvttpd2dq xmm0, xmm1": {
+      "ExpectedInstructionCount": 9,
+      "Comment": [
+        "Map 1 0b01 0xe6 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr d2, [x28, #2912]",
+        "ldr q3, [x28, #2864]",
+        "fcvtzs z4.s, p6/m, z17.d",
+        "uzp1 z4.s, z4.s, z4.s",
+        "mov v4.8b, v4.8b",
+        "fcmgt v3.2d, v3.2d, v17.2d",
+        "shrn v3.2s, v3.2d, #32",
+        "mov v16.16b, v3.16b",
+        "bsl v16.16b, v4.16b, v2.16b"
+      ]
+    },
+    "vcvttpd2dq xmm0, ymm1": {
+      "ExpectedInstructionCount": 15,
+      "Comment": [
+        "Map 1 0b01 0xe6 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr q2, [x28, #2912]",
+        "ldr x0, [x28, #2000]",
+        "ld1b {z3.b}, p7/z, [x0]",
+        "fcvtzs z4.s, p7/m, z17.d",
+        "uzp1 z4.s, z4.s, z4.s",
+        "mov v4.16b, v4.16b",
+        "fcmgt p0.d, p7/z, z3.d, z17.d",
+        "not z0.d, p0/m, z3.d",
+        "movprfx z3.d, p0/z, z3.d",
+        "orr z3.d, p0/m, z3.d, z0.d",
+        "shrnb z3.s, z3.d, #32",
+        "uzp1 z3.s, z3.s, z3.s",
+        "movprfx z0, z4",
+        "bsl z0.d, z0.d, z2.d, z3.d",
+        "mov z16.d, z0.d"
+      ]
+    },
+    "vcvtpd2dq xmm0, xmm1": {
+      "ExpectedInstructionCount": 10,
+      "Comment": [
+        "Map 1 0b11 0xe6 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frinti v2.2d, v17.2d",
+        "ldr d3, [x28, #2912]",
+        "ldr q4, [x28, #2864]",
+        "fcvtzs z5.s, p6/m, z2.d",
+        "uzp1 z5.s, z5.s, z5.s",
+        "mov v5.8b, v5.8b",
+        "fcmgt v2.2d, v4.2d, v2.2d",
+        "shrn v2.2s, v2.2d, #32",
+        "mov v16.16b, v2.16b",
+        "bsl v16.16b, v5.16b, v3.16b"
+      ]
+    },
+    "vcvtpd2dq xmm0, ymm1": {
+      "ExpectedInstructionCount": 16,
+      "Comment": [
+        "Map 1 0b11 0xe6 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "frinti z2.d, p7/m, z17.d",
+        "ldr q3, [x28, #2912]",
+        "ldr x0, [x28, #2000]",
+        "ld1b {z4.b}, p7/z, [x0]",
+        "fcvtzs z5.s, p7/m, z2.d",
+        "uzp1 z5.s, z5.s, z5.s",
+        "mov v5.16b, v5.16b",
+        "fcmgt p0.d, p7/z, z4.d, z2.d",
+        "not z0.d, p0/m, z4.d",
+        "movprfx z2.d, p0/z, z4.d",
+        "orr z2.d, p0/m, z2.d, z0.d",
+        "shrnb z2.s, z2.d, #32",
+        "uzp1 z2.s, z2.s, z2.s",
+        "movprfx z0, z5",
+        "bsl z0.d, z0.d, z3.d, z2.d",
+        "mov z16.d, z0.d"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -16,142 +16,93 @@
   },
   "Instructions": {
     "vcvttss2si eax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtzs w20, s16",
-        "mov w21, #0x80000000",
-        "ldr s2, [x28, #2816]",
-        "mrs x22, nzcv",
-        "fcmp s2, s16",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32z s2, s16",
+        "fcvtzs w4, s2"
       ]
     },
     "vcvttss2si rax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtzs x20, s16",
-        "mov x21, #0x8000000000000000",
-        "ldr s2, [x28, #2848]",
-        "mrs x22, nzcv",
-        "fcmp s2, s16",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64z s2, s16",
+        "fcvtzs x4, s2"
       ]
     },
     "vcvttsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtzs w20, d16",
-        "mov w21, #0x80000000",
-        "ldr d2, [x28, #2864]",
-        "mrs x22, nzcv",
-        "fcmp d2, d16",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32z d2, d16",
+        "fcvtzs w4, d2"
       ]
     },
     "vcvttsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0x2c 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtzs x20, d16",
-        "mov x21, #0x8000000000000000",
-        "ldr d2, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d2, d16",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64z d2, d16",
+        "fcvtzs x4, d2"
       ]
     },
     "vcvtss2si eax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti s2, s16",
-        "fcvtzs w20, s2",
-        "mov w21, #0x80000000",
-        "ldr s3, [x28, #2816]",
-        "mrs x22, nzcv",
-        "fcmp s3, s2",
-        "csel w4, w20, w21, gt",
-        "msr nzcv, x22"
+        "frint32x s2, s16",
+        "fcvtzs w4, s2"
       ]
     },
     "vcvtss2si rax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti s2, s16",
-        "fcvtzs x20, s2",
-        "mov x21, #0x8000000000000000",
-        "ldr s3, [x28, #2848]",
-        "mrs x22, nzcv",
-        "fcmp s3, s2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x s2, s16",
+        "fcvtzs x4, s2"
       ]
     },
     "vcvtsd2si eax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti d2, d16",
-        "fcvtzs x20, d2",
-        "mov x21, #0x8000000000000000",
-        "ldr d3, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d3, d2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x d2, d16",
+        "fcvtzs x4, d2"
       ]
     },
     "vcvtsd2si rax, xmm0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b11 0x2d 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti d2, d16",
-        "fcvtzs x20, d2",
-        "mov x21, #0x8000000000000000",
-        "ldr d3, [x28, #2896]",
-        "mrs x22, nzcv",
-        "fcmp d3, d2",
-        "csel x4, x20, x21, gt",
-        "msr nzcv, x22"
+        "frint64x d2, d16",
+        "fcvtzs x4, d2"
       ]
     },
     "vcvtps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti v2.4s, v17.4s",
-        "ldr q3, [x28, #2912]",
-        "ldr q4, [x28, #2816]",
-        "fcvtzs v5.4s, v2.4s",
-        "fcmgt v2.4s, v4.4s, v2.4s",
-        "mov v16.16b, v2.16b",
-        "bsl v16.16b, v5.16b, v3.16b"
+        "frint32x v2.4s, v17.4s",
+        "fcvtzs v16.4s, v2.4s"
       ]
     },
     "vcvtps2dq ymm0, ymm1": {
@@ -176,17 +127,13 @@
       ]
     },
     "vcvttps2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b10 0x5b 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr q2, [x28, #2912]",
-        "ldr q3, [x28, #2816]",
-        "fcvtzs v4.4s, v17.4s",
-        "fcmgt v3.4s, v3.4s, v17.4s",
-        "mov v16.16b, v3.16b",
-        "bsl v16.16b, v4.16b, v2.16b"
+        "frint32z v2.4s, v17.4s",
+        "fcvtzs v16.4s, v2.4s"
       ]
     },
     "vcvttps2dq ymm0, ymm1": {
@@ -210,20 +157,14 @@
       ]
     },
     "vcvttpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0xe6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "ldr d2, [x28, #2912]",
-        "ldr q3, [x28, #2864]",
-        "fcvtzs z4.s, p6/m, z17.d",
-        "uzp1 z4.s, z4.s, z4.s",
-        "mov v4.8b, v4.8b",
-        "fcmgt v3.2d, v3.2d, v17.2d",
-        "shrn v3.2s, v3.2d, #32",
-        "mov v16.16b, v3.16b",
-        "bsl v16.16b, v4.16b, v2.16b"
+        "frint32z v2.2d, v17.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v16.2s, v2.2d"
       ]
     },
     "vcvttpd2dq xmm0, ymm1": {
@@ -250,21 +191,14 @@
       ]
     },
     "vcvtpd2dq xmm0, xmm1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b11 0xe6 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "frinti v2.2d, v17.2d",
-        "ldr d3, [x28, #2912]",
-        "ldr q4, [x28, #2864]",
-        "fcvtzs z5.s, p6/m, z2.d",
-        "uzp1 z5.s, z5.s, z5.s",
-        "mov v5.8b, v5.8b",
-        "fcmgt v2.2d, v4.2d, v2.2d",
-        "shrn v2.2s, v2.2d, #32",
-        "mov v16.16b, v2.16b",
-        "bsl v16.16b, v5.16b, v3.16b"
+        "frint32x v2.2d, v17.2d",
+        "fcvtzs v2.2d, v2.2d",
+        "xtn v16.2s, v2.2d"
       ]
     },
     "vcvtpd2dq xmm0, ymm1": {


### PR DESCRIPTION
https://github.com/FEX-Emu/FEX/pull/4237 fixed our float->int conversions to match x86 semantics. That fixed a bunch of games, but unfortunately significantly regressed performance. Fortunately, when frintts is supported, we can optimize the sequence using the appropriate arm instruction. This should recover most of the perf lost by #4237.