### PR TITLE
unittests/instcountci: Adds missing lock xadd tests

### DIFF
--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -1450,6 +1450,52 @@
         "adds x26, x27, #0x1 (1)",
         "rmif x20, #63, #nzCv"
       ]
+    },
+    "lock xadd byte [rcx], al": {
+      "ExpectedInstructionCount": 8,
+      "ExpectedArm64ASM": [
+        "uxtb w20, w4",
+        "ldaddalb w20, w21, [x7]",
+        "eor x27, x21, x20",
+        "lsl w0, w21, #24",
+        "cmn w0, w20, lsl #24",
+        "add w26, w21, w20",
+        "bfxil x4, x21, #0, #8",
+        "cfinv"
+      ]
+    },
+    "lock xadd word [rcx], ax": {
+      "ExpectedInstructionCount": 8,
+      "ExpectedArm64ASM": [
+        "uxth w20, w4",
+        "ldaddalh w20, w21, [x7]",
+        "eor x27, x21, x20",
+        "lsl w0, w21, #16",
+        "cmn w0, w20, lsl #16",
+        "add w26, w21, w20",
+        "bfxil x4, x21, #0, #16",
+        "cfinv"
+      ]
+    },
+    "lock xadd dword [rcx], eax": {
+      "ExpectedInstructionCount": 5,
+      "ExpectedArm64ASM": [
+        "mov w20, w4",
+        "ldaddal w20, w4, [x7]",
+        "eor x27, x4, x20",
+        "adds w26, w4, w20",
+        "cfinv"
+      ]
+    },
+    "lock xadd qword [rcx], rax": {
+      "ExpectedInstructionCount": 5,
+      "ExpectedArm64ASM": [
+        "ldaddal x4, x20, [x7]",
+        "eor x27, x20, x4",
+        "adds x26, x20, x4",
+        "cfinv",
+        "mov x4, x20"
+      ]
     }
   }
 }


### PR DESCRIPTION
Realized we were missing these, Looks like some moves could be eliminated.