### PR TITLE
FEXCore/CPUID: Remove warning

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -115,7 +115,7 @@ public:
 
 private:
   const FEXCore::Context::ContextImpl* CTX;
-  bool SupportsCPUIndexInTPIDRRO {};
+  [[maybe_unused]] bool SupportsCPUIndexInTPIDRRO {};
   bool Hybrid {};
   uint32_t Cores {};
   FEX_CONFIG_OPT(HideHypervisorBit, HIDEHYPERVISORBIT);


### PR DESCRIPTION
This is currently only used on win32 builds because Linux doesn't understand TPIDRRO.