### PR TITLE
Ensure .clang-format-ignore is compatible with clang-format-19

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,8 +1,4 @@
 # This file is used to ignore files and directories from clang-format
-
-# Ignore all files in the External directory
-External/*
-
 Source/Common/cpp-optparse/*
 
 # Files with human-indented tables for readability - don't mess with these

--- a/External/.clang-format
+++ b/External/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true


### PR DESCRIPTION
Alternative to #4676 
@neobrain This might work instead of the alternative PR of bringing back the clang-format.py script.
