### PR TITLE
x87OptimizationPass: Fixes {Inc,Dec}StackPop

### DIFF
--- a/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
@@ -1044,7 +1044,7 @@ void X87StackOptimization::Run(IREmitter* Emit) {
 
       case OP_INCSTACKTOP: {
         if (SlowPath) {
-          UpdateTopForPush_Slow();
+          UpdateTopForPop_Slow();
         } else {
           StackData.rotate(false);
         }
@@ -1053,7 +1053,7 @@ void X87StackOptimization::Run(IREmitter* Emit) {
 
       case OP_DECSTACKTOP: {
         if (SlowPath) {
-          UpdateTopForPop_Slow();
+          UpdateTopForPush_Slow();
         } else {
           StackData.rotate(true);
         }

--- a/unittests/ASM/FEX_bugs/x87DecrementStackBug.asm
+++ b/unittests/ASM/FEX_bugs/x87DecrementStackBug.asm
@@ -1,0 +1,67 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0": ["0x4000000000000000", "0"]
+  }
+}
+%endif
+
+; FEX-Emu contains a bug. It's the buggiest bug that ever bugged. Something about conflicting results between fxch and fincstp.
+fld tword [rel .data1]
+fld tword [rel .data2]
+fld tword [rel .data3]
+fld tword [rel .data4]
+fld tword [rel .data5]
+fld tword [rel .data6]
+fld tword [rel .data7]
+fld tword [rel .data8]
+
+jmp .test
+
+.test:
+fxch st0, st1
+fdecstp
+
+jmp .end
+.end:
+
+fstp qword [rel .data_result]
+movups xmm0, [rel .data_result]
+
+hlt
+
+.data1:
+dt 2.0
+dq 0
+
+.data2:
+dt 4.0
+dq 0
+
+.data3:
+dt 8.0
+dq 0
+
+.data4:
+dt 16.0
+dq 0
+
+.data5:
+dt 32.0
+dq 0
+
+.data6:
+dt 64.0
+dq 0
+
+.data7:
+dt 128.0
+dq 0
+
+.data8:
+dt 256.0
+dq 0
+
+.data_result:
+dq 0
+dq 0

--- a/unittests/ASM/FEX_bugs/x87IncrementStackBug.asm
+++ b/unittests/ASM/FEX_bugs/x87IncrementStackBug.asm
@@ -1,0 +1,47 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "XMM0": ["0x4010000000000000", "0"]
+  }
+}
+%endif
+
+; FEX-Emu contains a bug. It's the buggiest bug that ever bugged. Something about conflicting results between fxch and fincstp.
+fld tword [rel .data1]
+fld tword [rel .data2]
+
+; ST(0) contains 4.0
+; ST(1) contains 2.0
+
+jmp .test
+
+.test:
+fxch st0, st1
+; ST(0) now contains 2.0
+; ST(1) now contains 4.0
+
+fincstp
+; ST(0) now contains 4.0
+; ST(7) now contains 2.0
+
+jmp .end
+.end:
+
+fstp qword [rel .data_result]
+movups xmm0, [rel .data_result]
+
+hlt
+
+; This or zero are incorrect results
+.data1:
+dt 2.0
+dq 0
+
+; Correct result
+.data2:
+dt 4.0
+dq 0
+
+.data_result:
+dq 0
+dq 0


### PR DESCRIPTION
On the slow path these were pushing and popping in the wrong direction.
Switch them around to ensure the unittests work.