### PR TITLE
Scripts/InstCountCI: Restrict git-add to relevant JSON files only

### DIFF
--- a/Scripts/update_instcountci.sh
+++ b/Scripts/update_instcountci.sh
@@ -11,4 +11,5 @@ ninja instcountci_tests || true
 ninja instcountci_update_tests
 
 # Commit the result in bulk.
-git commit -sam "InstCountCI: Update"
+git add -u :/unittests/InstructionCountCI/*.json
+git commit -sm "InstCountCI: Update"


### PR DESCRIPTION
Previously, the script would silently commit any other local changes as well.

`git add -u :/unittests/InstructionCountCI/*.json` will reliably only add the JSON files (recursively), independently of the current working directory (`:` is a shorthand for the repository root).