### PR TITLE
Windows: Misc cleanups and fixes

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -795,6 +795,8 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
   FEXCORE_PROFILE_SCOPED("CompileBlock");
   FEXCORE_PROFILE_ACCUMULATION(Thread, AccumulatedJITTime);
 
+  static_cast<ContextImpl*>(Thread->CTX)->SyscallHandler->PreCompile();
+
   // Invalidate might take a unique lock on this, to guarantee that during invalidation no code gets compiled
   auto lk = GuardSignalDeferringSection<std::shared_lock>(CodeInvalidationMutex, Thread);
 
@@ -870,6 +872,8 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
 uintptr_t ContextImpl::CompileSingleStep(FEXCore::Core::CpuStateFrame* Frame, uint64_t GuestRIP) {
   FEXCORE_PROFILE_SCOPED("CompileSingleStep");
   auto Thread = Frame->Thread;
+
+  static_cast<ContextImpl*>(Thread->CTX)->SyscallHandler->PreCompile();
 
   // Invalidate might take a unique lock on this, to guarantee that during invalidation no code gets compiled
   auto lk = GuardSignalDeferringSection<std::shared_lock>(CodeInvalidationMutex, Thread);

--- a/FEXCore/include/FEXCore/HLE/SyscallHandler.h
+++ b/FEXCore/include/FEXCore/HLE/SyscallHandler.h
@@ -76,6 +76,8 @@ public:
   virtual void UnmarkOvercommitRange(uint64_t Start, uint64_t Length) {}
   virtual AOTIRCacheEntryLookupResult LookupAOTIRCacheEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestAddr) = 0;
 
+  virtual void PreCompile() {}
+
   virtual SourcecodeResolver* GetSourcecodeResolver() {
     return nullptr;
   }

--- a/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
+++ b/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
@@ -58,7 +58,7 @@ inline void VirtualDontNeed(void* Ptr, size_t Size, bool Recommit = true) {
   ::VirtualQuery(Ptr, &Info, sizeof(Info));
   ::VirtualFree(Ptr, Size, MEM_DECOMMIT);
   if (Recommit) {
-    ::VirtualAlloc(Ptr, Size, MEM_COMMIT, Info.AllocationProtect);
+    ::VirtualAlloc(Ptr, Size, MEM_COMMIT, Info.Protect);
   }
 }
 

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -559,6 +559,10 @@ public:
   void UnmarkOvercommitRange(uint64_t Start, uint64_t Length) override {
     OvercommitTracker->UnmarkRange(Start, Length);
   }
+
+  void PreCompile() override {
+    ProcessPendingCrossProcessEmulatorWork();
+  }
 };
 } // namespace Exception
 

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -663,11 +663,11 @@ bool ResetToConsistentStateImpl(EXCEPTION_RECORD* Exception, CONTEXT* GuestConte
   FEXCORE_PROFILE_ACCUMULATION(Thread, AccumulatedSignalTime);
   LogMan::Msg::DFmt("Exception: Code: {:X} Address: {:X}", Exception->ExceptionCode, reinterpret_cast<uintptr_t>(Exception->ExceptionAddress));
 
-  if (Exception->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && Thread && InvalidationTracker) {
+  if (Exception->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
     const auto FaultAddress = static_cast<uint64_t>(Exception->ExceptionInformation[1]);
 
     std::scoped_lock Lock(ThreadCreationMutex);
-    if (InvalidationTracker->HandleRWXAccessViolation(FaultAddress)) {
+    if (InvalidationTracker && InvalidationTracker->HandleRWXAccessViolation(FaultAddress)) {
       FEXCORE_PROFILE_INSTANT_INCREMENT(Thread, AccumulatedSMCCount, 1);
       if (CTX->IsAddressInCodeBuffer(Thread, NativeContext->Pc) && !CTX->IsCurrentBlockSingleInst(CPUArea.ThreadState()) &&
           CTX->IsAddressInCurrentBlock(Thread, FaultAddress, 8)) {
@@ -687,7 +687,7 @@ bool ResetToConsistentStateImpl(EXCEPTION_RECORD* Exception, CONTEXT* GuestConte
     }
   }
 
-  if (!CTX->IsAddressInCodeBuffer(CPUArea.ThreadState(), NativeContext->Pc) && !IsDispatcherAddress(NativeContext->Pc)) {
+  if (!CTX->IsAddressInCodeBuffer(Thread, NativeContext->Pc) && !IsDispatcherAddress(NativeContext->Pc)) {
     LogMan::Msg::DFmt("Passing through exception");
     return false;
   }
@@ -700,8 +700,8 @@ bool ResetToConsistentStateImpl(EXCEPTION_RECORD* Exception, CONTEXT* GuestConte
   // The JIT (in CompileBlock) emits code to check the suspend doorbell at the start of every block, and run the following instruction if it is set:
   static constexpr uint32_t SuspendTrapMagic {0xD4395FC0}; // brk #0xCAFE
   if (Exception->ExceptionCode == EXCEPTION_ILLEGAL_INSTRUCTION && *reinterpret_cast<uint32_t*>(NativeContext->Pc) == SuspendTrapMagic) {
-    Exception::ReconstructThreadState(CPUArea.ThreadState(), *NativeContext);
-    *NativeContext = Exception::StoreStateToPackedECContext(CPUArea.ThreadState(), NativeContext->Fpcr, NativeContext->Fpsr);
+    Exception::ReconstructThreadState(Thread, *NativeContext);
+    *NativeContext = Exception::StoreStateToPackedECContext(Thread, NativeContext->Fpcr, NativeContext->Fpsr);
     LogMan::Msg::DFmt("Suspending: RIP: {:X} SP: {:X}", NativeContext->Pc, NativeContext->Sp);
     CPUArea.Area->InSimulation = 0;
     *CPUArea.Area->SuspendDoorbell = 0;

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -450,6 +450,10 @@ public:
   void UnmarkOvercommitRange(uint64_t Start, uint64_t Length) override {
     OvercommitTracker->UnmarkRange(Start, Length);
   }
+
+  void PreCompile() override {
+    Wow64ProcessPendingCrossProcessItems();
+  }
 };
 
 void BTCpuProcessInit() {


### PR DESCRIPTION
Cross process notifications need to be handled before compilation to avoid permissions changes from e.g. game launchers injecting code being missed.