### PR TITLE
Improve log message formatting

### DIFF
--- a/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -15,8 +15,6 @@ enum DebugLevels {
   ERROR = 2,  ///< Only Errors printed
   DEBUG = 3,  ///< Debug messages added
   INFO = 4,   ///< Info messages added
-  STDOUT = 5, ///< Meant to go to STDOUT
-  STDERR = 6, ///< Meant to go to STDERR
 };
 
 static inline const char* DebugLevelStr(uint32_t Level) {
@@ -26,8 +24,6 @@ static inline const char* DebugLevelStr(uint32_t Level) {
   case ERROR: return "E";
   case DEBUG: return "D";
   case INFO: return "I";
-  case STDOUT: return "STDOUT";
-  case STDERR: return "STDERR";
   default: return "???"; break;
   }
 }
@@ -113,16 +109,6 @@ namespace Msg {
       return;
     }
     MFmtImpl(INFO, fmt, fmt::make_format_args(args...));
-  }
-
-  template<typename... Args>
-  static inline void OutFmt(const char* fmt, const Args&... args) {
-    MFmtImpl(STDOUT, fmt, fmt::make_format_args(args...));
-  }
-
-  template<typename... Args>
-  static inline void ErrFmt(const char* fmt, const Args&... args) {
-    MFmtImpl(STDERR, fmt, fmt::make_format_args(args...));
   }
 
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED

--- a/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -6,6 +6,7 @@
 #include <cstdarg>
 
 #include <fmt/format.h>
+#include <fmt/color.h>
 
 namespace LogMan {
 enum DebugLevels {
@@ -28,6 +29,16 @@ static inline const char* DebugLevelStr(uint32_t Level) {
   case STDOUT: return "STDOUT";
   case STDERR: return "STDERR";
   default: return "???"; break;
+  }
+}
+
+static inline fmt::text_style DebugLevelStyle(uint32_t Level) {
+  switch (Level) {
+  case LogMan::ASSERT: return fmt::bg(fmt::color::red) | fmt::emphasis::bold | fmt::fg(fmt::color::white);
+  case LogMan::ERROR: return fmt::fg(fmt::color::red);
+  case LogMan::DEBUG: return fmt::fg(fmt::color::gray);
+  case LogMan::INFO: return fmt::fg(fmt::color::green);
+  default: return {}; break;
   }
 }
 

--- a/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -21,10 +21,10 @@ enum DebugLevels {
 static inline const char* DebugLevelStr(uint32_t Level) {
   switch (Level) {
   case NONE: return "NONE";
-  case ASSERT: return "ASSERT";
-  case ERROR: return "ERROR";
-  case DEBUG: return "DEBUG";
-  case INFO: return "INFO";
+  case ASSERT: return "A";
+  case ERROR: return "E";
+  case DEBUG: return "D";
+  case INFO: return "I";
   case STDOUT: return "STDOUT";
   case STDERR: return "STDERR";
   default: return "???"; break;

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -202,11 +202,11 @@ void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
     }
   }
 
-  fextl::fmt::print("[{}] {}\n", CharLevel, Message);
+  fextl::fmt::print("{} {}\n", CharLevel, Message);
 }
 
 void AssertHandler(const char* Message) {
-  fextl::fmt::print("[ASSERT] {}\n", Message);
+  fextl::fmt::print("A {}\n", Message);
 
   // make sure buffers are flushed
   fflush(nullptr);

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -9,6 +9,8 @@
 #include "Common/Config.h"
 #include "Common/FEXServerClient.h"
 
+#include <fmt/color.h>
+
 #include <chrono>
 #include <dirent.h>
 #include <fcntl.h>
@@ -23,20 +25,23 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <sys/wait.h>
+#include <termios.h>
 #include <thread>
 #include <unistd.h>
 
 static timespec StartTime {};
 
+// Set an empty style to disable coloring when FEXServer output is e.g. piped to a file
+static std::optional<fmt::text_style> DisableColors = isatty(STDOUT_FILENO) ? std::nullopt : std::optional {fmt::text_style {}};
+
 namespace Logging {
 void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
-  const auto Output = fmt::format("[{}] {}\n", LogMan::DebugLevelStr(Level), Message);
+  const auto Output = fmt::format("{} {}\n", fmt::styled(LogMan::DebugLevelStr(Level), DisableColors.value_or(DebugLevelStyle(Level))), Message);
   write(STDOUT_FILENO, Output.c_str(), Output.size());
 }
 
 void AssertHandler(const char* Message) {
-  const auto Output = fmt::format("[A] {}\n", Message);
-  write(STDOUT_FILENO, Output.c_str(), Output.size());
+  return MsgHandler(LogMan::ASSERT, Message);
 }
 
 void ClientMsgHandler(int FD, FEXServerClient::Logging::PacketMsg* const Msg, const char* MsgStr) {
@@ -45,8 +50,13 @@ void ClientMsgHandler(int FD, FEXServerClient::Logging::PacketMsg* const Msg, co
   }
   auto seconds = Msg->Header.Timestamp.tv_sec - StartTime.tv_sec - (Msg->Header.Timestamp.tv_nsec < StartTime.tv_nsec);
   auto nanos = (1'000'000'000 + Msg->Header.Timestamp.tv_nsec - StartTime.tv_nsec) % 1'000'000'000;
-  const auto Output = fmt::format("[{}][{}.{:03}][{}|{}] {}\n", LogMan::DebugLevelStr(Msg->Level), Msg->Header.Timestamp.tv_sec,
-                                  Msg->Header.Timestamp.tv_nsec, Msg->Header.PID, Msg->Header.TID, MsgStr);
+  char Metadata[128];
+  auto Cursor =
+    fmt::format_to(&Metadata[0], DisableColors.value_or(LogMan::DebugLevelStyle(Msg->Level)), "{}", LogMan::DebugLevelStr(Msg->Level));
+  Cursor = fmt::format_to(Cursor, DisableColors.value_or(fmt::fg(fmt::color::light_gray)), " {}|{} ", Msg->Header.PID, Msg->Header.TID);
+  Cursor = fmt::format_to(Cursor, DisableColors.value_or(fmt::fg(fmt::color::gray)), "{}.{:03}", seconds, nanos / 1000000);
+  *Cursor = 0;
+  auto Output = fmt::format("{} {}\n", Metadata, MsgStr);
   write(STDERR_FILENO, Output.c_str(), Output.size());
 }
 } // namespace Logging

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -45,7 +45,7 @@ void ClientMsgHandler(int FD, FEXServerClient::Logging::PacketMsg* const Msg, co
   }
   auto seconds = Msg->Header.Timestamp.tv_sec - StartTime.tv_sec - (Msg->Header.Timestamp.tv_nsec < StartTime.tv_nsec);
   auto nanos = (1'000'000'000 + Msg->Header.Timestamp.tv_nsec - StartTime.tv_nsec) % 1'000'000'000;
-  const auto Output = fmt::format("[{}][{}.{:03}][{}.{}] {}\n", LogMan::DebugLevelStr(Msg->Level), Msg->Header.Timestamp.tv_sec,
+  const auto Output = fmt::format("[{}][{}.{:03}][{}|{}] {}\n", LogMan::DebugLevelStr(Msg->Level), Msg->Header.Timestamp.tv_sec,
                                   Msg->Header.Timestamp.tv_nsec, Msg->Header.PID, Msg->Header.TID, MsgStr);
   write(STDERR_FILENO, Output.c_str(), Output.size());
 }

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -33,7 +33,7 @@ void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
 }
 
 void AssertHandler(const char* Message) {
-  const auto Output = fmt::format("[ASSERT] {}\n", Message);
+  const auto Output = fmt::format("[A] {}\n", Message);
   write(STDOUT_FILENO, Output.c_str(), Output.size());
 }
 

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -50,6 +50,9 @@ void ActionHandler(int sig, siginfo_t* info, void* context) {
   if (sig == SIGINT) {
     // Someone trying to kill us. Shutdown.
     ProcessPipe::Shutdown();
+
+    // Clear "^C" string that most terminals print when pressing Ctrl+C.
+    fprintf(stderr, "\r");
     return;
   }
   _exit(1);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -82,7 +82,7 @@ uint64_t SetSignal(GuestSAMask* Set, int Signal) {
 void SignalDelegator::HandleSignal(FEX::HLE::ThreadStateObject* Thread, int Signal, void* Info, void* UContext) {
   // Let the host take first stab at handling the signal
   if (!Thread) {
-    LogMan::Msg::AFmt("[{}] Thread has received a signal and hasn't registered itself with the delegate! Programming error!",
+    LogMan::Msg::AFmt("Thread {} has received a signal and hasn't registered itself with the delegate! Programming error!",
                       FHU::Syscalls::gettid());
   } else {
     SignalHandler& Handler = HostHandlers[Signal];

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -49,11 +49,11 @@ $end_info$
 #endif
 
 void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
-  fextl::fmt::print("[{}] {}\n", LogMan::DebugLevelStr(Level), Message);
+  fextl::fmt::print("{} {}\n", LogMan::DebugLevelStr(Level), Message);
 }
 
 void AssertHandler(const char* Message) {
-  fextl::fmt::print("[ASSERT] {}\n", Message);
+  fextl::fmt::print("A {}\n", Message);
 
   // make sure buffers are flushed
   fflush(nullptr);

--- a/Source/Windows/Common/Logging.cpp
+++ b/Source/Windows/Common/Logging.cpp
@@ -23,7 +23,7 @@ static void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
 }
 
 static void AssertHandler(const char* Message) {
-  const auto Output = fextl::fmt::format("[ASSERT] {}\n", Message);
+  const auto Output = fextl::fmt::format("[A] {}\n", Message);
   if (WineDbgOut) {
     WineDbgOut(Output.c_str());
   } else if (LogFile) {

--- a/Source/Windows/Common/Logging.cpp
+++ b/Source/Windows/Common/Logging.cpp
@@ -14,7 +14,7 @@ void (*WineDbgOut)(const char* Message);
 FILE* LogFile;
 
 static void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
-  const auto Output = fextl::fmt::format("[{}][{:X}] {}\n", LogMan::DebugLevelStr(Level), GetCurrentThreadId(), Message);
+  const auto Output = fextl::fmt::format("{} {:X} {}\n", LogMan::DebugLevelStr(Level), GetCurrentThreadId(), Message);
   if (WineDbgOut) {
     WineDbgOut(Output.c_str());
   } else if (LogFile) {
@@ -23,7 +23,7 @@ static void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
 }
 
 static void AssertHandler(const char* Message) {
-  const auto Output = fextl::fmt::format("[A] {}\n", Message);
+  const auto Output = fextl::fmt::format("A {}\n", Message);
   if (WineDbgOut) {
     WineDbgOut(Output.c_str());
   } else if (LogFile) {


### PR DESCRIPTION
* Changed "ERROR" strings to single-letters to reduce noise and to ensure message alignment
* Added mild use of colors
* Time stamps:
  * Fixed zero-padding for time stamps (previously `0.1234` would be printed when the actual time was `0.000001234`)
  * Using milliseconds instead of nanoseconds now, which should be more than sufficient and reduces clutter
  * Using time stamps relative to the first log message now
* Process ID and thread ID are separated using `|` instead of `.` to facilitate copy-paste
* Fixed `^C` being printed before the final message when exiting FEXServer running in the foreground

Before:
![log_before](https://github.com/user-attachments/assets/db956cb3-cd19-4013-9606-f0846e30ef0f)

After:
![log_after](https://github.com/user-attachments/assets/73760c90-8c88-401d-95ad-b0025b7a6eb7)
