### PR TITLE
ASIMD_Tests: Enable PMULL/PMULL2 tests

### DIFF
--- a/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -1229,23 +1229,11 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD three differen
   TEST_SINGLE(sqdmull2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmull2 v30.4s, v29.8h, v28.8h");
   TEST_SINGLE(sqdmull2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "sqdmull2 v30.2d, v29.4s, v28.4s");
 
-  // TEST_SINGLE(pmull(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.8b, v29.8b, v28.8b");
   TEST_SINGLE(pmull(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.8h, v29.8b, v28.8b");
-  // TEST_SINGLE(pmull(SubRegSize::i32Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.4s, v29.4h, v28.4h");
-  // TEST_SINGLE(pmull(SubRegSize::i64Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.2d, v29.2s, v28.2s");
-  if (false) {
-    // Vixl doesn't support this
-    TEST_SINGLE(pmull(SubRegSize::i128Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.1q, v29.1d, v28.1d");
-  }
+  TEST_SINGLE(pmull(SubRegSize::i128Bit, DReg::d30, DReg::d29, DReg::d28), "pmull v30.1q, v29.1d, v28.1d");
 
-  // TEST_SINGLE(pmull2(SubRegSize::i8Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.8b, v29.8b, v28.8b");
-  // TEST_SINGLE(pmull2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.8h, v29.16b, v28.16b");
-  // TEST_SINGLE(pmull2(SubRegSize::i32Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.4s, v29.8h, v28.8h");
-  // TEST_SINGLE(pmull2(SubRegSize::i64Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.2d, v29.4s, v28.4s");
-  if (false) {
-    // Vixl doesn't support this
-    TEST_SINGLE(pmull2(SubRegSize::i128Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.1q, v29.2d, v28.2d");
-  }
+  TEST_SINGLE(pmull2(SubRegSize::i16Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.8h, v29.16b, v28.16b");
+  TEST_SINGLE(pmull2(SubRegSize::i128Bit, QReg::q30, QReg::q29, QReg::q28), "pmull2 v30.1q, v29.2d, v28.2d");
 
   // TEST_SINGLE(uaddl(SubRegSize::i8Bit, DReg::d30, DReg::d29, DReg::d28), "uaddl v30.8b, v29.8b, v28.8b");
   TEST_SINGLE(uaddl(SubRegSize::i16Bit, DReg::d30, DReg::d29, DReg::d28), "uaddl v30.8h, v29.8b, v28.8b");


### PR DESCRIPTION
vixl now supports these. We can also get rid of the invalid data sizes, since only halfword and 128-bit variants are defined.