### PR TITLE
Fix 32-bit fadvise64

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
@@ -389,8 +389,6 @@ void RegisterCommon(FEX::HLE::SyscallHandler* Handler) {
                                    SyscallPassthrough3<SYSCALL_DEF(io_cancel)>);
   REGISTER_SYSCALL_IMPL_PASS_FLAGS(remap_file_pages, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                    SyscallPassthrough5<SYSCALL_DEF(remap_file_pages)>);
-  REGISTER_SYSCALL_IMPL_PASS_FLAGS(fadvise64, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
-                                   SyscallPassthrough4<SYSCALL_DEF(fadvise64)>);
   REGISTER_SYSCALL_IMPL_PASS_FLAGS(timer_getoverrun, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                    SyscallPassthrough1<SYSCALL_DEF(timer_getoverrun)>);
   REGISTER_SYSCALL_IMPL_PASS_FLAGS(timer_delete, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
@@ -720,6 +718,8 @@ namespace x64 {
                                          SyscallPassthrough4<SYSCALL_DEF(pidfd_send_signal)>);
     REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(process_madvise, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                          SyscallPassthrough5<SYSCALL_DEF(process_madvise)>);
+    REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(fadvise64, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+                                         SyscallPassthrough4<SYSCALL_DEF(fadvise64)>);
     if (Handler->IsHostKernelVersionAtLeast(6, 5, 0)) {
       REGISTER_SYSCALL_IMPL_X64_PASS_FLAGS(cachestat, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                            SyscallPassthrough4<SYSCALL_DEF(cachestat)>);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
@@ -735,14 +735,14 @@ void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
                               SYSCALL_ERRNO();
                             });
 
-  REGISTER_SYSCALL_IMPL_X32(fadvise64,
-                            [](FEXCore::Core::CpuStateFrame* Frame, int32_t fd, uint32_t offset_low, uint32_t offset_high, uint32_t len, int advice) -> uint64_t {
-                              uint64_t Offset = offset_high;
-                              Offset <<= 32;
-                              Offset |= offset_low;
-                              uint64_t Result = ::posix_fadvise64(fd, Offset, len, advice);
-                              SYSCALL_ERRNO();
-                            });
+  REGISTER_SYSCALL_IMPL_X32(
+    fadvise64, [](FEXCore::Core::CpuStateFrame* Frame, int32_t fd, uint32_t offset_low, uint32_t offset_high, uint32_t len, int advice) -> uint64_t {
+      uint64_t Offset = offset_high;
+      Offset <<= 32;
+      Offset |= offset_low;
+      uint64_t Result = ::posix_fadvise64(fd, Offset, len, advice);
+      SYSCALL_ERRNO();
+    });
 
   REGISTER_SYSCALL_IMPL_X32(fadvise64_64,
                             [](FEXCore::Core::CpuStateFrame* Frame, int32_t fd, uint32_t offset_low, uint32_t offset_high, uint32_t len_low,

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
@@ -735,6 +735,15 @@ void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
                               SYSCALL_ERRNO();
                             });
 
+  REGISTER_SYSCALL_IMPL_X32(fadvise64,
+                            [](FEXCore::Core::CpuStateFrame* Frame, int32_t fd, uint32_t offset_low, uint32_t offset_high, uint32_t len, int advice) -> uint64_t {
+                              uint64_t Offset = offset_high;
+                              Offset <<= 32;
+                              Offset |= offset_low;
+                              uint64_t Result = ::posix_fadvise64(fd, Offset, len, advice);
+                              SYSCALL_ERRNO();
+                            });
+
   REGISTER_SYSCALL_IMPL_X32(fadvise64_64,
                             [](FEXCore::Core::CpuStateFrame* Frame, int32_t fd, uint32_t offset_low, uint32_t offset_high, uint32_t len_low,
                                uint32_t len_high, int advice) -> uint64_t {


### PR DESCRIPTION
The 32-bit and 64-bit fadvise64 is not the same, the 32-bit version has a high+low offset and a 32-bit len

https://github.com/torvalds/linux/blob/master/arch/x86/kernel/sys_ia32.c#L112