### PR TITLE
Linux: Implement enough of ptrace to allow Ubisoft launcher

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Stubs.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Stubs.cpp
@@ -27,13 +27,6 @@ struct CpuStateFrame;
 
 namespace FEX::HLE {
 void RegisterStubs(FEX::HLE::SyscallHandler* Handler) {
-
-  REGISTER_SYSCALL_IMPL(
-    ptrace, [](FEXCore::Core::CpuStateFrame* Frame, int /*enum __ptrace_request*/ request, pid_t pid, void* addr, void* data) -> uint64_t {
-      // We don't support this
-      return -EPERM;
-    });
-
   REGISTER_SYSCALL_IMPL(modify_ldt, [](FEXCore::Core::CpuStateFrame* Frame, int func, void* ptr, unsigned long bytecount) -> uint64_t {
     SYSCALL_STUB(modify_ldt);
   });


### PR DESCRIPTION
Wine does some minimal attaching, peeking, poking, and detaching to have a different process inspect another's TEB region. Ubisoft's launcher does this to check if a debugger is attached and rejects it in the case that it is.

While this implementation isn't all-encompassing, it is good enough for this family of games.