### PR TITLE
A couple of barrier and timing fixes.

### DIFF
--- a/CodeEmitter/CodeEmitter/Emitter.h
+++ b/CodeEmitter/CodeEmitter/Emitter.h
@@ -355,6 +355,7 @@ enum class SystemRegister : uint32_t {
   TPIDRRO_EL0 = GenSystemReg<0b11, 0b011, 0b1101, 0b0000, 0b011>,
   CNTFRQ_EL0 = GenSystemReg<0b11, 0b011, 0b1110, 0b0000, 0b000>,
   CNTVCT_EL0 = GenSystemReg<0b11, 0b011, 0b1110, 0b0000, 0b010>,
+  CNTVCTSS_EL0 = GenSystemReg<0b11, 0b011, 0b1110, 0b0000, 0b110>,
 };
 
 template<uint32_t op1, uint32_t CRm, uint32_t op2>

--- a/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
@@ -34,6 +34,7 @@ DEF_OP(Fence) {
   case IR::Fence_Load.Val: dmb(ARMEmitter::BarrierScope::LD); break;
   case IR::Fence_LoadStore.Val: dmb(ARMEmitter::BarrierScope::SY); break;
   case IR::Fence_Store.Val: dmb(ARMEmitter::BarrierScope::ST); break;
+  case IR::Fence_Inst.Val: isb(); break;
   default: LOGMAN_MSG_A_FMT("Unknown Fence: {}", Op->Fence); break;
   }
 }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3076,10 +3076,10 @@ void OpDispatchBuilder::SMSWOp(OpcodeArgs) {
   StoreResult_WithOpSize(GPRClass, Op, Op->Dest, Const, DstSize, OpSize::iInvalid);
 }
 
-OpDispatchBuilder::CycleCounterPair OpDispatchBuilder::CycleCounter() {
+OpDispatchBuilder::CycleCounterPair OpDispatchBuilder::CycleCounter(bool SelfSynchronizingLoads) {
   Ref CounterLow {};
   Ref CounterHigh {};
-  auto Counter = _CycleCounter();
+  auto Counter = _CycleCounter(SelfSynchronizingLoads);
   if (CTX->Config.TSCScale) {
     CounterLow = _Lshl(OpSize::i32Bit, Counter, _Constant(CTX->Config.TSCScale));
     CounterHigh = _Lshr(OpSize::i64Bit, Counter, _Constant(32 - CTX->Config.TSCScale));
@@ -3095,7 +3095,7 @@ OpDispatchBuilder::CycleCounterPair OpDispatchBuilder::CycleCounter() {
 }
 
 void OpDispatchBuilder::RDTSCOp(OpcodeArgs) {
-  auto Counter = CycleCounter();
+  auto Counter = CycleCounter(false);
   StoreGPRRegister(X86State::REG_RAX, Counter.CounterLow);
   StoreGPRRegister(X86State::REG_RDX, Counter.CounterHigh);
 }
@@ -4582,7 +4582,7 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
     // This is used when QueryPerformanceCounter is called on recent Windows versions, it causes CNTVCT to be written into RAX.
     constexpr uint8_t GET_CNTVCT_LITERAL = 0x81;
     if (Literal == GET_CNTVCT_LITERAL) {
-      StoreGPRRegister(X86State::REG_RAX, _CycleCounter());
+      StoreGPRRegister(X86State::REG_RAX, _CycleCounter(false));
       return;
     }
 #endif
@@ -4770,8 +4770,7 @@ void OpDispatchBuilder::RDTSCPOp(OpcodeArgs) {
   // This instruction is not an execution fence, so subsequent instructions can execute after this
   //  - Explicitly use an LFENCE after RDTSCP if you want to block this behaviour
 
-  _Fence({FEXCore::IR::Fence_Load});
-  auto Counter = CycleCounter();
+  auto Counter = CycleCounter(true);
 
   auto ID = _ProcessorID();
   StoreGPRRegister(X86State::REG_RAX, Counter.CounterLow);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1349,6 +1349,7 @@ void OpDispatchBuilder::CPUIDOp(OpcodeArgs) {
   Ref RCX = _AllocateGPR(false);
   Ref RDX = _AllocateGPR(false);
 
+  _Fence({FEXCore::IR::Fence_Inst});
   _CPUID(Src, Leaf, RAX, RBX, RCX, RDX);
 
   StoreGPRRegister(X86State::REG_RAX, RAX);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -385,7 +385,7 @@ public:
     Ref CounterLow;
     Ref CounterHigh;
   };
-  CycleCounterPair CycleCounter();
+  CycleCounterPair CycleCounter(bool SelfSynchronizingLoads);
   void RDTSCOp(OpcodeArgs);
   void INCOp(OpcodeArgs);
   void DECOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -110,6 +110,7 @@
     "constexpr FEXCore::IR::FenceType Fence_Load      {0}",
     "constexpr FEXCore::IR::FenceType Fence_Store     {1}",
     "constexpr FEXCore::IR::FenceType Fence_LoadStore {2}",
+    "constexpr FEXCore::IR::FenceType Fence_Inst      {3}",
 
     "constexpr uint8_t ROUND_MODE_NEAREST           = 0",
     "constexpr uint8_t ROUND_MODE_NEGATIVE_INFINITY = 1",
@@ -1019,7 +1020,7 @@
         "DestSize": "OpSize::i64Bit"
       },
 
-      "GPR = CycleCounter": {
+      "GPR = CycleCounter i1:$SelfSynchronizingLoads": {
         "Desc": ["Returns the host 64bit cycle counter",
                  "Useful when emulating rdtsc",
                  "Be careful, the frequency of this counter changes based on host",
@@ -1027,7 +1028,8 @@
                  "On x86-64 make sure to query CPUID fn8000_0008[EDX_8] for constant TSC",
                  "x86-64 constant frequency lives in MSR_PLATFORM_INFO. Which is only available to kernel",
                  "Part of the ART frequency equation can be pulled from CPUID fn0000_0015[EBX & EAX]",
-                 "But it's missing the ART multiplier still?"
+                 "But it's missing the ART multiplier still?",
+                 "If the self-synchronizing flag is toggled then all instructions and loads must be completed before the cycle counter read"
                 ],
         "DestSize": "OpSize::i64Bit"
       },

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -37,6 +37,7 @@ struct HostFeatures {
   bool SupportsSVEBitPerm {};
   bool SupportsCPUIndexInTPIDRRO {};
   bool SupportsFRINTTS {};
+  bool SupportsECV {};
 
   // Float exception behaviour
   bool SupportsAFP {};

--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -483,6 +483,7 @@ FEXCore::HostFeatures FetchHostFeatures(FEX::CPUFeatures& Features, bool Support
   HostFeatures.SupportsFRINTTS = Features.Supports(CPUFeatures::Feature::FRINTTS);
   HostFeatures.SupportsRPRES = Features.Supports(CPUFeatures::Feature::RPRES);
   HostFeatures.SupportsSVEBitPerm = Features.Supports(CPUFeatures::Feature::SVE_BitPerm);
+  HostFeatures.SupportsECV = Features.Supports(CPUFeatures::Feature::ECV);
 
 #ifdef VIXL_SIMULATOR
   // Hardcode enable SVE with 256-bit wide registers.


### PR DESCRIPTION
Does a few minor things:
- Wires up ECV self-synchronizing timers if supported (Latest ARM devices but not Apple Silicon VMs)
- Use the Self-synchronizing cycle counter to match rdtscp behaviour
- Add an ISB fence to CPUID because some applications use CPUID as a serialization instruction (Because it is) around timing.
- Adds a bogomips calculation to Linux because some applications badly use that for timing, matching Linux behaviour.

Noticed these while trying to track down some timing issues in a game. Didn't solve that game's problem sadly. 