### PR TITLE
FEXCore/OpcodeDispatcher: Fix a spurious crash that can occur with mu…

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4510,7 +4510,9 @@ void OpDispatchBuilder::INTOp(OpcodeArgs) {
     constexpr uint8_t SYSCALL_LITERAL = 0x80;
     if (Literal == SYSCALL_LITERAL) {
       if (CTX->Config.Is64BitMode()) [[unlikely]] {
-        ERROR_AND_DIE_FMT("[Unsupported] Trying to execute 32-bit syscall from a 64-bit process.");
+        LogMan::Msg::EFmt("[Unsupported] Trying to execute 32-bit syscall from a 64-bit process.");
+        UnhandledOp(Op);
+        return;
       }
       // Syscall on linux
       SyscallOp(Op, false);

--- a/unittests/ASM/FEX_bugs/non_fatal_syscall.asm
+++ b/unittests/ASM/FEX_bugs/non_fatal_syscall.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0"
+  }
+}
+%endif
+
+; FEX-Emu had a bug where an `int 0x80` instruction that never gets executed would cause the emulator to assert.
+; This was due to multiblock's static analysis finding a 32-bit syscall in some code down a branch that would never execute.
+; Ensure this doesn't take down the emulator by doing something similar.
+mov rax, 0
+cmp rax, 0
+
+je .end
+
+mov rax, 1
+int 0x80
+
+.end:
+hlt


### PR DESCRIPTION
…ltiblock

If multiblock discovers a codepath with an `int 0x80` then it would crash the emulator even if it never gets executed. Ensure that this ERROR_AND_DIE_FMT instead just gets handled as an UnhandledOp to ensure the Core early terminates the block.

Found by having steamwebhelper spuriously crash when it hit this. Adds a simple unittest to ensure discovery doesn't break again.