### PR TITLE
Arm64Emitter: Fix signed overflow

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -495,7 +495,7 @@ void Arm64Emitter::LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, ui
   uint64_t AlignedPC = PC & ~0xFFFULL;
 
   // Offset from aligned PC
-  int64_t AlignedOffset = static_cast<int64_t>(Constant) - static_cast<int64_t>(AlignedPC);
+  auto AlignedOffset = std::bit_cast<int64_t>(Constant - AlignedPC);
 
   int NumMoves = 0;
 
@@ -511,7 +511,7 @@ void Arm64Emitter::LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, ui
     } else {
       // If the constant is within 1MB of PC then we can still use ADR to load in a single instruction
       // 21-bit signed integer here
-      int64_t SmallOffset = static_cast<int64_t>(Constant) - static_cast<int64_t>(PC);
+      auto SmallOffset = std::bit_cast<int64_t>(Constant - PC);
       if (ARMEmitter::Emitter::IsInt21(SmallOffset)) {
         adr(Reg, SmallOffset);
       } else {


### PR DESCRIPTION
This actually seems to be the only instance where FEX triggers signed integer over/underflows in normal operation. Changing `-fwrapv` to `-ftrapv` yields a functional FEX build with this patch.
