### PR TITLE
LinuxSyscalls: Fixes a major stack memory leak

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -14,6 +14,7 @@ $end_info$
 #include "LinuxSyscalls/x64/Thread.h"
 #include "LinuxSyscalls/x32/Syscalls.h"
 #include "LinuxSyscalls/x32/Thread.h"
+#include "LinuxSyscalls/Utils/Threads.h"
 
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/X86Enums.h>
@@ -461,8 +462,14 @@ void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
                                 }
 
                                 ThreadObject->StatusCode = status;
+
+                                void* StackBase {};
+                                if (ThreadObject->ExecutionThread) {
+                                  StackBase = FEX::LinuxEmulation::Threads::GetStackBase(ThreadObject->ExecutionThread.get());
+                                }
+                                FEX::HLE::_SyscallHandler->UninstallTLSState(ThreadObject);
                                 FEX::HLE::_SyscallHandler->TM.DestroyThread(ThreadObject, true);
-                                syscall(SYSCALL_DEF(exit), status);
+                                FEX::LinuxEmulation::Threads::DeallocateStackObjectAndExit(StackBase, status);
                                 // This will never be reached
                                 std::terminate();
                               });

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.h
@@ -7,6 +7,10 @@
 #include <cstddef>
 #include <mutex>
 
+namespace FEXCore::Threads {
+class Thread;
+}
+
 namespace FEX::LinuxEmulation::Threads {
 /**
  * @brief Size of the stack that this interface creates.
@@ -61,6 +65,8 @@ void* AllocateStackObject();
  */
 [[noreturn]]
 void DeallocateStackObjectAndExit(void* Ptr, int Status);
+
+void* GetStackBase(FEXCore::Threads::Thread* ThreadObject);
 
 /**
  * @brief Registers thread creation handlers with FEXCore.


### PR DESCRIPTION
Fixes an issue where a thread that exits with the `exit` syscall never actually frees its pivot stack. This is common practice and it was missed when I was fixing the previous stack pivot leak.

This was uncovered when looking at the game
[RUINER](https://store.steampowered.com/agecheck/app/464060/?curator_clanid=4777282) for timing bugs. Turns out the Linux build of the game creates and destroys a VLC object every tick of the engine. Creating this VLC object creates six threads behind the scenes. At what I assume the default tick of the engine is of 120Hz(?) this would mean it is attempting to create and destroy 720 threads per second, quickly leading to memory exhaustion under FEX.

While this hits the biggest memory leak we have around thread creation, this game is still hitting thread creation so hard that I can see other leaks that I need to track down still.