### PR TITLE
Build: Add nix-based helpers to facilitate cross-compilation

### DIFF
--- a/Data/nix/FEXLinuxTests/shell.nix
+++ b/Data/nix/FEXLinuxTests/shell.nix
@@ -1,0 +1,35 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  pkgsCross32 = pkgs.pkgsCross.gnu32;
+  pkgsCross64 = pkgs.pkgsCross.gnu64;
+
+  gcc32 = pkgs.writeText "toolchain_nix_gcc_x86_32.txt" ''
+    set(CMAKE_SYSTEM_PROCESSOR i686)
+    set(CMAKE_C_COMPILER ${pkgsCross32.buildPackages.gcc}/bin/i686-unknown-linux-gnu-gcc)
+    set(CMAKE_CXX_COMPILER ${pkgsCross32.buildPackages.gcc}/bin/i686-unknown-linux-gnu-g++)
+  '';
+
+  gcc64 = pkgs.writeText "toolchain_nix_gcc_x86_64.txt" ''
+    set(CMAKE_SYSTEM_PROCESSOR x86_64)
+    set(CMAKE_C_COMPILER ${pkgsCross64.buildPackages.gcc}/bin/x86_64-unknown-linux-gnu-gcc)
+    set(CMAKE_CXX_COMPILER ${pkgsCross64.buildPackages.gcc}/bin/x86_64-unknown-linux-gnu-g++)
+  '';
+in
+pkgs.mkShell {
+  buildInputs = [
+    pkgsCross64.buildPackages.clang
+    pkgsCross32.buildPackages.clang
+  ];
+
+  shellHook = ''
+    if [[ $- == *i* ]]; then
+      echo "toolchain32: ${gcc32}"
+      echo "toolchain64: ${gcc64}"
+      echo ""
+      echo "Use \$FEX_CMAKE_TOOLCHAINS to configure CMake."
+    fi
+  '';
+
+  FEX_CMAKE_TOOLCHAINS = "-DX86_32_TOOLCHAIN_FILE=${gcc32} -DX86_64_TOOLCHAIN_FILE=${gcc64}";
+}

--- a/Data/nix/LibraryForwarding/shell.nix
+++ b/Data/nix/LibraryForwarding/shell.nix
@@ -1,0 +1,83 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  pkgsCross32 = pkgs.pkgsCross.gnu32;
+  pkgsCross64 = pkgs.pkgsCross.gnu64;
+
+  devRootFS = pkgs.buildEnv {
+    name = "fex-dev-rootfs";
+    paths = [
+      pkgsCross64.stdenv.cc.libc_dev
+      pkgsCross32.stdenv.cc.libc_dev
+      pkgsCross64.stdenv.cc.cc
+      pkgsCross32.stdenv.cc.cc
+
+      pkgs.alsa-lib.dev
+      pkgs.libdrm.dev
+      pkgs.libGL.dev
+      pkgs.wayland.dev
+      pkgs.xorg.libX11.dev
+      pkgs.xorg.libxcb.dev
+      pkgs.xorg.libXrandr.dev
+      pkgs.xorg.libXrender.dev
+      pkgs.xorg.xorgproto
+    ];
+    ignoreCollisions = true;
+    pathsToLink = [
+      "/include"
+      "/lib"
+    ];
+
+    postBuild = ''
+      mkdir -p $out/usr
+      ln -s $out/include $out/usr/
+    '';
+  };
+
+  toolchain32 = pkgs.writeText "toolchain_nix_x86_32.txt" ''
+    set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_SYSTEM_PROCESSOR i686)
+    set(CMAKE_C_COMPILER clang)
+    set(CMAKE_CXX_COMPILER clang++)
+    set(CMAKE_C_COMPILER ${pkgsCross32.buildPackages.clang}/bin/i686-unknown-linux-gnu-clang)
+    set(CMAKE_CXX_COMPILER ${pkgsCross32.buildPackages.clang}/bin/i686-unknown-linux-gnu-clang++)
+    set(CLANG_FLAGS "-nodefaultlibs -nostartfiles -lstdc++ -target i686-linux-gnu -msse2 -mfpmath=sse --sysroot=${devRootFS} -iwithsysroot/include")
+    set(CMAKE_C_FLAGS "''${CMAKE_C_FLAGS} ''${CLANG_FLAGS}")
+    set(CMAKE_CXX_FLAGS "''${CMAKE_CXX_FLAGS} ''${CLANG_FLAGS}")
+  '';
+
+  toolchain64 = pkgs.writeText "toolchain_nix_x86_64.txt" ''
+    set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_SYSTEM_PROCESSOR x86_64)
+    set(CMAKE_C_COMPILER clang)
+    set(CMAKE_CXX_COMPILER clang++)
+    set(CMAKE_C_COMPILER ${pkgsCross64.buildPackages.clang}/bin/x86_64-unknown-linux-gnu-clang)
+    set(CMAKE_CXX_COMPILER ${pkgsCross64.buildPackages.clang}/bin/x86_64-unknown-linux-gnu-clang++)
+    set(CLANG_FLAGS "-nodefaultlibs -nostartfiles -lstdc++ -target x86_64-linux-gnu --sysroot=${devRootFS} -iwithsysroot/usr/include")
+    set(CMAKE_C_FLAGS "''${CMAKE_C_FLAGS} ''${CLANG_FLAGS}")
+    set(CMAKE_CXX_FLAGS "''${CMAKE_CXX_FLAGS} ''${CLANG_FLAGS}")
+  '';
+in
+pkgs.mkShell {
+  buildInputs = [
+    pkgsCross64.buildPackages.clang
+    pkgsCross32.buildPackages.clang
+  ];
+
+  shellHook = ''
+    if [[ $- == *i* ]]; then
+      echo "Set up dev RootFS at ${devRootFS}"
+      echo "toolchain32: ${toolchain32}"
+      echo "toolchain64: ${toolchain64}"
+      echo ""
+      echo "Use \$FEX_CMAKE_TOOLCHAINS to configure CMake."
+    fi
+  '';
+
+  FEX_CMAKE_TOOLCHAINS = "-DX86_32_TOOLCHAIN_FILE=${toolchain32} -DX86_64_TOOLCHAIN_FILE=${toolchain64} -DX86_DEV_ROOTFS=${devRootFS}";
+  ROOTFS = "${devRootFS}";
+}

--- a/Data/nix/WineOnArm/shell.nix
+++ b/Data/nix/WineOnArm/shell.nix
@@ -1,0 +1,52 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  toolchain = pkgs.fetchzip {
+    url = "https://github.com/bylaws/llvm-mingw/releases/download/20250305/llvm-mingw-20250305-ucrt-ubuntu-20.04-aarch64.tar.xz";
+    sha256 = "sha256-cA03/ab9O61eO9+S2JzIXD4V0HzTXK5/AYyxW2d73Po=";
+  };
+
+  cmakeToolchainFile = pkgs.substitute {
+    # Use absolute paths that are discoverable outside of the nix shell
+    src = ../../CMake/toolchain_mingw.cmake;
+    substitutions = ["--replace-fail" "\${MINGW_TRIPLE}-" "${toolchain}/bin/\${MINGW_TRIPLE}-"];
+  };
+
+  mesonCrossFile = pkgs.writeText "crossfile_llvm_mingw.txt" ''
+    [binaries]
+    ar = '${toolchain}/bin/arm64ec-w64-mingw32-ar'
+    c = '${toolchain}/bin/arm64ec-w64-mingw32-gcc'
+    cpp = '${toolchain}/bin/arm64ec-w64-mingw32-g++'
+    ld = '${toolchain}/bin/arm64ec-w64-mingw32-ld'
+    windres = '${toolchain}/bin/arm64ec-w64-mingw32-windres'
+    strip = '${toolchain}/bin/strip'
+    widl = '${toolchain}/bin/arm64ec-w64-mingw32-widl'
+    pkgconfig = 'aarch64-linux-gnu-pkg-config'
+    [host_machine]
+    system = 'windows'
+    cpu_family = 'aarch64'
+    cpu = 'aarch64'
+    endian = 'little'
+  '';
+in
+pkgs.mkShell {
+  buildInputs = [
+    toolchain
+  ];
+
+  shellHook = ''
+    if [[ $- == *i* ]]; then
+      echo "llvm-mingw set up at ${toolchain}."
+      echo ""
+      echo "To configure DXVK/vkd3d-proton: meson setup \$FEX_MESON_CROSSFILE"
+      echo ""
+      echo "To configure 32-bit FEX build: cmake \$FEX_CMAKE_TOOLCHAIN_WOW64"
+      echo "To configure 64-bit FEX build: cmake \$FEX_CMAKE_TOOLCHAIN_ARM64EC"
+    fi
+  '';
+
+  # E.g. cmake $FEX_CMAKE_TOOLCHAIN_ARM64EC -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_LTO=False -DBUILD_TESTS=False
+  FEX_CMAKE_TOOLCHAIN_ARM64EC = "--toolchain ${cmakeToolchainFile} -DMINGW_TRIPLE=arm64ec-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows";
+  FEX_CMAKE_TOOLCHAIN_WOW64 = "--toolchain ${cmakeToolchainFile} -DMINGW_TRIPLE=aarch64-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows";
+  FEX_MESON_CROSSFILE = "--cross-file ${mesonCrossFile}";
+}

--- a/Data/nix/cmake_configure_woa32.sh
+++ b/Data/nix/cmake_configure_woa32.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash WineOnArm/shell.nix
+
+# Helper script to configure CMake for building FEX as library for emulation
+# of 32-bit applications in Wine/Proton.
+# The required cross-toolchains will be set up and managed by nix.
+
+if [ $# -eq 0 ]
+then
+  echo "Expected CMake argument list"
+  exit 1
+fi
+
+if [ -f CMakeCache.txt ]
+then
+  echo "Expected empty build folder"
+  exit 1
+fi
+
+set -o xtrace
+cmake $FEX_CMAKE_TOOLCHAIN_WOW64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_LTO=False -DBUILD_TESTS=False $@

--- a/Data/nix/cmake_configure_woa64.sh
+++ b/Data/nix/cmake_configure_woa64.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash WineOnArm/shell.nix
+
+# Helper script to configure CMake for building FEX as library for emulation
+# of 64-bit applications in Wine/Proton
+# Nix is used to install and manage the required cross-toolchains.
+
+if [ $# -eq 0 ]
+then
+  echo "Expected CMake argument list"
+  exit 1
+fi
+
+if [ -f CMakeCache.txt ]
+then
+  echo "Expected empty build folder"
+  exit 1
+fi
+
+set -o xtrace
+cmake $FEX_CMAKE_TOOLCHAIN_ARM64EC -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_LTO=False -DBUILD_TESTS=False $@

--- a/Data/nix/cmake_enable_flt.sh
+++ b/Data/nix/cmake_enable_flt.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash FEXLinuxTests/shell.nix
+
+# Helper script to configure CMake for building FEXLinuxTests.
+# Nix is used to install and manage the required cross-toolchains.
+
+if [ ! -f CMakeCache.txt ]
+then
+  echo "Must be run from a pre-configured CMake build folder"
+  exit 1
+fi
+
+# Remove previous build to ensure the new toolchain is applied
+rm -rf unittests/FEXLinuxTests
+
+set -o xtrace
+cmake . $FEX_CMAKE_TOOLCHAINS -DBUILD_TESTS=ON -DBUILD_FEX_LINUX_TESTS=ON

--- a/Data/nix/cmake_enable_libfwd.sh
+++ b/Data/nix/cmake_enable_libfwd.sh
@@ -1,0 +1,22 @@
+# Helper script to configure CMake for library forwarding in FEX.
+# Nix is used to install and manage the required cross-toolchains.
+
+if [ ! -f CMakeCache.txt ]
+then
+  echo "Must be run from a pre-configured CMake build folder"
+  exit 1
+fi
+
+# Remove previous build to ensure the new toolchain is applied
+rm -rf guest-libs guest-libs-32 Guest Guest_32
+
+# Set clang executable path manually since the one from the nix store
+# will be picked up otherwise
+CLANG_EXEC_PATH=""
+if ! grep -q CLANG_EXEC_PATH CMakeCache.txt
+then
+  CLANG_EXEC_PATH="-DCLANG_EXEC_PATH=`which clang`"
+fi
+
+nix-shell `dirname -- "$0"`/LibraryForwarding/shell.nix \
+  --run "set -o xtrace; cmake . \$FEX_CMAKE_TOOLCHAINS -DBUILD_THUNKS=ON $CLANG_EXEC_PATH; set +o xtrace"


### PR DESCRIPTION
FEX has various subprojects that require cross-compilation with different compilers:
* FEXLinuxTests, requiring 32-bit gcc and 64-bit gcc targeting x86
* Library forwarding, requiring clang targeting x86 (both 32-bit and 64-bit) with a full C++ standard library
* Wine-on-Arm, requiring custom mingw-w64 toolchains

Having to set up a custom toolchain for Wine-on-Arm is merely a minor annoyance. However for the first two points we found that most Linux distributions besides Debian/Ubuntu simply lack the required cross-compilers to reliably enable these features. The situation has improved over time (see #3597 and #4230), however fundamentally the process is still very involved.

**Nix provides a general purpose solution that runs on any distribution.** This PR hence sets up a few convenience scripts to take the problem of setting up toolchains entirely off the user's shoulders.

For advanced uses, Nix also has a feature called `nix-shell` that allows loading up a bash shell with the toolchains directly available in the PATH. This is mainly useful to build VKD3D and vkd3d-proton.

## FEXLinuxTests

In an existing build folder, run `cmake_enable_flt.sh`:
```sh
cd build
../Data/nix/cmake_enable_flt.sh
ninja
```

## Library Forwarding

In an existing build folder, run `cmake_enable_libfwd.sh`:
```sh
cd build
../Data/nix/cmake_enable_libfwd.sh
ninja
```

## Wine-on-Arm

Create a fresh build folder and run `cmake_configure_woa*.sh` for the 64-bit build, then repeat for the 32-bit one:
```sh
mkdir -p build/arm64ec && cd build/arm64ec
../../Data/nix/cmake_configure_woa64.sh ../../ -G Ninja
ninja
mkdir ../wow64 && cd ../wow64
../../Data/nix/cmake_configure_woa32.sh ../../ -G Ninja
ninja
```

## Building VKD3D or vkd3d-proton

Open a `nix-shell` and follow the upstream instructions for the manual build:

```sh
nix-shell Data/nix/WineOnArm/shell.nix
meson setup $FEX_MESON_CROSSFILE
```
(After configuration, you can exit the nix-shell again)