### PR TITLE
LinuxSyscalls: Update signal mask at deferring time

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -277,6 +277,8 @@ private:
   bool HandleSignalPause(FEXCore::Core::InternalThreadState* Thread, int Signal, void* info, void* ucontext);
   bool HandleSIGILL(FEXCore::Core::InternalThreadState* Thread, int Signal, void* info, void* ucontext);
 
+  uint64_t GetNewSigMask(int Signal) const;
+
   std::mutex HostDelegatorMutex;
   std::mutex GuestDelegatorMutex;
   bool SupportsAVX;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -18,6 +18,7 @@ $end_info$
 #include <FEXCore/Utils/Profiler.h>
 #include <FEXCore/Utils/SignalScopeGuards.h>
 
+#include <bits/types/sigset_t.h>
 #include <cstdint>
 #include <linux/seccomp.h>
 
@@ -37,6 +38,7 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
   struct DeferredSignalState {
     siginfo_t Info;
     int Signal;
+    uint64_t SigMask;
   };
 
   FEXCore::Core::InternalThreadState* Thread;


### PR DESCRIPTION
In regular x86 programs, when a signal occurs, the signal will not be handled within the signal handler. However, under FEX's defer signal mechanism, the signal is not immediately masked when it is deferred. When returning to the location that receives the signal and continues processing, the signal might be received again, causing inconsistency between the emulation and the actual program.

Here is an unit test for this patch from ltp:
https://github.com/linux-test-project/ltp/blob/master/testcases/kernel/syscalls/timer_settime/timer_settime03.c