### PR TITLE
FEXCore: Reintroduce support for CSSC

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -2747,7 +2747,7 @@ void OpDispatchBuilder::XADDOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::PopcountOp(OpcodeArgs) {
-  Ref Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.AllowUpperGarbage = GetSrcSize(Op) >= 4});
+  Ref Src = LoadSource(GPRClass, Op, Op->Src[0], Op->Flags, {.AllowUpperGarbage = CTX->HostFeatures.SupportsCSSC || GetSrcSize(Op) >= 4});
   Src = _Popcount(OpSizeFromSrc(Op), Src);
   StoreResult(GPRClass, Op, Src, OpSize::iInvalid);
 

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "RPRES",
-      "AFP"
+      "AFP",
+      "CSSC"
     ]
   },
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
@@ -1,0 +1,50 @@
+{
+  "Features": {
+    "Bitness": 64,
+    "EnabledHostFeatures": [
+      "FLAGM",
+      "FLAGM2",
+      "CSSC"
+    ],
+    "DisabledHostFeatures": [
+      "SVE128",
+      "SVE256",
+      "RPRES",
+      "AFP"
+    ]
+  },
+  "Instructions": {
+    "popcnt ax, bx": {
+      "ExpectedInstructionCount": 6,
+      "Comment": "0xf3 0x0f 0xb8",
+      "ExpectedArm64ASM": [
+        "uxth w20, w6",
+        "cnt w20, w20",
+        "bfxil x4, x20, #0, #16",
+        "mov w27, #0x0",
+        "cmp w20, #0x0 (0)",
+        "mov w26, #0x1"
+      ]
+    },
+    "popcnt eax, ebx": {
+      "ExpectedInstructionCount": 4,
+      "Comment": "0xf3 0x0f 0xb8",
+      "ExpectedArm64ASM": [
+        "cnt w4, w6",
+        "mov w27, #0x0",
+        "cmp w4, #0x0 (0)",
+        "mov w26, #0x1"
+      ]
+    },
+    "popcnt rax, rbx": {
+      "ExpectedInstructionCount": 4,
+      "Comment": "0xf3 0x0f 0xb8",
+      "ExpectedArm64ASM": [
+        "cnt x4, x6",
+        "mov w27, #0x0",
+        "cmp w4, #0x0 (0)",
+        "mov w26, #0x1"
+      ]
+    }
+  }
+}

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -9,7 +9,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2",
-      "FRINTTS"
+      "FRINTTS",
+      "CSSC"
     ]
   },
   "Instructions": {


### PR DESCRIPTION
Now that the PF flag isn't using popcount, this is a win across the board if the hardware supports it.

Been a while since I last looked at this, added a new instcountci file to show the improvement.