### PR TITLE
Async: Don't destruct on self-moves

### DIFF
--- a/Source/Common/Async.h
+++ b/Source/Common/Async.h
@@ -422,6 +422,9 @@ struct posix_descriptor {
     , FD(std::exchange(Other.FD, -1)) {}
 
   posix_descriptor& operator=(posix_descriptor&& Other) {
+    if (&Other == this) {
+      return *this;
+    }
     posix_descriptor::~posix_descriptor();
     Reactor = Other.Reactor;
     FD = std::exchange(Other.FD, -1);


### PR DESCRIPTION
FEXServer's logger performs such self-moves for the log pipe posix_descriptor of short-lived clients. This resulted in a double-close previously, which could interfere with file operations on other threads (typically crashing FEXServer in effect).