### PR TITLE
LinuxSyscalls: Fixes 32-bit llseek result

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
@@ -293,6 +293,8 @@ void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
       if (Result != -1) {
         FaultSafeUserMemAccess::VerifyIsWritable(result, sizeof(*result));
         *result = Result;
+        // On non-error result, llseek returns zero (As the result is returned in pointer).
+        return 0;
       }
       SYSCALL_ERRNO();
     });


### PR DESCRIPTION
`llseek` returns only ever 0 or errno in the return register. This is in contrast to `lseek` which returns the result (or errno) in the return register.

We were accidentally returning the result on non-error conditions which could freak out some software. Thanks to
[OFFTKP](https://github.com/OFFTKP) for pointing out this issue