### PR TITLE
Windows: Support enabling hardware TSO on Asahi Linux

### DIFF
--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -653,6 +653,15 @@ NTSTATUS ProcessInit() {
   const uintptr_t KiUserExceptionDispatcherFFS = reinterpret_cast<uintptr_t>(GetProcAddress(NtDll, "KiUserExceptionDispatcher"));
   Exception::KiUserExceptionDispatcher = NtDllRedirectionLUT[KiUserExceptionDispatcherFFS - NtDllBase] + NtDllBase;
 
+  FEX_CONFIG_OPT(TSOEnabled, TSOENABLED);
+  if (TSOEnabled()) {
+    BOOL Enable = TRUE;
+    NTSTATUS Status = NtSetInformationProcess(NtCurrentProcess(), ProcessFexHardwareTso, &Enable, sizeof(Enable));
+    if (Status == STATUS_SUCCESS) {
+      CTX->SetHardwareTSOSupport(true);
+    }
+  }
+
   FEX_CONFIG_OPT(ProfileStats, PROFILESTATS);
   FEX_CONFIG_OPT(StartupSleep, STARTUPSLEEP);
   FEX_CONFIG_OPT(StartupSleepProcName, STARTUPSLEEPPROCNAME);

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -520,6 +520,15 @@ void BTCpuProcessInit() {
   // wow64.dll will only initialise the cross-process queue if this is set
   GetTLS().Wow64Info().CpuFlags = WOW64_CPUFLAGS_SOFTWARE;
 
+  FEX_CONFIG_OPT(TSOEnabled, TSOENABLED);
+  if (TSOEnabled()) {
+    BOOL Enable = TRUE;
+    NTSTATUS Status = NtSetInformationProcess(NtCurrentProcess(), ProcessFexHardwareTso, &Enable, sizeof(Enable));
+    if (Status == STATUS_SUCCESS) {
+      CTX->SetHardwareTSOSupport(true);
+    }
+  }
+
   FEX_CONFIG_OPT(ProfileStats, PROFILESTATS);
   FEX_CONFIG_OPT(StartupSleep, STARTUPSLEEP);
   FEX_CONFIG_OPT(StartupSleepProcName, STARTUPSLEEPPROCNAME);

--- a/Source/Windows/include/winternl.h
+++ b/Source/Windows/include/winternl.h
@@ -452,6 +452,8 @@ typedef enum _MEMORY_INFORMATION_CLASS {
   MemoryFexStatsShm = 2000,
 } MEMORY_INFORMATION_CLASS;
 
+#define ProcessFexHardwareTso (PROCESSINFOCLASS)2000
+
 typedef enum _KEY_VALUE_INFORMATION_CLASS {
   KeyValueBasicInformation,
   KeyValueFullInformation,


### PR DESCRIPTION
Relies on a [https://github.com/bylaws/wine/commit/d41dcbe25dcc707ffd3a110993e480053c5c8a1a](wine-side) patch to expose the prctl to the PE-side