### PR TITLE
Windows: Small fixups

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -380,7 +380,7 @@ bool ContextImpl::InitCore() {
   SignalDelegation->SetConfig(SignalConfig);
 
 #ifndef _WIN32
-#elif !defined(_M_ARM64EC)
+#elif !defined(_M_ARM_64EC)
   // WOW64 always needs the interrupt fault check to be enabled.
   Config.NeedsPendingInterruptFaultCheck = true;
 #endif

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/SecondaryTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/SecondaryTables.h
@@ -20,7 +20,6 @@ constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDisp
   {0x32, 2, &OpDispatchBuilder::PermissionRestrictedOp},
   {0x34, 3, &OpDispatchBuilder::UnimplementedOp},
 
-  {0x3F, 1, &OpDispatchBuilder::ThunkOp},
   {0x40, 16, &OpDispatchBuilder::CMOVOp},
   {0x6E, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::MOVBetweenGPR_FPR, OpDispatchBuilder::VectorOpType::MMX>},
   {0x6F, 1, &OpDispatchBuilder::MOVQMMXOp},
@@ -144,8 +143,11 @@ constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDisp
   {0xFD, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorALUOp, IR::OP_VADD, OpSize::i16Bit>},
   {0xFE, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorALUOp, IR::OP_VADD, OpSize::i32Bit>},
 
+#ifndef _WIN32
   // FEX reserved instructions
   {0x37, 1, &OpDispatchBuilder::CallbackReturnOp},
+  {0x3F, 1, &OpDispatchBuilder::ThunkOp},
+#endif
 };
 
 constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_SecondaryRepModTables[] = {

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -260,6 +260,7 @@ auto BaseOpsLambda = []() consteval {
     {0xFE, 1, X86InstInfo{"PADDD",    TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX,                                      0, nullptr}},
     {0xFF, 1, X86InstInfo{"UD0",      TYPE_INST, FLAGS_BLOCK_END,                                                                                           0, nullptr}},
 
+#ifndef _WIN32
     // FEX reserved instructions
     // Unused x86 encoding instruction.
 
@@ -267,6 +268,7 @@ auto BaseOpsLambda = []() consteval {
 
     // This was originally used by VIA to jump to its alternative instruction set. Used for OP_THUNK
     {0x3F, 1, X86InstInfo{"ALTINST",      TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            0, nullptr}},
+#endif
   };
 
   GenerateTable(&Table.at(0), TwoByteOpTable, std::size(TwoByteOpTable));


### PR DESCRIPTION
- Thunk opcodes are unused on windows and cause more garbage code to be explored in denuvo games
- Noticed suspend checks were being incorrectly emitted for arm64ec