### PR TITLE
LookupCache: Move CodePages to GuestToHostMap

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -166,7 +166,8 @@ public:
 
   void OnCodeBufferAllocated(CPU::CodeBuffer&) override;
   void ClearCodeCache(FEXCore::Core::InternalThreadState* Thread, bool NewCodeBuffer = true) override;
-  void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) override;
+  void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* Thread, InvalidatedEntryAccumulator& Accumulator, uint64_t Start,
+                                uint64_t Length) override;
   FEXCore::ForkableSharedMutex& GetCodeInvalidationMutex() override {
     return CodeInvalidationMutex;
   }

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -280,6 +280,7 @@ public:
     uint64_t TotalInstructionsLength;
     uint64_t StartAddr;
     uint64_t Length;
+    bool NeedsAddGuestCodeRanges;
   };
   [[nodiscard]]
   GenerateIRResult GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, bool ExtendedDebugInfo, uint64_t MaxInst);
@@ -289,6 +290,7 @@ public:
     fextl::unique_ptr<FEXCore::Core::DebugData> DebugData;
     uint64_t StartAddr;
     uint64_t Length;
+    bool NeedsAddGuestCodeRanges;
   };
   [[nodiscard]]
   CompileCodeResult CompileCode(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, uint64_t MaxInst = 0);

--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -1198,10 +1198,7 @@ void Decoder::DecodeInstructionsAtEntry(const uint8_t* _InstStream, uint64_t PC,
   FEXCORE_PROFILE_SCOPED("DecodeInstructions");
   BlockInfo.TotalInstructionCount = 0;
   BlockInfo.Blocks.clear();
-  BlockInfo.CodePages.clear();
-  BlocksToDecode.clear();
   VisitedBlocks.clear();
-  BlockInfo.EntryPoints.clear();
   // Reset internal state management
   DecodedSize = 0;
   MaxCondBranchForward = 0;
@@ -1211,7 +1208,7 @@ void Decoder::DecodeInstructionsAtEntry(const uint8_t* _InstStream, uint64_t PC,
   // XXX: Load symbol data
   SymbolAvailable = false;
   EntryPoint = PC;
-  BlockInfo.EntryPoints.emplace(PC);
+  BlockInfo.EntryPoints = {PC};
   InstStream = _InstStream;
 
   uint64_t TotalInstructions {};
@@ -1227,11 +1224,11 @@ void Decoder::DecodeInstructionsAtEntry(const uint8_t* _InstStream, uint64_t PC,
   DecodedMaxAddress = EntryPoint;
 
   // Entry is a jump target
-  BlocksToDecode.emplace(PC);
+  BlocksToDecode = {PC};
 
   uint64_t CurrentCodePage = PC & FEXCore::Utils::FEX_PAGE_MASK;
 
-  BlockInfo.CodePages.insert(CurrentCodePage);
+  BlockInfo.CodePages = {CurrentCodePage};
 
   if (MaxInst == 0) {
     MaxInst = CTX->Config.MaxInstPerBlock;

--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -1035,7 +1035,7 @@ void Decoder::BranchTargetInMultiblockRange() {
 
   if (DecodeInst->TableInfo->Flags & FEXCore::X86Tables::InstFlags::FLAGS_CALL) {
     AddBranchTarget(InstEnd);
-    BlockEntryPoints.emplace(InstEnd);
+    BlockInfo.EntryPoints.emplace(InstEnd);
     return;
   }
 
@@ -1198,9 +1198,10 @@ void Decoder::DecodeInstructionsAtEntry(const uint8_t* _InstStream, uint64_t PC,
   FEXCORE_PROFILE_SCOPED("DecodeInstructions");
   BlockInfo.TotalInstructionCount = 0;
   BlockInfo.Blocks.clear();
+  BlockInfo.CodePages.clear();
   BlocksToDecode.clear();
   VisitedBlocks.clear();
-  BlockEntryPoints.clear();
+  BlockInfo.EntryPoints.clear();
   // Reset internal state management
   DecodedSize = 0;
   MaxCondBranchForward = 0;
@@ -1210,7 +1211,7 @@ void Decoder::DecodeInstructionsAtEntry(const uint8_t* _InstStream, uint64_t PC,
   // XXX: Load symbol data
   SymbolAvailable = false;
   EntryPoint = PC;
-  BlockEntryPoints.emplace(PC);
+  BlockInfo.EntryPoints.emplace(PC);
   InstStream = _InstStream;
 
   uint64_t TotalInstructions {};
@@ -1230,7 +1231,7 @@ void Decoder::DecodeInstructionsAtEntry(const uint8_t* _InstStream, uint64_t PC,
 
   uint64_t CurrentCodePage = PC & FEXCore::Utils::FEX_PAGE_MASK;
 
-  fextl::set<uint64_t> CodePages = {CurrentCodePage};
+  BlockInfo.CodePages.insert(CurrentCodePage);
 
   if (MaxInst == 0) {
     MaxInst = CTX->Config.MaxInstPerBlock;
@@ -1295,12 +1296,12 @@ void Decoder::DecodeInstructionsAtEntry(const uint8_t* _InstStream, uint64_t PC,
 
       if (OpMinPage != CurrentCodePage) {
         CurrentCodePage = OpMinPage;
-        CodePages.insert(CurrentCodePage);
+        BlockInfo.CodePages.insert(CurrentCodePage);
       }
 
       if (OpMaxPage != CurrentCodePage) {
         CurrentCodePage = OpMaxPage;
-        CodePages.insert(CurrentCodePage);
+        BlockInfo.CodePages.insert(CurrentCodePage);
       }
 
       BlockIt->BlockStatus = DecodeInstruction(OpAddress);
@@ -1373,13 +1374,7 @@ void Decoder::DecodeInstructionsAtEntry(const uint8_t* _InstStream, uint64_t PC,
   BlockInfo.TotalInstructionCount = TotalInstructions;
 
   for (auto& Block : BlockInfo.Blocks) {
-    Block.IsEntryPoint = BlockEntryPoints.contains(Block.Entry);
-  }
-
-  for (auto CodePage : CodePages) {
-    if (Thread->LookupCache->AddBlockExecutableRange(BlockEntryPoints, CodePage, FEXCore::Utils::FEX_PAGE_SIZE)) {
-      CTX->SyscallHandler->MarkGuestExecutableRange(Thread, CodePage, FEXCore::Utils::FEX_PAGE_SIZE);
-    }
+    Block.IsEntryPoint = BlockInfo.EntryPoints.contains(Block.Entry);
   }
 }
 

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -38,6 +38,8 @@ public:
   struct DecodedBlockInformation final {
     uint64_t TotalInstructionCount;
     fextl::vector<DecodedBlocks> Blocks;
+    fextl::set<uint64_t> EntryPoints;
+    fextl::set<uint64_t> CodePages; // Start addresses of all pages touching the block
   };
 
   Decoder(FEXCore::Core::InternalThreadState* Thread);
@@ -129,7 +131,6 @@ private:
   fextl::set<uint64_t> BlocksToDecode;
   fextl::set<uint64_t> VisitedBlocks;
   fextl::set<uint64_t>* ExternalBranches {nullptr};
-  fextl::set<uint64_t> BlockEntryPoints;
 
   // ModRM rm decoding
   using DecodeModRMPtr = void (FEXCore::Frontend::Decoder::*)(X86Tables::DecodedOperand* Operand, X86Tables::ModRMDecoded ModRM);

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -64,6 +64,9 @@ public:
 
 using CodeRangeInvalidationFn = std::function<void(uint64_t start, uint64_t Length)>;
 
+// Nested vector of guest block entrypoints
+using InvalidatedEntryAccumulator = fextl::vector<fextl::vector<uint64_t>>;
+
 using CustomIREntrypointHandler = std::function<void(uintptr_t Entrypoint, IR::IREmitter*)>;
 
 using ExitHandler = std::function<void(Core::InternalThreadState* Thread)>;
@@ -172,7 +175,8 @@ public:
   FEX_DEFAULT_VISIBILITY virtual void WriteFilesWithCode(AOTIRCodeFileWriterFn Writer) = 0;
 
   FEX_DEFAULT_VISIBILITY virtual void ClearCodeCache(FEXCore::Core::InternalThreadState* Thread, bool NewCodeBuffer = true) = 0;
-  FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) = 0;
+  FEX_DEFAULT_VISIBILITY virtual void InvalidateGuestCodeRange(
+    FEXCore::Core::InternalThreadState* Thread, InvalidatedEntryAccumulator& Accumulator, uint64_t Start, uint64_t Length) = 0;
   FEX_DEFAULT_VISIBILITY virtual FEXCore::ForkableSharedMutex& GetCodeInvalidationMutex() = 0;
 
   FEX_DEFAULT_VISIBILITY virtual void MarkMemoryShared(FEXCore::Core::InternalThreadState* Thread) = 0;

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -52,7 +52,8 @@ public:
 
     {
       auto CodeInvalidationlk = FEXCore::GuardSignalDeferringSection(CTX->GetCodeInvalidationMutex(), Thread);
-      CTX->InvalidateGuestCodeRange(Thread, reinterpret_cast<uint64_t>(CodeStart), MAX_CODE_SIZE);
+      FEXCore::Context::InvalidatedEntryAccumulator Accumulator;
+      CTX->InvalidateGuestCodeRange(Thread, Accumulator, reinterpret_cast<uint64_t>(CodeStart), MAX_CODE_SIZE);
     }
 
     ClearStats();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -184,9 +184,10 @@ public:
     // Thread object isn't valid very early in frontend's initialization.
     // To be more optimal the frontend should provide this code with a valid Thread object earlier.
     auto CodeInvalidationlk = GuardSignalDeferringSectionWithFallback(CTX->GetCodeInvalidationMutex(), CallingThread);
+    FEXCore::Context::InvalidatedEntryAccumulator Accumulator;
 
     for (auto& Thread : Threads) {
-      CTX->InvalidateGuestCodeRange(Thread->Thread, Start, Length);
+      CTX->InvalidateGuestCodeRange(Thread->Thread, Accumulator, Start, Length);
     }
   }
 
@@ -198,9 +199,10 @@ public:
     // Thread object isn't valid very early in frontend's initialization.
     // To be more optimal the frontend should provide this code with a valid Thread object earlier.
     auto CodeInvalidationlk = GuardSignalDeferringSectionWithFallback(CTX->GetCodeInvalidationMutex(), CallingThread);
+    FEXCore::Context::InvalidatedEntryAccumulator Accumulator;
 
     for (auto& Thread : Threads) {
-      CTX->InvalidateGuestCodeRange(Thread->Thread, Start, Length);
+      CTX->InvalidateGuestCodeRange(Thread->Thread, Accumulator, Start, Length);
     }
 
     // Callback while holding the locks.

--- a/Source/Windows/Common/InvalidationTracker.cpp
+++ b/Source/Windows/Common/InvalidationTracker.cpp
@@ -53,8 +53,9 @@ void InvalidationTracker::HandleMemoryProtectionNotification(uint64_t Address, u
   if (NeedsInvalidate) {
     // IntervalsLock cannot be held during invalidation
     std::scoped_lock Lock(CTX.GetCodeInvalidationMutex());
+    FEXCore::Context::InvalidatedEntryAccumulator Accumulator;
     for (auto Thread : Threads) {
-      CTX.InvalidateGuestCodeRange(Thread.second, AlignedBase, AlignedSize);
+      CTX.InvalidateGuestCodeRange(Thread.second, Accumulator, AlignedBase, AlignedSize);
     }
   }
 }
@@ -94,8 +95,9 @@ InvalidationTracker::InvalidateContainingSectionResult InvalidationTracker::Inva
   }
   {
     std::scoped_lock Lock(CTX.GetCodeInvalidationMutex());
+    FEXCore::Context::InvalidatedEntryAccumulator Accumulator;
     for (auto Thread : Threads) {
-      CTX.InvalidateGuestCodeRange(Thread.second, SectionBase, SectionSize);
+      CTX.InvalidateGuestCodeRange(Thread.second, Accumulator, SectionBase, SectionSize);
     }
   }
 
@@ -119,8 +121,9 @@ void InvalidationTracker::InvalidateAlignedInterval(uint64_t Address, uint64_t S
 
   {
     std::scoped_lock Lock(CTX.GetCodeInvalidationMutex());
+    FEXCore::Context::InvalidatedEntryAccumulator Accumulator;
     for (auto Thread : Threads) {
-      CTX.InvalidateGuestCodeRange(Thread.second, AlignedBase, AlignedSize);
+      CTX.InvalidateGuestCodeRange(Thread.second, Accumulator, AlignedBase, AlignedSize);
     }
   }
 
@@ -170,8 +173,9 @@ bool InvalidationTracker::HandleRWXAccessViolation(uint64_t FaultAddress) {
   if (NeedsInvalidate) {
     // IntervalsLock cannot be held during invalidation
     std::scoped_lock Lock(CTX.GetCodeInvalidationMutex());
+    FEXCore::Context::InvalidatedEntryAccumulator Accumulator;
     for (auto Thread : Threads) {
-      CTX.InvalidateGuestCodeRange(Thread.second, FaultAddress & FEXCore::Utils::FEX_PAGE_MASK, FEXCore::Utils::FEX_PAGE_SIZE);
+      CTX.InvalidateGuestCodeRange(Thread.second, Accumulator, FaultAddress & FEXCore::Utils::FEX_PAGE_MASK, FEXCore::Utils::FEX_PAGE_SIZE);
     }
     return true;
   }


### PR DESCRIPTION
Prevents invalidations being missed under the following circumstances: Thread A JITs block A into the global codebuffer, adding the guest to host mapping to its CodePages, thread A is then killed. Thread B then performs SMC on block A. An exception will be triggered but as CodePages was stored per-thread, and thread A is now killed when all threads are iterated over by the frontend to perform invalidations it will be missed.