### PR TITLE
IR: Implement support for sha256h{2,}

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
@@ -248,6 +248,46 @@ DEF_OP(VSha1SU1) {
   }
 }
 
+DEF_OP(VSha256H) {
+  auto Op = IROp->C<IR::IROp_VSha256H>();
+
+  const auto Dst = GetVReg(Node);
+  const auto Src1 = GetVReg(Op->Src1.ID());
+  const auto Src2 = GetVReg(Op->Src2.ID());
+  const auto Src3 = GetVReg(Op->Src3.ID());
+
+  if (Dst == Src1) {
+    sha256h(Dst, Src2, Src3);
+  } else if (Dst != Src2 && Dst != Src3) {
+    mov(Dst.Q(), Src1.Q());
+    sha256h(Dst, Src2, Src3);
+  } else {
+    mov(VTMP1.Q(), Src1.Q());
+    sha256h(VTMP1, Src2, Src3);
+    mov(Dst.Q(), VTMP1.Q());
+  }
+}
+
+DEF_OP(VSha256H2) {
+  auto Op = IROp->C<IR::IROp_VSha256H2>();
+
+  const auto Dst = GetVReg(Node);
+  const auto Src1 = GetVReg(Op->Src1.ID());
+  const auto Src2 = GetVReg(Op->Src2.ID());
+  const auto Src3 = GetVReg(Op->Src3.ID());
+
+  if (Dst == Src1) {
+    sha256h2(Dst, Src2, Src3);
+  } else if (Dst != Src2 && Dst != Src3) {
+    mov(Dst.Q(), Src1.Q());
+    sha256h2(Dst, Src2, Src3);
+  } else {
+    mov(VTMP1.Q(), Src1.Q());
+    sha256h2(VTMP1, Src2, Src3);
+    mov(Dst.Q(), VTMP1.Q());
+  }
+}
+
 DEF_OP(VSha256U0) {
   auto Op = IROp->C<IR::IROp_VSha256U0>();
 

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -2771,6 +2771,16 @@
         "Desc": "Does vector scalar VSha256U1 instruction",
         "DestSize": "FEXCore::IR::OpSize::i128Bit"
       },
+      "FPR = VSha256H FPR:$Src1, FPR:$Src2, FPR:$Src3": {
+        "Desc": "Does vector scalar VSha256H instruction",
+        "DestSize": "FEXCore::IR::OpSize::i128Bit",
+        "TiedSource": 0
+      },
+      "FPR = VSha256H2 FPR:$Src1, FPR:$Src2, FPR:$Src3": {
+        "Desc": "Does vector scalar VSha256H2 instruction",
+        "DestSize": "FEXCore::IR::OpSize::i128Bit",
+        "TiedSource": 0
+      },
       "GPR = CRC32 GPR:$Src1, GPR:$Src2, OpSize:$SrcSize": {
         "Desc": ["CRC32 using polynomial 0x1EDC6F41"
                 ],


### PR DESCRIPTION
I keep carrying this patch around. Not yet wired up to the instruction implementation yet, but I don't want to forget about it.