### PR TITLE
Cleanup info test files for 32bits

### DIFF
--- a/unittests/gcc-target-tests-32/Disabled_Tests
+++ b/unittests/gcc-target-tests-32/Disabled_Tests
@@ -4,18 +4,6 @@ pr57275.c.gcc-target-test-64
 # Consistently crashes on Solidrun only in CI
 20080723-1.c.gcc-target-test-32
 
-# These tests fail because of things unrelated to the sse4.1 instructions
-sse4_1-ceil-sfix-vec.c.gcc-target-test-32
-sse4_1-ceilf-sfix-vec.c.gcc-target-test-32
-sse4_1-floor-sfix-vec.c.gcc-target-test-32
-sse4_1-floorf-sfix-vec.c.gcc-target-test-32
-sse4_1-rint-sfix-vec.c.gcc-target-test-32
-sse4_1-rintf-sfix-vec.c.gcc-target-test-32
-sse4_1-round-sfix-vec.c.gcc-target-test-32
-sse4_1-roundf-sfix-vec.c.gcc-target-test-32
-sse4_1-rint-vec.c.gcc-target-test-32
-sse4_1-roundf-vec.c.gcc-target-test-32
-
 # These tests fail on Nvidia Xavier ONLY
 sse4_1-rintf-vec.c.gcc-target-test-32
 sse4_1-round-vec.c.gcc-target-test-32

--- a/unittests/gcc-target-tests-32/Known_Failures
+++ b/unittests/gcc-target-tests-32/Known_Failures
@@ -1,24 +1,2 @@
 pr72867.c.gcc-target-test-32
 sse2-mmx-pextrw.c.gcc-target-test-32
-
-# Consistently crashes on Solidrun only in CI
-20080723-1.c.gcc-target-test-32
-
-# These tests fail because of things unrelated to the sse4.1 instructions
-sse4_1-ceil-sfix-vec.c.gcc-target-test-32
-sse4_1-ceilf-sfix-vec.c.gcc-target-test-32
-sse4_1-floor-sfix-vec.c.gcc-target-test-32
-sse4_1-floorf-sfix-vec.c.gcc-target-test-32
-sse4_1-rint-sfix-vec.c.gcc-target-test-32
-sse4_1-rintf-sfix-vec.c.gcc-target-test-32
-sse4_1-round-sfix-vec.c.gcc-target-test-32
-sse4_1-roundf-sfix-vec.c.gcc-target-test-32
-sse4_1-rint-vec.c.gcc-target-test-32
-sse4_1-roundf-vec.c.gcc-target-test-32
-
-# These tests fail on Nvidia Xavier ONLY
-sse4_1-rintf-vec.c.gcc-target-test-32
-sse4_1-round-vec.c.gcc-target-test-32
-
-# This has a race with SIGPROF
-mcount_pic.c.gcc-target-test-32


### PR DESCRIPTION
No point in duplicating test info between Disabled and Known Failures.

Leaving tests known to fail in Known_Failures. Flakes / Unreliable tests go into Disabled_Tests.