### PR TITLE
PoolBufferWithTimedRetirement: Unclaim in dtor

### DIFF
--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -69,10 +69,6 @@ Decoder::Decoder(FEXCore::Context::ContextImpl* ctx)
   , OSABI {ctx->SyscallHandler ? ctx->SyscallHandler->GetOSABI() : FEXCore::HLE::SyscallOSABI::OS_UNKNOWN}
   , PoolObject {ctx->FrontendAllocator, sizeof(FEXCore::X86Tables::DecodedInst) * DefaultDecodedBufferSize} {}
 
-Decoder::~Decoder() {
-  PoolObject.UnclaimBuffer();
-}
-
 uint8_t Decoder::ReadByte() {
   uint8_t Byte = InstStream[InstructionSize];
   LOGMAN_THROW_A_FMT(InstructionSize < MAX_INST_SIZE, "Max instruction size exceeded!");

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -34,7 +34,6 @@ public:
   };
 
   Decoder(FEXCore::Context::ContextImpl* ctx);
-  ~Decoder();
   void DecodeInstructionsAtEntry(const uint8_t* InstStream, uint64_t PC, uint64_t MaxInst,
                                  std::function<void(uint64_t BlockEntry, uint64_t Start, uint64_t Length)> AddContainedCodePage);
 

--- a/FEXCore/Source/Interface/IR/IntrusiveIRList.h
+++ b/FEXCore/Source/Interface/IR/IntrusiveIRList.h
@@ -127,10 +127,6 @@ public:
     PoolObject.ReownOrClaimBuffer();
   }
 
-  ~DualIntrusiveAllocatorThreadPool() {
-    PoolObject.UnclaimBuffer();
-  }
-
   void ReownOrClaimBuffer() {
     Data = PoolObject.ReownOrClaimBuffer();
     List = Data + MemorySize;

--- a/FEXCore/include/FEXCore/Utils/ThreadPoolAllocator.h
+++ b/FEXCore/include/FEXCore/Utils/ThreadPoolAllocator.h
@@ -445,6 +445,10 @@ public:
     : ThreadAllocator {Allocator}
     , Size {Size} {}
 
+  ~PoolBufferWithTimedRetirement() {
+    UnclaimBuffer();
+  }
+
   /**
    * @brief Return the owned buffer or allocate another one from the `Allocator`
    *


### PR DESCRIPTION
Buffers are tied to the lifetime of their owned flag, and as that is a member of PoolBufferWithTimedRetirement we must always unclaim here.

Avoids the need to manually remember this quirk (which was forgot for the temporary compilation buffer in JIT.cpp) at every use-site.