### PR TITLE
Linux/SMCTracking: Fixes nasty race condition causing invalid memory tracking

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -736,8 +736,7 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame* Frame, void* Ad
         NewBRK = (uint64_t)GuestMmap(Frame->Thread, (void*)(DataSpace + DataSpaceMaxSize), AllocateNewSize, PROT_READ | PROT_WRITE,
                                      MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
-
-        if (NewBRK != ~0ULL && NewBRK != (DataSpace + DataSpaceMaxSize)) {
+        if (!FEX::HLE::HasSyscallError(NewBRK) && NewBRK != (DataSpace + DataSpaceMaxSize)) {
           // Couldn't allocate that the region we wanted
           // Can happen if MAP_FIXED_NOREPLACE isn't understood by the kernel
           [[maybe_unused]] int ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(NewBRK), AllocateNewSize);
@@ -745,7 +744,7 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame* Frame, void* Ad
           NewBRK = ~0ULL;
         }
 
-        if (NewBRK == ~0ULL) {
+        if (FEX::HLE::HasSyscallError(NewBRK)) {
           // If we couldn't allocate a new region then out of memory
           return DataSpace + DataSpaceSize;
         } else {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
@@ -11,11 +11,13 @@ $end_info$
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Debug/InternalThreadState.h>
+#include <FEXCore/Utils/MathUtils.h>
 
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/shm.h>
 #include <system_error>
 #include <filesystem>
 
@@ -24,32 +26,56 @@ namespace FEX::HLE::x32 {
 void* x32SyscallHandler::GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
   LOGMAN_THROW_A_FMT((length >> 32) == 0, "values must fit to 32 bits");
 
-  auto Result = (uint64_t)GetAllocator()->Mmap((void*)addr, length, prot, flags, fd, offset);
+  uint64_t Result {};
+  size_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);
 
-  LOGMAN_THROW_A_FMT((Result >> 32) == 0 || (Result >> 32) == 0xFFFFFFFF, "values must fit to 32 bits");
-
-  if (!FEX::HLE::HasSyscallError(Result)) {
-    FEX::HLE::_SyscallHandler->TrackMmap(Thread, Result, length, prot, flags, fd, offset);
-    return (void*)Result;
-  } else {
-    errno = -Result;
-    return MAP_FAILED;
+  if (flags & MAP_SHARED) {
+    CTX->MarkMemoryShared(Thread);
   }
+
+  {
+    // NOTE: Frontend calls this with a nullptr Thread during initialization, but
+    //       providing this code with a valid Thread object earlier would allow
+    //       us to be more optimal by using GuardSignalDeferringSection instead
+    auto lk = FEXCore::GuardSignalDeferringSectionWithFallback(VMATracking.Mutex, Thread);
+
+    Result =
+      (uint64_t) static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Mmap((void*)addr, length, prot, flags, fd, offset);
+
+    if (FEX::HLE::HasSyscallError(Result)) {
+      return reinterpret_cast<void*>(Result);
+    }
+
+    LOGMAN_THROW_A_FMT((Result >> 32) == 0 || (Result >> 32) == 0xFFFFFFFF, "values must fit to 32 bits");
+
+    FEX::HLE::_SyscallHandler->TrackMmap(Thread, Result, length, prot, flags, fd, offset);
+  }
+
+  FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, Result, Size);
+  return reinterpret_cast<void*>(Result);
 }
 
-int x32SyscallHandler::GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) {
+uint64_t x32SyscallHandler::GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) {
   LOGMAN_THROW_A_FMT((uintptr_t(addr) >> 32) == 0, "values must fit to 32 bits");
   LOGMAN_THROW_A_FMT((length >> 32) == 0, "values must fit to 32 bits");
+  uint64_t Result {};
+  uint64_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);
 
-  auto Result = GetAllocator()->Munmap(addr, length);
+  {
+    // Frontend calls this with nullptr Thread during initialization.
+    // This is why `GuardSignalDeferringSectionWithFallback` is used here.
+    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
+    auto lk = FEXCore::GuardSignalDeferringSectionWithFallback(VMATracking.Mutex, Thread);
 
-  if (Result == 0) {
-    FEX::HLE::_SyscallHandler->TrackMunmap(Thread, (uintptr_t)addr, length);
-    return Result;
-  } else {
-    errno = -Result;
-    return -1;
+    Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Munmap(addr, length);
+    if (FEX::HLE::HasSyscallError(Result)) {
+      return Result;
+    }
+    FEX::HLE::_SyscallHandler->TrackMunmap(Thread, addr, length);
   }
+  FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uint64_t>(addr), Size);
+
+  return Result;
 }
 
 void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
@@ -77,29 +103,47 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
     });
 
   REGISTER_SYSCALL_IMPL_X32(munmap, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length) -> uint64_t {
-    uint64_t Result =
-      (uint64_t) static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GuestMunmap(Frame->Thread, addr, length);
-
-    SYSCALL_ERRNO();
+    return static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GuestMunmap(Frame->Thread, addr, length);
   });
 
   REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, uint32_t len, int prot) -> uint64_t {
-    uint64_t Result = ::mprotect(addr, len, prot);
-    if (Result != -1) {
-      FEX::HLE::_SyscallHandler->TrackMprotect(Frame->Thread, (uintptr_t)addr, len, prot);
+    auto Thread = Frame->Thread;
+    uint64_t Result {};
+
+    {
+      auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
+      Result = ::mprotect(addr, len, prot);
+      if (Result == -1) {
+        SYSCALL_ERRNO();
+      }
+
+      FEX::HLE::_SyscallHandler->TrackMprotect(Thread, addr, len, prot);
     }
+
+
+    FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uint64_t>(addr), len);
 
     SYSCALL_ERRNO();
   });
 
   REGISTER_SYSCALL_IMPL_X32(
     mremap, [](FEXCore::Core::CpuStateFrame* Frame, void* old_address, size_t old_size, size_t new_size, int flags, void* new_address) -> uint64_t {
-      uint64_t Result = reinterpret_cast<uint64_t>(
-        static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Mremap(old_address, old_size, new_size, flags, new_address));
+      auto Thread = Frame->Thread;
+      uint64_t Result {};
 
-      if (!FEX::HLE::HasSyscallError(Result)) {
-        FEX::HLE::_SyscallHandler->TrackMremap(Frame->Thread, (uintptr_t)old_address, old_size, new_size, flags, Result);
+      {
+        auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
+        Result = reinterpret_cast<uint64_t>(
+          static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Mremap(old_address, old_size, new_size, flags, new_address));
+
+        if (FEX::HLE::HasSyscallError(Result)) {
+          return Result;
+        }
+
+        FEX::HLE::_SyscallHandler->TrackMremap(Thread, reinterpret_cast<uint64_t>(old_address), old_size, new_size, flags, Result);
       }
+
+      FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessaryOnRemap(Thread, reinterpret_cast<uint64_t>(old_address), Result, old_size, new_size);
 
       return Result;
     });
@@ -116,27 +160,54 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
 
   REGISTER_SYSCALL_IMPL_X32(shmat, [](FEXCore::Core::CpuStateFrame* Frame, int shmid, const void* shmaddr, int shmflg) -> uint64_t {
     // also implemented in ipc:OP_SHMAT
+    auto Thread = Frame->Thread;
+    auto CTX = Thread->CTX;
+    uint64_t Result {};
     uint32_t ResultAddr {};
-    uint64_t Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)
-                        ->GetAllocator()
-                        ->Shmat(shmid, reinterpret_cast<const void*>(shmaddr), shmflg, &ResultAddr);
+    uint64_t Length {};
+    CTX->MarkMemoryShared(Thread);
 
-    if (!FEX::HLE::HasSyscallError(Result)) {
-      FEX::HLE::_SyscallHandler->TrackShmat(Frame->Thread, shmid, ResultAddr, shmflg);
-      return ResultAddr;
-    } else {
-      return Result;
+    {
+      auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
+
+      Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)
+                 ->GetAllocator()
+                 ->Shmat(shmid, reinterpret_cast<const void*>(shmaddr), shmflg, &ResultAddr);
+
+      if (FEX::HLE::HasSyscallError(Result)) {
+        return Result;
+      }
+
+      shmid_ds stat;
+
+      [[maybe_unused]] auto res = shmctl(shmid, IPC_STAT, &stat);
+      LOGMAN_THROW_A_FMT(res != -1, "shmctl IPC_STAT failed");
+
+      Length = stat.shm_segsz;
+      FEX::HLE::_SyscallHandler->TrackShmat(Thread, shmid, ResultAddr, shmflg, Length);
     }
+
+    FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, ResultAddr, Length);
+    return ResultAddr;
   });
 
   REGISTER_SYSCALL_IMPL_X32(shmdt, [](FEXCore::Core::CpuStateFrame* Frame, const void* shmaddr) -> uint64_t {
     // also implemented in ipc:OP_SHMDT
-    uint64_t Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Shmdt(shmaddr);
+    auto Thread = Frame->Thread;
+    uint64_t Result {};
+    uint64_t Length {};
+    {
+      auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
+      Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Shmdt(shmaddr);
 
-    if (!FEX::HLE::HasSyscallError(Result)) {
-      FEX::HLE::_SyscallHandler->TrackShmdt(Frame->Thread, (uintptr_t)shmaddr);
+      if (FEX::HLE::HasSyscallError(Result)) {
+        return Result;
+      }
+
+      Length = FEX::HLE::_SyscallHandler->TrackShmdt(Thread, reinterpret_cast<uintptr_t>(shmaddr));
     }
 
+    FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uintptr_t>(shmaddr), Length);
     return Result;
   });
 }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
@@ -88,18 +88,14 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
     uint32_t offset;
   };
   REGISTER_SYSCALL_IMPL_X32(mmap, [](FEXCore::Core::CpuStateFrame* Frame, const old_mmap_struct* arg) -> uint64_t {
-    uint64_t Result = (uint64_t) static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)
-                        ->GuestMmap(Frame->Thread, reinterpret_cast<void*>(arg->addr), arg->len, arg->prot, arg->flags, arg->fd, arg->offset);
-
-    SYSCALL_ERRNO();
+    return (uint64_t) static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)
+      ->GuestMmap(Frame->Thread, reinterpret_cast<void*>(arg->addr), arg->len, arg->prot, arg->flags, arg->fd, arg->offset);
   });
 
   REGISTER_SYSCALL_IMPL_X32(
     mmap2, [](FEXCore::Core::CpuStateFrame* Frame, uint32_t addr, uint32_t length, int prot, int flags, int fd, uint32_t pgoffset) -> uint64_t {
-      uint64_t Result = (uint64_t) static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)
-                          ->GuestMmap(Frame->Thread, reinterpret_cast<void*>(addr), length, prot, flags, fd, (uint64_t)pgoffset * 0x1000);
-
-      SYSCALL_ERRNO();
+      return (uint64_t) static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)
+        ->GuestMmap(Frame->Thread, reinterpret_cast<void*>(addr), length, prot, flags, fd, (uint64_t)pgoffset * 0x1000);
     });
 
   REGISTER_SYSCALL_IMPL_X32(munmap, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length) -> uint64_t {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
@@ -42,7 +42,7 @@ public:
     return AllocHandler.get();
   }
   void* GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) override;
-  int GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) override;
+  uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) override;
 
   void RegisterSyscall_32(int SyscallNumber, int32_t HostSyscallNumber, FEXCore::IR::SyscallFlags Flags,
 #ifdef DEBUG_STRACE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
@@ -20,46 +20,68 @@ $end_info$
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Utils/Allocator.h>
+#include <FEXCore/Utils/MathUtils.h>
 
 namespace FEX::HLE::x64 {
 
 void* x64SyscallHandler::GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
   uint64_t Result {};
+  size_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);
 
-  bool Map32Bit = flags & FEX::HLE::X86_64_MAP_32BIT;
-  if (Map32Bit) {
-    Result = (uint64_t)Get32BitAllocator()->Mmap(addr, length, prot, flags, fd, offset);
-    if (FEX::HLE::HasSyscallError(Result)) {
-      errno = -Result;
-      Result = -1;
+  if (flags & MAP_SHARED) {
+    CTX->MarkMemoryShared(Thread);
+  }
+
+  {
+    // NOTE: Frontend calls this with a nullptr Thread during initialization, but
+    //       providing this code with a valid Thread object earlier would allow
+    //       us to be more optimal by using GuardSignalDeferringSection instead
+    auto lk = FEXCore::GuardSignalDeferringSectionWithFallback(VMATracking.Mutex, Thread);
+
+    bool Map32Bit = flags & FEX::HLE::X86_64_MAP_32BIT;
+    if (Map32Bit) {
+      Result = (uint64_t)Get32BitAllocator()->Mmap(addr, length, prot, flags, fd, offset);
+      if (FEX::HLE::HasSyscallError(Result)) {
+        return reinterpret_cast<void*>(Result);
+      }
+    } else {
+      Result = reinterpret_cast<uint64_t>(::mmap(reinterpret_cast<void*>(addr), length, prot, flags, fd, offset));
+      if (Result == ~0ULL) {
+        return reinterpret_cast<void*>(-errno);
+      }
     }
-  } else {
-    Result = reinterpret_cast<uint64_t>(::mmap(reinterpret_cast<void*>(addr), length, prot, flags, fd, offset));
+
+    FEX::HLE::_SyscallHandler->TrackMmap(Thread, Result, length, prot, flags, fd, offset);
   }
 
-  if (Result != -1) {
-    FEX::HLE::_SyscallHandler->TrackMmap(Thread, (uintptr_t)Result, length, prot, flags, fd, offset);
-  }
-
+  FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, Result, Size);
   return reinterpret_cast<void*>(Result);
 }
 
-int x64SyscallHandler::GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) {
+uint64_t x64SyscallHandler::GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) {
   uint64_t Result {};
-  if (reinterpret_cast<uintptr_t>(addr) < 0x1'0000'0000ULL) {
-    Result = Get32BitAllocator()->Munmap(addr, length);
+  uint64_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);
 
-    if (FEX::HLE::HasSyscallError(Result)) {
-      errno = -Result;
-      Result = -1;
+  {
+    // Frontend calls this with nullptr Thread during initialization.
+    // This is why `GuardSignalDeferringSectionWithFallback` is used here.
+    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
+    auto lk = FEXCore::GuardSignalDeferringSectionWithFallback(VMATracking.Mutex, Thread);
+
+    if (reinterpret_cast<uintptr_t>(addr) < 0x1'0000'0000ULL) {
+      Result = FEX::HLE::_SyscallHandler->Get32BitAllocator()->Munmap(addr, length);
+      if (FEX::HLE::HasSyscallError(Result)) {
+        return Result;
+      }
+    } else {
+      Result = ::munmap(addr, length);
+      if (Result == -1) {
+        return -errno;
+      }
     }
-  } else {
-    Result = ::munmap(addr, length);
+    FEX::HLE::_SyscallHandler->TrackMunmap(Thread, addr, length);
   }
-
-  if (Result != -1) {
-    FEX::HLE::_SyscallHandler->TrackMunmap(Thread, reinterpret_cast<uintptr_t>(addr), length);
-  }
+  FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uint64_t>(addr), Size);
 
   return Result;
 }
@@ -70,59 +92,104 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
   REGISTER_SYSCALL_IMPL_X64_FLAGS(
     mmap, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
     [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length, int prot, int flags, int fd, off_t offset) -> uint64_t {
-      uint64_t Result = (uint64_t) static_cast<FEX::HLE::x64::x64SyscallHandler*>(FEX::HLE::_SyscallHandler)
-                          ->GuestMmap(Frame->Thread, addr, length, prot, flags, fd, offset);
-
-      SYSCALL_ERRNO();
+      return (uint64_t)FEX::HLE::_SyscallHandler->GuestMmap(Frame->Thread, addr, length, prot, flags, fd, offset);
     });
 
-  REGISTER_SYSCALL_IMPL_X64_FLAGS(
-    munmap, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
-    [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length) -> uint64_t {
-      uint64_t Result = static_cast<FEX::HLE::x64::x64SyscallHandler*>(FEX::HLE::_SyscallHandler)->GuestMunmap(Frame->Thread, addr, length);
-
-      SYSCALL_ERRNO();
-    });
+  REGISTER_SYSCALL_IMPL_X64_FLAGS(munmap, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+                                  [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length) -> uint64_t {
+                                    return FEX::HLE::_SyscallHandler->GuestMunmap(Frame->Thread, addr, length);
+                                  });
 
   REGISTER_SYSCALL_IMPL_X64_FLAGS(
     mremap, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
     [](FEXCore::Core::CpuStateFrame* Frame, void* old_address, size_t old_size, size_t new_size, int flags, void* new_address) -> uint64_t {
-      uint64_t Result = reinterpret_cast<uint64_t>(::mremap(old_address, old_size, new_size, flags, new_address));
+      auto Thread = Frame->Thread;
+      uint64_t Result {};
 
-      if (Result != -1) {
-        FEX::HLE::_SyscallHandler->TrackMremap(Frame->Thread, (uintptr_t)old_address, old_size, new_size, flags, Result);
+      {
+        auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
+        Result = reinterpret_cast<uint64_t>(::mremap(old_address, old_size, new_size, flags, new_address));
+
+        if (Result == -1) {
+          SYSCALL_ERRNO();
+        }
+        FEX::HLE::_SyscallHandler->TrackMremap(Thread, reinterpret_cast<uint64_t>(old_address), old_size, new_size, flags, Result);
       }
-      SYSCALL_ERRNO();
+
+      FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessaryOnRemap(Thread, reinterpret_cast<uint64_t>(old_address), Result, old_size, new_size);
+
+      return Result;
     });
 
   REGISTER_SYSCALL_IMPL_X64_FLAGS(mprotect, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                   [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t len, int prot) -> uint64_t {
-                                    uint64_t Result = ::mprotect(addr, len, prot);
+                                    auto Thread = Frame->Thread;
+                                    uint64_t Result {};
 
-                                    if (Result != -1) {
-                                      FEX::HLE::_SyscallHandler->TrackMprotect(Frame->Thread, (uintptr_t)addr, len, prot);
+                                    {
+                                      auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
+                                      Result = ::mprotect(addr, len, prot);
+                                      if (Result == -1) {
+                                        SYSCALL_ERRNO();
+                                      }
+
+                                      FEX::HLE::_SyscallHandler->TrackMprotect(Thread, addr, len, prot);
                                     }
+
+
+                                    FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uint64_t>(addr), len);
+
                                     SYSCALL_ERRNO();
                                   });
 
   REGISTER_SYSCALL_IMPL_X64_FLAGS(shmat, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
-                                  [](FEXCore::Core::CpuStateFrame* Frame, int shmid, const void* shmaddr, int shmflg) -> uint64_t {
-                                    uint64_t Result = reinterpret_cast<uint64_t>(shmat(shmid, shmaddr, shmflg));
+                                  ([](FEXCore::Core::CpuStateFrame* Frame, int shmid, const void* shmaddr, int shmflg) -> uint64_t {
+                                    auto Thread = Frame->Thread;
+                                    auto CTX = Thread->CTX;
+                                    uint64_t Result {};
+                                    uint64_t Length {};
+                                    CTX->MarkMemoryShared(Thread);
 
-                                    if (Result != -1) {
-                                      FEX::HLE::_SyscallHandler->TrackShmat(Frame->Thread, shmid, Result, shmflg);
+                                    {
+                                      auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
+                                      Result = reinterpret_cast<uint64_t>(::shmat(shmid, shmaddr, shmflg));
+
+                                      if (Result == -1) {
+                                        SYSCALL_ERRNO();
+                                      }
+
+                                      shmid_ds stat;
+
+                                      [[maybe_unused]] auto res = shmctl(shmid, IPC_STAT, &stat);
+                                      LOGMAN_THROW_A_FMT(res != -1, "shmctl IPC_STAT failed");
+
+                                      Length = stat.shm_segsz;
+                                      FEX::HLE::_SyscallHandler->TrackShmat(Thread, shmid, Result, shmflg, Length);
                                     }
-                                    SYSCALL_ERRNO();
-                                  });
 
-  REGISTER_SYSCALL_IMPL_X64_FLAGS(shmdt, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
-                                  [](FEXCore::Core::CpuStateFrame* Frame, const void* shmaddr) -> uint64_t {
-                                    uint64_t Result = ::shmdt(shmaddr);
-
-                                    if (Result != -1) {
-                                      FEX::HLE::_SyscallHandler->TrackShmdt(Frame->Thread, (uintptr_t)shmaddr);
-                                    }
+                                    FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, Result, Length);
                                     SYSCALL_ERRNO();
-                                  });
+                                  }));
+
+  REGISTER_SYSCALL_IMPL_X64_FLAGS(
+    shmdt, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY, [](FEXCore::Core::CpuStateFrame* Frame, const void* shmaddr) -> uint64_t {
+      auto Thread = Frame->Thread;
+      uint64_t Result {};
+      uint64_t Length {};
+      {
+        auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
+        Result = ::shmdt(shmaddr);
+
+        if (Result == -1) {
+          SYSCALL_ERRNO();
+          return Result;
+        }
+
+        Length = FEX::HLE::_SyscallHandler->TrackShmdt(Thread, reinterpret_cast<uintptr_t>(shmaddr));
+      }
+
+      FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uintptr_t>(shmaddr), Length);
+      SYSCALL_ERRNO();
+    });
 }
 } // namespace FEX::HLE::x64

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
@@ -36,7 +36,7 @@ public:
   x64SyscallHandler(FEXCore::Context::Context* ctx, FEX::HLE::SignalDelegator* _SignalDelegation, FEX::HLE::ThunkHandler* ThunkHandler);
 
   void* GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) override;
-  int GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) override;
+  uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) override;
 
 
   void RegisterSyscall_64(int SyscallNumber, int32_t HostSyscallNumber, FEXCore::IR::SyscallFlags Flags,


### PR DESCRIPTION
This has been a bug that we have technically lived with ever since SMC
tracking was introduced. The problem boils down to the fact that memory
management syscalls from multiple threads can race our SMC tracking.

This was only uncovered due to recent changes in the Steam client where
downloading games has more aggressively started reallocating memory.
This causes Steam to oversubscribe the CPU by a small margin, causing
threads to context switch more heavily during memory management.

The strace that finally managed to capture this:
```
41574 munmap(0xba84e000, 724992 <unfinished ...>
<...>
41227 mmap(NULL, 540672, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -3, 0 <unfinished ...>
<...>
41574 <... munmap resumed>)             = 0
<...>
41227 <... mmap resumed>)               = 0xba87b000
```

While FEX's tracking linearly was:
```
mmap, 0xba87b000, 0x84000, 0x3, 0x22, 0xfffffffd, 0x0
munmap, 0xba84e000, 0xb1000
```

The way munmap and mmap perfectly interleave while getting context switched meant that the kernel's view of munmap then mmap didn't match our view of mmap completing first then munmap happening afterwards.
The kernel/strace is obviously the correct view in this instance.

This all comes down to how these threads are racing the VMA tracking
mutex after the syscall happens and not guaranteeing sequential
consistency that matches the kernel's view.

The only way to correct this sanely is to extend the locking period to
also encompass the syscalls getting executed. This is a bit tricky since
the VMA tracking needs to ensure that the lock is no longer held once
ThreadManager invalidation occurs so a callback to do the syscall
operation is about the only sane approach here. Luckily we now have
fextl::move_only_function.

Fixes consistent crashes with Steam game downloads (and maybe some
chromium crashes?)