### PR TITLE
Miscellaneous log changes

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -66,7 +66,7 @@ void OpDispatchBuilder::SyscallOp(OpcodeArgs, bool IsSyscallInst) {
     GPRIndexes = nullptr;
     DefaultSyscallFlags = FEXCore::IR::SyscallFlags::NORETURNEDRESULT;
   } else {
-    LogMan::Msg::DFmt("Unhandled OSABI syscall");
+    ERROR_AND_DIE_FMT("Unhandled OSABI syscall");
   }
 
   // Calculate flags early.

--- a/FEXCore/Source/Utils/AllocatorOverride.cpp
+++ b/FEXCore/Source/Utils/AllocatorOverride.cpp
@@ -106,7 +106,7 @@ void EvaluateReturnAddress(void* Return) {
   // We don't know where we are when allocating. Make sure to be safe and generate the string on the stack.
   // Print an error message to let a developer know that an allocation faulted.
   char Tmp[512];
-  auto Res = fmt::format_to_n(Tmp, 512, "Allocation from 0x{:x}\n", reinterpret_cast<uint64_t>(Return));
+  auto Res = fmt::format_to_n(Tmp, 512, "ERROR: Requested memory using non-FEX allocator at 0x{:x}\n", reinterpret_cast<uint64_t>(Return));
   Tmp[Res.size] = 0;
   write(STDERR_FILENO, Tmp, Res.size);
 

--- a/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -143,7 +143,7 @@ namespace Msg {
 
 #define ERROR_AND_DIE_FMT(...)      \
   do {                              \
-    LogMan::Msg::EFmt(__VA_ARGS__); \
+    LogMan::Msg::MFmt(LogMan::ASSERT, __VA_ARGS__); \
     FEX_TRAP_EXECUTION;             \
   } while (0)
 


### PR DESCRIPTION
Ensures that `ERROR_AND_DIE_FMT` gets printed with the ASSERT level. Also changed one error message that I hit to be critical, since there's no reliable way to proceed after hitting it.