### PR TITLE
Use -print-libgcc-file-name to get the compiler-rt file name

### DIFF
--- a/Source/Windows/ARM64EC/CMakeLists.txt
+++ b/Source/Windows/ARM64EC/CMakeLists.txt
@@ -23,7 +23,8 @@ target_link_libraries(arm64ecfex
   ntdll_ex
 )
 
-target_link_options(arm64ecfex PRIVATE -static -nostdlib -nostartfiles -nodefaultlibs -lc++ -lc++abi -lunwind -lclang_rt.builtins-arm64ec)
+target_link_options(arm64ecfex PRIVATE -static -nostdlib -nostartfiles -nodefaultlibs -lc++ -lc++abi -lunwind)
+target_link_libraries(arm64ecfex PRIVATE ${LIBGCC_PATH})
 install(TARGETS arm64ecfex
   RUNTIME
   DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Source/Windows/CMakeLists.txt
+++ b/Source/Windows/CMakeLists.txt
@@ -19,6 +19,10 @@ function(patch_library_wine target)
   )
 endfunction()
 
+execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -print-libgcc-file-name
+                OUTPUT_VARIABLE LIBGCC_PATH
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 build_implib(ntdll)
 build_implib(wow64)
 

--- a/Source/Windows/WOW64/CMakeLists.txt
+++ b/Source/Windows/WOW64/CMakeLists.txt
@@ -23,7 +23,8 @@ target_link_libraries(wow64fex
   ntdll_ex
 )
 
-target_link_options(wow64fex PRIVATE -static -nostdlib -nostartfiles -nodefaultlibs -lc++ -lc++abi -lunwind -lclang_rt.builtins-aarch64)
+target_link_options(wow64fex PRIVATE -static -nostdlib -nostartfiles -nodefaultlibs -lc++ -lc++abi -lunwind)
+target_link_libraries(wow64fex PRIVATE ${LIBGCC_PATH})
 install(TARGETS wow64fex
   RUNTIME
   DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
Avoid hardcoding the file name. Upstream Clang currently expects the aarch64 variant of compiler-rt. Changing this to use arm64ec in the file name could be problematic in the future, if the MinGW toolchain gains support for ARM64X. Querying Clang for the correct file name is the most forward-compatible approach.