### PR TITLE
Support multiple entrypoints into a multiblock and executable permission tracking

### DIFF
--- a/Data/CMake/toolchain_mingw.cmake
+++ b/Data/CMake/toolchain_mingw.cmake
@@ -4,6 +4,7 @@ set(CMAKE_RC_COMPILER ${MINGW_TRIPLE}-windres)
 set(CMAKE_C_COMPILER ${MINGW_TRIPLE}-clang)
 set(CMAKE_CXX_COMPILER ${MINGW_TRIPLE}-clang++)
 set(CMAKE_DLLTOOL ${MINGW_TRIPLE}-dlltool)
+set(CMAKE_AR ${MINGW_TRIPLE}-ar)
 
 # Compile everything as static to avoid requiring the MinGW runtime libraries, force page aligned sections so that
 # debug symbols work correctly, and disable loop alignment to workaround an LLVM bug

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -284,7 +284,7 @@ public:
   GenerateIRResult GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, bool ExtendedDebugInfo, uint64_t MaxInst);
 
   struct CompileCodeResult {
-    void* CompiledCode;
+    CPU::CPUBackend::CompiledCode CompiledCode;
     fextl::unique_ptr<FEXCore::Core::DebugData> DebugData;
     uint64_t StartAddr;
     uint64_t Length;

--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -13,6 +13,7 @@ $end_info$
 #include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/vector.h>
+#include <FEXCore/fextl/map.h>
 
 #include <cstdint>
 
@@ -94,15 +95,7 @@ namespace CPU {
     struct CompiledCode {
       // Where this code block begins.
       uint8_t* BlockBegin;
-      /**
-       * The function entrypoint to this codeblock.
-       *
-       * This may or may not equal `BlockBegin` above. Depending on the CPU backend, it may stick data
-       * prior to the BlockEntry.
-       *
-       * Is actually a function pointer of type `void (FEXCore::Core::ThreadState *Thread)`
-       */
-      uint8_t* BlockEntry;
+      fextl::map<uint64_t, uint8_t*> EntryPoints;
       // The total size of the codeblock from [BlockBegin, BlockBegin+Size).
       size_t Size;
     };

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -557,9 +557,9 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
     bool HadDispatchError {false};
     bool HadInvalidInst {false};
 
-    Thread->FrontendDecoder->DecodeInstructionsAtEntry(GuestCode, GuestRIP, MaxInst,
-                                                       [Thread](uint64_t BlockEntry, uint64_t Start, uint64_t Length) {
-      if (Thread->LookupCache->AddBlockExecutableRange(BlockEntry, Start, Length)) {
+    Thread->FrontendDecoder->DecodeInstructionsAtEntry(
+      GuestCode, GuestRIP, MaxInst, [Thread](const fextl::set<uint64_t>& BlockEntryPoints, uint64_t Start, uint64_t Length) {
+      if (Thread->LookupCache->AddBlockExecutableRange(BlockEntryPoints, Start, Length)) {
         static_cast<ContextImpl*>(Thread->CTX)->SyscallHandler->MarkGuestExecutableRange(Thread, Start, Length);
       }
     });

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -412,7 +412,7 @@ void ContextImpl::InitializeCompiler(FEXCore::Core::InternalThreadState* Thread)
   Thread->OpDispatcher = fextl::make_unique<FEXCore::IR::OpDispatchBuilder>(this);
   Thread->OpDispatcher->SetMultiblock(Config.Multiblock);
   Thread->LookupCache = fextl::make_unique<FEXCore::LookupCache>(this);
-  Thread->FrontendDecoder = fextl::make_unique<FEXCore::Frontend::Decoder>(this);
+  Thread->FrontendDecoder = fextl::make_unique<FEXCore::Frontend::Decoder>(Thread);
   Thread->PassManager = fextl::make_unique<FEXCore::IR::PassManager>();
 
   Thread->CurrentFrame->Pointers.Common.L1Pointer = Thread->LookupCache->GetL1Pointer();
@@ -557,12 +557,7 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
     bool HadDispatchError {false};
     bool HadInvalidInst {false};
 
-    Thread->FrontendDecoder->DecodeInstructionsAtEntry(
-      GuestCode, GuestRIP, MaxInst, [Thread](const fextl::set<uint64_t>& BlockEntryPoints, uint64_t Start, uint64_t Length) {
-      if (Thread->LookupCache->AddBlockExecutableRange(BlockEntryPoints, Start, Length)) {
-        static_cast<ContextImpl*>(Thread->CTX)->SyscallHandler->MarkGuestExecutableRange(Thread, Start, Length);
-      }
-    });
+    Thread->FrontendDecoder->DecodeInstructionsAtEntry(GuestCode, GuestRIP, MaxInst);
 
     auto BlockInfo = Thread->FrontendDecoder->GetDecodedBlockInfo();
     auto CodeBlocks = &BlockInfo->Blocks;

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -907,6 +907,10 @@ uintptr_t ContextImpl::CompileSingleStep(FEXCore::Core::CpuStateFrame* Frame, ui
 }
 
 static void InvalidateGuestThreadCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) {
+  // Ensures now-modified mappings aren't cached as being in their previous non-executable state.
+  // Accessing FrontendDecoder is safe as the thread's code invalidation mutex must be locked here.
+  Thread->FrontendDecoder->ResetExecutableRangeCache();
+
   auto lk = Thread->LookupCache->AcquireLock();
 
   auto lower = Thread->LookupCache->CodePages.lower_bound(Start >> 12);

--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -1330,6 +1330,8 @@ void Decoder::DecodeInstructionsAtEntry(const uint8_t* _InstStream, uint64_t PC,
           DecodedSize = BlockStartOffset;
           InstStream -= PCOffset;
           EraseBlock = true;
+        } else {
+          LogMan::Msg::EFmt("Invalid instruction in entry block: {:X}", OpAddress);
         }
         break;
       }

--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -9,6 +9,7 @@ $end_info$
 #include "Interface/Context/Context.h"
 #include "Interface/Core/Frontend.h"
 #include "Interface/Core/X86Tables/X86Tables.h"
+#include "Interface/Core/X86HelperGen.h"
 #include "Interface/Core/LookupCache.h"
 
 #include <array>
@@ -73,6 +74,11 @@ Decoder::Decoder(FEXCore::Core::InternalThreadState* Thread)
   , PoolObject {CTX->FrontendAllocator, sizeof(FEXCore::X86Tables::DecodedInst) * DefaultDecodedBufferSize} {}
 
 bool Decoder::CheckRangeExecutable(uint64_t Address, uint64_t Size) {
+  // Treat FEX-internal X86 callbacks as always executable
+  if (EntryPoint == CTX->X86CodeGen.CallbackReturn) {
+    return true;
+  }
+
   while (Address < ExecutableRangeBase || Address + Size > ExecutableRangeEnd) {
     auto RangeInfo = CTX->SyscallHandler->QueryGuestExecutableRange(Thread, Address);
     ExecutableRangeBase = RangeInfo.Base;

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -34,9 +34,8 @@ public:
     fextl::vector<DecodedBlocks> Blocks;
   };
 
-  Decoder(FEXCore::Context::ContextImpl* ctx);
-  void DecodeInstructionsAtEntry(const uint8_t* InstStream, uint64_t PC, uint64_t MaxInst,
-                                 std::function<void(const fextl::vector<uint64_t>& BlockEntryPoints, uint64_t Start, uint64_t Length)> AddContainedCodePage);
+  Decoder(FEXCore::Core::InternalThreadState* Thread);
+  void DecodeInstructionsAtEntry(const uint8_t* InstStream, uint64_t PC, uint64_t MaxInst);
 
   const DecodedBlockInformation* GetDecodedBlockInfo() const {
     return &BlockInfo;
@@ -65,6 +64,7 @@ private:
     bool L;       // VEX.L bit (if set then 256 bit operation, if unset then scalar or 128-bit operation)
   };
 
+  FEXCore::Core::InternalThreadState* Thread;
   FEXCore::Context::ContextImpl* CTX;
   const FEXCore::HLE::SyscallOSABI OSABI {};
 

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -55,6 +55,10 @@ public:
     PoolObject.DelayedDisownBuffer();
   }
 
+  void ResetExecutableRangeCache() {
+    ExecutableRangeBase = ExecutableRangeEnd = 0;
+  }
+
 private:
   // To pass any information from instruction prefixes
   // down into the actual instruction handling machinery.
@@ -68,6 +72,7 @@ private:
   FEXCore::Context::ContextImpl* CTX;
   const FEXCore::HLE::SyscallOSABI OSABI {};
 
+  bool DecodeInstructionImpl(uint64_t PC);
   bool DecodeInstruction(uint64_t PC);
 
   void BranchTargetInMultiblockRange();
@@ -75,8 +80,10 @@ private:
 
   void AddBranchTarget(uint64_t Target);
 
+  bool CheckRangeExecutable(uint64_t Address, uint64_t Size);
+
   uint8_t ReadByte();
-  uint8_t PeekByte(uint8_t Offset) const;
+  std::optional<uint8_t> PeekByte(uint8_t Offset);
   uint64_t ReadData(uint8_t Size);
   void SkipBytes(uint8_t Size) {
     InstructionSize += Size;
@@ -89,6 +96,10 @@ private:
   FEXCore::X86Tables::DecodedInst* DecodedBuffer {};
   Utils::PoolBufferWithTimedRetirement<FEXCore::X86Tables::DecodedInst*, 5000, 500> PoolObject;
   size_t DecodedSize {};
+
+  uint64_t ExecutableRangeBase {};
+  uint64_t ExecutableRangeEnd {};
+  bool HitNonExecutableRange {};
 
   const uint8_t* InstStream {};
 

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -26,6 +26,7 @@ public:
     uint64_t NumInstructions {};
     FEXCore::X86Tables::DecodedInst* DecodedInstructions;
     bool HasInvalidInstruction {};
+    bool IsEntryPoint {};
   };
 
   struct DecodedBlockInformation final {
@@ -35,7 +36,7 @@ public:
 
   Decoder(FEXCore::Context::ContextImpl* ctx);
   void DecodeInstructionsAtEntry(const uint8_t* InstStream, uint64_t PC, uint64_t MaxInst,
-                                 std::function<void(uint64_t BlockEntry, uint64_t Start, uint64_t Length)> AddContainedCodePage);
+                                 std::function<void(const fextl::vector<uint64_t>& BlockEntryPoints, uint64_t Start, uint64_t Length)> AddContainedCodePage);
 
   const DecodedBlockInformation* GetDecodedBlockInfo() const {
     return &BlockInfo;
@@ -111,6 +112,7 @@ private:
   fextl::set<uint64_t> BlocksToDecode;
   fextl::set<uint64_t> VisitedBlocks;
   fextl::set<uint64_t>* ExternalBranches {nullptr};
+  fextl::set<uint64_t> BlockEntryPoints;
 
   // ModRM rm decoding
   using DecodeModRMPtr = void (FEXCore::Frontend::Decoder::*)(X86Tables::DecodedOperand* Operand, X86Tables::ModRMDecoded ModRM);

--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -375,6 +375,8 @@ private:
 
   void EmitInterruptChecks(bool CheckTF);
 
+  void EmitEntryPoint(ARMEmitter::BackwardLabel& HeaderLabel, bool CheckTF);
+
   // Runtime selection;
   // Load and store TSO memory style
   OpType RT_LoadMemTSO;

--- a/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/FEXCore/Source/Interface/Core/LookupCache.h
@@ -157,9 +157,9 @@ public:
 
   fextl::map<uint64_t, fextl::vector<uint64_t>> CodePages;
 
-  // Appends Block {Address} to CodePages [Start, Start + Length)
+  // Appends a list of Block {Address} to CodePages [Start, Start + Length)
   // Returns true if new pages are marked as containing code
-  bool AddBlockExecutableRange(uint64_t Address, uint64_t Start, uint64_t Length) {
+  bool AddBlockExecutableRange(const fextl::set<uint64_t>& Addresses, uint64_t Start, uint64_t Length) {
     auto lk = Shared->AcquireLock();
 
     bool rv = false;
@@ -167,7 +167,7 @@ public:
     for (auto CurrentPage = Start >> 12, EndPage = (Start + Length - 1) >> 12; CurrentPage <= EndPage; CurrentPage++) {
       auto& CodePage = CodePages[CurrentPage];
       rv |= CodePage.empty();
-      CodePage.push_back(Address);
+      CodePage.insert(CodePage.end(), Addresses.begin(), Addresses.end());
     }
 
     return rv;

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3852,7 +3852,7 @@ void OpDispatchBuilder::CMPXCHGPairOp(OpcodeArgs) {
 void OpDispatchBuilder::CreateJumpBlocks(const fextl::vector<FEXCore::Frontend::Decoder::DecodedBlocks>* Blocks) {
   Ref PrevCodeBlock {};
   for (auto& Target : *Blocks) {
-    auto CodeNode = CreateCodeNode();
+    auto CodeNode = CreateCodeNode(Target.IsEntryPoint, Target.Entry - Entry);
 
     JumpTargets.try_emplace(Target.Entry, JumpTargetInfo {CodeNode, false});
 

--- a/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -187,7 +187,7 @@ std::array<X86InstInfo, MAX_PRIMARY_TABLE_SIZE> BaseOps = []() consteval {
     {0xE4, 2, X86InstInfo{"IN",     TYPE_INST, FLAGS_BLOCK_END,                                                                                                      1, nullptr}},
     {0xE6, 2, X86InstInfo{"OUT",    TYPE_INST, FLAGS_BLOCK_END,                                                                                                      1, nullptr}},
 
-    {0xE8, 1, X86InstInfo{"CALL",   TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_BLOCK_END , 4, nullptr}},
+    {0xE8, 1, X86InstInfo{"CALL",   TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_BLOCK_END | FLAGS_CALL , 4, nullptr}},
     {0xE9, 1, X86InstInfo{"JMP",    TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_SRC_SEXT | FLAGS_DISPLACE_SIZE_DIV_2 | FLAGS_BLOCK_END , 4, nullptr}},
     {0xEB, 1, X86InstInfo{"JMP",    TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_SRC_SEXT | FLAGS_BLOCK_END ,                             1, nullptr}},
 

--- a/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
@@ -128,7 +128,7 @@ std::array<X86InstInfo, MAX_INST_GROUP_TABLE_SIZE> PrimaryInstGroupOps = []() co
     // GROUP 5
     {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 0), 1, X86InstInfo{"INC",   TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                     0, nullptr}},
     {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 1), 1, X86InstInfo{"DEC",   TYPE_INST, FLAGS_MODRM | FLAGS_SF_MOD_DST,                                                     0, nullptr}},
-    {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 2), 1, X86InstInfo{"CALL",  TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_MODRM | FLAGS_BLOCK_END , 0, nullptr}},
+    {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 2), 1, X86InstInfo{"CALL",  TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_MODRM | FLAGS_BLOCK_END | FLAGS_CALL , 0, nullptr}},
     {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 3), 1, X86InstInfo{"CALLF", TYPE_INST, FLAGS_SETS_RIP | FLAGS_MODRM | FLAGS_BLOCK_END,                  0, nullptr}},
     {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 4), 1, X86InstInfo{"JMP",   TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_MODRM | FLAGS_BLOCK_END , 0, nullptr}},
     {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 5), 1, X86InstInfo{"JMPF",  TYPE_INST, FLAGS_SETS_RIP | FLAGS_MODRM | FLAGS_BLOCK_END,                  0, nullptr}},

--- a/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -360,6 +360,8 @@ constexpr InstFlagType FLAGS_VEX_L_1             = (1ULL << 27);
 constexpr InstFlagType FLAGS_REX_W_0             = (1ULL << 28);
 constexpr InstFlagType FLAGS_REX_W_1             = (1ULL << 29);
 
+constexpr InstFlagType FLAGS_CALL             = (1ULL << 30);
+
 constexpr InstFlagType FLAGS_SIZE_DST_OFF = 58;
 constexpr InstFlagType FLAGS_SIZE_SRC_OFF = FLAGS_SIZE_DST_OFF + 3;
 

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -171,7 +171,7 @@
         "SwitchGen": false,
         "JITDispatchOverride": "NoOp"
       },
-      "CodeBlock SSA:$Begin, SSA:$Last, u32:$ID": {
+      "CodeBlock SSA:$Begin, SSA:$Last, u32:$ID, i1:$EntryPoint{false}, u32:$GuestEntryOffset{0}": {
         "SwitchGen": false,
         "RAOverride": "0",
         "JITDispatchOverride": "NoOp"

--- a/FEXCore/Source/Interface/IR/IREmitter.h
+++ b/FEXCore/Source/Interface/IR/IREmitter.h
@@ -248,11 +248,11 @@ public:
    *
    * @return OrderedNode
    */
-  IRPair<IROp_CodeBlock> CreateCodeNode() {
+  IRPair<IROp_CodeBlock> CreateCodeNode(bool EntryPoint = false, uint32_t GuestEntryOffset = 0) {
     SetWriteCursor(nullptr); // Orphan from any previous nodes
 
     auto ID = ViewIR().GetHeader()->BlockCount++;
-    auto CodeNode = _CodeBlock(InvalidNode, InvalidNode, ID);
+    auto CodeNode = _CodeBlock(InvalidNode, InvalidNode, ID, EntryPoint, GuestEntryOffset);
 
     CodeBlocks.emplace_back(CodeNode);
 

--- a/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -42,6 +42,12 @@ enum class SyscallOSABI {
   OS_GENERIC, // No JIT-side argument handling, spill/fill all regs.
 };
 
+struct ExecutableRangeInfo {
+  uint64_t Base;
+  uint64_t Size;
+  bool Writable;
+};
+
 class SyscallHandler;
 class SourcecodeResolver;
 
@@ -74,6 +80,7 @@ public:
   virtual void MarkGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) {}
   virtual void MarkOvercommitRange(uint64_t Start, uint64_t Length) {}
   virtual void UnmarkOvercommitRange(uint64_t Start, uint64_t Length) {}
+  virtual ExecutableRangeInfo QueryGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Address) = 0;
   virtual AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestAddr) = 0;
 
   virtual void PreCompile() {}

--- a/FEXCore/include/FEXCore/Utils/IntervalList.h
+++ b/FEXCore/include/FEXCore/Utils/IntervalList.h
@@ -31,6 +31,7 @@ public:
     bool Enclosed;       ///< If the given offset was enclosed by an interval
     DifferenceType Size; ///< Size of the interval starting from the query offset, or distance to the next interval if
                          /// `Enclosed` is false (if there is no next interval, size is 0)
+    Interval Interval;   ///< The interval that the query offset is enclosed by, or the next interval if `Enclosed` is false
   };
 
   void Clear() {
@@ -134,11 +135,11 @@ public:
     }); // Lowest offset interval that (maybe) overlaps with the query offset
 
     if (It == Intervals.end()) { // No overlaps past offset
-      return {false, {}};
+      return {false, 0, {}};
     } else if (It->Offset > Offset) { // No overlap, return the distance to the next possible overlap
-      return {false, It->Offset - Offset};
+      return {false, It->Offset - Offset, *It};
     } else { // Overlap, return the distance to the end of the overlap
-      return {true, It->End - Offset};
+      return {true, It->End - Offset, *It};
     }
   }
 

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -462,6 +462,10 @@ public:
   FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestAddr) override {
     return {0, 0};
   }
+
+  FEXCore::HLE::ExecutableRangeInfo QueryGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Address) override {
+    return {0, UINT64_MAX, true};
+  }
 };
 } // namespace
 

--- a/Source/Tools/CommonTools/DummyHandlers.h
+++ b/Source/Tools/CommonTools/DummyHandlers.h
@@ -21,6 +21,10 @@ public:
   FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestAddr) override {
     return {0, 0};
   }
+
+  FEXCore::HLE::ExecutableRangeInfo QueryGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Address) override {
+    return {0, UINT64_MAX, true};
+  }
 };
 
 class DummySignalDelegator final : public FEXCore::SignalDelegator, public FEXCore::Allocator::FEXAllocOperators {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -292,6 +292,8 @@ public:
   // AOTIRCacheEntryLookupResult also includes a shared lock guard, so the pointed AOTIRCacheEntry return can be safely used
   FEXCore::HLE::AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestAddr) final override;
 
+  FEXCore::HLE::ExecutableRangeInfo QueryGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Address) override;
+
   ///// FORK tracking /////
   void LockBeforeFork(FEXCore::Core::InternalThreadState* Thread);
   void UnlockAfterFork(FEXCore::Core::InternalThreadState* LiveThread, bool Child);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -12,6 +12,7 @@ $end_info$
 #include <filesystem>
 #include <sys/shm.h>
 #include <sys/mman.h>
+#include <sys/personality.h>
 
 #include "LinuxSyscalls/Syscalls.h"
 
@@ -155,9 +156,11 @@ FEXCore::HLE::AOTIRCacheEntryLookupResult SyscallHandler::LookupAOTIRCacheEntry(
 
 FEXCore::HLE::ExecutableRangeInfo SyscallHandler::QueryGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Address) {
   auto lk = FEXCore::GuardSignalDeferringSection<std::shared_lock>(VMATracking.Mutex, Thread);
+  auto ThreadObject = FEX::HLE::ThreadManager::GetStateObjectFromFEXCoreThread(Thread);
 
   auto Entry = VMATracking.FindVMAEntry(Address);
-  if (Entry == VMATracking.VMAs.end() || !Entry->second.Prot.Executable) {
+  if (Entry == VMATracking.VMAs.end() ||
+      (!Entry->second.Prot.Executable && (!(ThreadObject->persona & READ_IMPLIES_EXEC) || !Entry->second.Prot.Readable))) {
     return {0, 0, false};
   }
   return {Entry->first, Entry->second.Length, Entry->second.Prot.Writable};

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -578,6 +578,10 @@ public:
     OvercommitTracker->UnmarkRange(Start, Length);
   }
 
+  FEXCore::HLE::ExecutableRangeInfo QueryGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Address) override {
+    return InvalidationTracker->QueryExecutableRange(Address);
+  }
+
   void PreCompile() override {
     ProcessPendingCrossProcessEmulatorWork();
   }

--- a/Source/Windows/Common/InvalidationTracker.h
+++ b/Source/Windows/Common/InvalidationTracker.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <FEXCore/Utils/IntervalList.h>
+#include <FEXCore/HLE/SyscallHandler.h>
 #include <mutex>
 #include <unordered_map>
 
@@ -30,6 +31,7 @@ public:
   void InvalidateAlignedInterval(uint64_t Address, uint64_t Size, bool Free);
   void ReprotectRWXIntervals(uint64_t Address, uint64_t Size);
   bool HandleRWXAccessViolation(uint64_t FaultAddress);
+  FEXCore::HLE::ExecutableRangeInfo QueryExecutableRange(uint64_t Address);
 
 private:
   FEXCore::IntervalList<uint64_t> XIntervals;

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -451,6 +451,10 @@ public:
     OvercommitTracker->UnmarkRange(Start, Length);
   }
 
+  FEXCore::HLE::ExecutableRangeInfo QueryGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Address) override {
+    return InvalidationTracker->QueryExecutableRange(Address);
+  }
+
   void PreCompile() override {
     Wow64ProcessPendingCrossProcessItems();
   }


### PR DESCRIPTION
This allows a single JIT call to translate the entire bodies of most functions not using indirect jumps, previously multiblocks would end at calls which often led to regions being translated multiple times as in e.g.:

```
if (a)
  do_b()
a = false; // <-- this would be translated twice prior to this if ran with both a=false then a=true
...
```

This paves the way for call-ret optimisations and decreases MB-enabled nodejs startup JIT time by ~8%.

Executable permission tracking is necessary to avoid following a non-taken return location into unmapped memory - this occurs in many unity games.