### PR TITLE
Config: Use CMAKE_INSTALL_FULL_LIBDIR when templating default values

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -118,7 +118,7 @@
       },
       "ThunkHostLibs": {
         "Type": "str",
-        "Default": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/fex-emu/HostThunks/",
+        "Default": "@CMAKE_INSTALL_FULL_LIBDIR@/fex-emu/HostThunks/",
         "ShortArg": "t",
         "Desc": [
           "Folder to find the host-side thunking libraries."
@@ -134,7 +134,7 @@
       },
       "ThunkHostLibs32": {
         "Type": "str",
-        "Default": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/fex-emu/HostThunks_32/",
+        "Default": "@CMAKE_INSTALL_FULL_LIBDIR@/fex-emu/HostThunks_32/",
         "Desc": [
           "Folder to find the 32-bit host-side thunking libraries."
         ]


### PR DESCRIPTION
Same as #4603. This ensures nix builds will use the correct defaults for ThunkLibs paths.
