### PR TITLE
IR: drop DestSize inference

### DIFF
--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -723,20 +723,7 @@ def print_ir_allocator_helpers():
                     if not arg.Temporary and not arg.IsSSA:
                         output_file.write("\t\t_Op.first->{} = {};\n".format(arg.Name, arg.Name))
 
-            if (op.HasDest):
-                # We can only infer a size if we have arguments
-                if op.DestSize == None:
-                    # We need to infer destination size
-                    output_file.write("\t\tIR::OpSize InferSize = OpSize::iUnsized;\n")
-                    if len(op.Arguments) != 0:
-                        for arg in op.Arguments:
-                            if arg.IsSSA:
-                                output_file.write("\t\tauto Size{} = GetOpSize({});\n".format(arg.Name, arg.Name))
-                        for arg in op.Arguments:
-                            if arg.IsSSA:
-                                output_file.write("\t\tInferSize = std::max(InferSize, Size{});\n".format(arg.Name))
-
-                    output_file.write("\t\t_Op.first->Header.Size = InferSize;\n")
+            assert not (op.HasDest and op.DestSize is None)
 
             # Some ops without a destination still need an operating size
             # Effectively reusing the destination size value for operation size

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -972,7 +972,7 @@ void ContextImpl::AddThunkTrampolineIRHandler(uintptr_t Entrypoint, uintptr_t Gu
       emit->_StoreContext(GPRSize, IR::FPRClass, emit->_VCastFromGPR(IR::OpSize::i64Bit, IR::OpSize::i64Bit, emit->_Constant(Entrypoint)),
                           offsetof(Core::CPUState, mm[0][0]));
     }
-    emit->_ExitFunction(emit->_Constant(GuestThunkEntrypoint));
+    emit->_ExitFunction(IR::OpSize::i64Bit, emit->_Constant(GuestThunkEntrypoint));
     },
     ThunkHandler, (void*)GuestThunkEntrypoint);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -161,7 +161,7 @@ public:
   }
   IRPair<IROp_ExitFunction> ExitFunction(Ref NewRIP) {
     FlushRegisterCache();
-    return _ExitFunction(NewRIP);
+    return _ExitFunction(GetOpSize(NewRIP), NewRIP);
   }
   IRPair<IROp_Break> Break(BreakDefinition Reason) {
     FlushRegisterCache();

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -294,11 +294,11 @@
         "HasSideEffects": true,
         "RAOverride": "2"
       },
-      "ExitFunction GPR:$NewRIP": {
+      "ExitFunction OpSize:#Size, GPR:$NewRIP": {
         "Desc": ["Exits the current JIT function with a target RIP"
                 ],
         "HasSideEffects": true,
-        "DestSize": "GetOpSize(NewRIP)"
+        "DestSize": "Size"
       },
       "Break BreakDefinition:$Reason": {
         "HasSideEffects": true

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -679,6 +679,7 @@
           "This is a special move that indicates the result will be poisoned by a non-SSA instruction writing to its result.",
           "In effect, it serves to prevent invalid optimizations with non-SSA instructions."
         ],
+        "DestSize": "OpSize::i64Bit",
         "HasSideEffects": true,
         "TiedSource": 0
       },

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -500,7 +500,7 @@
         ]
       },
 
-      "SSA = FillRegister SSA:$OriginalValue, u32:$Slot, RegisterClass:$Class": {
+      "SSA = FillRegister OpSize:#Size, OpSize:#ElementSize, SSA:$OriginalValue, u32:$Slot, RegisterClass:$Class": {
         "Desc": ["Fills a register from a spill slot",
                  "Spill slots are register allocated and has live ranges calculated to handle slot calculation",
                  "```diff\n- !Don't use this op. It is for RA to handle spilling and filling!\n```",
@@ -508,6 +508,8 @@
                  "The OriginalValue SSA arg points at the original SSA value spilled, and only exists for",
                  "RA validation purposes"
                 ],
+        "DestSize": "Size",
+        "ElementSize": "ElementSize",
         "EmitValidation": [
           "WalkFindRegClass($OriginalValue) == $Class"
         ]

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -163,11 +163,7 @@ private:
     LOGMAN_THROW_A_FMT(SlotPlusOne >= 1, "Old must have been spilled");
 
     RegisterClassType RegClass = GetRegClassFromNode(IR, IROp);
-
-    auto Fill = IREmit->_FillRegister(Old, SlotPlusOne - 1, RegClass);
-    Fill.first->Header.Size = IROp->Size;
-    Fill.first->Header.ElementSize = IROp->ElementSize;
-    return Fill;
+    return IREmit->_FillRegister(IROp->Size, IROp->ElementSize, Old, SlotPlusOne - 1, RegClass);
   };
 
   // IP of next-use of each Old source. IPs are measured from the end of the


### PR DESCRIPTION
In the near future we'll want to create instructions without knowing what instructions wrote the sources... the dest size inference gets in the way of that. Luckily, it's not load bearing. This PR drops it as a preliminary cleanup.