### PR TITLE
Fix: wrong magic value in fpstate.

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator/GuestFramesManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator/GuestFramesManagement.cpp
@@ -93,7 +93,7 @@ template<typename T>
 static void SetXStateInfo(T* xstate, bool is_avx_enabled) {
   auto* fpstate = &xstate->fpstate;
 
-  fpstate->sw_reserved.magic1 = FEXCore::x86_64::fpx_sw_bytes::FP_XSTATE_MAGIC;
+  fpstate->sw_reserved.magic1 = is_avx_enabled ? FEXCore::x86_64::fpx_sw_bytes::FP_XSTATE_MAGIC : 0;
   fpstate->sw_reserved.extended_size = is_avx_enabled ? sizeof(T) : 0;
 
   fpstate->sw_reserved.xfeatures |= FEXCore::x86_64::fpx_sw_bytes::FEATURE_FP | FEXCore::x86_64::fpx_sw_bytes::FEATURE_SSE;


### PR DESCRIPTION
FEX should only set fpx_sw_bytes.magic1 with FP_XSTATE_MAGIC when avx is enabled. Otherwise it may cause segfault in ntdll::save_context, which requires access to extended xstate info if magic1 equals FP_XSTATE_MAGIC.