### PR TITLE
Reduce JIT time by 25% by sharing code buffers between threads

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -75,7 +75,7 @@ struct CustomIRResult {
 using BlockDelinkerFunc = void (*)(FEXCore::Core::CpuStateFrame* Frame, FEXCore::Context::ExitFunctionLinkData* Record);
 constexpr uint32_t TSC_SCALE_MAXIMUM = 1'000'000'000; ///< 1Ghz
 
-class ContextImpl final : public FEXCore::Context::Context {
+class ContextImpl final : public FEXCore::Context::Context, CPU::CodeBufferManager {
 public:
   // Context base class implementation.
   bool InitCore() override;

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -302,6 +302,7 @@ public:
 
   FEXCore::Utils::PooledAllocatorVirtual OpDispatcherAllocator;
   FEXCore::Utils::PooledAllocatorVirtual FrontendAllocator;
+  FEXCore::Utils::PooledAllocatorVirtual CPUBackendAllocator;
 
   // If Atomic-based TSO emulation is enabled or not.
   bool IsAtomicTSOEnabled() const {

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -288,6 +288,8 @@ public:
     fextl::unique_ptr<FEXCore::Core::DebugData> DebugData;
     uint64_t StartAddr;
     uint64_t Length;
+    // Lock for further CodeBuffer and LookupCache operations.
+    // If empty, compilation was skipped since another thread already compiled the block.
     std::unique_lock<ForkableUniqueMutex> CodeBufferLock;
   };
   [[nodiscard]]

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -288,9 +288,6 @@ public:
     fextl::unique_ptr<FEXCore::Core::DebugData> DebugData;
     uint64_t StartAddr;
     uint64_t Length;
-    // Lock for further CodeBuffer and LookupCache operations.
-    // If empty, compilation was skipped since another thread already compiled the block.
-    std::unique_lock<ForkableUniqueMutex> CodeBufferLock;
   };
   [[nodiscard]]
   CompileCodeResult CompileCode(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, uint64_t MaxInst = 0);

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -501,7 +501,10 @@ void Arm64Emitter::LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, ui
 
   // If the aligned offset is within the 4GB window then we can use ADRP+ADD
   // and the number of move segments more than 1
-  if (RequiredMoveSegments > 1 && ARMEmitter::Emitter::IsInt32(AlignedOffset)) {
+  // NOTE: JIT output is moved to a different buffer after compilation, so the
+  //       current cursor address doesn't match the runtime instruction address.
+  //       Hence this optimization is disabled until we enable code relocation patches.
+  if (RequiredMoveSegments > 1 && ARMEmitter::Emitter::IsInt32(AlignedOffset) && false) {
     // If this is 4k page aligned then we only need ADRP
     if ((AlignedOffset & 0xFFF) == 0) {
       adrp(Reg, AlignedOffset >> 12);

--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -266,10 +266,10 @@ namespace CPU {
     return TotalLUT;
   }()};
 
-  CPUBackend::CPUBackend(CodeBufferManager& manager, FEXCore::Core::InternalThreadState* ThreadState, size_t MaxCodeSize)
+  CPUBackend::CPUBackend(CodeBufferManager& CodeBuffers, FEXCore::Core::InternalThreadState* ThreadState, size_t MaxCodeSize)
     : ThreadState(ThreadState)
     , MaxCodeSize(MaxCodeSize)
-    , manager(manager) {
+    , CodeBuffers(CodeBuffers) {
 
     auto& Common = ThreadState->CurrentFrame->Pointers.Common;
 
@@ -312,7 +312,7 @@ namespace CPU {
     auto PrevCodeBuffer = CurrentCodeBuffer;
 
     // Resize the code buffer and reallocate our code size
-    CurrentCodeBuffer = manager.StartLargerCodeBuffer(MaxCodeSize);
+    CurrentCodeBuffer = CodeBuffers.StartLargerCodeBuffer(MaxCodeSize);
 
     RegisterForSignalHandler(PrevCodeBuffer);
     return CurrentCodeBuffer.get();
@@ -331,7 +331,7 @@ namespace CPU {
 
   fextl::shared_ptr<CodeBuffer> CPUBackend::CheckCodeBufferUpdate() {
     fextl::shared_ptr<CodeBuffer> OldCodeBuffer;
-    auto NewCodeBuffer = manager.GetLatest();
+    auto NewCodeBuffer = CodeBuffers.GetLatest();
     if (CurrentCodeBuffer != NewCodeBuffer) {
       RegisterForSignalHandler(CurrentCodeBuffer);
       return std::exchange(CurrentCodeBuffer, NewCodeBuffer);

--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -309,42 +309,34 @@ namespace CPU {
   auto CPUBackend::GetEmptyCodeBuffer() -> CodeBuffer* {
     if (ThreadState->CurrentFrame->SignalHandlerRefCounter == 0) {
       if (CodeBuffers.empty()) {
-        auto NewCodeBuffer = AllocateNewCodeBuffer(InitialCodeSize);
-        EmplaceNewCodeBuffer(NewCodeBuffer);
+        EmplaceNewCodeBuffer(manager.AllocateNew(InitialCodeSize));
       } else {
         // If we have more than one code buffer we are tracking then walk them and delete
         // This is a cleanup step
         CodeBuffers.resize(1);
 
-        // Set the current code buffer to the initial
-        CurrentCodeBuffer = CodeBuffers[0];
-
-        if (CurrentCodeBuffer->Size != MaxCodeSize) {
-          auto Size = CurrentCodeBuffer->Size;
+        if (CurrentCodeBufferSize != MaxCodeSize) {
           CodeBuffers.clear();
-          CurrentCodeBuffer.reset();
 
           // Resize the code buffer and reallocate our code size
-          Size *= 1.5;
-          Size = std::min(Size, MaxCodeSize);
+          CurrentCodeBufferSize *= 1.5;
+          CurrentCodeBufferSize = std::min(CurrentCodeBufferSize, MaxCodeSize);
 
-          CurrentCodeBuffer = AllocateNewCodeBuffer(Size);
-          EmplaceNewCodeBuffer(CurrentCodeBuffer);
+          EmplaceNewCodeBuffer(manager.AllocateNew(CurrentCodeBufferSize));
         }
       }
     } else {
       // We have signal handlers that have generated code
       // This means that we can not safely clear the code at this point in time
       // Allocate some new code buffers that we can switch over to instead
-      auto NewCodeBuffer = AllocateNewCodeBuffer(InitialCodeSize);
-      EmplaceNewCodeBuffer(NewCodeBuffer);
+      EmplaceNewCodeBuffer(manager.AllocateNew(InitialCodeSize));
     }
 
-    return CurrentCodeBuffer.get();
+    return CodeBuffers.back().get();
   }
 
   void CPUBackend::EmplaceNewCodeBuffer(fextl::shared_ptr<CodeBuffer> Buffer) {
-    CurrentCodeBuffer = Buffer;
+    CurrentCodeBufferSize = Buffer->Size;
     CodeBuffers.emplace_back(Buffer);
   }
 
@@ -362,10 +354,11 @@ namespace CPU {
   }
 
   CodeBuffer::~CodeBuffer() {
+    // TODO: Assert that mutex is held?
     FEXCore::Allocator::VirtualFree(Ptr, Size);
   }
 
-  auto CPUBackend::AllocateNewCodeBuffer(size_t Size) -> fextl::shared_ptr<CodeBuffer> {
+  auto CodeBufferManager::AllocateNew(size_t Size) -> fextl::shared_ptr<CodeBuffer> {
 #ifndef _WIN32
 // MDWE (Memory-Deny-Write-Execute) is a new Linux 6.3 feature.
 // It's equivalent to systemd's `MemoryDenyWriteExecute` but implemented entirely in the kernel.
@@ -393,9 +386,10 @@ namespace CPU {
 
     auto Buffer = fextl::make_shared<CodeBuffer>(Size);
 
-    if (static_cast<Context::ContextImpl*>(ThreadState->CTX)->Config.GlobalJITNaming()) {
-      static_cast<Context::ContextImpl*>(ThreadState->CTX)->Symbols.RegisterJITSpace(Buffer->Ptr, Buffer->Size);
-    }
+    // TODO: Re-enable
+    // if (static_cast<Context::ContextImpl*>(ThreadState->CTX)->Config.GlobalJITNaming()) {
+    //   static_cast<Context::ContextImpl*>(ThreadState->CTX)->Symbols.RegisterJITSpace(Buffer.Ptr, Buffer.Size);
+    // }
 
     return Buffer;
   }

--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -9,6 +9,7 @@ $end_info$
 #pragma once
 
 #include <FEXCore/Utils/CompilerDefs.h>
+#include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/vector.h>
 
@@ -32,12 +33,21 @@ namespace CodeSerialize {
 }
 
 namespace CPU {
+  struct CodeBuffer {
+    uint8_t* Ptr;
+    size_t Size;
+
+    CodeBuffer(size_t Size);
+    CodeBuffer(const CodeBuffer&) = delete;
+    CodeBuffer& operator=(const CodeBuffer&) = delete;
+    CodeBuffer(CodeBuffer&& oth) = delete;
+    CodeBuffer& operator=(CodeBuffer&&) = delete;
+
+    ~CodeBuffer();
+  };
+
   class CPUBackend {
   public:
-    struct CodeBuffer {
-      uint8_t* Ptr;
-      size_t Size;
-    };
 
     /**
      * @param InitialCodeSize - Initial size for the code buffers
@@ -154,19 +164,16 @@ namespace CPU {
     CodeBuffer* GetEmptyCodeBuffer();
 
     // This is the current code buffer that we are tracking
-    CodeBuffer* CurrentCodeBuffer {};
+    std::shared_ptr<CodeBuffer> CurrentCodeBuffer;
 
   private:
-    CodeBuffer AllocateNewCodeBuffer(size_t Size);
-    void FreeCodeBuffer(CodeBuffer Buffer);
+    fextl::shared_ptr<CodeBuffer> AllocateNewCodeBuffer(size_t Size);
 
-    void EmplaceNewCodeBuffer(CodeBuffer Buffer) {
-      CurrentCodeBuffer = &CodeBuffers.emplace_back(Buffer);
-    }
+    void EmplaceNewCodeBuffer(fextl::shared_ptr<CodeBuffer> Buffer);
 
     // This is the array of code buffers. Unless signals force us to keep more than
     // buffer, there will be only one entry here
-    fextl::vector<CodeBuffer> CodeBuffers {};
+    fextl::vector<fextl::shared_ptr<CodeBuffer>> CodeBuffers;
   };
 
 } // namespace CPU

--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -73,7 +73,7 @@ namespace CPU {
     // Write offset into the latest CodeBuffer
     std::size_t LatestOffset;
 
-    // Protects writes to the latest CodeBuffer
+    // Protects writes to the latest CodeBuffer and changes to LatestOffset
     FEXCore::ForkableUniqueMutex CodeBufferWriteMutex;
 
     virtual void OnCodeBufferAllocated(CodeBuffer&) {};

--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -46,6 +46,11 @@ namespace CPU {
     ~CodeBuffer();
   };
 
+  class CodeBufferManager {
+  public:
+    fextl::shared_ptr<CodeBuffer> AllocateNew(size_t Size);
+  };
+
   class CPUBackend {
   public:
 
@@ -53,7 +58,7 @@ namespace CPU {
      * @param InitialCodeSize - Initial size for the code buffers
      * @param MaxCodeSize - Max size for the code buffers
      */
-    CPUBackend(FEXCore::Core::InternalThreadState* ThreadState, size_t InitialCodeSize, size_t MaxCodeSize);
+    CPUBackend(FEXCore::Core::InternalThreadState*, size_t InitialCodeSize, size_t MaxCodeSize);
 
     virtual ~CPUBackend();
 
@@ -163,12 +168,12 @@ namespace CPU {
     [[nodiscard]]
     CodeBuffer* GetEmptyCodeBuffer();
 
-    // This is the current code buffer that we are tracking
-    std::shared_ptr<CodeBuffer> CurrentCodeBuffer;
+    // This is the size of the last code buffer we allocated
+    size_t CurrentCodeBufferSize = 0;
+
+    CodeBufferManager manager; // TODO: Rename
 
   private:
-    fextl::shared_ptr<CodeBuffer> AllocateNewCodeBuffer(size_t Size);
-
     void EmplaceNewCodeBuffer(fextl::shared_ptr<CodeBuffer> Buffer);
 
     // This is the array of code buffers. Unless signals force us to keep more than

--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -66,9 +66,9 @@ namespace CPU {
     // This is the only CodeBuffer that data may be written to.
     fextl::shared_ptr<CodeBuffer> GetLatest();
 
-    // Allocate a new CodeBuffer with geometric growth.
+    // Allocate a new CodeBuffer with geometric growth up to an internal maximum.
     // Subsequent calls to GetLatest will point to the returned buffer.
-    fextl::shared_ptr<CodeBuffer> StartLargerCodeBuffer(size_t MaxCodeSize);
+    fextl::shared_ptr<CodeBuffer> StartLargerCodeBuffer();
 
     // Write offset into the latest CodeBuffer
     std::size_t LatestOffset;
@@ -87,10 +87,7 @@ namespace CPU {
   class CPUBackend {
   public:
 
-    /**
-     * @param MaxCodeSize - Max size for the code buffers
-     */
-    CPUBackend(CodeBufferManager&, FEXCore::Core::InternalThreadState*, size_t MaxCodeSize);
+    CPUBackend(CodeBufferManager&, FEXCore::Core::InternalThreadState*);
 
     virtual ~CPUBackend();
 

--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -212,7 +212,7 @@ namespace CPU {
     // Old CodeBuffer generations required to be valid until returning from signal handlers
     fextl::vector<fextl::shared_ptr<CodeBuffer>> SignalHandlerCodeBuffers;
 
-    CodeBufferManager& manager; // TODO: Rename
+    CodeBufferManager& CodeBuffers;
 
   private:
     void RegisterForSignalHandler(fextl::shared_ptr<CodeBuffer>);

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -503,7 +503,7 @@ void ContextImpl::ClearCodeCache(FEXCore::Core::InternalThreadState* Thread) {
     // Use the thread's object cache ref counter for this
     CodeSerialize::CodeObjectSerializeService::WaitForEmptyJobQueue(&Thread->ObjectCacheRefCounter);
   }
-  std::lock_guard<std::recursive_mutex> lk(Thread->LookupCache->WriteLock);
+  auto lk = Thread->LookupCache->AcquireLock();
 
   Thread->LookupCache->ClearCache();
   Thread->CPUBackend->ClearCache();
@@ -884,7 +884,7 @@ uintptr_t ContextImpl::CompileSingleStep(FEXCore::Core::CpuStateFrame* Frame, ui
 }
 
 static void InvalidateGuestThreadCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) {
-  std::lock_guard<std::recursive_mutex> lk(Thread->LookupCache->WriteLock);
+  auto lk = Thread->LookupCache->AcquireLock();
 
   auto lower = Thread->LookupCache->CodePages.lower_bound(Start >> 12);
   auto upper = Thread->LookupCache->CodePages.upper_bound((Start + Length - 1) >> 12);
@@ -912,7 +912,7 @@ void ContextImpl::MarkMemoryShared(FEXCore::Core::InternalThreadState* Thread) {
 
     if (Config.TSOAutoMigration) {
       // Only the lookup cache is cleared here, so that old code can keep running until next compilation
-      std::lock_guard<std::recursive_mutex> lkLookupCache(Thread->LookupCache->WriteLock);
+      auto lk = Thread->LookupCache->AcquireLock();
       Thread->LookupCache->ClearCache();
     }
   }

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -780,6 +780,18 @@ ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalT
   // Attempt to get the CPU backend to compile this code
 
   auto Lock = std::unique_lock {CodeBufferWriteMutex};
+
+  // Re-check if another thread raced us in compiling this block.
+  // We could lock CodeBufferWriteMutex earlier to prevent this from happening,
+  // but this would increase lock contention. Redundant frontend runs aren't
+  // as expensive and are easily reverted.
+  if (MaxInst != 1) {
+    if (auto Block = Thread->LookupCache->FindBlock(GuestRIP)) {
+      Thread->OpDispatcher->DelayedDisownBuffer();
+      return {.CompiledCode = reinterpret_cast<void*>(Block), .DebugData = nullptr, .StartAddr = 0, .Length = 0, .CodeBufferLock {}};
+    }
+  }
+
   auto CompiledCode = Thread->CPUBackend->CompileCode(GuestRIP, Length, TotalInstructions == 1, &*IRView, DebugData.get(), TFSet);
 
   // Release the IR
@@ -816,6 +828,9 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
   auto [CodePtr, DebugData, StartAddr, Length, CodeBufferLock] = CompileCode(Thread, GuestRIP, MaxInst);
   if (CodePtr == nullptr) {
     return 0;
+  } else if (!CodeBufferLock) {
+    // Lock was released, indicating another thread raced us for compiling this block
+    return reinterpret_cast<uintptr_t>(CodePtr);
   }
 
   // The core managed to compile the code.

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -693,7 +693,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
 
   // Fairly excessive buffer range to make sure we don't overflow
   uint32_t BufferRange = SSACount * 16;
-  if ((GetCursorOffset() + BufferRange) > (CurrentCodeBuffer->Size - Utils::FEX_PAGE_SIZE)) {
+  if ((GetCursorOffset() + BufferRange) > (CurrentCodeBufferSize - Utils::FEX_PAGE_SIZE)) {
     CTX->ClearCodeCache(ThreadState);
   }
 

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -549,7 +549,7 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl* ctx, FEXCore::Core::In
     AArch64.LREM = reinterpret_cast<uint64_t>(LREM);
   }
 
-  CurrentCodeBuffer = manager.GetLatest();
+  CurrentCodeBuffer = CodeBuffers.GetLatest();
   ThreadState->LookupCache->Shared = CurrentCodeBuffer->LookupCache.get();
 
   // Setup dynamic dispatch.
@@ -704,7 +704,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
   }
 
   SetBuffer(CurrentCodeBuffer->Ptr, CurrentCodeBuffer->Size);
-  SetCursorOffset(manager.LatestOffset);
+  SetCursorOffset(CodeBuffers.LatestOffset);
   if ((GetCursorOffset() + BufferRange) > (CurrentCodeBuffer->Size - Utils::FEX_PAGE_SIZE)) {
     CTX->ClearCodeCache(ThreadState);
   }
@@ -879,7 +879,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
 
   JITBlockTail->Size = CodeData.Size;
 
-  manager.LatestOffset = GetCursorOffset();
+  CodeBuffers.LatestOffset = GetCursorOffset();
 
   ClearICache(CodeData.BlockBegin, CodeOnlySize);
 

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -698,7 +698,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
   this->IR = IR;
 
   // Fairly excessive buffer range to make sure we don't overflow
-  uint32_t BufferRange = SSACount * 16;
+  uint32_t BufferRange = 0x100 + SSACount * 24;
 
   // JIT output is first written to a temporary buffer and later relocated to the CodeBuffer.
   // This minimizes lock contention of CodeBufferWriteMutex.

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -40,9 +40,6 @@ $end_info$
 #include <string.h>
 #include <limits>
 
-// We don't want to move above 128MB atm because that means we will have to encode longer jumps
-static constexpr size_t MAX_CODE_SIZE = 1024 * 1024 * 128;
-
 namespace {
 static uint64_t LUDIV(uint64_t SrcHigh, uint64_t SrcLow, uint64_t Divisor) {
   __uint128_t Source = (static_cast<__uint128_t>(SrcHigh) << 64) | SrcLow;
@@ -497,7 +494,7 @@ static uint64_t Arm64JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame* Fram
 void Arm64JITCore::Op_NoOp(const IR::IROp_Header* IROp, IR::Ref Node) {}
 
 Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl* ctx, FEXCore::Core::InternalThreadState* Thread)
-  : CPUBackend(*ctx, Thread, MAX_CODE_SIZE)
+  : CPUBackend(*ctx, Thread)
   , Arm64Emitter(ctx)
   , HostSupportsSVE128 {ctx->HostFeatures.SupportsSVE128}
   , HostSupportsSVE256 {ctx->HostFeatures.SupportsSVE256}

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -453,6 +453,8 @@ static void DirectBlockDelinker(FEXCore::Core::CpuStateFrame* Frame, FEXCore::Co
 
 static uint64_t Arm64JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame* Frame, FEXCore::Context::ExitFunctionLinkData* Record) {
   auto Thread = Frame->Thread;
+  auto Lock = Thread->LookupCache->AcquireLock();
+
   bool TFSet = Thread->CurrentFrame->State.flags[X86State::RFLAG_TF_RAW_LOC];
   uintptr_t HostCode {};
   auto GuestRip = Record->GuestRIP;

--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -64,6 +64,8 @@ private:
 
   fextl::map<IR::NodeID, ARMEmitter::BiDirectionalLabel> JumpTargets;
 
+  Utils::PoolBufferWithTimedRetirement<uint8_t*, 5000, 500> TempAllocator;
+
   [[nodiscard]]
   ARMEmitter::Register GetReg(IR::PhysicalRegister Reg) const {
     LOGMAN_THROW_A_FMT(Reg.Class == IR::GPRFixedClass.Val || Reg.Class == IR::GPRClass.Val, "Unexpected Class: {}", Reg.Class);

--- a/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -65,20 +65,27 @@ LookupCache::~LookupCache() {
 }
 
 void LookupCache::ClearL2Cache() {
-  auto lk = L3.AcquireLock();
+  auto lk = Shared->AcquireLock();
   // Clear out the page memory
   // PagePointer and PageMemory are sequential with each other. Clear both at once.
   FEXCore::Allocator::VirtualDontNeed(reinterpret_cast<void*>(PagePointer), ctx->Config.VirtualMemSize / 4096 * 8 + CODE_SIZE, false);
   AllocateOffset = 0;
 }
 
+void LookupCache::ClearThreadLocalCaches() {
+  auto lk = Shared->AcquireLock();
+
+  // Clear L1 and L2 by clearing the full cache.
+  FEXCore::Allocator::VirtualDontNeed(reinterpret_cast<void*>(PagePointer), TotalCacheSize, false);
+}
+
 void LookupCache::ClearCache() {
-  auto lk = L3.AcquireLock();
+  auto lk = Shared->AcquireLock();
 
   // Clear L1 and L2 by clearing the full cache.
   FEXCore::Allocator::VirtualDontNeed(reinterpret_cast<void*>(PagePointer), TotalCacheSize, false);
 
-  L3.ClearCache(lk);
+  Shared->ClearCache(lk);
 }
 
 void GuestToHostMap::ClearCache(const LockToken&) {

--- a/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/FEXCore/Source/Interface/Core/LookupCache.h
@@ -61,6 +61,10 @@ struct GuestToHostMap {
   // Adds to Guest -> Host code mapping
   void AddBlockMapping(uint64_t Address, void* HostCode, const LockToken&) {
     // This may replace an existing mapping
+    // NOTE: Generally no previous entry should exist, however there is one exception:
+    //       If the backend updates the active thread's CodeBuffer, the new associated LookupCache
+    //       may already contain the block address. Since is comparatively rare, we'll just leak
+    //       one of the two blocks in this case.
     BlockList[Address] = (uintptr_t)HostCode;
   }
 
@@ -102,6 +106,13 @@ public:
   LookupCache(FEXCore::Context::ContextImpl* CTX);
   ~LookupCache();
 
+  // Swaps out the underlying GuestToHostMap and clears all associated caches.
+  // This interface requires the previous CodeBuffer to be provided despite not using it. This ensures the shared write lock is still valid.
+  void ChangeGuestToHostMapping([[maybe_unused]] CPU::CodeBuffer& Prev, GuestToHostMap& NewMap) {
+    ClearThreadLocalCaches();
+    Shared = &NewMap;
+  }
+
   uintptr_t FindBlock(uint64_t Address) {
     // Try L1, no lock needed
     auto& L1Entry = reinterpret_cast<LookupCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
@@ -110,7 +121,7 @@ public:
     }
 
     // L2 and L3 need to be locked
-    auto lk = L3.AcquireLock();
+    auto lk = Shared->AcquireLock();
 
     // Try L2
     const auto PageIndex = (Address & (VirtualMemSize - 1)) >> 12;
@@ -132,7 +143,7 @@ public:
     }
 
     // Try L3
-    auto HostCode = L3.FindBlock(Address, lk);
+    auto HostCode = Shared->FindBlock(Address, lk);
     if (HostCode) {
       CacheBlockMapping(Address, HostCode.value());
       return HostCode.value();
@@ -142,15 +153,14 @@ public:
     return 0;
   }
 
-  GuestToHostMap L3;
+  GuestToHostMap* Shared = nullptr;
 
   fextl::map<uint64_t, fextl::vector<uint64_t>> CodePages;
 
   // Appends Block {Address} to CodePages [Start, Start + Length)
   // Returns true if new pages are marked as containing code
   bool AddBlockExecutableRange(uint64_t Address, uint64_t Start, uint64_t Length) {
-    auto lk = L3.AcquireLock();
-
+    auto lk = Shared->AcquireLock();
 
     bool rv = false;
 
@@ -165,9 +175,9 @@ public:
 
   // Adds to Guest -> Host code mapping
   void AddBlockMapping(uint64_t Address, void* HostCode) {
-    auto lk = L3.AcquireLock();
+    auto lk = Shared->AcquireLock();
 
-    L3.AddBlockMapping(Address, HostCode, lk);
+    Shared->AddBlockMapping(Address, HostCode, lk);
 
     // There is no need to update L1 or L2, they will get updated on first lookup
     // However, adding to L1 here increases performance
@@ -176,10 +186,13 @@ public:
     L1Entry.HostCode = (uintptr_t)HostCode;
   }
 
+  // NOTE: It's the caller's responsibility to call Erase() for all other
+  //       GuestToHostMaps that share the same LookupCache. Otherwise, the
+  //       L1/L2 caches will contain stale references to deallocated memory.
   void Erase(FEXCore::Core::CpuStateFrame* Frame, uint64_t Address) {
-    auto lk = L3.AcquireLock();
+    auto lk = Shared->AcquireLock();
 
-    L3.Erase(Frame, Address, lk);
+    Shared->Erase(Frame, Address, lk);
 
     // Do L1
     auto& L1Entry = reinterpret_cast<LookupCacheEntry*>(L1Pointer)[Address & L1_ENTRIES_MASK];
@@ -209,12 +222,13 @@ public:
   }
 
   void AddBlockLink(uint64_t GuestDestination, FEXCore::Context::ExitFunctionLinkData* HostLink, const FEXCore::Context::BlockDelinkerFunc& delinker) {
-    auto lk = L3.AcquireLock();
-    L3.AddBlockLink(GuestDestination, HostLink, delinker, lk);
+    auto lk = Shared->AcquireLock();
+    Shared->AddBlockLink(GuestDestination, HostLink, delinker, lk);
   }
 
   void ClearCache();
   void ClearL2Cache();
+  void ClearThreadLocalCaches();
 
   uintptr_t GetL1Pointer() const {
     return L1Pointer;
@@ -237,7 +251,7 @@ public:
   // This approach has not been fully vetted yet.
   // Also note that L1 lookups might be inlined in the JIT Dispatcher and/or block ends.
   auto AcquireLock() {
-    return L3.AcquireLock();
+    return Shared->AcquireLock();
   }
 
 private:

--- a/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/FEXCore/Source/Interface/Core/LookupCache.h
@@ -78,7 +78,7 @@ public:
 
     for (auto CurrentPage = Start >> 12, EndPage = (Start + Length - 1) >> 12; CurrentPage <= EndPage; CurrentPage++) {
       auto& CodePage = CodePages[CurrentPage];
-      rv |= CodePage.size() == 0;
+      rv |= CodePage.empty();
       CodePage.push_back(Address);
     }
 

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -171,7 +171,7 @@ public:
   FEX_DEFAULT_VISIBILITY virtual void FinalizeAOTIRCache() = 0;
   FEX_DEFAULT_VISIBILITY virtual void WriteFilesWithCode(AOTIRCodeFileWriterFn Writer) = 0;
 
-  FEX_DEFAULT_VISIBILITY virtual void ClearCodeCache(FEXCore::Core::InternalThreadState* Thread) = 0;
+  FEX_DEFAULT_VISIBILITY virtual void ClearCodeCache(FEXCore::Core::InternalThreadState* Thread, bool NewCodeBuffer = true) = 0;
   FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) = 0;
   FEX_DEFAULT_VISIBILITY virtual FEXCore::ForkableSharedMutex& GetCodeInvalidationMutex() = 0;
 
@@ -181,7 +181,7 @@ public:
   ConfigureAOTGen(FEXCore::Core::InternalThreadState* Thread, fextl::set<uint64_t>* ExternalBranches, uint64_t SectionMaxAddress) = 0;
 
   /**
-   * @brief Checks if a PC is inside of a thread's JIT code buffer.
+   * @brief Checks if a PC is inside any code buffer used by the thread's JIT.
    *
    * @param Thread Which thread's code buffers to check inside of.
    * @param Address The PC to check against.

--- a/FEXCore/include/FEXCore/fextl/memory.h
+++ b/FEXCore/include/FEXCore/fextl/memory.h
@@ -25,11 +25,20 @@ struct default_delete : public std::default_delete<T> {
 template<class T, class Deleter = fextl::default_delete<T>>
 using unique_ptr = std::unique_ptr<T, Deleter>;
 
+template<class T>
+using shared_ptr = std::shared_ptr<T>;
+
 template<class T, class... Args>
 requires (!std::is_array_v<T>)
 fextl::unique_ptr<T> make_unique(Args&&... args) {
   auto ptr = FEXCore::Allocator::aligned_alloc(std::alignment_of_v<T>, sizeof(T));
   auto Result = ::new (ptr) T(std::forward<Args>(args)...);
   return fextl::unique_ptr<T>(Result);
+}
+
+template<class T, class... Args>
+requires (!std::is_array_v<T>)
+fextl::shared_ptr<T> make_shared(Args&&... args) {
+  return std::allocate_shared<T>(fextl::FEXAlloc<T> {}, std::forward<Args>(args)...);
 }
 } // namespace fextl

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -297,7 +297,7 @@ void ThreadManager::Step() {
     // Walk the threads and tell them to clear their caches
     // Useful when our block size is set to a large number and we need to step a single instruction
     for (auto& Thread : Threads) {
-      CTX->ClearCodeCache(Thread->Thread);
+      CTX->ClearCodeCache(Thread->Thread, false);
     }
   }
 


### PR DESCRIPTION
## Overview

To ease state management, FEX currently dedicates a separate CodeBuffer to each thread for storing the output of JIT binary recompilation. Effectively, this means lots of code must be compiled multiple times, particularly during startup and loadscreens of an application. This PR fixes this by sharing CodeBuffers between threads wherever possible, drastically reducing JIT time and mitigating microstutters (see below for benchmarks).

The broader goal here is that CodeBuffer memory should never be discarded unless strictly necessary, establishing the invariant "every guest block is compiled exactly once". This will also prepare us for effective on-disk code caching (which will further reduce startup times).

## Implementation: Partially persistent data structures

> ... partially what now?

This is an [idea from functional programming](https://en.wikipedia.org/wiki/Persistent_data_structure) to ensure thread-safe data access: Trying to modify an object will branch its state into a new version for the active thread but preserving the old version as a read-only copy in other threads. This can be implemented without CPU overhead as long as write accesses are mutex-protected.

This PR turns CodeBuffer into such a partially persistent data structure. In practice this means:
* Exactly one CodeBuffer is now designated as "active", which means data can be *appended* to it
* Lossy modifications to the active CodeBuffer will not invalidate any data in use by other threads (which is what enables save CodeBuffer sharing across threads)
* Instead, such lossy modifications trigger a new "version" of the data in the modifying thread. Old versions of the CodeBuffer persist as read-only data for use by the other threads.
* The other threads can update their version of the CodeBuffer. This will decrease the reference count and eventually trigger deallocation of the old version

With the code in this PR, starting a new CodeBuffer version will wipe its entire contents (similar to today's semantics), but that's an implementation detail. In the future we can carry over old data to the new CodeBuffer using relocations, which would still be in line with the persistence model.

## Measurements

Preliminary testing yielded the following numbers (gathered from Tracy):

|| Mirror's Edge[^1] | God of War[^3] | Yooka-Laylee[^4] | Hollow Knight[^5] |
|-|------------------|----------------|-------------------|-----|
| JIT invocations (million) | 6.9⇨3.1(⇨2.9[^2]) | 0.97⇨0.72(⇨0.56) | 0.80⇨0.72(⇨0.53) | 0.71⇨6.8(⇨4.1)|
| Total JIT time (sec) | 20.9⇨15.5(⇨13.0)| 10.3⇨8.4(⇨5.1) | 6.3⇨5.1(⇨3.9) | 5.0⇨4.4(⇨2.7)|
| JIT time savings (%) | 26% (38%) | 19% (50%) | 19% (38%) | 11% (47%) |

[^1]: Tested first 100s of the game, trying to gain control of the character as quickly as possible
[^2]: Potential for follow-up change to carry over CodeBuffer data on resize
[^3]: Tested first 60s of the game without entering any inputs
[^4]: Tested first 45s of the game, trying to enter one level in my save file as quickly as possible and waiting for the camera to stop moving
[^5]: Tested first 36s of the game, loading my last save file and jumping once

I also measured the Steam startup time (up to the completed first render of the Library view). Since we can't profile JIT time across multiple processes, I had to measure the total startup time. The results are perhaps weakly favorable towards this PR (best measurement 35s⇨33s), but the fluctuation is too strong to say with confidence.

## Implementation notes

### Events that trigger a new CodeBuffer version

* Running out of CodeBuffer space
* TSO auto-migration (i.e. a one-time event upon starting the second application thread)
* Single-stepping

Notably, switching between threads that compile new code does *not* trigger a new version. However, modifying accesses must be serialized, so a global lock is used when running the JIT backend (see next point).

### Global JIT lock

This approach to sharing code buffers requires all JIT (backend) compilation to be logically single-threaded, so a global `CodeBufferWriteMutex` mutex is used. This incurs some contention during startup of heavily multithreaded applications. In Mirror's Edge, I measured a lock contention of 9% (5%[^2]) of total time spent in JIT (worst case was 14% in smaller time windows). That overhead is *included* in the net improvements above, so this indicates practical room for further improvement.

It seems unlikely that even strongly multithreaded applications would suffer from this: Whereas now threads are merely fighting for a global lock, the app threads would've previously wasted time recompiling the same code over and over again.

In the future, the lock contention can be minimized by compiling to a short-lived thread-local buffer and relocating the resulting code to the actual CodeBuffer. Only the relocation would need to be mutex-protected then.

### Interaction with L3 LookupCache

We must rethink the semantics of the L3 LookupCache: It's not really a cache but rather the source for mapping guest addresses to host code pointers. Subsequently, the PR decouples it from the L1/L2 LookupCaches, renames it to GuestToHostMap, and embeds it into CodeBuffer. This means the same versioning effect applies to all data contained in GuestToHostMap. Overall, this makes sense since without sharing this mapping, we'd use the same CodeBuffer but we wouldn't know where to find blocks already compiled on other threads.

Since this data was assumed to be thread-local previously, care must be taken when invalidating it (e.g. for self-modifying code). I checked existing invalidation code paths and verified they are either idempotent (i.e. they run the same action multiple times without order-dependence or other change in effect) or already unused/broken today. ~~The SMC-full mode is an exception that needs to be fixed.~~ The latter group includes SMC-full mode, which has been non-functional on main for an unknown amount of time.

### Signal handlers

Currently, FEX has dedicated CodeBuffer code to cope with signal handlers that must extend the lifetime of a CodeBuffer. This mechanism is now based on persistence as well, which makes it much more straightforward. Signal handlers will now simply increase the refcount of a CodeBuffer so that it doesn't get deallocated too early.

### Stale CodeBuffer versions

Old CodeBuffer versions only get deallocated when all threads that reference it cooperatively *update* to a newer CodeBuffer. This may never happen in some cases (imagine e.g. a background thread spawned at start that enters a syscall for an event that's never raised until program end). Due to geometric growth, the *combined* worst-case memory overhead of all such CodeBuffers is the size of the active CodeBuffer.

It's unclear if this can be fully resolved. However, we can largely mitigate this by minimizing the number of events that trigger version branching in the first place:
* Use a larger initial size of the first CodeBuffer (possibly using a heuristic based on the program size itself)
* Maybe more?

## TODO
* [x] Clean up
* [x] ~~Fix SMC-full mode~~ (actually broken on main)
* [x] Revisit single-stepping code (`ThreadManager::Step`)
* [x] ~~WoA support?~~ (nothing special to do)
* [x] Verify invalidation logic for thread-local LookupCaches is functionally equivalent
* [x] ~~Deallocate previously compiled code on TSO auto-migration~~ (will just carry around dead code until a CodeBuffer clear for now)

## Future

See #4514 for ideas to mitigate single-threaded compilation and other follow-up optimizations.
