### PR TITLE
FEXCore/OpcodeDispatcher: Removes tuple usage for Dispatch tables

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4834,18 +4834,18 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
   constexpr uint16_t PF_38_66 = (1U << 0);
   constexpr uint16_t PF_38_F2 = (1U << 1);
 
-  constexpr static std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> H0F38_SHA[] = {
+  constexpr static DispatchTableEntry H0F38_SHA[] = {
     {OPD(PF_38_NONE, 0xC8), 1, &OpDispatchBuilder::SHA1NEXTEOp},  {OPD(PF_38_NONE, 0xC9), 1, &OpDispatchBuilder::SHA1MSG1Op},
     {OPD(PF_38_NONE, 0xCA), 1, &OpDispatchBuilder::SHA1MSG2Op},   {OPD(PF_38_NONE, 0xCB), 1, &OpDispatchBuilder::SHA256RNDS2Op},
     {OPD(PF_38_NONE, 0xCC), 1, &OpDispatchBuilder::SHA256MSG1Op}, {OPD(PF_38_NONE, 0xCD), 1, &OpDispatchBuilder::SHA256MSG2Op},
   };
 
-  constexpr static std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> H0F38_AES[] = {
+  constexpr static DispatchTableEntry H0F38_AES[] = {
     {OPD(PF_38_66, 0xDB), 1, &OpDispatchBuilder::AESImcOp},     {OPD(PF_38_66, 0xDC), 1, &OpDispatchBuilder::AESEncOp},
     {OPD(PF_38_66, 0xDD), 1, &OpDispatchBuilder::AESEncLastOp}, {OPD(PF_38_66, 0xDE), 1, &OpDispatchBuilder::AESDecOp},
     {OPD(PF_38_66, 0xDF), 1, &OpDispatchBuilder::AESDecLastOp},
   };
-  constexpr static std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> H0F38_CRC[] = {
+  constexpr static DispatchTableEntry H0F38_CRC[] = {
     {OPD(PF_38_F2, 0xF0), 1, &OpDispatchBuilder::CRC32},
     {OPD(PF_38_F2, 0xF1), 1, &OpDispatchBuilder::CRC32},
 
@@ -4857,11 +4857,11 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
 #define OPD(REX, prefix, opcode) ((REX << 9) | (prefix << 8) | opcode)
 #define PF_3A_NONE 0
 #define PF_3A_66 1
-  constexpr static std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> H0F3A_AES[] = {
+  constexpr static DispatchTableEntry H0F3A_AES[] = {
     {OPD(0, PF_3A_66, 0xDF), 1, &OpDispatchBuilder::AESKeyGenAssist},
     {OPD(1, PF_3A_66, 0xDF), 1, &OpDispatchBuilder::AESKeyGenAssist},
   };
-  constexpr static std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> H0F3A_PCLMUL[] = {
+  constexpr static DispatchTableEntry H0F3A_PCLMUL[] = {
     {OPD(0, PF_3A_66, 0x44), 1, &OpDispatchBuilder::PCLMULQDQOp},
     {OPD(1, PF_3A_66, 0x44), 1, &OpDispatchBuilder::PCLMULQDQOp},
   };
@@ -4871,7 +4871,7 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
 #undef OPD
 
 #define OPD(map_select, pp, opcode) (((map_select - 1) << 10) | (pp << 8) | (opcode))
-  constexpr static std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> VEX_PCLMUL[] = {
+  constexpr static DispatchTableEntry VEX_PCLMUL[] = {
     {OPD(3, 0b01, 0x44), 1, &OpDispatchBuilder::VPCLMULQDQOp},
   };
 #undef OPD
@@ -4880,7 +4880,7 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
   constexpr uint16_t PF_NONE = 0;
   constexpr uint16_t PF_66 = 2;
 
-  constexpr static std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> SecondaryExtensionOp_RDRAND[] = {
+  constexpr static DispatchTableEntry SecondaryExtensionOp_RDRAND[] = {
     // GROUP 9
     {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_NONE, 6), 1, &OpDispatchBuilder::RDRANDOp<false>},
     {OPD(FEXCore::X86Tables::TYPE_GROUP_9, PF_NONE, 7), 1, &OpDispatchBuilder::RDRANDOp<true>},
@@ -4890,12 +4890,12 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
   };
 #undef OPD
 
-  constexpr static std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> SecondaryModRMExtensionOp_CLZero[] = {
+  constexpr static DispatchTableEntry SecondaryModRMExtensionOp_CLZero[] = {
     {((3 << 3) | 4), 1, &OpDispatchBuilder::CLZeroOp},
   };
 
 #define OPD(map_select, pp, opcode) (((map_select - 1) << 10) | (pp << 8) | (opcode))
-  static constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> AVXTable[] = {
+  static constexpr DispatchTableEntry AVXTable[] = {
     {OPD(1, 0b00, 0x10), 1, &OpDispatchBuilder::VMOVUPS_VMOVUPDOp},
     {OPD(1, 0b01, 0x10), 1, &OpDispatchBuilder::VMOVUPS_VMOVUPDOp},
     {OPD(1, 0b10, 0x10), 1, &OpDispatchBuilder::VMOVSSOp},
@@ -5297,7 +5297,7 @@ void OpDispatchBuilder::InstallHostSpecificOpcodeHandlers() {
 #undef OPD
 
 #define OPD(group, pp, opcode) (((group - X86Tables::TYPE_VEX_GROUP_12) << 4) | (pp << 3) | (opcode))
-  static constexpr std::tuple<uint8_t, uint8_t, X86Tables::OpDispatchPtr> VEXTableGroupOps[] {
+  static constexpr DispatchTableEntry VEXTableGroupOps[] {
     {OPD(X86Tables::TYPE_VEX_GROUP_12, 1, 0b010), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VPSRLIOp, OpSize::i16Bit>},
     {OPD(X86Tables::TYPE_VEX_GROUP_12, 1, 0b110), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VPSLLIOp, OpSize::i16Bit>},
     {OPD(X86Tables::TYPE_VEX_GROUP_12, 1, 0b100), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VPSRAIOp, OpSize::i16Bit>},
@@ -5356,7 +5356,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
 // All OPDReg versions need it
 #define OPDReg(op, reg) ((1 << 15) | ((op - 0xD8) << 8) | (reg << 3))
 #define OPD(op, modrmop) (((op - 0xD8) << 8) | modrmop)
-  constexpr static std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> X87F64OpTable[] = {
+  constexpr static DispatchTableEntry X87F64OpTable[] = {
     {OPDReg(0xD8, 0) | 0x00, 8, &OpDispatchBuilder::Bind<&OpDispatchBuilder::FADDF64, OpSize::i32Bit, false, OpDispatchBuilder::OpResult::RES_ST0>},
 
     {OPDReg(0xD8, 1) | 0x00, 8, &OpDispatchBuilder::Bind<&OpDispatchBuilder::FMULF64, OpSize::i32Bit, false, OpDispatchBuilder::OpResult::RES_ST0>},
@@ -5620,7 +5620,7 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
      &OpDispatchBuilder::Bind<&OpDispatchBuilder::FCOMIF64, OpSize::f80Bit, false, OpDispatchBuilder::FCOMIFlags::FLAGS_RFLAGS, false>},
   };
 
-  constexpr static std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> X87OpTable[] = {
+  constexpr static DispatchTableEntry X87OpTable[] = {
     {OPDReg(0xD8, 0) | 0x00, 8, &OpDispatchBuilder::Bind<&OpDispatchBuilder::FADD, OpSize::i32Bit, false, OpDispatchBuilder::OpResult::RES_ST0>},
 
     {OPDReg(0xD8, 1) | 0x00, 8, &OpDispatchBuilder::Bind<&OpDispatchBuilder::FMUL, OpSize::i32Bit, false, OpDispatchBuilder::OpResult::RES_ST0>},
@@ -5878,11 +5878,11 @@ void InstallOpcodeHandlers(Context::OperatingMode Mode) {
 
   auto InstallToX87Table = [](auto& FinalTable, auto& LocalTable) {
     for (auto Op : LocalTable) {
-      auto OpNum = std::get<0>(Op);
+      auto OpNum = Op.Op;
       bool Repeat = (OpNum & 0x8000) != 0;
       OpNum = OpNum & 0x7FF;
-      auto Dispatcher = std::get<2>(Op);
-      for (uint8_t i = 0; i < std::get<1>(Op); ++i) {
+      auto Dispatcher = Op.Ptr;
+      for (uint8_t i = 0; i < Op.Count; ++i) {
         LOGMAN_THROW_A_FMT(FinalTable[OpNum + i].OpcodeDispatcher == nullptr, "Duplicate Entry");
         FinalTable[OpNum + i].OpcodeDispatcher = Dispatcher;
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -80,6 +80,12 @@ struct LoadSourceOptions {
   bool AllowUpperGarbage = false;
 };
 
+struct DispatchTableEntry {
+  uint16_t Op;
+  uint8_t Count;
+  X86Tables::OpDispatchPtr Ptr;
+};
+
 class OpDispatchBuilder final : public IREmitter {
   friend class FEXCore::IR::Pass;
   friend class FEXCore::IR::PassManager;
@@ -2623,9 +2629,9 @@ private:
 
 constexpr inline void InstallToTable(auto& FinalTable, const auto& LocalTable) {
   for (const auto& Op : LocalTable) {
-    auto OpNum = std::get<0>(Op);
-    auto Dispatcher = std::get<2>(Op);
-    for (uint8_t i = 0; i < std::get<1>(Op); ++i) {
+    auto OpNum = Op.Op;
+    auto Dispatcher = Op.Ptr;
+    for (uint8_t i = 0; i < Op.Count; ++i) {
       auto& TableOp = FinalTable[OpNum + i];
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       if (TableOp.OpcodeDispatcher) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -23,7 +23,7 @@ class OrderedNode;
 
 void OpDispatchBuilder::InstallAVX128Handlers() {
 #define OPD(map_select, pp, opcode) (((map_select - 1) << 10) | (pp << 8) | (opcode))
-  static constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> AVX128Table[] = {
+  static constexpr DispatchTableEntry AVX128Table[] = {
     {OPD(1, 0b00, 0x10), 1, &OpDispatchBuilder::AVX128_VMOVAPS},
     {OPD(1, 0b01, 0x10), 1, &OpDispatchBuilder::AVX128_VMOVAPS},
     {OPD(1, 0b10, 0x10), 1, &OpDispatchBuilder::AVX128_VMOVSS},
@@ -426,7 +426,7 @@ void OpDispatchBuilder::InstallAVX128Handlers() {
 #undef OPD
 
 #define OPD(group, pp, opcode) (((group - X86Tables::TYPE_VEX_GROUP_12) << 4) | (pp << 3) | (opcode))
-  static constexpr std::tuple<uint8_t, uint8_t, X86Tables::OpDispatchPtr> VEX128TableGroupOps[] {
+  static constexpr DispatchTableEntry VEX128TableGroupOps[] {
     // VPSRLI
     {OPD(X86Tables::TYPE_VEX_GROUP_12, 1, 0b010), 1,
      &OpDispatchBuilder::Bind<&OpDispatchBuilder::AVX128_VectorShiftImmImpl, OpSize::i16Bit, IROps::OP_VUSHRI>},
@@ -465,7 +465,7 @@ void OpDispatchBuilder::InstallAVX128Handlers() {
 #undef OPD
 
 #define OPD(map_select, pp, opcode) (((map_select - 1) << 10) | (pp << 8) | (opcode))
-  constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> VEX128_PCLMUL[] = {
+  constexpr DispatchTableEntry VEX128_PCLMUL[] = {
     {OPD(3, 0b01, 0x44), 1, &OpDispatchBuilder::AVX128_VPCLMULQDQ},
   };
 #undef OPD

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/BaseTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/BaseTables.h
@@ -3,7 +3,7 @@
 #include "Interface/Core/OpcodeDispatcher.h"
 
 namespace FEXCore::IR {
-constexpr inline std::tuple<uint8_t, uint8_t, X86Tables::OpDispatchPtr> OpDispatch_BaseOpTable[] = {
+constexpr inline DispatchTableEntry OpDispatch_BaseOpTable[] = {
   // Instructions
   {0x00, 6, &OpDispatchBuilder::Bind<&OpDispatchBuilder::ALUOp, FEXCore::IR::IROps::OP_ADD, FEXCore::IR::IROps::OP_ATOMICFETCHADD, 0>},
 
@@ -76,12 +76,12 @@ constexpr inline std::tuple<uint8_t, uint8_t, X86Tables::OpDispatchPtr> OpDispat
   {0xFC, 2, &OpDispatchBuilder::FLAGControlOp},
 };
 
-constexpr inline std::tuple<uint8_t, uint8_t, X86Tables::OpDispatchPtr> OpDispatch_BaseOpTable_64[] = {
+constexpr inline DispatchTableEntry OpDispatch_BaseOpTable_64[] = {
   {0x63, 1, &OpDispatchBuilder::MOVSXDOp},
   {0xA0, 4, &OpDispatchBuilder::MOVOffsetOp},
 };
 
-constexpr inline std::tuple<uint8_t, uint8_t, X86Tables::OpDispatchPtr> OpDispatch_BaseOpTable_32[] = {
+constexpr inline DispatchTableEntry OpDispatch_BaseOpTable_32[] = {
   {0x06, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::PUSHSegmentOp, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX>},
   {0x07, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::POPSegmentOp, FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX>},
   {0x0E, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::PUSHSegmentOp, FEXCore::X86Tables::DecodeFlags::FLAG_CS_PREFIX>},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/DDDTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/DDDTables.h
@@ -3,7 +3,7 @@
 #include "Interface/Core/OpcodeDispatcher.h"
 
 namespace FEXCore::IR {
-constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_DDDTable[] = {
+constexpr DispatchTableEntry OpDispatch_DDDTable[] = {
   {0x0C, 1, &OpDispatchBuilder::PI2FWOp},
   {0x0D, 1, &OpDispatchBuilder::Vector_CVT_Int_To_Float<OpSize::i32Bit, false>},
   {0x1C, 1, &OpDispatchBuilder::PF2IWOp},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/H0F38Tables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/H0F38Tables.h
@@ -8,7 +8,7 @@ constexpr uint16_t PF_38_NONE = 0;
 constexpr uint16_t PF_38_66 = (1U << 0);
 constexpr uint16_t PF_38_F3 = (1U << 2);
 
-constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_H0F38Table[] = {
+constexpr DispatchTableEntry OpDispatch_H0F38Table[] = {
   {OPD(PF_38_NONE, 0x00), 1, &OpDispatchBuilder::PSHUFBOp},
   {OPD(PF_38_66, 0x00), 1, &OpDispatchBuilder::PSHUFBOp},
   {OPD(PF_38_NONE, 0x01), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorALUOp, IR::OP_VADDP, OpSize::i16Bit>},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/H0F3ATables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/H0F3ATables.h
@@ -8,7 +8,7 @@ namespace FEXCore::IR {
 #define PF_3A_66 1
 constexpr auto OpDispatchTableGenH0F3A = []() consteval {
   constexpr auto OpDispatchTableGenH0F3AREX = []<uint16_t REX>() consteval {
-    constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> Table[] = {
+    constexpr DispatchTableEntry Table[] = {
       {OPD(REX, PF_3A_66, 0x08), 1, &OpDispatchBuilder::VectorRound<OpSize::i32Bit>},
       {OPD(REX, PF_3A_66, 0x09), 1, &OpDispatchBuilder::VectorRound<OpSize::i64Bit>},
       {OPD(REX, PF_3A_66, 0x0A), 1, &OpDispatchBuilder::InsertScalarRound<OpSize::i32Bit>},
@@ -60,12 +60,12 @@ constexpr auto OpDispatchTableGenH0F3A = []() consteval {
 
 constexpr auto OpDispatch_H0F3ATableIgnoreREX = OpDispatchTableGenH0F3A();
 
-constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_H0F3ATableNeedsREX0[] = {
+constexpr DispatchTableEntry OpDispatch_H0F3ATableNeedsREX0[] = {
   {OPD(0, PF_3A_66, 0x16), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::PExtrOp, OpSize::i32Bit>},
   {OPD(0, PF_3A_66, 0x22), 1, &OpDispatchBuilder::PINSROp<OpSize::i32Bit>},
 };
 
-constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_H0F3ATable_64[] = {
+constexpr DispatchTableEntry OpDispatch_H0F3ATable_64[] = {
   {OPD(1, PF_3A_66, 0x16), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::PExtrOp, OpSize::i64Bit>},
   {OPD(1, PF_3A_66, 0x22), 1, &OpDispatchBuilder::PINSROp<OpSize::i64Bit>},
 };

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/PrimaryGroupTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/PrimaryGroupTables.h
@@ -5,7 +5,7 @@
 namespace FEXCore::IR {
 using X86Tables::OpToIndex;
 #define OPD(group, prefix, Reg) (((group - FEXCore::X86Tables::TYPE_GROUP_1) << 6) | (prefix) << 3 | (Reg))
-constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_PrimaryGroupTables[] = {
+constexpr DispatchTableEntry OpDispatch_PrimaryGroupTables[] = {
   // GROUP 1
   {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x80), 0), 1, &OpDispatchBuilder::SecondaryALUOp},
   {OPD(FEXCore::X86Tables::TYPE_GROUP_1, OpToIndex(0x80), 1), 1, &OpDispatchBuilder::SecondaryALUOp},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/SecondaryGroupTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/SecondaryGroupTables.h
@@ -8,7 +8,7 @@ constexpr uint16_t PF_NONE = 0;
 constexpr uint16_t PF_F3 = 1;
 constexpr uint16_t PF_66 = 2;
 constexpr uint16_t PF_F2 = 3;
-constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_SecondaryGroupTables[] = {
+constexpr DispatchTableEntry OpDispatch_SecondaryGroupTables[] = {
   // GROUP 6
   {OPD(FEXCore::X86Tables::TYPE_GROUP_6, PF_NONE, 3), 1, &OpDispatchBuilder::PermissionRestrictedOp},
   {OPD(FEXCore::X86Tables::TYPE_GROUP_6, PF_F3, 3), 1, &OpDispatchBuilder::PermissionRestrictedOp},
@@ -154,7 +154,7 @@ constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDis
   {OPD(FEXCore::X86Tables::TYPE_GROUP_P, PF_F2, 0), 8, &OpDispatchBuilder::NOPOp},
 };
 
-constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_SecondaryGroupTables_64[] = {
+constexpr DispatchTableEntry OpDispatch_SecondaryGroupTables_64[] = {
   // GROUP 15
   {OPD(FEXCore::X86Tables::TYPE_GROUP_15, PF_F3, 0), 1,
    &OpDispatchBuilder::Bind<&OpDispatchBuilder::ReadSegmentReg, OpDispatchBuilder::Segment::FS>},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/SecondaryModRMTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/SecondaryModRMTables.h
@@ -3,7 +3,7 @@
 #include "Interface/Core/OpcodeDispatcher.h"
 
 namespace FEXCore::IR {
-constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_SecondaryModRMTables[] = {
+constexpr DispatchTableEntry OpDispatch_SecondaryModRMTables[] = {
   // REG /1
   {((0 << 3) | 0), 1, &OpDispatchBuilder::UnimplementedOp},
   {((0 << 3) | 1), 1, &OpDispatchBuilder::UnimplementedOp},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/SecondaryTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/SecondaryTables.h
@@ -3,7 +3,7 @@
 #include "Interface/Core/OpcodeDispatcher.h"
 
 namespace FEXCore::IR {
-constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_TwoByteOpTable[] = {
+constexpr DispatchTableEntry OpDispatch_TwoByteOpTable[] = {
   // Instructions
   {0x03, 1, &OpDispatchBuilder::LSLOp},
   {0x06, 1, &OpDispatchBuilder::PermissionRestrictedOp},
@@ -150,7 +150,7 @@ constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDisp
 #endif
 };
 
-constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_SecondaryRepModTables[] = {
+constexpr DispatchTableEntry OpDispatch_SecondaryRepModTables[] = {
   {0x10, 2, &OpDispatchBuilder::MOVSSOp},
   {0x12, 1, &OpDispatchBuilder::VMOVSLDUPOp},
   {0x16, 1, &OpDispatchBuilder::VMOVSHDUPOp},
@@ -181,7 +181,7 @@ constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDisp
   {0xE6, 1, &OpDispatchBuilder::Vector_CVT_Int_To_Float<OpSize::i32Bit, true>},
 };
 
-constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_SecondaryRepNEModTables[] = {
+constexpr DispatchTableEntry OpDispatch_SecondaryRepNEModTables[] = {
   {0x10, 2, &OpDispatchBuilder::MOVSDOp},
   {0x12, 1, &OpDispatchBuilder::MOVDDUPOp},
   {0x2A, 1, &OpDispatchBuilder::InsertCVTGPR_To_FPR<OpSize::i64Bit>},
@@ -207,7 +207,7 @@ constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDisp
   {0xF0, 1, &OpDispatchBuilder::MOVVectorUnalignedOp},
 };
 
-constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_SecondaryOpSizeModTables[] = {
+constexpr DispatchTableEntry OpDispatch_SecondaryOpSizeModTables[] = {
   {0x10, 2, &OpDispatchBuilder::MOVVectorUnalignedOp},
   {0x12, 2, &OpDispatchBuilder::MOVLPOp},
   {0x14, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::PUNPCKLOp, OpSize::i64Bit>},
@@ -314,7 +314,7 @@ constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDisp
   {0xFE, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorALUOp, IR::OP_VADD, OpSize::i32Bit>},
 };
 
-constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_TwoByteOpTable_64[] = {
+constexpr DispatchTableEntry OpDispatch_TwoByteOpTable_64[] = {
   {0x05, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::SyscallOp, true>},
   {0xA0, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::PUSHSegmentOp, FEXCore::X86Tables::DecodeFlags::FLAG_FS_PREFIX>},
   {0xA1, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::POPSegmentOp, FEXCore::X86Tables::DecodeFlags::FLAG_FS_PREFIX>},
@@ -322,7 +322,7 @@ constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDisp
   {0xA9, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::POPSegmentOp, FEXCore::X86Tables::DecodeFlags::FLAG_GS_PREFIX>},
 };
 
-constexpr std::tuple<uint8_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_TwoByteOpTable_32[] = {
+constexpr DispatchTableEntry OpDispatch_TwoByteOpTable_32[] = {
   {0x05, 1, &OpDispatchBuilder::NOPOp},
   {0xA0, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::PUSHSegmentOp, FEXCore::X86Tables::DecodeFlags::FLAG_FS_PREFIX>},
   {0xA1, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::POPSegmentOp, FEXCore::X86Tables::DecodeFlags::FLAG_FS_PREFIX>},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/VEXTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/VEXTables.h
@@ -4,7 +4,7 @@
 
 namespace FEXCore::IR {
 #define OPD(map_select, pp, opcode) (((map_select - 1) << 10) | (pp << 8) | (opcode))
-constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDispatch_VEXTable[] = {
+constexpr DispatchTableEntry OpDispatch_VEXTable[] = {
   {OPD(2, 0b00, 0xF2), 1, &OpDispatchBuilder::ANDNBMIOp}, {OPD(2, 0b00, 0xF5), 1, &OpDispatchBuilder::BZHI},
   {OPD(2, 0b10, 0xF5), 1, &OpDispatchBuilder::PEXT},      {OPD(2, 0b11, 0xF5), 1, &OpDispatchBuilder::PDEP},
   {OPD(2, 0b11, 0xF6), 1, &OpDispatchBuilder::MULX},      {OPD(2, 0b00, 0xF7), 1, &OpDispatchBuilder::BEXTRBMIOp},
@@ -16,7 +16,7 @@ constexpr std::tuple<uint16_t, uint8_t, FEXCore::X86Tables::OpDispatchPtr> OpDis
 #undef OPD
 
 #define OPD(group, pp, opcode) (((group - X86Tables::InstType::TYPE_VEX_GROUP_12) << 4) | (pp << 3) | (opcode))
-constexpr std::tuple<uint8_t, uint8_t, X86Tables::OpDispatchPtr> OpDispatch_VEXGroupTable[] = {
+constexpr DispatchTableEntry OpDispatch_VEXGroupTable[] = {
   {OPD(X86Tables::InstType::TYPE_VEX_GROUP_17, 0, 0b001), 1, &OpDispatchBuilder::BLSRBMIOp},
   {OPD(X86Tables::InstType::TYPE_VEX_GROUP_17, 0, 0b010), 1, &OpDispatchBuilder::BLSMSKBMIOp},
   {OPD(X86Tables::InstType::TYPE_VEX_GROUP_17, 0, 0b011), 1, &OpDispatchBuilder::BLSIBMIOp},


### PR DESCRIPTION
NFC