### PR TITLE
mprotect last page of CodeBuffer

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -13,7 +13,6 @@ $end_info$
 #include <FEXCore/fextl/vector.h>
 
 #include <cstdint>
-#include <memory>
 
 namespace FEXCore {
 
@@ -131,7 +130,7 @@ namespace CPU {
      * @return An executable function pointer relocated from the cache object
      */
     [[nodiscard]]
-    virtual void* RelocateJITObjectCode(uint64_t Entry, const CodeSerialize::CodeObjectFileSection* SerializationData) {
+    virtual void* RelocateJITObjectCode(uint64_t /* Entry */, const CodeSerialize::CodeObjectFileSection* /* SerializationData */) {
       return nullptr;
     }
 

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -13,6 +13,7 @@ $end_info$
 
 #include "Common/SoftFloat.h"
 #include "FEXCore/Utils/Telemetry.h"
+#include "FEXCore/Utils/TypeDefines.h"
 #include "Interface/Context/Context.h"
 #include "Interface/Core/LookupCache.h"
 
@@ -754,7 +755,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
 
   // Fairly excessive buffer range to make sure we don't overflow
   uint32_t BufferRange = SSACount * 16;
-  if ((GetCursorOffset() + BufferRange) > CurrentCodeBuffer->Size) {
+  if ((GetCursorOffset() + BufferRange) > (CurrentCodeBuffer->Size - Utils::FEX_PAGE_SIZE)) {
     CTX->ClearCodeCache(ThreadState);
   }
 

--- a/FEXCore/include/FEXCore/Core/SignalDelegator.h
+++ b/FEXCore/include/FEXCore/Core/SignalDelegator.h
@@ -4,10 +4,7 @@
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/fextl/vector.h>
 
-#include <array>
 #include <cstdint>
-#include <functional>
-#include <utility>
 #include <signal.h>
 #include <stddef.h>
 
@@ -62,8 +59,8 @@ public:
     uint8_t SRAFPRMapping[16];
   };
 
-  void SetConfig(const SignalDelegatorConfig& _Config) {
-    Config = _Config;
+  void SetConfig(const SignalDelegatorConfig& Config) {
+    this->Config = Config;
   }
 
   const SignalDelegatorConfig& GetConfig() const {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -26,7 +26,6 @@ $end_info$
 #include <string.h>
 
 #include <errno.h>
-#include <exception>
 #include <functional>
 #include <linux/futex.h>
 #include <signal.h>

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -17,7 +17,6 @@ $end_info$
 
 #include <array>
 #include <atomic>
-#include <signal.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <mutex>


### PR DESCRIPTION
protects last page of codebuffer. This should cause a SIGSEGV if we try to access it. Until now it was possible to go over and access out of bounds.

In addition, there a couple of clang-tidy fixes which should be NFC.