### PR TITLE
LinuxSyscalls: Reduce code duplication between 32-bit and 64-bit paths

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -241,9 +241,12 @@ public:
 
   // does a mmap as if done via a guest syscall
   virtual void* GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) = 0;
+  void* GuestMmap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset);
 
   // does a guest munmap as if done via a guest syscall
   virtual uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) = 0;
+  uint64_t GuestMunmap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length);
+
 
   ///// Memory Manager tracking /////
   void TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t addr, size_t length, int prot, int flags, int fd, off_t offset);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -247,7 +247,8 @@ public:
   virtual uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) = 0;
   uint64_t GuestMunmap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length);
 
-  uint64_t GuestMremap(bool Is64Bit, FEXCore::Core::InternalThreadState*, void* old_address, size_t old_size, size_t new_size, int flags, void* new_address);
+  uint64_t GuestMremap(bool Is64Bit, FEXCore::Core::InternalThreadState*, void* old_address, size_t old_size, size_t new_size, int flags,
+                       void* new_address);
   uint64_t GuestMprotect(FEXCore::Core::InternalThreadState*, void* addr, size_t len, int prot);
   uint64_t GuestShmat(bool Is64Bit, FEXCore::Core::InternalThreadState*, int shmid, const void* shmaddr, int shmflg);
   uint64_t GuestShmdt(bool Is64Bit, FEXCore::Core::InternalThreadState*, const void* shmaddr);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -247,6 +247,7 @@ public:
   virtual uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) = 0;
   uint64_t GuestMunmap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length);
 
+  uint64_t GuestMprotect(FEXCore::Core::InternalThreadState*, void* addr, size_t len, int prot);
 
   ///// Memory Manager tracking /////
   void TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t addr, size_t length, int prot, int flags, int fd, off_t offset);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -247,6 +247,7 @@ public:
   virtual uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) = 0;
   uint64_t GuestMunmap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length);
 
+  uint64_t GuestMremap(bool Is64Bit, FEXCore::Core::InternalThreadState*, void* old_address, size_t old_size, size_t new_size, int flags, void* new_address);
   uint64_t GuestMprotect(FEXCore::Core::InternalThreadState*, void* addr, size_t len, int prot);
   uint64_t GuestShmat(bool Is64Bit, FEXCore::Core::InternalThreadState*, int shmid, const void* shmaddr, int shmflg);
   uint64_t GuestShmdt(bool Is64Bit, FEXCore::Core::InternalThreadState*, const void* shmaddr);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -235,7 +235,7 @@ public:
     return Version & 0xFFFF;
   }
 
-  FEX::HLE::MemAllocator* Get32BitAllocator() {
+  virtual FEX::HLE::MemAllocator* Get32BitAllocator() {
     return Alloc32Handler.get();
   }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -249,6 +249,7 @@ public:
 
   uint64_t GuestMprotect(FEXCore::Core::InternalThreadState*, void* addr, size_t len, int prot);
   uint64_t GuestShmat(bool Is64Bit, FEXCore::Core::InternalThreadState*, int shmid, const void* shmaddr, int shmflg);
+  uint64_t GuestShmdt(bool Is64Bit, FEXCore::Core::InternalThreadState*, const void* shmaddr);
 
   ///// Memory Manager tracking /////
   void TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t addr, size_t length, int prot, int flags, int fd, off_t offset);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -248,6 +248,7 @@ public:
   uint64_t GuestMunmap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length);
 
   uint64_t GuestMprotect(FEXCore::Core::InternalThreadState*, void* addr, size_t len, int prot);
+  uint64_t GuestShmat(bool Is64Bit, FEXCore::Core::InternalThreadState*, int shmid, const void* shmaddr, int shmflg);
 
   ///// Memory Manager tracking /////
   void TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t addr, size_t length, int prot, int flags, int fd, off_t offset);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -153,6 +153,74 @@ FEXCore::HLE::AOTIRCacheEntryLookupResult SyscallHandler::LookupAOTIRCacheEntry(
   return {Entry->second.Resource ? Entry->second.Resource->AOTIRCacheEntry : nullptr, Entry->second.Base - Entry->second.Offset};
 }
 
+void* SyscallHandler::GuestMmap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  LOGMAN_THROW_A_FMT(Is64Bit || (length >> 32) == 0, "values must fit to 32 bits");
+
+  uint64_t Result {};
+  size_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);
+
+  if (flags & MAP_SHARED) {
+    CTX->MarkMemoryShared(Thread);
+  }
+
+  {
+    // NOTE: Frontend calls this with a nullptr Thread during initialization, but
+    //       providing this code with a valid Thread object earlier would allow
+    //       us to be more optimal by using GuardSignalDeferringSection instead
+    auto lk = FEXCore::GuardSignalDeferringSectionWithFallback(VMATracking.Mutex, Thread);
+
+    bool Map32Bit = !Is64Bit || (flags & FEX::HLE::X86_64_MAP_32BIT);
+    if (Map32Bit) {
+      Result = (uint64_t)Get32BitAllocator()->Mmap((void*)addr, length, prot, flags, fd, offset);
+      if (FEX::HLE::HasSyscallError(Result)) {
+        return reinterpret_cast<void*>(Result);
+      }
+      LOGMAN_THROW_A_FMT(Is64Bit || (Result >> 32) == 0 || (Result >> 32) == 0xFFFFFFFF, "values must fit to 32 bits");
+    } else {
+      Result = reinterpret_cast<uint64_t>(::mmap(reinterpret_cast<void*>(addr), length, prot, flags, fd, offset));
+      if (Result == ~0ULL) {
+        return reinterpret_cast<void*>(-errno);
+      }
+    }
+
+    FEX::HLE::_SyscallHandler->TrackMmap(Thread, Result, length, prot, flags, fd, offset);
+  }
+
+  FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, Result, Size);
+  return reinterpret_cast<void*>(Result);
+}
+
+uint64_t SyscallHandler::GuestMunmap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) {
+  LOGMAN_THROW_A_FMT(Is64Bit || (reinterpret_cast<uintptr_t>(addr) >> 32) == 0, "values must fit to 32 bits: {}", fmt::ptr(addr));
+  LOGMAN_THROW_A_FMT(Is64Bit || (length >> 32) == 0, "values must fit to 32 bits");
+
+  uint64_t Result {};
+  uint64_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);
+
+  {
+    // Frontend calls this with nullptr Thread during initialization.
+    // This is why `GuardSignalDeferringSectionWithFallback` is used here.
+    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
+    auto lk = FEXCore::GuardSignalDeferringSectionWithFallback(VMATracking.Mutex, Thread);
+
+    if (reinterpret_cast<uintptr_t>(addr) < 0x1'0000'0000ULL) {
+      Result = FEX::HLE::_SyscallHandler->Get32BitAllocator()->Munmap(addr, length);
+      if (FEX::HLE::HasSyscallError(Result)) {
+        return Result;
+      }
+    } else {
+      Result = ::munmap(addr, length);
+      if (Result == -1) {
+        return -errno;
+      }
+    }
+    FEX::HLE::_SyscallHandler->TrackMunmap(Thread, addr, length);
+  }
+  FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uint64_t>(addr), Size);
+
+  return Result;
+}
+
 // MMan Tracking
 void SyscallHandler::TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t addr, size_t length, int prot, int flags, int fd, off_t offset) {
   size_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -153,7 +153,8 @@ FEXCore::HLE::AOTIRCacheEntryLookupResult SyscallHandler::LookupAOTIRCacheEntry(
   return {Entry->second.Resource ? Entry->second.Resource->AOTIRCacheEntry : nullptr, Entry->second.Base - Entry->second.Offset};
 }
 
-void* SyscallHandler::GuestMmap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
+void* SyscallHandler::GuestMmap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags,
+                                int fd, off_t offset) {
   LOGMAN_THROW_A_FMT(Is64Bit || (length >> 32) == 0, "values must fit to 32 bits");
 
   uint64_t Result {};
@@ -221,7 +222,8 @@ uint64_t SyscallHandler::GuestMunmap(bool Is64Bit, FEXCore::Core::InternalThread
   return Result;
 }
 
-uint64_t SyscallHandler::GuestMremap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* old_address, size_t old_size, size_t new_size, int flags, void* new_address) {
+uint64_t SyscallHandler::GuestMremap(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, void* old_address, size_t old_size,
+                                     size_t new_size, int flags, void* new_address) {
   uint64_t Result {};
 
   {
@@ -232,7 +234,8 @@ uint64_t SyscallHandler::GuestMremap(bool Is64Bit, FEXCore::Core::InternalThread
         return Result;
       }
     } else {
-      Result = reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->Get32BitAllocator()->Mremap(old_address, old_size, new_size, flags, new_address));
+      Result =
+        reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->Get32BitAllocator()->Mremap(old_address, old_size, new_size, flags, new_address));
       if (FEX::HLE::HasSyscallError(Result)) {
         return Result;
       }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -231,7 +231,7 @@ uint64_t SyscallHandler::GuestMremap(bool Is64Bit, FEXCore::Core::InternalThread
     if (Is64Bit) {
       Result = reinterpret_cast<uint64_t>(::mremap(old_address, old_size, new_size, flags, new_address));
       if (Result == -1) {
-        return Result;
+        return -errno;
       }
     } else {
       Result =
@@ -254,7 +254,7 @@ uint64_t SyscallHandler::GuestMprotect(FEXCore::Core::InternalThreadState* Threa
     auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
     Result = ::mprotect(addr, len, prot);
     if (Result == -1) {
-      return Result;
+      return -errno;
     }
 
     FEX::HLE::_SyscallHandler->TrackMprotect(Thread, addr, len, prot);
@@ -276,7 +276,7 @@ uint64_t SyscallHandler::GuestShmat(bool Is64Bit, FEXCore::Core::InternalThreadS
     if (Is64Bit) {
       Result = reinterpret_cast<uint64_t>(::shmat(shmid, shmaddr, shmflg));
       if (Result == -1) {
-        return Result;
+        return -errno;
       }
     } else {
       uint32_t Addr;
@@ -308,7 +308,7 @@ uint64_t SyscallHandler::GuestShmdt(bool Is64Bit, FEXCore::Core::InternalThreadS
     if (Is64Bit) {
       Result = ::shmdt(shmaddr);
       if (Result == -1) {
-        return Result;
+        return -errno;
       }
     } else {
       Result = FEX::HLE::_SyscallHandler->Get32BitAllocator()->Shmdt(shmaddr);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
@@ -23,61 +23,6 @@ $end_info$
 
 namespace FEX::HLE::x32 {
 
-void* x32SyscallHandler::GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
-  LOGMAN_THROW_A_FMT((length >> 32) == 0, "values must fit to 32 bits");
-
-  uint64_t Result {};
-  size_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);
-
-  if (flags & MAP_SHARED) {
-    CTX->MarkMemoryShared(Thread);
-  }
-
-  {
-    // NOTE: Frontend calls this with a nullptr Thread during initialization, but
-    //       providing this code with a valid Thread object earlier would allow
-    //       us to be more optimal by using GuardSignalDeferringSection instead
-    auto lk = FEXCore::GuardSignalDeferringSectionWithFallback(VMATracking.Mutex, Thread);
-
-    Result =
-      (uint64_t) static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Mmap((void*)addr, length, prot, flags, fd, offset);
-
-    if (FEX::HLE::HasSyscallError(Result)) {
-      return reinterpret_cast<void*>(Result);
-    }
-
-    LOGMAN_THROW_A_FMT((Result >> 32) == 0 || (Result >> 32) == 0xFFFFFFFF, "values must fit to 32 bits");
-
-    FEX::HLE::_SyscallHandler->TrackMmap(Thread, Result, length, prot, flags, fd, offset);
-  }
-
-  FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, Result, Size);
-  return reinterpret_cast<void*>(Result);
-}
-
-uint64_t x32SyscallHandler::GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) {
-  LOGMAN_THROW_A_FMT((uintptr_t(addr) >> 32) == 0, "values must fit to 32 bits");
-  LOGMAN_THROW_A_FMT((length >> 32) == 0, "values must fit to 32 bits");
-  uint64_t Result {};
-  uint64_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);
-
-  {
-    // Frontend calls this with nullptr Thread during initialization.
-    // This is why `GuardSignalDeferringSectionWithFallback` is used here.
-    // To be more optimal the frontend should provide this code with a valid Thread object earlier.
-    auto lk = FEXCore::GuardSignalDeferringSectionWithFallback(VMATracking.Mutex, Thread);
-
-    Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Munmap(addr, length);
-    if (FEX::HLE::HasSyscallError(Result)) {
-      return Result;
-    }
-    FEX::HLE::_SyscallHandler->TrackMunmap(Thread, addr, length);
-  }
-  FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uint64_t>(addr), Size);
-
-  return Result;
-}
-
 void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
   struct old_mmap_struct {
     uint32_t addr;
@@ -88,18 +33,16 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
     uint32_t offset;
   };
   REGISTER_SYSCALL_IMPL_X32(mmap, [](FEXCore::Core::CpuStateFrame* Frame, const old_mmap_struct* arg) -> uint64_t {
-    return (uint64_t) static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)
-      ->GuestMmap(Frame->Thread, reinterpret_cast<void*>(arg->addr), arg->len, arg->prot, arg->flags, arg->fd, arg->offset);
+    return reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->GuestMmap(false, Frame->Thread, reinterpret_cast<void*>(arg->addr), arg->len, arg->prot, arg->flags, arg->fd, arg->offset));
   });
 
   REGISTER_SYSCALL_IMPL_X32(
     mmap2, [](FEXCore::Core::CpuStateFrame* Frame, uint32_t addr, uint32_t length, int prot, int flags, int fd, uint32_t pgoffset) -> uint64_t {
-      return (uint64_t) static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)
-        ->GuestMmap(Frame->Thread, reinterpret_cast<void*>(addr), length, prot, flags, fd, (uint64_t)pgoffset * 0x1000);
+      return reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->GuestMmap(false, Frame->Thread, reinterpret_cast<void*>(addr), length, prot, flags, fd, (uint64_t)pgoffset * 0x1000));
     });
 
   REGISTER_SYSCALL_IMPL_X32(munmap, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length) -> uint64_t {
-    return static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GuestMunmap(Frame->Thread, addr, length);
+    return FEX::HLE::_SyscallHandler->GuestMunmap(Frame->Thread, addr, length);
   });
 
   REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, uint32_t len, int prot) -> uint64_t {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
@@ -48,8 +48,7 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
   });
 
   REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, uint32_t len, int prot) -> uint64_t {
-    auto Result = FEX::HLE::_SyscallHandler->GuestMprotect(Frame->Thread, addr, len, prot);
-    SYSCALL_ERRNO();
+    return FEX::HLE::_SyscallHandler->GuestMprotect(Frame->Thread, addr, len, prot);
   });
 
   REGISTER_SYSCALL_IMPL_X32(

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
@@ -33,12 +33,14 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
     uint32_t offset;
   };
   REGISTER_SYSCALL_IMPL_X32(mmap, [](FEXCore::Core::CpuStateFrame* Frame, const old_mmap_struct* arg) -> uint64_t {
-    return reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->GuestMmap(false, Frame->Thread, reinterpret_cast<void*>(arg->addr), arg->len, arg->prot, arg->flags, arg->fd, arg->offset));
+    return reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->GuestMmap(false, Frame->Thread, reinterpret_cast<void*>(arg->addr),
+                                                                           arg->len, arg->prot, arg->flags, arg->fd, arg->offset));
   });
 
   REGISTER_SYSCALL_IMPL_X32(
     mmap2, [](FEXCore::Core::CpuStateFrame* Frame, uint32_t addr, uint32_t length, int prot, int flags, int fd, uint32_t pgoffset) -> uint64_t {
-      return reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->GuestMmap(false, Frame->Thread, reinterpret_cast<void*>(addr), length, prot, flags, fd, (uint64_t)pgoffset * 0x1000));
+      return reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->GuestMmap(false, Frame->Thread, reinterpret_cast<void*>(addr), length,
+                                                                             prot, flags, fd, (uint64_t)pgoffset * 0x1000));
     });
 
   REGISTER_SYSCALL_IMPL_X32(munmap, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length) -> uint64_t {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
@@ -86,23 +86,7 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
   });
 
   REGISTER_SYSCALL_IMPL_X32(shmdt, [](FEXCore::Core::CpuStateFrame* Frame, const void* shmaddr) -> uint64_t {
-    // also implemented in ipc:OP_SHMDT
-    auto Thread = Frame->Thread;
-    uint64_t Result {};
-    uint64_t Length {};
-    {
-      auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
-      Result = FEX::HLE::_SyscallHandler->Get32BitAllocator()->Shmdt(shmaddr);
-
-      if (FEX::HLE::HasSyscallError(Result)) {
-        return Result;
-      }
-
-      Length = FEX::HLE::_SyscallHandler->TrackShmdt(Thread, reinterpret_cast<uintptr_t>(shmaddr));
-    }
-
-    FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uintptr_t>(shmaddr), Length);
-    return Result;
+    return FEX::HLE::_SyscallHandler->GuestShmdt(false, Frame->Thread, shmaddr);
   });
 }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
@@ -129,8 +129,7 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
 
       {
         auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
-        Result = reinterpret_cast<uint64_t>(
-          static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Mremap(old_address, old_size, new_size, flags, new_address));
+        Result = reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->Get32BitAllocator()->Mremap(old_address, old_size, new_size, flags, new_address));
 
         if (FEX::HLE::HasSyscallError(Result)) {
           return Result;
@@ -166,9 +165,7 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
     {
       auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
 
-      Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)
-                 ->GetAllocator()
-                 ->Shmat(shmid, reinterpret_cast<const void*>(shmaddr), shmflg, &ResultAddr);
+      Result = FEX::HLE::_SyscallHandler->Get32BitAllocator()->Shmat(shmid, reinterpret_cast<const void*>(shmaddr), shmflg, &ResultAddr);
 
       if (FEX::HLE::HasSyscallError(Result)) {
         return Result;
@@ -194,7 +191,7 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
     uint64_t Length {};
     {
       auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
-      Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Shmdt(shmaddr);
+      Result = FEX::HLE::_SyscallHandler->Get32BitAllocator()->Shmdt(shmaddr);
 
       if (FEX::HLE::HasSyscallError(Result)) {
         return Result;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
@@ -46,22 +46,7 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
   });
 
   REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, uint32_t len, int prot) -> uint64_t {
-    auto Thread = Frame->Thread;
-    uint64_t Result {};
-
-    {
-      auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
-      Result = ::mprotect(addr, len, prot);
-      if (Result == -1) {
-        SYSCALL_ERRNO();
-      }
-
-      FEX::HLE::_SyscallHandler->TrackMprotect(Thread, addr, len, prot);
-    }
-
-
-    FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uint64_t>(addr), len);
-
+    auto Result = FEX::HLE::_SyscallHandler->GuestMprotect(Frame->Thread, addr, len, prot);
     SYSCALL_ERRNO();
   });
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
@@ -304,9 +304,7 @@ uint64_t _ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first
     {
       auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
 
-      Result = static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)
-                 ->GetAllocator()
-                 ->Shmat(first, reinterpret_cast<const void*>(ptr), second, &ResultAddr);
+      Result = FEX::HLE::_SyscallHandler->Get32BitAllocator()->Shmat(first, reinterpret_cast<const void*>(ptr), second, &ResultAddr);
 
       if (FEX::HLE::HasSyscallError(Result)) {
         return Result;
@@ -333,8 +331,7 @@ uint64_t _ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first
     uint64_t Length {};
     {
       auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
-      Result =
-        static_cast<FEX::HLE::x32::x32SyscallHandler*>(FEX::HLE::_SyscallHandler)->GetAllocator()->Shmdt(reinterpret_cast<const void*>(ptr));
+      Result = FEX::HLE::_SyscallHandler->Get32BitAllocator()->Shmdt(reinterpret_cast<const void*>(ptr));
 
       if (FEX::HLE::HasSyscallError(Result)) {
         return Result;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
@@ -300,23 +300,7 @@ uint64_t _ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first
     return Result;
   }
   case OP_SHMDT: {
-    // also implemented in memory:shmdt
-    auto Thread = Frame->Thread;
-    uint64_t Result {};
-    uint64_t Length {};
-    {
-      auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
-      Result = FEX::HLE::_SyscallHandler->Get32BitAllocator()->Shmdt(reinterpret_cast<const void*>(ptr));
-
-      if (FEX::HLE::HasSyscallError(Result)) {
-        return Result;
-      }
-
-      Length = FEX::HLE::_SyscallHandler->TrackShmdt(Thread, static_cast<uint64_t>(ptr));
-    }
-
-    FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, static_cast<uint64_t>(ptr), Length);
-    return Result;
+    return FEX::HLE::_SyscallHandler->GuestShmdt(false, Frame->Thread, reinterpret_cast<const void*>(ptr));
   }
   case OP_SHMGET: {
     Result = ::shmget(first, second, third);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
@@ -293,35 +293,10 @@ uint64_t _ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first
       // shmat explicitly doesn't support version 1.
       return -EINVAL;
     }
-    // also implemented in memory:shmat
-    auto Thread = Frame->Thread;
-    auto CTX = Thread->CTX;
-    uint64_t Result {};
-    uint32_t ResultAddr {};
-    uint64_t Length {};
-    CTX->MarkMemoryShared(Thread);
-
-    {
-      auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
-
-      Result = FEX::HLE::_SyscallHandler->Get32BitAllocator()->Shmat(first, reinterpret_cast<const void*>(ptr), second, &ResultAddr);
-
-      if (FEX::HLE::HasSyscallError(Result)) {
-        return Result;
-      }
-
-      shmid_ds stat;
-
-      [[maybe_unused]] auto res = shmctl(first, IPC_STAT, &stat);
-      LOGMAN_THROW_A_FMT(res != -1, "shmctl IPC_STAT failed");
-
-      Length = stat.shm_segsz;
-      FEX::HLE::_SyscallHandler->TrackShmat(Thread, first, ResultAddr, second, Length);
+    auto Result = FEX::HLE::_SyscallHandler->GuestShmat(false, Frame->Thread, first, reinterpret_cast<const void*>(ptr), second);
+    if (!FEX::HLE::HasSyscallError(Result)) {
+      *reinterpret_cast<uint32_t*>(third) = Result;
     }
-
-    FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, ResultAddr, Length);
-
-    *reinterpret_cast<uint32_t*>(third) = ResultAddr;
     return Result;
   }
   case OP_SHMDT: {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
@@ -41,6 +41,10 @@ public:
   FEX::HLE::MemAllocator* GetAllocator() {
     return AllocHandler.get();
   }
+  FEX::HLE::MemAllocator* Get32BitAllocator() override {
+    return GetAllocator();
+  }
+
   void* GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) override;
   uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) override;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
@@ -45,8 +45,12 @@ public:
     return GetAllocator();
   }
 
-  void* GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) override;
-  uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) override;
+  void* GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) override {
+    return FEX::HLE::SyscallHandler::GuestMmap(false, Thread, addr, length, prot, flags, fd, offset);
+  }
+  uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) override {
+    return FEX::HLE::SyscallHandler::GuestMunmap(false, Thread, addr, length);
+  }
 
   void RegisterSyscall_32(int SyscallNumber, int32_t HostSyscallNumber, FEXCore::IR::SyscallFlags Flags,
 #ifdef DEBUG_STRACE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
@@ -41,26 +41,22 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
   REGISTER_SYSCALL_IMPL_X64_FLAGS(
     mremap, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
     [](FEXCore::Core::CpuStateFrame* Frame, void* old_address, size_t old_size, size_t new_size, int flags, void* new_address) -> uint64_t {
-      auto Result = FEX::HLE::_SyscallHandler->GuestMremap(true, Frame->Thread, old_address, old_size, new_size, flags, new_address);
-      SYSCALL_ERRNO();
+      return FEX::HLE::_SyscallHandler->GuestMremap(true, Frame->Thread, old_address, old_size, new_size, flags, new_address);
     });
 
   REGISTER_SYSCALL_IMPL_X64_FLAGS(mprotect, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                   [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t len, int prot) -> uint64_t {
-                                    auto Result = FEX::HLE::_SyscallHandler->GuestMprotect(Frame->Thread, addr, len, prot);
-                                    SYSCALL_ERRNO();
+                                    return FEX::HLE::_SyscallHandler->GuestMprotect(Frame->Thread, addr, len, prot);
                                   });
 
   REGISTER_SYSCALL_IMPL_X64_FLAGS(shmat, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                   ([](FEXCore::Core::CpuStateFrame* Frame, int shmid, const void* shmaddr, int shmflg) -> uint64_t {
-                                    auto Result = FEX::HLE::_SyscallHandler->GuestShmat(true, Frame->Thread, shmid, shmaddr, shmflg);
-                                    SYSCALL_ERRNO();
+                                    return FEX::HLE::_SyscallHandler->GuestShmat(true, Frame->Thread, shmid, shmaddr, shmflg);
                                   }));
 
   REGISTER_SYSCALL_IMPL_X64_FLAGS(shmdt, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                   [](FEXCore::Core::CpuStateFrame* Frame, const void* shmaddr) -> uint64_t {
-                                    auto Result = FEX::HLE::_SyscallHandler->GuestShmdt(true, Frame->Thread, shmaddr);
-                                    SYSCALL_ERRNO();
+                                    return FEX::HLE::_SyscallHandler->GuestShmdt(true, Frame->Thread, shmaddr);
                                   });
 }
 } // namespace FEX::HLE::x64

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
@@ -57,10 +57,10 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
                                     SYSCALL_ERRNO();
                                   }));
 
-  REGISTER_SYSCALL_IMPL_X64_FLAGS(
-    shmdt, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY, [](FEXCore::Core::CpuStateFrame* Frame, const void* shmaddr) -> uint64_t {
-      auto Result = FEX::HLE::_SyscallHandler->GuestShmdt(true, Frame->Thread, shmaddr);
-      SYSCALL_ERRNO();
-    });
+  REGISTER_SYSCALL_IMPL_X64_FLAGS(shmdt, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
+                                  [](FEXCore::Core::CpuStateFrame* Frame, const void* shmaddr) -> uint64_t {
+                                    auto Result = FEX::HLE::_SyscallHandler->GuestShmdt(true, Frame->Thread, shmaddr);
+                                    SYSCALL_ERRNO();
+                                  });
 }
 } // namespace FEX::HLE::x64

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
@@ -61,22 +61,7 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
 
   REGISTER_SYSCALL_IMPL_X64_FLAGS(mprotect, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY,
                                   [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t len, int prot) -> uint64_t {
-                                    auto Thread = Frame->Thread;
-                                    uint64_t Result {};
-
-                                    {
-                                      auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
-                                      Result = ::mprotect(addr, len, prot);
-                                      if (Result == -1) {
-                                        SYSCALL_ERRNO();
-                                      }
-
-                                      FEX::HLE::_SyscallHandler->TrackMprotect(Thread, addr, len, prot);
-                                    }
-
-
-                                    FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uint64_t>(addr), len);
-
+                                    auto Result = FEX::HLE::_SyscallHandler->GuestMprotect(Frame->Thread, addr, len, prot);
                                     SYSCALL_ERRNO();
                                   });
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
@@ -73,22 +73,7 @@ void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
 
   REGISTER_SYSCALL_IMPL_X64_FLAGS(
     shmdt, SyscallFlags::OPTIMIZETHROUGH | SyscallFlags::NOSYNCSTATEONENTRY, [](FEXCore::Core::CpuStateFrame* Frame, const void* shmaddr) -> uint64_t {
-      auto Thread = Frame->Thread;
-      uint64_t Result {};
-      uint64_t Length {};
-      {
-        auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);
-        Result = ::shmdt(shmaddr);
-
-        if (Result == -1) {
-          SYSCALL_ERRNO();
-          return Result;
-        }
-
-        Length = FEX::HLE::_SyscallHandler->TrackShmdt(Thread, reinterpret_cast<uintptr_t>(shmaddr));
-      }
-
-      FEX::HLE::_SyscallHandler->InvalidateCodeRangeIfNecessary(Thread, reinterpret_cast<uintptr_t>(shmaddr), Length);
+      auto Result = FEX::HLE::_SyscallHandler->GuestShmdt(true, Frame->Thread, shmaddr);
       SYSCALL_ERRNO();
     });
 }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
@@ -35,8 +35,12 @@ class x64SyscallHandler final : public FEX::HLE::SyscallHandler {
 public:
   x64SyscallHandler(FEXCore::Context::Context* ctx, FEX::HLE::SignalDelegator* _SignalDelegation, FEX::HLE::ThunkHandler* ThunkHandler);
 
-  void* GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) override;
-  uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) override;
+  void* GuestMmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length, int prot, int flags, int fd, off_t offset) override {
+    return FEX::HLE::SyscallHandler::GuestMmap(true, Thread, addr, length, prot, flags, fd, offset);
+  }
+  uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) override {
+    return FEX::HLE::SyscallHandler::GuestMunmap(true, Thread, addr, length);
+  }
 
 
   void RegisterSyscall_64(int SyscallNumber, int32_t HostSyscallNumber, FEXCore::IR::SyscallFlags Flags,


### PR DESCRIPTION
We can deal with the differences between these much more easily with a dedicated Is64Bit parameter instead of using runtime polymorphism.

Additionally, moving `Get32BitAllocator` to the parent class as a virtual member function makes the 32-bit implementation closer to the 64-bit one.

~~(Marking as draft until we decide whether to merge #4581 first or later.)~~