### PR TITLE
FEXCore/JIT: Switch over to new vl64pair for RIP reconstruction 

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -158,14 +158,12 @@ uint64_t ContextImpl::RestoreRIPFromHostPC(FEXCore::Core::InternalThreadState* T
       uint64_t StartingGuestRIP = InlineTail->RIP;
 
       for (uint32_t i = 0; i < InlineTail->NumberOfRIPEntries; ++i) {
-        auto HostPCOffset = FEXCore::Utils::vl64::Decode(RIPEntry);
-        RIPEntry += HostPCOffset.Size;
-        auto GuestRIPOffset = FEXCore::Utils::vl64::Decode(RIPEntry);
-        RIPEntry += GuestRIPOffset.Size;
-        if (HostPC >= (StartingHostPC + HostPCOffset.Integer)) {
+        auto Offset = FEXCore::Utils::vl64pair::Decode(RIPEntry);
+        RIPEntry += Offset.Size;
+        if (HostPC >= (StartingHostPC + Offset.IntegerARMPC)) {
           // We are beyond this entry, keep going forward.
-          StartingHostPC += HostPCOffset.Integer;
-          StartingGuestRIP += GuestRIPOffset.Integer;
+          StartingHostPC += Offset.IntegerARMPC;
+          StartingGuestRIP += Offset.IntegerX86RIP;
         } else {
           // Passed where the Host PC is at. Break now.
           break;

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -862,11 +862,7 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
       int64_t HostPCOffset = GuestOpcode.HostEntryOffset - CurrentPCOffset;
       int64_t GuestRIPOffset = GuestOpcode.GuestEntryOffset - CurrentRIPOffset;
 
-      size_t Size = FEXCore::Utils::vl64::Encode(JITRIPEntriesLocation, HostPCOffset);
-      JITRIPEntriesLocation += Size;
-
-      Size = FEXCore::Utils::vl64::Encode(JITRIPEntriesLocation, GuestRIPOffset);
-      JITRIPEntriesLocation += Size;
+      JITRIPEntriesLocation += FEXCore::Utils::vl64pair::Encode(JITRIPEntriesLocation, HostPCOffset, GuestRIPOffset);
 
       CurrentPCOffset = GuestOpcode.HostEntryOffset;
       CurrentRIPOffset = GuestOpcode.GuestEntryOffset;

--- a/FEXCore/Source/Utils/variable_length_integer.h
+++ b/FEXCore/Source/Utils/variable_length_integer.h
@@ -166,4 +166,230 @@ private:
   constexpr static int64_t vl64_max = std::numeric_limits<int64_t>::max();
 };
 
+// Variable length pair that optimizes around FEXCore's JITRIPReconstruction.
+//
+// 8-bit:
+// bit[7]   = 0 - 8-bit
+// bit[6:4] = 3-bit unsigned - 1. [1 - 8] range.
+// bit[3:0] = 4-bit unsigned divided by 4 - 1. [4 - 64 byte] range.
+//
+// 16-bit:
+// byte1[7:6] = 0b10 - 16-bit
+// byte1[5:0] = 6-bit signed value [-32 - 31] range
+// byte2[7:0] = 8-bit signed value divided by 4. [-512 - 508] byte range.
+//
+// 32-bit and 64-bit don't attempt to do any compression beyond range checks.
+// 32-bit
+// byte1[7:5] = 0b110 - 32-bit
+// byte1[4:0] = <reserved>
+// word1[31:0] = signed word
+// word2[31:0] = signed word
+//
+// 64-bit
+// byte1[7:5] = 0b111 - 64-bit
+// byte1[4:0] = <reserved>
+// dword1[63:0] = signed dword
+// dword2[63:0] = signed dword
+
+struct vl64pair final {
+public:
+  static size_t EncodedSize(uint64_t data_arm, uint64_t data_rip) {
+    if (can_encode_vl8(data_arm, data_rip)) {
+      return sizeof(vl8_enc);
+    } else if (can_encode_vl16(data_arm, data_rip)) {
+      return sizeof(vl16_enc);
+    } else if (can_encode_vl32(data_arm, data_rip)) {
+      return sizeof(vl32_enc);
+    }
+    return sizeof(vl64_enc);
+  }
+
+  struct Decoded {
+    uint64_t IntegerARMPC;
+    uint64_t IntegerX86RIP;
+    size_t Size;
+  };
+
+  static Decoded Decode(const uint8_t* data) {
+    auto vl8_type = reinterpret_cast<const vl8_enc*>(data);
+    auto vl16_type = reinterpret_cast<const vl16_enc*>(data);
+    auto vl32_type = reinterpret_cast<const vl32_enc*>(data);
+    auto vl64_type = reinterpret_cast<const vl64_enc*>(data);
+
+    if (vl8_type->Type == vl8_type_header) {
+      return Decode(vl8_type);
+    } else if (vl16_type->HighBits.Type == vl16_type_header) {
+      return Decode(vl16_type);
+    } else if (vl32_type->Type == vl32_type_header) {
+      return Decode(vl32_type);
+    }
+    return {vl64_type->IntegerARMPC, vl64_type->IntegerX86RIP, sizeof(vl64_enc)};
+  }
+
+  static size_t Encode(uint8_t* dst, uint64_t data_arm, uint64_t data_rip) {
+    auto vl8_type = reinterpret_cast<vl8_enc*>(dst);
+    auto vl16_type = reinterpret_cast<vl16_enc*>(dst);
+    auto vl32_type = reinterpret_cast<vl32_enc*>(dst);
+    auto vl64_type = reinterpret_cast<vl64_enc*>(dst);
+
+    if (can_encode_vl8(data_arm, data_rip)) {
+      *vl8_type = {
+        .IntegerARMPC = static_cast<uint8_t>((data_arm - 1) >> vl8_arm_align_bits),
+        .IntegerX86RIP = static_cast<uint8_t>(data_rip - 1),
+        .Type = vl8_type_header,
+      };
+      return sizeof(vl8_enc);
+    } else if (can_encode_vl16(data_arm, data_rip)) {
+      *vl16_type = {
+        .HighBits {
+          .IntegerX86RIP = static_cast<int8_t>(static_cast<int64_t>(data_rip)),
+          .Type = vl16_type_header,
+        },
+        .IntegerARMPC = static_cast<int8_t>(static_cast<int64_t>(data_arm) >> vl8_arm_align_bits),
+      };
+      return sizeof(vl16_enc);
+    } else if (can_encode_vl32(data_arm, data_rip)) {
+      *vl32_type = {
+        .Type = vl32_type_header,
+        .IntegerARMPC = static_cast<int32_t>(data_arm),
+        .IntegerX86RIP = static_cast<int32_t>(data_rip),
+      };
+      return sizeof(vl32_enc);
+    }
+
+    *vl64_type = {
+      .Type = vl64_type_header,
+      .IntegerARMPC = data_arm,
+      .IntegerX86RIP = data_rip,
+    };
+    return sizeof(vl64_enc);
+  }
+
+private:
+  struct vl8_enc {
+    uint8_t IntegerARMPC  : 4;
+    uint8_t IntegerX86RIP : 3;
+    uint8_t Type          : 1;
+  };
+  static_assert(sizeof(vl8_enc) == 1);
+
+  static inline Decoded Decode(const vl8_enc* enc) {
+    const uint64_t data_arm = enc->IntegerARMPC;
+    const uint64_t data_rip = enc->IntegerX86RIP;
+    return {(data_arm + 1) << vl8_arm_align_bits, data_rip + 1, sizeof(vl8_enc)};
+  }
+
+  struct vl16_enc {
+    struct {
+      int8_t IntegerX86RIP : 6;
+      uint8_t Type         : 2;
+    } HighBits;
+    int8_t IntegerARMPC;
+  };
+  static_assert(sizeof(vl16_enc) == 2);
+
+  static inline Decoded Decode(const vl16_enc* enc) {
+    int64_t arm_pc = enc->IntegerARMPC << vl8_arm_align_bits;
+    int64_t x86_rip = enc->HighBits.IntegerX86RIP;
+    return {static_cast<uint64_t>(arm_pc), static_cast<uint64_t>(x86_rip), sizeof(vl16_enc)};
+  }
+
+  struct FEX_PACKED vl32_enc {
+    uint8_t Type;
+    int32_t IntegerARMPC;
+    int32_t IntegerX86RIP;
+  };
+  static_assert(sizeof(vl32_enc) == 9);
+
+  static inline Decoded Decode(const vl32_enc* enc) {
+    int64_t arm_pc = enc->IntegerARMPC;
+    int64_t x86_rip = enc->IntegerX86RIP;
+    return {static_cast<uint64_t>(arm_pc), static_cast<uint64_t>(x86_rip), sizeof(vl32_enc)};
+  }
+
+  struct FEX_PACKED vl64_enc {
+    uint8_t Type;
+    uint64_t IntegerARMPC;
+    uint64_t IntegerX86RIP;
+  };
+  static_assert(sizeof(vl64_enc) == 17);
+
+  // vl8 can hold a two small unsigned integers.
+  // Encoded in 8-bit.
+  constexpr static int64_t vl8_type_header = 0;
+  constexpr static int64_t vl8_arm_min = 1;
+  constexpr static int64_t vl8_arm_max = 16;
+  constexpr static int64_t vl8_arm_align_bits = 2;
+  constexpr static int64_t vl8_arm_shift_mask = (1U << vl8_arm_align_bits) - 1;
+  constexpr static int64_t vl8_pc_min = 1;
+  constexpr static int64_t vl8_pc_max = 8;
+  static bool can_encode_vl8(uint64_t data_arm, uint64_t data_rip) {
+    // GuestPC can only be [1,8] bytes.
+    if (data_rip < vl8_pc_min || data_rip > vl8_pc_max) {
+      return false;
+    }
+    // Unaligned doesn't fit at all.
+    if (data_arm & vl8_arm_shift_mask) {
+      return false;
+    }
+
+    // HostPC can only be [1,16] instructions.
+    int64_t ShiftedHostPC = data_arm >> vl8_arm_align_bits;
+    if (ShiftedHostPC < vl8_arm_min || ShiftedHostPC > vl8_arm_max) {
+      return false;
+    }
+
+    return true;
+  }
+
+  // vl16 can hold a two small signed integers
+  // Encoded in one 16-bit value.
+  constexpr static int64_t vl16_type_header = 0b10;
+  constexpr static int64_t vl16_arm_min = -128;
+  constexpr static int64_t vl16_arm_max = 127;
+  constexpr static int64_t vl16_arm_align_bits = 2;
+  constexpr static int64_t vl16_arm_shift_mask = (1U << vl16_arm_align_bits) - 1;
+  constexpr static int64_t vl16_pc_min = -32;
+  constexpr static int64_t vl16_pc_max = 31;
+  static bool can_encode_vl16(int64_t data_arm, int64_t data_rip) {
+    // GuestPC can only be [-32,31] bytes.
+    if (data_rip < vl16_pc_min || data_rip > vl16_pc_max) {
+      return false;
+    }
+
+    // Unaligned doesn't fit at all.
+    if (data_arm & vl16_arm_shift_mask) {
+      return false;
+    }
+
+    // HostPC can only be [-128,127] instructions.
+    int64_t ShiftedHostPC = data_arm >> vl16_arm_align_bits;
+    if (ShiftedHostPC < vl16_arm_min || ShiftedHostPC > vl16_arm_max) {
+      return false;
+    }
+
+    return true;
+  }
+
+  // vl32 can hold a two 32-bit integers.
+  // Encoded in 8-bit and two 32-bit values.
+  constexpr static int64_t vl32_type_header = 0b1100'0000;
+  constexpr static int64_t vl32_min = std::numeric_limits<int32_t>::min();
+  constexpr static int64_t vl32_max = std::numeric_limits<int32_t>::max();
+  static bool can_encode_vl32(int64_t data_arm, int64_t data_rip) {
+    if (data_rip < vl32_min || data_rip > vl32_max) {
+      return false;
+    }
+    if (data_arm < vl32_min || data_arm > vl32_max) {
+      return false;
+    }
+
+    return true;
+  }
+
+  // vl64 can hold a two 64-bit integers.
+  // Encoded in 8-bit and two 64-bit values.
+  constexpr static int64_t vl64_type_header = 0b1110'0000;
+};
+
 } // namespace FEXCore::Utils


### PR DESCRIPTION
As said in the implementation of this struct commit message. This new
pair struct optimizes specific cases of small forward only increments
that can fit in to 8-bit space, and small forward or backward jump cases
that fit in to 16-bit space.

Some stats of this change:
- Steam: 5.88MB down to 4.34MB. 73.8% the space consumed
- Steamwebhelper: 15.8MB down to 13.24MB. 83.8% space consumed
- Sonic Mania: 3.6MB down to 2.58MB. 71.6% space consumed

As for absolute stats when compared to all code buffer size:
- Steam: 86MB of code buffer to 5.88MB -> 4.34MB of RIP reconstruction.
  - 6.8% -> 5% code buffer space used for RIP reconstruction
- Steamwebhelper: 285MB of code buffer to 17MB -> 14.26MB of RIP reconstruction.
  - 5.9% -> 4.9% code buffer space used for RIP reconstruction
- Sonic Mania: 48.53MB of code buffer to 3.55MB -> 2.53MB of RIP reconstruction.
  - 7.3% -> 5.2% code buffer space used for RIP reconstruction