### PR TITLE
updated Dockerfile to reflect latest FEX-Emu releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,31 @@
 # --- Stage 1: Builder ---
-FROM ubuntu:20.04 as builder
+FROM ubuntu:22.04 as builder
 
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update
 RUN DEBIAN_FRONTEND="noninteractive" apt install -y cmake \
-clang-10 llvm-10 nasm ninja-build pkg-config \
+clang-13 llvm-13 nasm ninja-build pkg-config \
 libcap-dev libglfw3-dev libepoxy-dev python3-dev libsdl2-dev \
-python3 linux-headers-generic \
-git
+python3 linux-headers-generic  \
+git  qtbase5-dev qtdeclarative5-dev lld
 
 RUN git clone --recurse-submodules https://github.com/FEX-Emu/FEX.git
+WORKDIR /FEX
+RUN mkdir build
 
-CMD [ "mkdir /opt/FEX/build" ]
-
-WORKDIR /opt/FEX/build
-
-ARG CC=clang-10
-ARG CXX=clang++-10
-RUN cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release
+ARG CC=clang-13
+ARG CXX=clang++-13
+RUN cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DUSE_LINKER=lld -DENABLE_LTO=True -DBUILD_TESTS=False -DENABLE_ASSERTIONS=False -G Ninja .
 RUN ninja
 
+WORKDIR /FEX/build
+
 # --- Stage 2: Runner ---
-FROM ubuntu:20.04
+FROM builder as runner
 
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update
 RUN DEBIAN_FRONTEND="noninteractive" apt install -y \
 libcap-dev libglfw3-dev libepoxy-dev
 
-COPY --from=builder /opt/FEX/build/Bin/* /usr/bin/
+COPY --from=builder /FEX/Bin/* /usr/bin/
 
-WORKDIR /root
+WORKDIR /


### PR DESCRIPTION
Add multi-stage Dockerfile for FEX emulator build

- Stage 1 (Builder): Sets up build environment with Ubuntu 22.04
  - Installs development tools and dependencies
  - Builds FEX using clang-13 with optimized settings
  - Configures cmake with LTO enabled and tests disabled

- Stage 2 (Runner): Creates minimal runtime image
  - Includes only necessary runtime libraries
  - Copies built binaries from builder stage