### PR TITLE
Emitter: Add missing ASIMD crypto operations

### DIFF
--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -4511,7 +4511,28 @@ public:
   }
 
   // Cryptographic three-register SHA 512
-  // TODO
+  void sha512h(VRegister rd, VRegister rn, VRegister rm) {
+    Crypto3RegSHA512(0, 0b00, rm, rn, rd);
+  }
+  void sha512h2(VRegister rd, VRegister rn, VRegister rm) {
+    Crypto3RegSHA512(0, 0b01, rm, rn, rd);
+  }
+  void sha512su1(VRegister rd, VRegister rn, VRegister rm) {
+    Crypto3RegSHA512(0, 0b10, rm, rn, rd);
+  }
+  void rax1(VRegister rd, VRegister rn, VRegister rm) {
+    Crypto3RegSHA512(0, 0b11, rm, rn, rd);
+  }
+  void sm3partw1(VRegister rd, VRegister rn, VRegister rm) {
+    Crypto3RegSHA512(1, 0b00, rm, rn, rd);
+  }
+  void sm3partw2(VRegister rd, VRegister rn, VRegister rm) {
+    Crypto3RegSHA512(1, 0b01, rm, rn, rd);
+  }
+  void sm4ekey(VRegister rd, VRegister rn, VRegister rm) {
+    Crypto3RegSHA512(1, 0b10, rm, rn, rd);
+  }
+
   // Cryptographic four-register
   // TODO
   // Cryptographic two-register SHA 512
@@ -4975,6 +4996,16 @@ private:
     uint32_t Instr = 0b1100'1110'0100'0000'1000'0000'0000'0000;
     Instr |= rm.Idx() << 16;
     Instr |= index << 12;
+    Instr |= opcode << 10;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
+  void Crypto3RegSHA512(uint32_t o, uint32_t opcode, VRegister rm, VRegister rn, VRegister rd) {
+    uint32_t Instr = 0b1100'1110'0110'0000'1000'0000'0000'0000;
+    Instr |= rm.Idx() << 16;
+    Instr |= o << 14;
     Instr |= opcode << 10;
     Instr |= rn.Idx() << 5;
     Instr |= rd.Idx();

--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -4497,7 +4497,19 @@ public:
   }
 
   // Cryptographic three-register, imm2
-  // TODO
+  void sm3tt1a(VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    Crypto3RegImm(index, 0b00, rm, rn, rd);
+  }
+  void sm3tt1b(VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    Crypto3RegImm(index, 0b01, rm, rn, rd);
+  }
+  void sm3tt2a(VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    Crypto3RegImm(index, 0b10, rm, rn, rd);
+  }
+   void sm3tt2b(VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    Crypto3RegImm(index, 0b11, rm, rn, rd);
+  }
+
   // Cryptographic three-register SHA 512
   // TODO
   // Cryptographic four-register
@@ -4952,6 +4964,18 @@ private:
     Instr |= rm.Idx() << 16;
     Instr |= opcode << 12;
     Instr |= H << 11;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
+  void Crypto3RegImm(uint32_t index, uint32_t opcode, VRegister rm, VRegister rn, VRegister rd) {
+    LOGMAN_THROW_A_FMT(index <= 3, "index ({}) must be within [0-3]", index);
+
+    uint32_t Instr = 0b1100'1110'0100'0000'1000'0000'0000'0000;
+    Instr |= rm.Idx() << 16;
+    Instr |= index << 12;
+    Instr |= opcode << 10;
     Instr |= rn.Idx() << 5;
     Instr |= rd.Idx();
     dc32(Instr);

--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -4534,7 +4534,16 @@ public:
   }
 
   // Cryptographic four-register
-  // TODO
+  void eor3(VRegister rd, VRegister rn, VRegister rm, VRegister ra) {
+    Crypto4Register(0b00, rm, ra, rn, rd);
+  }
+  void bcax(VRegister rd, VRegister rn, VRegister rm, VRegister ra) {
+    Crypto4Register(0b01, rm, ra, rn, rd);
+  }
+  void sm3ss1(VRegister rd, VRegister rn, VRegister rm, VRegister ra) {
+    Crypto4Register(0b10, rm, ra, rn, rd);
+  }
+
   // Cryptographic two-register SHA 512
   // TODO
   // Conversion between floating-point and fixed-point
@@ -5007,6 +5016,16 @@ private:
     Instr |= rm.Idx() << 16;
     Instr |= o << 14;
     Instr |= opcode << 10;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
+  void Crypto4Register(uint32_t opcode, VRegister rm, VRegister ra, VRegister rn, VRegister rd) {
+    uint32_t Instr = 0b1100'1110'0000'0000'0000'0000'0000'0000;
+    Instr |= opcode << 21;
+    Instr |= rm.Idx() << 16;
+    Instr |= ra.Idx() << 10;
     Instr |= rn.Idx() << 5;
     Instr |= rd.Idx();
     dc32(Instr);

--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -4545,7 +4545,13 @@ public:
   }
 
   // Cryptographic two-register SHA 512
-  // TODO
+  void sha512su0(VRegister rd, VRegister rn) {
+    Crypto2RegSHA512(0b00, rn, rd);
+  }
+  void sm4e(VRegister rd, VRegister rn) {
+    Crypto2RegSHA512(0b01, rn, rd);
+  }
+
   // Conversion between floating-point and fixed-point
   void scvtf(ARMEmitter::ScalarRegSize ScalarSize, ARMEmitter::VRegister rd, ARMEmitter::Size GPRSize, ARMEmitter::Register rn,
              uint32_t FractionalBits) {
@@ -5026,6 +5032,14 @@ private:
     Instr |= opcode << 21;
     Instr |= rm.Idx() << 16;
     Instr |= ra.Idx() << 10;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
+  void Crypto2RegSHA512(uint32_t opcode, VRegister rn, VRegister rd) {
+    uint32_t Instr = 0b1100'1110'1100'0000'1000'0000'0000'0000;
+    Instr |= opcode << 10;
     Instr |= rn.Idx() << 5;
     Instr |= rd.Idx();
     dc32(Instr);

--- a/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -3107,7 +3107,25 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD vector x index
   TEST_SINGLE(sqrdmlsh(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d15, 3), "sqrdmlsh v30.2s, v29.2s, v15.s[3]");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic three-register, imm2") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(sm3tt1a(VReg::v30, VReg::v29, VReg::v15, 0), "sm3tt1a v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(sm3tt1a(VReg::v30, VReg::v29, VReg::v15, 1), "sm3tt1a v30.4s, v29.4s, v15.s[1]");
+  TEST_SINGLE(sm3tt1a(VReg::v30, VReg::v29, VReg::v15, 2), "sm3tt1a v30.4s, v29.4s, v15.s[2]");
+  TEST_SINGLE(sm3tt1a(VReg::v30, VReg::v29, VReg::v15, 3), "sm3tt1a v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sm3tt1b(VReg::v30, VReg::v29, VReg::v15, 0), "sm3tt1b v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(sm3tt1b(VReg::v30, VReg::v29, VReg::v15, 1), "sm3tt1b v30.4s, v29.4s, v15.s[1]");
+  TEST_SINGLE(sm3tt1b(VReg::v30, VReg::v29, VReg::v15, 2), "sm3tt1b v30.4s, v29.4s, v15.s[2]");
+  TEST_SINGLE(sm3tt1b(VReg::v30, VReg::v29, VReg::v15, 3), "sm3tt1b v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sm3tt2a(VReg::v30, VReg::v29, VReg::v15, 0), "sm3tt2a v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(sm3tt2a(VReg::v30, VReg::v29, VReg::v15, 1), "sm3tt2a v30.4s, v29.4s, v15.s[1]");
+  TEST_SINGLE(sm3tt2a(VReg::v30, VReg::v29, VReg::v15, 2), "sm3tt2a v30.4s, v29.4s, v15.s[2]");
+  TEST_SINGLE(sm3tt2a(VReg::v30, VReg::v29, VReg::v15, 3), "sm3tt2a v30.4s, v29.4s, v15.s[3]");
+
+  TEST_SINGLE(sm3tt2b(VReg::v30, VReg::v29, VReg::v15, 0), "sm3tt2b v30.4s, v29.4s, v15.s[0]");
+  TEST_SINGLE(sm3tt2b(VReg::v30, VReg::v29, VReg::v15, 1), "sm3tt2b v30.4s, v29.4s, v15.s[1]");
+  TEST_SINGLE(sm3tt2b(VReg::v30, VReg::v29, VReg::v15, 2), "sm3tt2b v30.4s, v29.4s, v15.s[2]");
+  TEST_SINGLE(sm3tt2b(VReg::v30, VReg::v29, VReg::v15, 3), "sm3tt2b v30.4s, v29.4s, v15.s[3]");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic three-register SHA 512") {
   // TODO: Implement in emitter.

--- a/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -3137,7 +3137,9 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic three-register
   TEST_SINGLE(sm4ekey(VReg::v30, VReg::v29, VReg::v15), "sm4ekey v30.4s, v29.4s, v15.4s");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic four-register") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(eor3(VReg::v30, VReg::v29, VReg::v15, VReg::v7), "eor3 v30.16b, v29.16b, v15.16b, v7.16b");
+  TEST_SINGLE(bcax(VReg::v30, VReg::v29, VReg::v15, VReg::v7), "bcax v30.16b, v29.16b, v15.16b, v7.16b");
+  TEST_SINGLE(sm3ss1(VReg::v30, VReg::v29, VReg::v15, VReg::v7), "sm3ss1 v30.4s, v29.4s, v15.4s, v7.4s");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic two-register SHA 512") {
   // TODO: Implement in emitter.

--- a/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -3142,7 +3142,8 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic four-register"
   TEST_SINGLE(sm3ss1(VReg::v30, VReg::v29, VReg::v15, VReg::v7), "sm3ss1 v30.4s, v29.4s, v15.4s, v7.4s");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic two-register SHA 512") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(sha512su0(VReg::v30, VReg::v29), "sha512su0 v30.2d, v29.2d");
+  TEST_SINGLE(sm4e(VReg::v30, VReg::v29), "sm4e v30.4s, v29.4s");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Conversion between floating-point and fixed-point") {
   TEST_SINGLE(scvtf(ScalarRegSize::i16Bit, VReg::v29, Size::i32Bit, Reg::r30, 1), "scvtf h29, w30, #1");

--- a/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -3128,7 +3128,13 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic three-register
   TEST_SINGLE(sm3tt2b(VReg::v30, VReg::v29, VReg::v15, 3), "sm3tt2b v30.4s, v29.4s, v15.s[3]");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic three-register SHA 512") {
-  // TODO: Implement in emitter.
+  TEST_SINGLE(sha512h(VReg::v30, VReg::v29, VReg::v15), "sha512h q30, q29, v15.2d");
+  TEST_SINGLE(sha512h2(VReg::v30, VReg::v29, VReg::v15), "sha512h2 q30, q29, v15.2d");
+  TEST_SINGLE(sha512su1(VReg::v30, VReg::v29, VReg::v15), "sha512su1 v30.2d, v29.2d, v15.2d");
+  TEST_SINGLE(rax1(VReg::v30, VReg::v29, VReg::v15), "rax1 v30.2d, v29.2d, v15.2d");
+  TEST_SINGLE(sm3partw1(VReg::v30, VReg::v29, VReg::v15), "sm3partw1 v30.4s, v29.4s, v15.4s");
+  TEST_SINGLE(sm3partw2(VReg::v30, VReg::v29, VReg::v15), "sm3partw2 v30.4s, v29.4s, v15.4s");
+  TEST_SINGLE(sm4ekey(VReg::v30, VReg::v29, VReg::v15), "sm4ekey v30.4s, v29.4s, v15.4s");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Cryptographic four-register") {
   // TODO: Implement in emitter.


### PR DESCRIPTION
Like with the SVE side of things, we can just drop these into place, now that vixl supports them