### PR TITLE
CodeEmitter/ScalarOps: Add two more instruction categories

### DIFF
--- a/CodeEmitter/CodeEmitter/ScalarOps.inl
+++ b/CodeEmitter/CodeEmitter/ScalarOps.inl
@@ -752,10 +752,51 @@ public:
     const uint32_t immb = InvertedShift & 0b111;
     ASIMDScalarShiftByImm(1, immh, immb, 0b10011, rd, rn);
   }
+
   // TODO: UCVTF, FCVTZU
+
   // Advanced SIMD scalar x indexed element
-  // XXX:
-  //
+  void sqdmlal(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i64Bit, "Scalar size must not be 64-bit");
+    ASIMDScalarXIndexedElement(0, size, 0b0011, rm, rn, rd, index);
+  }
+  void sqdmlsl(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i64Bit, "Scalar size must not be 64-bit");
+    ASIMDScalarXIndexedElement(0, size, 0b0111, rm, rn, rd, index);
+  }
+  void sqdmull(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i64Bit, "Scalar size must not be 64-bit");
+    ASIMDScalarXIndexedElement(0, size, 0b1011, rm, rn, rd, index);
+  }
+  void sqdmulh(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i64Bit, "Scalar size must not be 64-bit");
+    ASIMDScalarXIndexedElement(0, size, 0b1100, rm, rn, rd, index);
+  }
+  void sqrdmulh(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i64Bit, "Scalar size must not be 64-bit");
+    ASIMDScalarXIndexedElement(0, size, 0b1101, rm, rn, rd, index);
+  }
+  void fmla(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    ASIMDScalarXIndexedElement(0, size, 0b0001, rm, rn, rd, index);
+  }
+  void fmls(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    ASIMDScalarXIndexedElement(0, size, 0b0101, rm, rn, rd, index);
+  }
+  void fmul(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    ASIMDScalarXIndexedElement(0, size, 0b1001, rm, rn, rd, index);
+  }
+  void sqrdmlah(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i64Bit, "Scalar size must not be 64-bit");
+    ASIMDScalarXIndexedElement(1, size, 0b1101, rm, rn, rd, index);
+  }
+  void sqrdmlsh(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i64Bit, "Scalar size must not be 64-bit");
+    ASIMDScalarXIndexedElement(1, size, 0b1111, rm, rn, rd, index);
+  }
+  void fmulx(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm, uint32_t index) {
+    ASIMDScalarXIndexedElement(1, size, 0b1001, rm, rn, rd, index);
+  }
+
   // Floating-point data-processing (1 source)
   void fmov(ScalarRegSize size, VRegister rd, VRegister rn) {
     Float1Source(size, 0, 0, 0b000000, rd, rn);
@@ -1337,8 +1378,50 @@ private:
     Instr |= Encode_rd(rd);
     dc32(Instr);
   }
+
   // Advanced SIMD scalar x indexed element
-  // XXX:
+  void ASIMDScalarXIndexedElement(uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rm, VRegister rn, VRegister rd, uint32_t index) {
+    LOGMAN_THROW_A_FMT(size != ScalarRegSize::i8Bit, "Scalar size must not be 8-bit");
+
+    [[maybe_unused]] const auto invalid_bound = 16U >> FEXCore::ToUnderlying(size);
+    LOGMAN_THROW_A_FMT(index < invalid_bound, "Index ({}) must be within [0-{}]", index, invalid_bound - 1);
+
+    uint32_t Instr = 0b0101'1111'0000'0000'0000'0000'0000'0000;
+
+    // FMUL/FMLA/FMLS indexed variants deal with size differently.
+    if (opcode == 0b0001 || opcode == 0b0101 || opcode == 0b1001) {
+      // Unlike other instructions in the group, 16-bit is encoded as zero
+      // and 32/64-bit are encoded with the top bit always set to one.
+      if (size != ScalarRegSize::i16Bit) {
+        Instr |= (0b10 | (FEXCore::ToUnderlying(size) & 1)) << 22;
+      }
+    } else {
+      Instr |= FEXCore::ToUnderlying(size) << 22;
+    }
+
+    uint32_t H = 0;
+    uint32_t LM = 0;
+    if (size == ScalarRegSize::i16Bit) {
+      LOGMAN_THROW_A_FMT(rm <= VReg::v15, "rm ({}) must be within [v0-v15]", rm.Idx());
+      H = (index >> 2) & 1;
+      LM = index & 0b11;
+    } else if (size == ScalarRegSize::i32Bit) {
+      H = (index >> 1) & 1;
+      LM = (index & 0b01) << 1;
+    } else {
+      H = index & 1;
+    }
+
+    Instr |= U << 29;
+    Instr |= LM << 20;
+    Instr |= rm.Idx() << 16;
+    Instr |= opcode << 12;
+    Instr |= H << 11;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
   // Floating-point data-processing (1 source)
   void Float1Source(uint32_t M, uint32_t S, uint32_t ptype, uint32_t opcode, VRegister rd, VRegister rn) {
     uint32_t Instr = 0b0001'1110'0010'0000'0100'0000'0000'0000;

--- a/CodeEmitter/CodeEmitter/ScalarOps.inl
+++ b/CodeEmitter/CodeEmitter/ScalarOps.inl
@@ -1301,8 +1301,6 @@ private:
     dc32(Instr);
   }
 
-  // Advanced SIMD scalar pairwise
-  // XXX:
   // Advanced SIMD scalar three different
   void ASIMD3RegDifferent(uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rd, VRegister rn, VRegister rm) {
     uint32_t Instr = 0b0101'1110'0010'0000'0000'0000'0000'0000;

--- a/CodeEmitter/CodeEmitter/ScalarOps.inl
+++ b/CodeEmitter/CodeEmitter/ScalarOps.inl
@@ -137,7 +137,15 @@ public:
   }
 
   // Advanced SIMD scalar three same extra
-  // XXX:
+  void sqrdmlah(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i32Bit, "Only supports 16/32-bit");
+    ASIMDScalarThreeSameExtra(1, size, 0b0000, rm, rn, rd);
+  }
+  void sqrdmlsh(ScalarRegSize size, VRegister rd, VRegister rn, VRegister rm) {
+    LOGMAN_THROW_A_FMT(size == ScalarRegSize::i16Bit || size == ScalarRegSize::i32Bit, "Only supports 16/32-bit");
+    ASIMDScalarThreeSameExtra(1, size, 0b0001, rm, rn, rd);
+  }
+
   // Advanced SIMD scalar two-register miscellaneous
   void suqadd(ScalarRegSize size, VRegister rd, VRegister rn) {
     ASIMDScalar2RegMisc(0, 0, size, 0b00011, rd, rn);
@@ -1269,7 +1277,17 @@ private:
   }
 
   // Advanced SIMD scalar three same extra
-  // XXX:
+  void ASIMDScalarThreeSameExtra(uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rm, VRegister rn, VRegister rd) {
+    uint32_t Instr = 0b0101'1110'0000'0000'1000'0100'0000'0000;
+    Instr |= U << 29;
+    Instr |= FEXCore::ToUnderlying(size) << 22;
+    Instr |= rm.Idx() << 16;
+    Instr |= opcode << 11;
+    Instr |= rn.Idx() << 5;
+    Instr |= rd.Idx();
+    dc32(Instr);
+  }
+
   // Advanced SIMD scalar two-register miscellaneous
   void ASIMDScalar2RegMisc(uint32_t b20, uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rd, VRegister rn) {
     uint32_t Instr = 0b0101'1110'0010'0000'0000'1000'0000'0000;

--- a/FEXCore/unittests/Emitter/Scalar_Tests.cpp
+++ b/FEXCore/unittests/Emitter/Scalar_Tests.cpp
@@ -635,7 +635,68 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar shift 
   // TODO: Implement `UCVTF, FCVTZU' in emitter
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar x indexed element") {
-  // TODO: Implement in emitter
+  TEST_SINGLE(sqdmlal(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "sqdmlal s30, h29, v15.h[4]");
+  TEST_SINGLE(sqdmlal(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqdmlal s30, h29, v15.h[7]");
+  TEST_SINGLE(sqdmlal(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqdmlal d30, s29, v28.s[0]");
+  TEST_SINGLE(sqdmlal(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqdmlal d30, s29, v28.s[3]");
+
+  TEST_SINGLE(sqdmlsl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "sqdmlsl s30, h29, v15.h[4]");
+  TEST_SINGLE(sqdmlsl(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqdmlsl s30, h29, v15.h[7]");
+  TEST_SINGLE(sqdmlsl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqdmlsl d30, s29, v28.s[0]");
+  TEST_SINGLE(sqdmlsl(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqdmlsl d30, s29, v28.s[3]");
+
+  TEST_SINGLE(sqdmull(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "sqdmull s30, h29, v15.h[4]");
+  TEST_SINGLE(sqdmull(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqdmull s30, h29, v15.h[7]");
+  TEST_SINGLE(sqdmull(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqdmull d30, s29, v28.s[0]");
+  TEST_SINGLE(sqdmull(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqdmull d30, s29, v28.s[3]");
+
+  TEST_SINGLE(sqdmulh(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "sqdmulh h30, h29, v15.h[4]");
+  TEST_SINGLE(sqdmulh(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqdmulh h30, h29, v15.h[7]");
+  TEST_SINGLE(sqdmulh(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqdmulh s30, s29, v28.s[0]");
+  TEST_SINGLE(sqdmulh(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqdmulh s30, s29, v28.s[3]");
+
+  TEST_SINGLE(sqrdmulh(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "sqrdmulh h30, h29, v15.h[4]");
+  TEST_SINGLE(sqrdmulh(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqrdmulh h30, h29, v15.h[7]");
+  TEST_SINGLE(sqrdmulh(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqrdmulh s30, s29, v28.s[0]");
+  TEST_SINGLE(sqrdmulh(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqrdmulh s30, s29, v28.s[3]");
+
+  TEST_SINGLE(fmla(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "fmla h30, h29, v15.h[4]");
+  TEST_SINGLE(fmla(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "fmla h30, h29, v15.h[7]");
+  TEST_SINGLE(fmla(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "fmla s30, s29, v28.s[0]");
+  TEST_SINGLE(fmla(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "fmla s30, s29, v28.s[3]");
+  TEST_SINGLE(fmla(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "fmla d30, d29, v28.d[0]");
+  TEST_SINGLE(fmla(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 1), "fmla d30, d29, v28.d[1]");
+
+  TEST_SINGLE(fmls(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "fmls h30, h29, v15.h[4]");
+  TEST_SINGLE(fmls(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "fmls h30, h29, v15.h[7]");
+  TEST_SINGLE(fmls(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "fmls s30, s29, v28.s[0]");
+  TEST_SINGLE(fmls(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "fmls s30, s29, v28.s[3]");
+  TEST_SINGLE(fmls(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "fmls d30, d29, v28.d[0]");
+  TEST_SINGLE(fmls(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 1), "fmls d30, d29, v28.d[1]");
+
+  TEST_SINGLE(fmul(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "fmul h30, h29, v15.h[4]");
+  TEST_SINGLE(fmul(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "fmul h30, h29, v15.h[7]");
+  TEST_SINGLE(fmul(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "fmul s30, s29, v28.s[0]");
+  TEST_SINGLE(fmul(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "fmul s30, s29, v28.s[3]");
+  TEST_SINGLE(fmul(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "fmul d30, d29, v28.d[0]");
+  TEST_SINGLE(fmul(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 1), "fmul d30, d29, v28.d[1]");
+
+  TEST_SINGLE(sqrdmlah(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "sqrdmlah h30, h29, v15.h[4]");
+  TEST_SINGLE(sqrdmlah(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqrdmlah h30, h29, v15.h[7]");
+  TEST_SINGLE(sqrdmlah(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqrdmlah s30, s29, v28.s[0]");
+  TEST_SINGLE(sqrdmlah(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqrdmlah s30, s29, v28.s[3]");
+
+  TEST_SINGLE(sqrdmlsh(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "sqrdmlsh h30, h29, v15.h[4]");
+  TEST_SINGLE(sqrdmlsh(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "sqrdmlsh h30, h29, v15.h[7]");
+  TEST_SINGLE(sqrdmlsh(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "sqrdmlsh s30, s29, v28.s[0]");
+  TEST_SINGLE(sqrdmlsh(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "sqrdmlsh s30, s29, v28.s[3]");
+
+  TEST_SINGLE(fmulx(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 4), "fmulx h30, h29, v15.h[4]");
+  TEST_SINGLE(fmulx(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v15, 7), "fmulx h30, h29, v15.h[7]");
+  TEST_SINGLE(fmulx(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 0), "fmulx s30, s29, v28.s[0]");
+  TEST_SINGLE(fmulx(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28, 3), "fmulx s30, s29, v28.s[3]");
+  TEST_SINGLE(fmulx(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 0), "fmulx d30, d29, v28.d[0]");
+  TEST_SINGLE(fmulx(ScalarRegSize::i64Bit, VReg::v30, VReg::v29, VReg::v28, 1), "fmulx d30, d29, v28.d[1]");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Floating-point data-processing (1 source)") {
   TEST_SINGLE(fmov(SReg::s30, SReg::s29), "fmov s30, s29");

--- a/FEXCore/unittests/Emitter/Scalar_Tests.cpp
+++ b/FEXCore/unittests/Emitter/Scalar_Tests.cpp
@@ -61,7 +61,11 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar two-re
   TEST_SINGLE(frsqrte(HReg::h30, HReg::h29), "frsqrte h30, h29");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar three same extra") {
-  // TODO: Implement in emitter
+  TEST_SINGLE(sqrdmlah(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqrdmlah h30, h29, h28");
+  TEST_SINGLE(sqrdmlah(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqrdmlah s30, s29, s28");
+
+  TEST_SINGLE(sqrdmlsh(ScalarRegSize::i16Bit, VReg::v30, VReg::v29, VReg::v28), "sqrdmlsh h30, h29, h28");
+  TEST_SINGLE(sqrdmlsh(ScalarRegSize::i32Bit, VReg::v30, VReg::v29, VReg::v28), "sqrdmlsh s30, s29, s28");
 }
 TEST_CASE_METHOD(TestDisassembler, "Emitter: Scalar: Advanced SIMD scalar two-register miscellaneous") {
   // Commented out lines showcase unallocated encodings.


### PR DESCRIPTION
Crosses off two related scalar categories, now the scalar side of things only has 3 TODO's left