### PR TITLE
TestHarnessRunner: Stop setting the guest RSP for ARM test runner.

### DIFF
--- a/Source/Tools/CommonTools/HarnessHelpers.h
+++ b/Source/Tools/CommonTools/HarnessHelpers.h
@@ -406,13 +406,8 @@ public:
   }
 
   uint64_t GetStackPointer() override {
-    if (Config.Is64BitMode()) {
-      return reinterpret_cast<uint64_t>(FEXCore::Allocator::VirtualAlloc(StackSize())) + StackSize();
-    } else {
-      uint64_t Result = reinterpret_cast<uint64_t>(FEXCore::Allocator::VirtualAlloc(reinterpret_cast<void*>(STACK_OFFSET), StackSize()));
-      LOGMAN_THROW_A_FMT(Result != ~0ULL, "Stack Pointer mmap failed");
-      return Result + StackSize();
-    }
+    LOGMAN_MSG_A_FMT("This should be unused.");
+    FEX_UNREACHABLE;
   }
 
   uint64_t DefaultRIP() const override {
@@ -458,6 +453,11 @@ public:
     // Map the memory regions the test file asks for
     for (auto& [region, size] : Config.GetMemoryRegions()) {
       DoMMap(region, size);
+    }
+
+    if (!Config.Is64BitMode()) {
+      // 32-bit gets a fixed page allocated for stack.
+      DoMMap(STACK_OFFSET, StackSize());
     }
 
     LoadMemory();

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -332,7 +332,7 @@ int main(int argc, char** argv, char** const envp) {
     if (!CTX->InitCore()) {
       return 1;
     }
-    auto ParentThread = SyscallHandler->TM.CreateThread(Loader.DefaultRIP(), Loader.GetStackPointer());
+    auto ParentThread = SyscallHandler->TM.CreateThread(Loader.DefaultRIP(), 0);
     SyscallHandler->TM.TrackThread(ParentThread);
     SignalDelegation->RegisterTLSState(ParentThread);
 
@@ -384,7 +384,7 @@ int main(int argc, char** argv, char** const envp) {
       return -ENOEXEC;
     }
 
-    RunAsHost(SignalDelegation, Loader.DefaultRIP(), Loader.GetStackPointer(), &State);
+    RunAsHost(SignalDelegation, Loader.DefaultRIP(), &State);
     SignalDelegation->UninstallTLSState(&ThreadStateObject);
   }
 #endif

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.cpp
@@ -282,8 +282,7 @@ private:
   }
 };
 
-void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, uintptr_t InitialRip, uintptr_t StackPointer,
-               FEXCore::Core::CPUState* OutputState) {
+void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, uintptr_t InitialRip, FEXCore::Core::CPUState* OutputState) {
   x86HostRunner runner;
   SignalDelegation->RegisterHostSignalHandler(
     SIGSEGV,
@@ -295,8 +294,7 @@ void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, u
   runner.Dispatch(InitialRip);
 }
 #else
-void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, uintptr_t InitialRip, uintptr_t StackPointer,
-               FEXCore::Core::CPUState* OutputState) {
+void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, uintptr_t InitialRip, FEXCore::Core::CPUState* OutputState) {
   LOGMAN_MSG_A_FMT("RunAsHost doesn't exist for this host");
 }
 #endif

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.h
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.h
@@ -18,5 +18,4 @@ namespace FEX::HLE {
 class SignalDelegator;
 }
 
-void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, uintptr_t InitialRip, uintptr_t StackPointer,
-               FEXCore::Core::CPUState* OutputState);
+void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, uintptr_t InitialRip, FEXCore::Core::CPUState* OutputState);


### PR DESCRIPTION
This matches behaviour with the x86 host runner that RSP isn't guaranteed to be set to a valid memory location. Make sure when running tests on ARM that it gets the same behaviour.