### PR TITLE
Link to mincore instead of kernelbase on ARM64EC

### DIFF
--- a/FEXCore/Source/CMakeLists.txt
+++ b/FEXCore/Source/CMakeLists.txt
@@ -120,7 +120,7 @@ if (NOT MINGW_BUILD)
 else()
   list (APPEND LIBS synchronization)
   if (_M_ARM_64EC)
-    list (APPEND LIBS kernelbase)
+    list (APPEND LIBS mincore)
   endif()
 endif()
 


### PR DESCRIPTION
The kernelbase import library is not available in upstream mingw-w64. Instead, similar to MSVC, we can use mincore, which allows importing the relevant functions via apisets.