### PR TITLE
NFC: FEXCore: Removes unused argument on CreateThread

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -104,7 +104,6 @@ public:
    * @param InitialRIP The starting RIP of this thread
    * @param StackPointer The starting RSP of this thread
    * @param NewThreadState The initial thread state to setup for our state, if inheriting.
-   * @param ParentTID The PID that was the parent thread that created this
    *
    * @return The InternalThreadState object that tracks all of the emulated thread's state
    *
@@ -125,8 +124,7 @@ public:
    *    - HandleCallback(Thread, RIP);
    */
 
-  FEXCore::Core::InternalThreadState*
-  CreateThread(uint64_t InitialRIP, uint64_t StackPointer, const FEXCore::Core::CPUState* NewThreadState, uint64_t ParentTID) override;
+  FEXCore::Core::InternalThreadState* CreateThread(uint64_t InitialRIP, uint64_t StackPointer, const FEXCore::Core::CPUState* NewThreadState) override;
 
   /**
    * @brief Destroys this FEX thread object and stops tracking it internally

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -433,7 +433,7 @@ void ContextImpl::InitializeCompiler(FEXCore::Core::InternalThreadState* Thread)
 }
 
 FEXCore::Core::InternalThreadState*
-ContextImpl::CreateThread(uint64_t InitialRIP, uint64_t StackPointer, const FEXCore::Core::CPUState* NewThreadState, uint64_t ParentTID) {
+ContextImpl::CreateThread(uint64_t InitialRIP, uint64_t StackPointer, const FEXCore::Core::CPUState* NewThreadState) {
   FEXCore::Core::InternalThreadState* Thread = new FEXCore::Core::InternalThreadState {
     .CTX = this,
   };

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -141,13 +141,12 @@ public:
    * @param InitialRIP The starting RIP of this thread
    * @param StackPointer The starting RSP of this thread
    * @param NewThreadState The thread state to inherit from if not nullptr.
-   * @param ParentTID The thread ID that the parent is inheriting from
    *
    * @return A new InternalThreadState object for using with a new guest thread.
    */
 
-  FEX_DEFAULT_VISIBILITY virtual FEXCore::Core::InternalThreadState* CreateThread(
-    uint64_t InitialRIP, uint64_t StackPointer, const FEXCore::Core::CPUState* NewThreadState = nullptr, uint64_t ParentTID = 0) = 0;
+  FEX_DEFAULT_VISIBILITY virtual FEXCore::Core::InternalThreadState*
+  CreateThread(uint64_t InitialRIP, uint64_t StackPointer, const FEXCore::Core::CPUState* NewThreadState = nullptr) = 0;
 
   FEX_DEFAULT_VISIBILITY virtual void DestroyThread(FEXCore::Core::InternalThreadState* Thread) = 0;
 #ifndef _WIN32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -163,7 +163,7 @@ FEX::HLE::ThreadStateObject* ThreadManager::CreateThread(uint64_t InitialRIP, ui
 
   ThreadStateObject->ThreadInfo.TID = FHU::Syscalls::gettid();
 
-  ThreadStateObject->Thread = CTX->CreateThread(InitialRIP, StackPointer, NewThreadState, ParentTID);
+  ThreadStateObject->Thread = CTX->CreateThread(InitialRIP, StackPointer, NewThreadState);
   ThreadStateObject->Thread->FrontendPtr = ThreadStateObject;
   if (ProfileStats()) {
     ThreadStateObject->Thread->ThreadStats = Stat.AllocateSlot(ThreadStateObject->ThreadInfo.TID);


### PR DESCRIPTION
ParentTID is purely a Linux construct and has been moved entirely to the frontend at this point. Remove this argument which is now unused.

NFC