### PR TITLE
XXFileHash: Drop unnecessary use of value_or

### DIFF
--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -749,13 +749,13 @@ bool ValidateCheckExists(const WebFileFetcher::FileTargets& Target) {
 
     auto Res = XXFileHash::HashFile(PathName);
     if (Result == 0) {
-      if (Res.value_or(0) == ExpectedHash) {
+      if (Res == ExpectedHash) {
         fextl::string Text = fextl::fmt::format("{} matches expected hash. Skipping download", filename);
         ExecWithInfo(Text);
         return false;
       }
     } else if (Result == 1) {
-      if (Res.value_or(0) != ExpectedHash) {
+      if (Res != ExpectedHash) {
         return AskForConfirmation("RootFS doesn't match hash!\nDo you want to redownload?");
       } else {
         fextl::string Text = fextl::fmt::format("{} matches expected hash", filename);
@@ -907,12 +907,12 @@ bool ValidateCheckExists(const WebFileFetcher::FileTargets& Target) {
     fmt::print("Validating RootFS hash...\n");
     auto Res = XXFileHash::HashFile(PathName);
     if (Result == 0) {
-      if (Res.value_or(0) == ExpectedHash) {
+      if (Res == ExpectedHash) {
         fmt::print("{} matches expected hash. Skipping downloading\n", filename);
         return false;
       }
     } else if (Result == 1) {
-      if (Res.value_or(0) != ExpectedHash) {
+      if (Res != ExpectedHash) {
         fmt::print("RootFS doesn't match hash!\n");
         return AskForConfirmation("Do you want to redownload?");
       } else {
@@ -1178,7 +1178,7 @@ int main(int argc, char** argv, char** const envp) {
 
             if (std::filesystem::exists(PathName, ec)) {
               auto Res = XXFileHash::HashFile(PathName);
-              if (Res.value_or(0) != ExpectedHash) {
+              if (Res != ExpectedHash) {
                 fextl::string Text = fextl::fmt::format("Couldn't hash the rootfs or hash didn't match\n");
                 Text += fmt::format("Hash {:x} != Expected Hash {:x}\n", Res.value_or(0), ExpectedHash);
                 ExecWithInfo(Text);


### PR DESCRIPTION
`std::nullopt` compares as not equal to any value that's not `std::nullopt` itself.