### PR TITLE
JIT: Make code patching during (un-/)linking thread-safe

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
@@ -65,6 +65,10 @@ DEF_OP(ExitFunction) {
       br(TMP2);
     } else {
 #endif
+      // Align to 16 byte to allow atomic patching of the following 16 byte
+      // of code (excluding the RIP data) on platforms that support LSE2
+      Align16B();
+
       ARMEmitter::ForwardLabel l_BranchHost;
       ldr(TMP1, &l_BranchHost);
       blr(TMP1);

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -486,20 +486,16 @@ void Arm64JITCore::Op_Unhandled(const IR::IROp_Header* IROp, IR::NodeID Node) {
 }
 
 static void DirectBlockDelinker(FEXCore::Core::CpuStateFrame* Frame, FEXCore::Context::ExitFunctionLinkData* Record) {
-  auto LinkerAddress = Frame->Pointers.Common.ExitFunctionLinker;
-  uintptr_t branch = (uintptr_t)(Record)-8;
-  ARMEmitter::Emitter emit((uint8_t*)(branch), 8);
-  ARMEmitter::ForwardLabel l_BranchHost;
-  emit.ldr(TMP1, &l_BranchHost);
+  // Emit new 16 bytes of code to a temporary patch, then atomically apply it
+  __uint128_t Patch;
+  ARMEmitter::Emitter emit((uint8_t*)&Patch, sizeof(Patch));
+  emit.ldr(TMP1, 8); // PC-relative value pointing to constant after blr
   emit.blr(TMP1);
-  emit.Bind(&l_BranchHost);
-  emit.dc64(LinkerAddress);
-  ARMEmitter::Emitter::ClearICache((void*)branch, 8);
-}
+  emit.dc64(Frame->Pointers.Common.ExitFunctionLinker);
 
-static void IndirectBlockDelinker(FEXCore::Core::CpuStateFrame* Frame, FEXCore::Context::ExitFunctionLinkData* Record) {
-  auto LinkerAddress = Frame->Pointers.Common.ExitFunctionLinker;
-  Record->HostBranch = LinkerAddress;
+  auto branch = reinterpret_cast<__uint128_t*>((uintptr_t)Record - 8);
+  std::atomic_ref<__uint128_t>(*branch).store(Patch, std::memory_order::relaxed);
+  ARMEmitter::Emitter::ClearICache((void*)branch, sizeof(*branch));
 }
 
 static uint64_t Arm64JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame* Frame, FEXCore::Context::ExitFunctionLinkData* Record) {
@@ -519,24 +515,22 @@ static uint64_t Arm64JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame* Fram
   }
 
   uintptr_t branch = (uintptr_t)(Record)-8;
+  LOGMAN_THROW_A_FMT((branch % 16) == 0, "Incorrect alignment for block linking record");
 
   auto offset = HostCode / 4 - branch / 4;
   if (ARMEmitter::Emitter::IsInt26(offset)) {
-    // optimal case - can branch directly
-    // patch the code
-    ARMEmitter::Emitter emit((uint8_t*)(branch), 4);
-    emit.b(offset);
+    // This is the optimal case, where the target can be encoded in a single instruction.
+    // Atomically patch the code with a relative branch.
+    const uint32_t Patch = (0b0001'01 << 26) | (offset & ((1u << 26) - 1));
+    std::atomic_ref<uint32_t>(*reinterpret_cast<uint32_t*>(branch)).store(Patch, std::memory_order::relaxed);
     ARMEmitter::Emitter::ClearICache((void*)branch, 4);
-
-    // Add de-linking handler
-    Thread->LookupCache->AddBlockLink(GuestRip, Record, DirectBlockDelinker);
   } else {
     // fallback case - do a soft-er link by patching the pointer
-    Record->HostBranch = HostCode;
-
-    // Add de-linking handler
-    Thread->LookupCache->AddBlockLink(GuestRip, Record, IndirectBlockDelinker);
+    std::atomic_ref<uint64_t>(Record->HostBranch).store(HostCode, std::memory_order::seq_cst);
   }
+
+  // Add de-linking handler
+  Thread->LookupCache->AddBlockLink(GuestRip, Record, DirectBlockDelinker);
 
   return HostCode;
 }

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -527,6 +527,10 @@ static uint64_t Arm64JITCore_ExitFunctionLink(FEXCore::Core::CpuStateFrame* Fram
   } else {
     // fallback case - do a soft-er link by patching the pointer
     std::atomic_ref<uint64_t>(Record->HostBranch).store(HostCode, std::memory_order::seq_cst);
+#ifdef _M_ARM_64
+    // Make memory write visible to other threads reading the same location
+    asm volatile("dc cvau, %0; dsb ish" : : "r"(Record->HostBranch) :);
+#endif
   }
 
   // Add de-linking handler


### PR DESCRIPTION
## Overview

LSE2 platforms give us free (?) atomic 128-bit stores. We can use these to make the block (de-/)linking code apply their patches atomically, which allows blocks to be shared across threads without adding further thread-safety issues.

Credits for this idea go to @Sonicadvance1 .

I think all potential tearing issues are considered, but I'm not fully confident my atomicity/cache behavior assumptions are correct. I've done my best :innocent: 

## Details

For context, the unpatched code generally looks like this:
```
0x00000000: ldr x1, +8
0x00000004: blr x1
0x00000008: <address of ExitFunctionLinker>
0x0000000c: <address of ExitFunctionLinker>
0x00000010: <GuestRIP>
0x00000014: <GuestRIP>
```

On LSE2 platforms (as specified at build-time via `-mcpu`), DirectBlockDelinker will compile roughly to the following assembly:
```
# load ExitFunctionLinker
ldr     x9, [x0, #2304]
# Load `ldr x1, +8` and `blr x1` encodings
mov     x10, #0x40                      // #64
movk    x10, #0x5800, lsl #16
mov     x0, x8
movk    x10, #0xd63f, lsl #48
# Apply 128-bit patch
stp     x10, x9, [x1, #-8]
# Flush caches
bl      109420 <__clear_cache@plt>
```

Without LSE2 enabled at build-time, less efficient code will be generated, which seems fine considering we'll be dropping support for those platforms soon.

## Potential race conditions

There are some potential races to consider. Crucially, this concerns only robustness of code execution. The order of linking and unlinking itself requires external synchronization:

### Two threads simultaneously unlinking the same block

The atomic 128-bit store in `DirectBlockDelinker` ensures there is no tearing.

### Two threads simultaneously linking the same block

The threads will link the block to the same target, so either:
* they will both atomically patch the branch instruction at the very beginning (`ldr x1, +8` -> `b +0x1234`)
* they will both atomically patch the 64-bits of data at offset 8 (`<address of ExitFunctionLinker>`->`address of target`)

Since the patches are applied atomically, there is no tearing.

### One thread unlinking a block that is being executed in another thread

We don't have external synchronization to prevent this from happening, but we can look at potential tearing issues with regards to code execution.

The only critical state of the linking thread is at offset 4. If the unlinking thread's patch becomes visible at this point, the linking thread will jump to the *unpatched* target address. The code itself is robust, but this race condition requires external synchronization to be resolved.

### One thread linking a block that is being executed in another thread

This is similar to the previous case, with the small nuance that the linking code will only patch the first 32-bits. The `blr x1` instruction (and data) will remain untouched, so in case the other thread already loaded the value at `0x00000008`, execution will indeed be able to continue properly.

The fallback case will patch the 64-bits at offset 0x8 instead, which is also fine since the load in the other thread is atomic due to being aligned.

### One thread unlinking a block that is simultaneously being linked

I'm not sure if this can happen, but atomicity on both sides ensures that the resulting code is valid and tear-free even though the linking thread patches only a subset of the code. The result will be either of two code blocks, which is a race condition that requires external synchronization to be resolved.

## Further resources

There's a good overview of cache/barrier instructions on ARM at https://mariokartwii.com/armv8/ch30.html .