### PR TITLE
LinuxEmulation: Fix bad compile time definition check

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -290,11 +290,11 @@ void SyscallHandler::TrackMremap(FEXCore::Core::InternalThreadState* Thread, uin
       VMATracking.SetUnsafe(CTX, OldResource, NewAddress, OldOffset, NewSize, OldFlags, OldProt);
     } else {
 
-// MREMAP_DONTUNMAP is kernel 5.7+
-#ifdef MREMAP_DONTUNMAP
-      if (!(flags & MREMAP_DONTUNMAP))
+#ifndef MREMAP_DONTUNMAP
+// MREMAP_DONTUNMAP is kernel 5.7+ and might not exist
+#define MREMAP_DONTUNMAP 4
 #endif
-      {
+      if (!(flags & MREMAP_DONTUNMAP)) {
         VMATracking.ClearUnsafe(CTX, OldAddress, OldSize, OldResource);
       }
 


### PR DESCRIPTION
We don't want this to be compiled out if the definition doesn't exist. Actually define it in that case.