### PR TITLE
Linux/SMCTracking: Stop calling mprotect on a memory region times the number of threads

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -169,7 +169,6 @@ public:
 
   void ClearCodeCache(FEXCore::Core::InternalThreadState* Thread) override;
   void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) override;
-  void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length, CodeRangeInvalidationFn callback) override;
   FEXCore::ForkableSharedMutex& GetCodeInvalidationMutex() override {
     return CodeInvalidationMutex;
   }

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -905,12 +905,6 @@ void ContextImpl::InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* T
   InvalidateGuestThreadCodeRange(Thread, Start, Length);
 }
 
-void ContextImpl::InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length,
-                                           CodeRangeInvalidationFn CallAfter) {
-  InvalidateGuestThreadCodeRange(Thread, Start, Length);
-  CallAfter(Start, Length);
-}
-
 void ContextImpl::MarkMemoryShared(FEXCore::Core::InternalThreadState* Thread) {
   if (!Thread) {
     return;
@@ -1012,7 +1006,8 @@ void ContextImpl::RemoveCustomIREntrypoint(uintptr_t Entrypoint) {
 
   std::scoped_lock lk(CustomIRMutex);
 
-  InvalidateGuestCodeRange(nullptr, Entrypoint, 1, [this](uint64_t Entrypoint, uint64_t) { CustomIRHandlers.erase(Entrypoint); });
+  InvalidateGuestCodeRange(nullptr, Entrypoint, 1);
+  CustomIRHandlers.erase(Entrypoint);
 
   HasCustomIRHandlers = !CustomIRHandlers.empty();
 }

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -174,8 +174,6 @@ public:
 
   FEX_DEFAULT_VISIBILITY virtual void ClearCodeCache(FEXCore::Core::InternalThreadState* Thread) = 0;
   FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) = 0;
-  FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length,
-                                                               CodeRangeInvalidationFn callback) = 0;
   FEX_DEFAULT_VISIBILITY virtual FEXCore::ForkableSharedMutex& GetCodeInvalidationMutex() = 0;
 
   FEX_DEFAULT_VISIBILITY virtual void MarkMemoryShared(FEXCore::Core::InternalThreadState* Thread) = 0;


### PR DESCRIPTION
I noticed this cascade of mprotects when poking at Crypt of the Necrodancer, since it consistently is invalidating code. I saw us calling mprotect on the same page 32 times in a tight loop and thought surely this isn't FEX doing this.

Turns out we were calling the callback after invalidating each thread. It should instead be done once at the end of invalidating the thread's caches while still holding the locks.

Fixes this weird cascade of mprotects that equal the number of FEX threads.