### PR TITLE
LinuxEmulation: Fixes remaining memory leak on pthread teardown

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.h
@@ -11,6 +11,10 @@ namespace FEXCore::Threads {
 class Thread;
 }
 
+namespace FEX::HLE {
+struct ThreadStateObject;
+}
+
 namespace FEX::LinuxEmulation::Threads {
 /**
  * @brief Size of the stack that this interface creates.
@@ -34,6 +38,8 @@ public:
   bool* AddStackToDeadPool(void* Ptr);
   void AddStackToLivePool(void* Ptr);
   void RemoveStackFromLivePool(void* Ptr);
+
+  void DeallocateStackObjectImmediately(void* Ptr);
 
   [[noreturn]]
   void DeallocateStackObjectAndExit(void* Ptr, int Status);
@@ -67,6 +73,9 @@ void* AllocateStackObject();
 void DeallocateStackObjectAndExit(void* Ptr, int Status);
 
 void* GetStackBase(FEXCore::Threads::Thread* ThreadObject);
+
+[[noreturn]]
+void LongjumpDeallocateAndExit(FEX::HLE::ThreadStateObject* ThreadObject, int Status);
 
 /**
  * @brief Registers thread creation handlers with FEXCore.


### PR DESCRIPTION
With the previous stack leak fix, RUINER reduced its memory leaking down to around 50MB/s. The remaining memory leaks come from the pthread stack that we are required to allocate (128KB per thread) and some internal DTV tracking structures.

The problems come in the fact that glibc/pthread only tears down its internal state for these if the pthread function actually returns! We can **technically** switch the initial stack over to a "user" stack but that introduces more problems around internal dtv tracking that we already fixed months ago, so we can't actually do that in practice.

This leaves us no choice, we effectively are mandated to return from the pthread function in order to free the memory from glibc. The only way we can safely do this is with a long jump and deferring some data structure management until that case.

This is all incredibly sucky but it's necessary to work. With these changes, RUINER is no longer leaking memory (Hovering at around 3GB used while in-game) and even Steam is consuming less memory.

It doesn't solve the problem that thread creation and teardown could likely be faster, but not many applications are creating 720 threads/second.