### PR TITLE
InstcountCI: Changes how code size is calculated 

### DIFF
--- a/CodeEmitter/CodeEmitter/SystemOps.inl
+++ b/CodeEmitter/CodeEmitter/SystemOps.inl
@@ -13,6 +13,12 @@ struct EmitterOps : Emitter {
 #endif
 
 public:
+  // Reserved
+  void udf(uint32_t Imm) {
+    LOGMAN_THROW_A_FMT(Imm < 0x1'0000, "Immediate needs to be 16-bit");
+    dc32(Imm);
+  }
+
   // System with result
   // TODO: SYSL
   // System Instruction

--- a/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
@@ -49,6 +49,11 @@ DEF_OP(ExitFunction) {
 
   ResetStack();
 
+  if (CTX->HostFeatures.IsInstCountCI) [[unlikely]] {
+    // Emit function end marker
+    udf(0x420F);
+  }
+
   uint64_t NewRIP;
 
   if (IsInlineConstant(Op->NewRIP, &NewRIP) || IsInlineEntrypointOffset(Op->NewRIP, &NewRIP)) {

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -43,6 +43,9 @@ struct HostFeatures {
   bool SupportsAFP {};
   bool SupportsFloatExceptions {};
 
+  // Flag if this is InstCountCI
+  bool IsInstCountCI {};
+
   // MIDR information
   // Also used for determining number of CPU cores for CPUID
   fextl::vector<uint32_t> CPUMIDRs;

--- a/FEXCore/unittests/Emitter/System_Tests.cpp
+++ b/FEXCore/unittests/Emitter/System_Tests.cpp
@@ -6,6 +6,10 @@
 
 using namespace ARMEmitter;
 
+TEST_CASE_METHOD(TestDisassembler, "Emitter: Reserved") {
+  TEST_SINGLE(udf(0), "udf #0x0");
+  TEST_SINGLE(udf(0xFFFF), "udf #0xffff");
+}
 TEST_CASE_METHOD(TestDisassembler, "Emitter: System: System with result") {
   // TODO: Implement in emitter.
 }

--- a/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
@@ -26853,14 +26853,10 @@
         "mov w23, #0x1",
         "lsl w21, w23, w21",
         "bic w21, w22, w21",
-        "strb w21, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x20, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb w21, [x28, #1298]"
       ],
       "x86InstructionCount": 809,
-      "ExpectedInstructionCount": 26033
+      "ExpectedInstructionCount": 26029
     }
   }
 }

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -2716,7 +2716,7 @@
     },
     "Block4": {
       "x86InstructionCount": 54,
-      "ExpectedInstructionCount": 198,
+      "ExpectedInstructionCount": 194,
       "x86Insts": [
         "push ebp",
         "push edi",
@@ -2967,16 +2967,12 @@
         "mov w23, #0x1",
         "lsl w20, w23, w20",
         "bic w20, w22, w20",
-        "strb w20, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb w20, [x28, #1298]"
       ]
     },
     "Block5": {
       "x86InstructionCount": 49,
-      "ExpectedInstructionCount": 914,
+      "ExpectedInstructionCount": 910,
       "x86Insts": [
         "fld dword [esp + 0x80]",
         "fsub dword [esp + 0x7c]",
@@ -3938,11 +3934,7 @@
         "ldrb w23, [x28, #1298]",
         "lsl w20, w21, w20",
         "bic w20, w23, w20",
-        "strb w20, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x22, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb w20, [x28, #1298]"
       ]
     },
     "Block6": {
@@ -5688,7 +5680,7 @@
     },
     "Block8": {
       "x86InstructionCount": 25,
-      "ExpectedInstructionCount": 251,
+      "ExpectedInstructionCount": 247,
       "x86Insts": [
         "fstp st0",
         "fstp st3",
@@ -5963,16 +5955,12 @@
         "mov w21, #0xd0b4",
         "movk w21, #0x6, lsl #16",
         "add w21, w20, w21",
-        "str w20, [x8, #-4]!",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "str w20, [x8, #-4]!"
       ]
     },
     "Block9": {
       "x86InstructionCount": 25,
-      "ExpectedInstructionCount": 251,
+      "ExpectedInstructionCount": 247,
       "x86Insts": [
         "fstp st0",
         "fstp st3",
@@ -6247,16 +6235,12 @@
         "mov w21, #0xd0b4",
         "movk w21, #0x6, lsl #16",
         "add w21, w20, w21",
-        "str w20, [x8, #-4]!",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "str w20, [x8, #-4]!"
       ]
     },
     "Block10": {
       "x86InstructionCount": 125,
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 22,
       "x86Insts": [
         "push esi",
         "push ebx",
@@ -6406,11 +6390,7 @@
         "mov w21, #0x9060",
         "movk w21, #0x1, lsl #16",
         "add w21, w20, w21",
-        "str w20, [x8, #-4]!",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "str w20, [x8, #-4]!"
       ]
     }
   }

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -41475,7 +41475,7 @@
     },
     "Block3": {
       "x86InstructionCount": 649,
-      "ExpectedInstructionCount": 10841,
+      "ExpectedInstructionCount": 10837,
       "x86Insts": [
         "fld dword [esi + 0x64]",
         "mov eax,dword [esi + 0x88]",
@@ -52964,16 +52964,12 @@
         "ldrb w23, [x28, #1298]",
         "lsl w20, w22, w20",
         "bic w20, w23, w20",
-        "strb w20, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb w20, [x28, #1298]"
       ]
     },
     "Block4": {
       "x86InstructionCount": 2050,
-      "ExpectedInstructionCount": 63,
+      "ExpectedInstructionCount": 59,
       "x86Insts": [
         "fldz",
         "push 0x0",
@@ -55085,16 +55081,12 @@
         "mov w23, #0x1",
         "lsl w20, w23, w20",
         "bic w20, w22, w20",
-        "strb w20, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb w20, [x28, #1298]"
       ]
     },
     "Block5": {
       "x86InstructionCount": 368,
-      "ExpectedInstructionCount": 268,
+      "ExpectedInstructionCount": 264,
       "x86Insts": [
         "mov ebx,dword [eax + 0x68]",
         "fld dword [esi + 0x2c]",
@@ -55729,16 +55721,12 @@
         "mov w23, #0x1",
         "lsl w20, w23, w20",
         "bic w20, w22, w20",
-        "strb w20, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb w20, [x28, #1298]"
       ]
     },
     "Block6": {
       "x86InstructionCount": 315,
-      "ExpectedInstructionCount": 58,
+      "ExpectedInstructionCount": 54,
       "x86Insts": [
         "mov eax,dword [esp + 0x110]",
         "fldz",
@@ -56110,11 +56098,7 @@
         "mov w23, #0x1",
         "lsl w20, w23, w20",
         "bic w20, w22, w20",
-        "strb w20, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb w20, [x28, #1298]"
       ]
     },
     "Block7": {
@@ -69816,7 +69800,7 @@
     },
     "Block9": {
       "x86InstructionCount": 260,
-      "ExpectedInstructionCount": 239,
+      "ExpectedInstructionCount": 235,
       "x86Insts": [
         "fld dword [edi]",
         "fmul st0",
@@ -70314,16 +70298,12 @@
         "ldrb w23, [x28, #1298]",
         "lsl w20, w22, w20",
         "orr w20, w23, w20",
-        "strb w20, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb w20, [x28, #1298]"
       ]
     },
     "Block10": {
       "x86InstructionCount": 206,
-      "ExpectedInstructionCount": 440,
+      "ExpectedInstructionCount": 436,
       "x86Insts": [
         "fld dword [0x00b42a74]",
         "push ecx",
@@ -70968,11 +70948,7 @@
         "mov w21, #0x39db",
         "movk w21, #0x79, lsl #16",
         "add w21, w20, w21",
-        "str w20, [x8, #-4]!",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "str w20, [x8, #-4]!"
       ]
     }
   }

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -29550,7 +29550,7 @@
     },
     "Block3": {
       "x86InstructionCount": 702,
-      "ExpectedInstructionCount": 108,
+      "ExpectedInstructionCount": 104,
       "x86Insts": [
         "mov eax,dword [ebp + 0xffffff44]",
         "mov ecx,dword [eax + 0x4]",
@@ -30359,11 +30359,7 @@
         "movk w21, #0x819, lsl #16",
         "add w21, w20, w21",
         "str w20, [x8, #-4]!",
-        "cfinv",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "cfinv"
       ]
     },
     "Block4": {
@@ -54480,7 +54476,7 @@
     },
     "Block6": {
       "x86InstructionCount": 409,
-      "ExpectedInstructionCount": 7075,
+      "ExpectedInstructionCount": 7071,
       "x86Insts": [
         "mov eax,dword [ebp + 0x10]",
         "fld dword [eax + 0x30]",
@@ -61963,16 +61959,12 @@
         "movk w21, #0x818, lsl #16",
         "add w21, w20, w21",
         "str w20, [x8, #-4]!",
-        "strb wzr, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb wzr, [x28, #1298]"
       ]
     },
     "Block7": {
       "x86InstructionCount": 418,
-      "ExpectedInstructionCount": 7082,
+      "ExpectedInstructionCount": 7078,
       "x86Insts": [
         "push ebp",
         "mov ebp,esp",
@@ -69471,11 +69463,7 @@
         "movk w21, #0x818, lsl #16",
         "add w21, w20, w21",
         "str w20, [x8, #-4]!",
-        "strb wzr, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb wzr, [x28, #1298]"
       ]
     },
     "Block8": {
@@ -86021,7 +86009,7 @@
     },
     "Block10": {
       "x86InstructionCount": 420,
-      "ExpectedInstructionCount": 6065,
+      "ExpectedInstructionCount": 6061,
       "x86Insts": [
         "push ebp",
         "mov ebp,esp",
@@ -92505,11 +92493,7 @@
         "mov w23, #0x1",
         "lsl w20, w23, w20",
         "bic w20, w22, w20",
-        "strb w20, [x28, #1298]",
-        "ldr x0, [x28, #2376]",
-        "ubfiz x3, x21, #4, #20",
-        "add x0, x0, x3",
-        "ldp x1, x0, [x0]"
+        "strb w20, [x28, #1298]"
       ]
     }
   }


### PR DESCRIPTION
Due to how jit block tail padding is working, there's no real good way
to determine the true "implementation size" of an instruction without
the backend being aware of wanting to investigate it.

Trying to inject another instruction, or another IR operation actually
subtly changes codegen in a way that gives invalid results. The only
real way to get around this is to inject a known token in to the
instruction stream as we `ExitFunction`.

So inject a `udf #0x420f`, and change the scanning behaviour to find the
first one and cut everything else off afterwards.

This already scoops out some code in some game blocks that were
accidentally landing ExitFunction code in the json.

This also has been tested to work with https://github.com/FEX-Emu/FEX/pull/4528 with its InstCountCI
specific changes reverted.

This means we don't need to play subtle padding tricks in the JIT to get
the information we want in InstcountCI.