### PR TITLE
FEXConfig: Fix layout issues on Qt 6.9

### DIFF
--- a/Source/Tools/FEXConfig/main.qml
+++ b/Source/Tools/FEXConfig/main.qml
@@ -293,10 +293,7 @@ ApplicationWindow {
     }
 
     StackLayout {
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: tabBar.bottom
-        anchors.bottom: parent.bottom
+        anchors.fill: parent
 
         currentIndex: tabBar.currentIndex
 


### PR DESCRIPTION
Not sure why I didn't use `anchors.fill: parent` here before, but my testing today found that it's working just fine on Qt 5 / 6.6 / 6.9.

Fixes #4507.
