### PR TITLE
Windows: Fix building with llvm-libcxx

### DIFF
--- a/Source/Windows/Common/WinAPI/IO.cpp
+++ b/Source/Windows/Common/WinAPI/IO.cpp
@@ -351,6 +351,10 @@ DLLEXPORT_FUNC(void, GetSystemTimeAsFileTime, (LPFILETIME lpSystemTimeAsFileTime
   lpSystemTimeAsFileTime->dwHighDateTime = Time.HighPart;
 }
 
+DLLEXPORT_FUNC(void, GetSystemTimePreciseAsFileTime, (LPFILETIME lpSystemTimeAsFileTime)) {
+  GetSystemTimeAsFileTime(lpSystemTimeAsFileTime);
+}
+
 DLLEXPORT_FUNC(WINBOOL, SetCurrentDirectoryA, (LPCSTR lpPathName)) {
   UNIMPLEMENTED();
 }


### PR DESCRIPTION
Libcxx uses GetSystemTimePreciseAsFileTime if _WIN32_WINNT specifies a version new enough to have it.