### PR TITLE
InstructionCountCI: add 32-bit division cases

### DIFF
--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -213,6 +213,48 @@
         "mov x4, x20"
       ]
     },
+    "signed div narrow 32-bit": {
+      "x86InstructionCount": 3,
+      "ExpectedInstructionCount": 10,
+      "x86Insts": [
+        "mov    eax, edi",
+        "cdq",
+        "idiv    esi"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w4, w11",
+        "asr w5, w4, #31",
+        "mov w20, w10",
+        "mov x0, x4",
+        "bfi x0, x5, #32, #32",
+        "sxtw x1, w20",
+        "sdiv x22, x0, x1",
+        "msub x24, x22, x1, x0",
+        "mov w4, w22",
+        "mov w5, w24"
+      ]
+    },
+    "unsigned div narrow 32-bit": {
+      "x86InstructionCount": 3,
+      "ExpectedInstructionCount": 10,
+      "x86Insts": [
+        "mov    eax, edi",
+        "xor    edx, edx",
+        "div    esi"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w4, w11",
+        "mov w5, #0x0",
+        "subs w26, w5, #0x0 (0)",
+        "mov w20, w10",
+        "mov x0, x4",
+        "bfi x0, x5, #32, #32",
+        "udiv x22, x0, x20",
+        "msub x24, x22, x20, x0",
+        "mov w4, w22",
+        "mov w5, w24"
+      ]
+    },
     "inline syscall": {
       "x86InstructionCount": 2,
       "ExpectedInstructionCount": 106,


### PR DESCRIPTION
snippets from clang  for 32-bit integer division