### PR TITLE
Arm64Emitter: Fix overalignment in Align16B

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -1086,7 +1086,7 @@ void Arm64Emitter::FillForPreserveAllABICall(bool FPRs) {
 
 void Arm64Emitter::Align16B() {
   uint64_t CurrentOffset = GetCursorAddress<uint64_t>();
-  for (uint64_t i = (16 - (CurrentOffset & 0xF)); i != 0; i -= 4) {
+  for (uint64_t i = (-CurrentOffset & 0xF); i != 0; i -= 4) {
     nop();
   }
 }


### PR DESCRIPTION
Previously, 16 additional bytes were emitted if the buffer was already aligned.

In practice this fix reduces CodeBuffer size by about 0.2%.
