### PR TITLE
Remove code generation build step for install prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,10 +436,6 @@ endif()
 
 add_compile_options(-Wall)
 
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/Config.h.in
-  ${CMAKE_BINARY_DIR}/generated/ConfigDefines.h)
-
 include(CTest)
 if (BUILD_TESTS)
   message(STATUS "Unit tests are enabled")

--- a/Source/Tools/FEXBash/CMakeLists.txt
+++ b/Source/Tools/FEXBash/CMakeLists.txt
@@ -1,9 +1,5 @@
 add_executable(FEXBash FEXBash.cpp)
-target_include_directories(FEXBash
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/Source/
-    ${CMAKE_BINARY_DIR}/generated
-)
+target_include_directories(FEXBash PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 
 target_link_libraries(FEXBash
   PRIVATE

--- a/Source/Tools/FEXGetConfig/Main.cpp
+++ b/Source/Tools/FEXGetConfig/Main.cpp
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-#include "ConfigDefines.h"
 #include "Common/cpp-optparse/OptionParser.h"
 #include "Common/Config.h"
 #include "Common/FEXServerClient.h"
@@ -155,7 +154,13 @@ int main(int argc, char** argv, char** envp) {
   }
 
   if (Options.is_set_by_user("install_prefix")) {
-    fprintf(stdout, FEX_INSTALL_PREFIX "\n");
+    char SelfPath[PATH_MAX];
+    auto Result = readlink("/proc/self/exe", SelfPath, PATH_MAX);
+    if (Result == -1) {
+      Result = 0;
+    }
+    auto InstallPrefix = std::filesystem::path(&SelfPath[0], &SelfPath[Result]).parent_path().parent_path().string();
+    fprintf(stdout, "%s\n", InstallPrefix.c_str());
   }
 
   if (Options.is_set_by_user("current_rootfs")) {

--- a/include/Config.h.in
+++ b/include/Config.h.in
@@ -1,4 +1,0 @@
-#pragma once
-
-#define FEX_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@"
-#define FEXINTERPRETER_PATH FEX_INSTALL_PREFIX "/bin/FEXInterpreter"


### PR DESCRIPTION
Having a dedicated build step just for the install prefix is unnecessarily involved. This information can easily be retrieved otherwise, which also has the upside of not triggering a source rebuild when changing the install prefix.

Furthermore, this cuts down the number of files FEX uses that start with "Config" from 10 to 8 and the number of top-level folders from 16 to 15. Baby steps.

Some functional changes to FEXBash are documented via PR comments.