### PR TITLE
CodeEmitter/ASIMDOps: Support RADDHN{2}/RSUBHN{2}

### DIFF
--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -2151,7 +2151,24 @@ public:
 
     ASIMD3Different(Op, 1, 0b0011, ConvertedSize, rd, rn, rm);
   }
-  // XXX: RADDHN/2
+  ///< Size is dest size
+  void raddhn(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size)};
+
+    ASIMD3Different(Op, 1, 0b0100, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  void raddhn2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size)};
+
+    ASIMD3Different(Op, 1, 0b0100, ConvertedSize, rd, rn, rm);
+  }
   ///< Size is dest size
   void uabal(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");
@@ -2170,7 +2187,24 @@ public:
 
     ASIMD3Different(Op, 1, 0b0101, ConvertedSize, rd, rn, rm);
   }
-  // XXX: RSUBHN/2
+  ///< Size is dest size
+  void rsubhn(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size)};
+
+    ASIMD3Different(Op, 1, 0b0110, ConvertedSize, rd, rn, rm);
+  }
+  ///< Size is dest size
+  void rsubhn2(SubRegSize size, QRegister rd, QRegister rn, QRegister rm) {
+    LOGMAN_THROW_A_FMT(size != SubRegSize::i64Bit, "No 64-bit dest support.");
+
+    constexpr uint32_t Op = 0b0000'1110'0010'0000'0000'00 << 10;
+    const auto ConvertedSize = SubRegSize {FEXCore::ToUnderlying(size)};
+
+    ASIMD3Different(Op, 1, 0b0110, ConvertedSize, rd, rn, rm);
+  }
   ///< Size is dest size
   void uabdl(SubRegSize size, DRegister rd, DRegister rn, DRegister rm) {
     LOGMAN_THROW_A_FMT(size != SubRegSize::i8Bit, "No 8-bit dest support.");

--- a/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -1287,7 +1287,14 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD three differen
   TEST_SINGLE(usubw2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "usubw2 v30.4s, v29.4s, v28.8h");
   TEST_SINGLE(usubw2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "usubw2 v30.2d, v29.2d, v28.4s");
 
-  //// XXX: RADDHN/2
+  TEST_SINGLE(raddhn(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "raddhn v30.8b, v29.8h, v28.8h");
+  TEST_SINGLE(raddhn(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "raddhn v30.4h, v29.4s, v28.4s");
+  TEST_SINGLE(raddhn(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "raddhn v30.2s, v29.2d, v28.2d");
+
+  TEST_SINGLE(raddhn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "raddhn2 v30.16b, v29.8h, v28.8h");
+  TEST_SINGLE(raddhn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "raddhn2 v30.8h, v29.4s, v28.4s");
+  TEST_SINGLE(raddhn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "raddhn2 v30.4s, v29.2d, v28.2d");
+
   // TEST_SINGLE(uabal(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uabal v30.8b, v29.8b, v28.8b");
   TEST_SINGLE(uabal(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uabal v30.8h, v29.8b, v28.8b");
   TEST_SINGLE(uabal(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uabal v30.4s, v29.4h, v28.4h");
@@ -1298,7 +1305,14 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD three differen
   TEST_SINGLE(uabal2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "uabal2 v30.4s, v29.8h, v28.8h");
   TEST_SINGLE(uabal2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "uabal2 v30.2d, v29.4s, v28.4s");
 
-  //// XXX: RSUBHN/2
+  TEST_SINGLE(rsubhn(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "rsubhn v30.8b, v29.8h, v28.8h");
+  TEST_SINGLE(rsubhn(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "rsubhn v30.4h, v29.4s, v28.4s");
+  TEST_SINGLE(rsubhn(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "rsubhn v30.2s, v29.2d, v28.2d");
+
+  TEST_SINGLE(rsubhn2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "rsubhn2 v30.16b, v29.8h, v28.8h");
+  TEST_SINGLE(rsubhn2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "rsubhn2 v30.8h, v29.4s, v28.4s");
+  TEST_SINGLE(rsubhn2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "rsubhn2 v30.4s, v29.2d, v28.2d");
+
   // TEST_SINGLE(uabdl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uabdl v30.8b, v29.8b, v28.8b");
   TEST_SINGLE(uabdl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uabdl v30.8h, v29.8b, v28.8b");
   TEST_SINGLE(uabdl(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "uabdl v30.4s, v29.4h, v28.4h");


### PR DESCRIPTION
These are trivial enough to just drop right in.