### PR TITLE
FEXServer: Fixes squashfs/erofs with newer fuse releases

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -235,7 +235,8 @@ int ConnectToAndStartServer(std::string_view InterpreterPath) {
     // We want to ignore the signal so that if FEXServer starts in daemon mode, it
     // doesn't leave a zombie process around waiting for something to get the result.
     struct sigaction action {};
-    action.sa_handler = SIG_IGN, sigaction(SIGCHLD, &action, &action);
+    action.sa_handler = SIG_IGN;
+    sigaction(SIGCHLD, &action, &action);
 
     pid_t pid = fork();
     if (pid == 0) {

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -74,9 +74,9 @@ void SetupSignals() {
 
   // Ignore SIGPIPE, we will be checking for pipe closure which could send this signal
   signal(SIGPIPE, SIG_IGN);
-  // SIGCHLD if squashfuse exits early.
-  // Ignore it for now
-  signal(SIGCHLD, SIG_IGN);
+  // Reset SIGCHLD which is likely SIG_IGN if FEXInterpreter started the server.
+  // We now wait for child processes with waitpid, newer libfuse also requires SIGCHLD to not be ignored by child processes.
+  signal(SIGCHLD, SIG_DFL);
 }
 
 /**


### PR DESCRIPTION
Newer fuse releases changed how they are waiting on child processes to exit. Setting the signal action to SIG_IGN would cause erofsfuse/squashfuse to inherit the ignored action and cause their internal `wait4` syscalls to fail with ECHLD.

Set the action back to default inside the FEXServer because our original reasoning for setting the ignoring is no longer valid. FEXInterpreter still ignores SIGCHLD while launching FEXServer.

Maybe fixes the muvm thing people have been complaining about.

Also fixes accidental comma delimiter usage.