### PR TITLE
FEXCore: Reduce stack usage in CalculateNumberOfCPUs

### DIFF
--- a/FEXCore/Source/CMakeLists.txt
+++ b/FEXCore/Source/CMakeLists.txt
@@ -4,7 +4,6 @@ set (MAN_DIR share/man CACHE PATH "MAN_DIR")
 set (FEXCORE_BASE_SRCS
   Interface/Config/Config.cpp
   Utils/Allocator.cpp
-  Utils/CPUInfo.cpp
   Utils/FileLoading.cpp
   Utils/ForcedAssert.cpp
   Utils/LogManager.cpp

--- a/FEXCore/Source/Interface/Config/Config.cpp
+++ b/FEXCore/Source/Interface/Config/Config.cpp
@@ -4,7 +4,6 @@
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Utils/Allocator.h>
-#include <FEXCore/Utils/CPUInfo.h>
 #include <FEXCore/Utils/FileLoading.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/StringUtils.h>

--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -13,7 +13,6 @@ $end_info$
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/CPUID.h>
 #include <FEXCore/Core/HostFeatures.h>
-#include <FEXCore/Utils/CPUInfo.h>
 #include <FEXCore/Utils/FileLoading.h>
 #include <FEXCore/fextl/string.h>
 #include <FEXHeaderUtils/Syscalls.h>

--- a/FEXCore/Source/Utils/CPUInfo.cpp
+++ b/FEXCore/Source/Utils/CPUInfo.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <FEXHeaderUtils/Filesystem.h>
 
+#include <fmt/compile.h>
 #include <fmt/format.h>
 
 #include <cstddef>
@@ -14,11 +15,13 @@
 namespace FEXCore::CPUInfo {
 #ifndef _WIN32
 uint32_t CalculateNumberOfCPUs() {
-  char Tmp[PATH_MAX];
+  constexpr auto parse_string = FMT_COMPILE("/sys/devices/system/cpu/cpu{}");
+  constexpr auto max_parse_size = ::fmt::formatted_size(parse_string, UINT32_MAX);
+  char Tmp[max_parse_size];
   size_t CPUs = 1;
 
   for (;; ++CPUs) {
-    auto Size = fmt::format_to_n(Tmp, sizeof(Tmp), "/sys/devices/system/cpu/cpu{}", CPUs);
+    auto Size = fmt::format_to_n(Tmp, max_parse_size, parse_string, CPUs);
     Tmp[Size.size] = 0;
     if (!FHU::Filesystem::Exists(Tmp)) {
       break;

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(cpp-optparse/)
 set(NAME Common)
 set(SRCS
   Config.cpp
+  CPUInfo.cpp
   ArgumentLoader.cpp
   EnvironmentLoader.cpp
   HostFeatures.cpp

--- a/Source/Common/CPUInfo.cpp
+++ b/Source/Common/CPUInfo.cpp
@@ -12,7 +12,7 @@
 #include <linux/limits.h>
 #endif
 
-namespace FEXCore::CPUInfo {
+namespace FEX::CPUInfo {
 #ifndef _WIN32
 uint32_t CalculateNumberOfCPUs() {
   constexpr auto parse_string = FMT_COMPILE("/sys/devices/system/cpu/cpu{}");
@@ -36,4 +36,4 @@ uint32_t CalculateNumberOfCPUs() {
   return std::thread::hardware_concurrency();
 }
 #endif
-} // namespace FEXCore::CPUInfo
+} // namespace FEX::CPUInfo

--- a/Source/Common/CPUInfo.h
+++ b/Source/Common/CPUInfo.h
@@ -4,11 +4,11 @@
 
 #include <cstdint>
 
-namespace FEXCore::CPUInfo {
+namespace FEX::CPUInfo {
 /**
  * @brief Calculate the number of CPUs in the system regardless of affinity mask.
  *
  * @return The number of CPUs in the system.
  */
-FEX_DEFAULT_VISIBILITY uint32_t CalculateNumberOfCPUs();
-} // namespace FEXCore::CPUInfo
+uint32_t CalculateNumberOfCPUs();
+} // namespace FEX::CPUInfo

--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
+#include "Common/CPUInfo.h"
 #include "Common/HostFeatures.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/HostFeatures.h>
-#include <FEXCore/Utils/CPUInfo.h>
 #include <FEXCore/Utils/FileLoading.h>
 #include <FEXCore/Utils/StringUtils.h>
 
@@ -14,7 +14,7 @@
 namespace FEX {
 
 void FillMIDRInformationViaLinux(FEXCore::HostFeatures* Features) {
-  auto Cores = FEXCore::CPUInfo::CalculateNumberOfCPUs();
+  auto Cores = FEX::CPUInfo::CalculateNumberOfCPUs();
   Features->CPUMIDRs.resize(Cores);
 #ifdef _M_ARM_64
   for (size_t i = 0; i < Cores; ++i) {

--- a/Source/Tools/FEXLoader/AOT/AOTGenerator.cpp
+++ b/Source/Tools/FEXLoader/AOT/AOTGenerator.cpp
@@ -104,7 +104,8 @@ void AOTGenSection(FEXCore::Context::Context* CTX, ELFCodeLoader::LoadedSection&
 
   // This code is tricky to refactor so it doesn't allocate memory through glibc.
   FEXCore::Allocator::YesIKnowImNotSupposedToUseTheGlibcAllocator glibc;
-  for (int i = 0; i < FEX::CPUInfo::CalculateNumberOfCPUs(); i++) {
+  const auto Cores = FEX::CPUInfo::CalculateNumberOfCPUs();
+  for (int i = 0; i < Cores; i++) {
     std::thread thd([&BranchTargets, CTX, &counter, &Compiled, &Section, &QueueMutex, SectionMaxAddress]() {
       // Set the priority of the thread so it doesn't overwhelm the system when running in the background
       setpriority(PRIO_PROCESS, FHU::Syscalls::gettid(), 19);

--- a/Source/Tools/FEXLoader/AOT/AOTGenerator.cpp
+++ b/Source/Tools/FEXLoader/AOT/AOTGenerator.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
+#include "Common/CPUInfo.h"
+
 #include "ELFCodeLoader.h"
 #include "Linux/Utils/ELFContainer.h"
 
 #include <FEXCore/Core/Context.h>
-#include <FEXCore/Utils/CPUInfo.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/fextl/queue.h>
 #include <FEXCore/fextl/set.h>
@@ -103,7 +104,7 @@ void AOTGenSection(FEXCore::Context::Context* CTX, ELFCodeLoader::LoadedSection&
 
   // This code is tricky to refactor so it doesn't allocate memory through glibc.
   FEXCore::Allocator::YesIKnowImNotSupposedToUseTheGlibcAllocator glibc;
-  for (int i = 0; i < FEXCore::CPUInfo::CalculateNumberOfCPUs(); i++) {
+  for (int i = 0; i < FEX::CPUInfo::CalculateNumberOfCPUs(); i++) {
     std::thread thd([&BranchTargets, CTX, &counter, &Compiled, &Section, &QueueMutex, SectionMaxAddress]() {
       // Set the priority of the thread so it doesn't overwhelm the system when running in the background
       setpriority(PRIO_PROCESS, FHU::Syscalls::gettid(), 19);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -8,6 +8,7 @@ $end_info$
 
 #include "CodeLoader.h"
 
+#include "Common/CPUInfo.h"
 #include "Common/FDUtils.h"
 #include "LinuxSyscalls/Syscalls.h"
 #include "LinuxSyscalls/EmulatedFiles/EmulatedFiles.h"
@@ -15,7 +16,6 @@ $end_info$
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CPUID.h>
-#include <FEXCore/Utils/CPUInfo.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/fextl/fmt.h>
 #include <FEXCore/fextl/string.h>
@@ -490,7 +490,7 @@ fextl::string GenerateCPUInfo(FEXCore::Context::Context* ctx, uint32_t CPUCores)
 
 EmulatedFDManager::EmulatedFDManager(FEXCore::Context::Context* ctx)
   : CTX {ctx}
-  , ThreadsConfig {FEXCore::CPUInfo::CalculateNumberOfCPUs()} {
+  , ThreadsConfig {FEX::CPUInfo::CalculateNumberOfCPUs()} {
   FDReadCreators["/proc/cpuinfo"] = [&](FEXCore::Context::Context* ctx, int32_t fd, const char* pathname, int32_t flags, mode_t mode) -> int32_t {
     // Only allow a single thread to initialize the cpu_info.
     // Jit in-case multiple threads try to initialize at once.

--- a/Source/Windows/Common/CPUFeatures.cpp
+++ b/Source/Windows/Common/CPUFeatures.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 
+#include "Common/CPUInfo.h"
+
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/HostFeatures.h>
-#include <FEXCore/Utils/CPUInfo.h>
 #include <FEXCore/fextl/fmt.h>
 
 #include <windows.h>

--- a/docs/ProgrammingConcerns.md
+++ b/docs/ProgrammingConcerns.md
@@ -26,7 +26,7 @@ Most C++ APIs allow you to replace their allocators, but some don't and we need 
 running might run out of memory. This isn't an all encompassing list and we will add to it as our CI captures more problems.
 
 ### `get_nprocs_conf`
-Use `FEXCore::CPUInfo::CalculateNumberOfCPUs` instead.
+Use `FEX::CPUInfo::CalculateNumberOfCPUs` instead.
 
 ### `getcwd`
 Don't use getcwd with a nullptr buffer. It will allocate memory behind our back and return a pointer that needs a free.


### PR DESCRIPTION
Nothing crazy, just recalculate the maximum string length rather than
use PATH_MAX.