### PR TITLE
Add --changed flag to reformat.sh script

### DIFF
--- a/Scripts/reformat.sh
+++ b/Scripts/reformat.sh
@@ -3,12 +3,48 @@
 # Save current directory
 DIR=$(pwd)
 
+# Get the absolute path to the Scripts directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Parse arguments
+CHANGED_ONLY=false
+TARGET_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --changed) # Only reformat changed files (staged and unstaged)
+            CHANGED_ONLY=true
+            shift
+            ;;
+        *)
+            TARGET_DIR=$1
+            shift
+            ;;
+    esac
+done
+
 # Change to the directory passed as argument if any
-if [ $# -eq 1 ]; then
-    cd $1
+if [ -n "$TARGET_DIR" ]; then
+    cd "$TARGET_DIR"
 fi
 
-# Reformat whole tree.
-# This is run by the reformat target.
-git ls-files -z '*.cpp' '*.h' '*.inl' ':(exclude)External/*' | xargs -0 -n 1 -P $(nproc) clang-format-19 -i
+# Reformat files
+if [ "$CHANGED_ONLY" = true ]; then
+    # Check for unstaged deletions
+    if git ls-files -d | head -1 | grep -q .; then
+        echo "Error: Unstaged deletions detected. Please stage or discard deletions before formatting."
+        exit 1
+    fi
+
+    CHANGED_FILES=$(git ls-files -m '*.cpp' '*.h' '*.inl')
+    if [ -n "$CHANGED_FILES" ]; then
+        echo "$CHANGED_FILES" | xargs -d '\n' -n 1 -P $(nproc) python3 "$SCRIPT_DIR/clang-format.py" -i
+    else
+        echo "No changed files to format."
+    fi
+else
+    # Reformat whole tree (original behavior)
+    git ls-files -z '*.cpp' '*.h' '*.inl' | xargs -0 -n 1 -P $(nproc) python3 "$SCRIPT_DIR/clang-format.py" -i
+fi
+
 cd $DIR


### PR DESCRIPTION
The flag and the optional directory helps target the reformatting changes. In any case, this should be backwards compatible. Running it without flags should do what it did before.