### PR TITLE
Profiler: Decouple profile stats from the profiler option

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -46,6 +46,7 @@ $end_info$
 #include "FEXCore/Utils/SignalScopeGuards.h"
 #include <FEXCore/Utils/Threads.h>
 #include <FEXCore/Utils/Profiler.h>
+#include <FEXCore/Utils/SHMStats.h>
 #include <FEXCore/fextl/fmt.h>
 #include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/set.h>

--- a/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/F80Fallbacks.h
+++ b/FEXCore/Source/Interface/Core/Interpreter/Fallbacks/F80Fallbacks.h
@@ -6,7 +6,7 @@
 #include "Interface/IR/IR.h"
 
 #include <FEXCore/Debug/InternalThreadState.h>
-#include <FEXCore/Utils/Profiler.h>
+#include <FEXCore/Utils/SHMStats.h>
 
 namespace FEXCore::CPU {
 FEXCORE_PRESERVE_ALL_ATTR static softfloat_state SoftFloatStateFromFCW(uint16_t FCW, bool Force80BitPrecision = false) {

--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -36,7 +36,7 @@ class OpDispatchBuilder;
 class PassManager;
 } // namespace FEXCore::IR
 
-namespace FEXCore::Profiler {
+namespace FEXCore::SHMStats {
 struct ThreadStats;
 };
 
@@ -100,7 +100,7 @@ struct InternalThreadState : public FEXCore::Allocator::FEXAllocOperators {
   std::shared_mutex ObjectCacheRefCounter {};
 
   // This pointer is owned by the frontend.
-  FEXCore::Profiler::ThreadStats* ThreadStats {};
+  FEXCore::SHMStats::ThreadStats* ThreadStats {};
 
   ///< Data pointer for exclusive use by the frontend
   void* FrontendPtr;

--- a/FEXCore/include/FEXCore/Utils/Profiler.h
+++ b/FEXCore/include/FEXCore/Utils/Profiler.h
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
-#include <atomic>
 #include <cstdint>
 #include <string_view>
-
-#ifdef _M_X86_64
-#include <x86intrin.h>
-#endif
 
 #include <FEXCore/Utils/CompilerDefs.h>
 
@@ -19,62 +14,6 @@
 #endif
 
 namespace FEXCore::Profiler {
-// FEXCore live-stats
-constexpr uint8_t STATS_VERSION = 2;
-enum class AppType : uint8_t {
-  LINUX_32,
-  LINUX_64,
-  WIN_ARM64EC,
-  WIN_WOW64,
-};
-
-struct ThreadStatsHeader {
-  uint8_t Version;
-  AppType app_type;
-  uint8_t _pad[2];
-  char fex_version[48];
-  std::atomic<uint32_t> Head;
-  std::atomic<uint32_t> Size;
-  uint32_t Pad;
-};
-
-struct ThreadStats {
-  std::atomic<uint32_t> Next;
-  std::atomic<uint32_t> TID;
-
-  // Accumulated time (In unscaled CPU cycles!)
-  uint64_t AccumulatedJITTime;
-  uint64_t AccumulatedSignalTime;
-
-  // Accumulated event counts
-  uint64_t AccumulatedSIGBUSCount;
-  uint64_t AccumulatedSMCCount;
-  uint64_t AccumulatedFloatFallbackCount;
-};
-
-#ifdef _M_ARM_64
-/**
- * @brief Get the raw cycle counter with synchronizing isb.
- *
- * `CNTVCTSS_EL0` also does the same thing, but requires the FEAT_ECV feature.
- */
-static inline uint64_t GetCycleCounter() {
-  uint64_t Result {};
-  __asm volatile(R"(
-      isb;
-      mrs %[Res], CNTVCT_EL0;
-    )"
-                 : [Res] "=r"(Result));
-  return Result;
-}
-#else
-static inline uint64_t GetCycleCounter() {
-  unsigned dummy;
-  uint64_t tsc = __rdtscp(&dummy);
-  return tsc;
-}
-#endif
-
 #define UniqueScopeName2(name, line) name##line
 #define UniqueScopeName(name, line) UniqueScopeName2(name, line)
 
@@ -130,34 +69,4 @@ static void TraceObject(const std::string_view, uint64_t) {}
   } while (0)
 
 #endif
-
-template<typename T, size_t FlatOffset = 0>
-class AccumulationBlock final {
-public:
-  AccumulationBlock(T* Stat)
-    : Begin {GetCycleCounter()}
-    , Stat {Stat} {}
-
-  ~AccumulationBlock() {
-    const auto Duration = GetCycleCounter() - Begin + FlatOffset;
-    if (Stat) {
-      auto ref = std::atomic_ref<T>(*Stat);
-      ref.fetch_add(Duration, std::memory_order_relaxed);
-    }
-  }
-
-private:
-  uint64_t Begin;
-  T* Stat;
-};
-
-#define FEXCORE_PROFILE_ACCUMULATION(ThreadState, Stat)                                                                          \
-  FEXCore::Profiler::AccumulationBlock<decltype(ThreadState->ThreadStats->Stat)> UniqueScopeName(ScopedAccumulation_, __LINE__)( \
-    ThreadState->ThreadStats ? &ThreadState->ThreadStats->Stat : nullptr);
-#define FEXCORE_PROFILE_INSTANT_INCREMENT(ThreadState, Stat, value) \
-  do {                                                              \
-    if (ThreadState->ThreadStats) {                                 \
-      ThreadState->ThreadStats->Stat += value;                      \
-    }                                                               \
-  } while (0)
 } // namespace FEXCore::Profiler

--- a/FEXCore/include/FEXCore/Utils/SHMStats.h
+++ b/FEXCore/include/FEXCore/Utils/SHMStats.h
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include <atomic>
+#include <cstdint>
+
+#ifdef _M_X86_64
+#include <x86intrin.h>
+#endif
+
+namespace FEXCore::SHMStats {
+#ifdef _M_ARM_64
+/**
+ * @brief Get the raw cycle counter with synchronizing isb.
+ *
+ * `CNTVCTSS_EL0` also does the same thing, but requires the FEAT_ECV feature.
+ */
+static inline uint64_t GetCycleCounter() {
+  uint64_t Result {};
+  __asm volatile(R"(
+      isb;
+      mrs %[Res], CNTVCT_EL0;
+    )"
+                 : [Res] "=r"(Result));
+  return Result;
+}
+#else
+static inline uint64_t GetCycleCounter() {
+  unsigned dummy;
+  uint64_t tsc = __rdtscp(&dummy);
+  return tsc;
+}
+#endif
+// FEXCore live-stats
+constexpr uint8_t STATS_VERSION = 2;
+enum class AppType : uint8_t {
+  LINUX_32,
+  LINUX_64,
+  WIN_ARM64EC,
+  WIN_WOW64,
+};
+
+struct ThreadStatsHeader {
+  uint8_t Version;
+  AppType app_type;
+  uint8_t _pad[2];
+  char fex_version[48];
+  std::atomic<uint32_t> Head;
+  std::atomic<uint32_t> Size;
+  uint32_t Pad;
+};
+
+struct ThreadStats {
+  std::atomic<uint32_t> Next;
+  std::atomic<uint32_t> TID;
+
+  // Accumulated time (In unscaled CPU cycles!)
+  uint64_t AccumulatedJITTime;
+  uint64_t AccumulatedSignalTime;
+
+  // Accumulated event counts
+  uint64_t AccumulatedSIGBUSCount;
+  uint64_t AccumulatedSMCCount;
+  uint64_t AccumulatedFloatFallbackCount;
+};
+
+template<typename T, size_t FlatOffset = 0>
+class AccumulationBlock final {
+public:
+  AccumulationBlock(T* Stat)
+    : Begin {GetCycleCounter()}
+    , Stat {Stat} {}
+
+  ~AccumulationBlock() {
+    const auto Duration = GetCycleCounter() - Begin + FlatOffset;
+    if (Stat) {
+      auto ref = std::atomic_ref<T>(*Stat);
+      ref.fetch_add(Duration, std::memory_order_relaxed);
+    }
+  }
+
+private:
+  uint64_t Begin;
+  T* Stat;
+};
+#define UniqueScopeName2(name, line) name##line
+#define UniqueScopeName(name, line) UniqueScopeName2(name, line)
+
+#define FEXCORE_PROFILE_ACCUMULATION(ThreadState, Stat)                                                                          \
+  FEXCore::SHMStats::AccumulationBlock<decltype(ThreadState->ThreadStats->Stat)> UniqueScopeName(ScopedAccumulation_, __LINE__)( \
+    ThreadState->ThreadStats ? &ThreadState->ThreadStats->Stat : nullptr);
+#define FEXCORE_PROFILE_INSTANT_INCREMENT(ThreadState, Stat, value) \
+  do {                                                              \
+    if (ThreadState->ThreadStats) {                                 \
+      ThreadState->ThreadStats->Stat += value;                      \
+    }                                                               \
+  } while (0)
+
+} // namespace FEXCore::SHMStats

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SRCS
   HostFeatures.cpp
   JSONPool.cpp
   StringUtil.cpp
-  Profiler.cpp)
+  SHMStats.cpp)
 
 if (NOT MINGW_BUILD)
   list (APPEND SRCS

--- a/Source/Common/SHMStats.h
+++ b/Source/Common/SHMStats.h
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 /*
 $info$
-tags: Common|Profiler
+tags: Common|SHMStats
 desc: Frontend profiler common code
 $end_info$
 */
 #pragma once
-#include <FEXCore/Utils/Profiler.h>
+#include <FEXCore/Utils/SHMStats.h>
 
 namespace FEXCore::Core {
 struct InternalThreadState;
@@ -24,33 +24,33 @@ static inline void store_memory_barrier() {
 }
 #endif
 
-namespace FEX::Profiler {
+namespace FEX::SHMStats {
 class StatAllocBase {
 protected:
-  FEXCore::Profiler::ThreadStats* AllocateSlot(uint32_t TID);
-  void DeallocateSlot(FEXCore::Profiler::ThreadStats* AllocatedSlot);
+  FEXCore::SHMStats::ThreadStats* AllocateSlot(uint32_t TID);
+  void DeallocateSlot(FEXCore::SHMStats::ThreadStats* AllocatedSlot);
 
-  uint32_t OffsetFromStat(FEXCore::Profiler::ThreadStats* Stat) const {
+  uint32_t OffsetFromStat(FEXCore::SHMStats::ThreadStats* Stat) const {
     return reinterpret_cast<uint64_t>(Stat) - reinterpret_cast<uint64_t>(Base);
   }
   uint32_t TotalSlotsFromSize() const {
-    return (CurrentSize - sizeof(FEXCore::Profiler::ThreadStatsHeader)) / sizeof(FEXCore::Profiler::ThreadStats) - 1;
+    return (CurrentSize - sizeof(FEXCore::SHMStats::ThreadStatsHeader)) / sizeof(FEXCore::SHMStats::ThreadStats) - 1;
   }
   static uint32_t TotalSlotsFromSize(uint32_t Size) {
-    return (Size - sizeof(FEXCore::Profiler::ThreadStatsHeader)) / sizeof(FEXCore::Profiler::ThreadStats) - 1;
+    return (Size - sizeof(FEXCore::SHMStats::ThreadStatsHeader)) / sizeof(FEXCore::SHMStats::ThreadStats) - 1;
   }
 
   static uint32_t SlotIndexFromOffset(uint32_t Offset) {
-    return (Offset - sizeof(FEXCore::Profiler::ThreadStatsHeader)) / sizeof(FEXCore::Profiler::ThreadStats);
+    return (Offset - sizeof(FEXCore::SHMStats::ThreadStatsHeader)) / sizeof(FEXCore::SHMStats::ThreadStats);
   }
 
-  void SaveHeader(FEXCore::Profiler::AppType AppType);
+  void SaveHeader(FEXCore::SHMStats::AppType AppType);
 
   void* Base {};
   uint32_t CurrentSize {};
-  FEXCore::Profiler::ThreadStatsHeader* Head {};
-  FEXCore::Profiler::ThreadStats* Stats {};
-  FEXCore::Profiler::ThreadStats* StatTail {};
+  FEXCore::SHMStats::ThreadStatsHeader* Head {};
+  FEXCore::SHMStats::ThreadStats* Stats {};
+  FEXCore::SHMStats::ThreadStats* StatTail {};
   uint32_t RemainingSlots {};
 
   // Limited to 4MB which should be a few hundred threads of tracking capability.
@@ -66,4 +66,4 @@ private:
   bool AllocateMoreSlots();
 };
 
-} // namespace FEX::Profiler
+} // namespace FEX::SHMStats

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -17,7 +17,7 @@ namespace FEX::HLE {
 
 ThreadManager::StatAlloc::StatAlloc() {
   Initialize();
-  SaveHeader(Is64BitMode() ? FEXCore::Profiler::AppType::LINUX_64 : FEXCore::Profiler::AppType::LINUX_32);
+  SaveHeader(Is64BitMode() ? FEXCore::SHMStats::AppType::LINUX_64 : FEXCore::SHMStats::AppType::LINUX_32);
 }
 
 void ThreadManager::StatAlloc::Initialize() {
@@ -97,12 +97,12 @@ err:
   return NewSize;
 }
 
-FEXCore::Profiler::ThreadStats* ThreadManager::StatAlloc::AllocateSlot(uint32_t TID) {
+FEXCore::SHMStats::ThreadStats* ThreadManager::StatAlloc::AllocateSlot(uint32_t TID) {
   std::scoped_lock lk(StatMutex);
   return StatAllocBase::AllocateSlot(TID);
 }
 
-void ThreadManager::StatAlloc::DeallocateSlot(FEXCore::Profiler::ThreadStats* AllocatedSlot) {
+void ThreadManager::StatAlloc::DeallocateSlot(FEXCore::SHMStats::ThreadStats* AllocatedSlot) {
   if (!AllocatedSlot) {
     return;
   }
@@ -147,7 +147,7 @@ void ThreadManager::StatAlloc::UnlockAfterFork(FEXCore::Core::InternalThreadStat
   Thread->ThreadStats = nullptr;
 
   Initialize();
-  SaveHeader(Is64BitMode() ? FEXCore::Profiler::AppType::LINUX_64 : FEXCore::Profiler::AppType::LINUX_32);
+  SaveHeader(Is64BitMode() ? FEXCore::SHMStats::AppType::LINUX_64 : FEXCore::SHMStats::AppType::LINUX_32);
 
   // Update this thread's ThreadStats object
   auto ThreadObject = FEX::HLE::ThreadManager::GetStateObjectFromFEXCoreThread(Thread);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -8,7 +8,7 @@ $end_info$
 
 #pragma once
 
-#include "Common/Profiler.h"
+#include "Common/SHMStats.h"
 
 #include "LinuxSyscalls/Types.h"
 #include "LinuxSyscalls/Seccomp/SeccompEmulator.h"
@@ -123,7 +123,7 @@ public:
 
   ~ThreadManager();
 
-  class StatAlloc final : public FEX::Profiler::StatAllocBase {
+  class StatAlloc final : public FEX::SHMStats::StatAllocBase {
   public:
     StatAlloc();
 
@@ -132,8 +132,8 @@ public:
 
     void CleanupForExit();
 
-    FEXCore::Profiler::ThreadStats* AllocateSlot(uint32_t TID);
-    void DeallocateSlot(FEXCore::Profiler::ThreadStats* AllocatedSlot);
+    FEXCore::SHMStats::ThreadStats* AllocateSlot(uint32_t TID);
+    void DeallocateSlot(FEXCore::SHMStats::ThreadStats* AllocatedSlot);
 
   private:
     void Initialize();

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -18,6 +18,7 @@ $end_info$
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/Threads.h>
 #include <FEXCore/Utils/Profiler.h>
+#include <FEXCore/Utils/SHMStats.h>
 #include <FEXCore/Utils/EnumOperators.h>
 #include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/FPState.h>
@@ -40,7 +41,7 @@ $end_info$
 #include "Common/PortabilityInfo.h"
 #include "DummyHandlers.h"
 #include "BTInterface.h"
-#include "Windows/Common/Profiler.h"
+#include "Windows/Common/SHMStats.h"
 
 #include <cstdint>
 #include <cstdio>
@@ -664,7 +665,7 @@ NTSTATUS ProcessInit() {
   FEX_CONFIG_OPT(StartupSleepProcName, STARTUPSLEEPPROCNAME);
 
   if (IsWine && ProfileStats()) {
-    StatAllocHandler = fextl::make_unique<FEX::Windows::StatAlloc>(FEXCore::Profiler::AppType::WIN_ARM64EC);
+    StatAllocHandler = fextl::make_unique<FEX::Windows::StatAlloc>(FEXCore::SHMStats::AppType::WIN_ARM64EC);
   }
 
   if (StartupSleep() && (StartupSleepProcName().empty() || ExecutablePath == StartupSleepProcName())) {

--- a/Source/Windows/Common/CMakeLists.txt
+++ b/Source/Windows/Common/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(CommonWindows STATIC CPUFeatures.cpp Profiler.cpp InvalidationTracker.cpp Logging.cpp LoadConfig.S)
+add_library(CommonWindows STATIC CPUFeatures.cpp SHMStats.cpp InvalidationTracker.cpp Logging.cpp LoadConfig.S)
 add_subdirectory(CRT)
 add_subdirectory(WinAPI)
 target_link_libraries(CommonWindows FEXCore_Base JemallocLibs)

--- a/Source/Windows/Common/SHMStats.cpp
+++ b/Source/Windows/Common/SHMStats.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-#include "Windows/Common/Profiler.h"
+#include "Windows/Common/SHMStats.h"
 
 #include <FEXCore/fextl/fmt.h>
 #include <FEXCore/Utils/LogManager.h>
@@ -40,7 +40,7 @@ uint32_t StatAlloc::FrontendAllocateSlots(uint32_t NewSize) {
   return CurrentSize;
 }
 
-StatAlloc::StatAlloc(FEXCore::Profiler::AppType AppType) {
+StatAlloc::StatAlloc(FEXCore::SHMStats::AppType AppType) {
   // Try wine+fex magic path.
 
   {

--- a/Source/Windows/Common/SHMStats.h
+++ b/Source/Windows/Common/SHMStats.h
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "Common/Profiler.h"
+#include "Common/SHMStats.h"
 
 namespace FEX::Windows {
-class StatAlloc final : public FEX::Profiler::StatAllocBase {
+class StatAlloc final : public FEX::SHMStats::StatAllocBase {
 public:
-  StatAlloc(FEXCore::Profiler::AppType AppType);
+  StatAlloc(FEXCore::SHMStats::AppType AppType);
   virtual ~StatAlloc();
 
-  FEXCore::Profiler::ThreadStats* AllocateSlot(uint32_t TID) {
+  FEXCore::SHMStats::ThreadStats* AllocateSlot(uint32_t TID) {
     return StatAllocBase::AllocateSlot(TID);
   }
 
-  void DeallocateSlot(FEXCore::Profiler::ThreadStats* AllocatedSlot) {
+  void DeallocateSlot(FEXCore::SHMStats::ThreadStats* AllocatedSlot) {
     if (!AllocatedSlot) {
       return;
     }

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -20,6 +20,7 @@ $end_info$
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/Threads.h>
 #include <FEXCore/Utils/Profiler.h>
+#include <FEXCore/Utils/SHMStats.h>
 #include <FEXCore/Utils/EnumOperators.h>
 #include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/FPState.h>
@@ -40,7 +41,7 @@ $end_info$
 #include "Common/PortabilityInfo.h"
 #include "DummyHandlers.h"
 #include "BTInterface.h"
-#include "Windows/Common/Profiler.h"
+#include "Windows/Common/SHMStats.h"
 
 #include <cstdint>
 #include <type_traits>
@@ -539,7 +540,7 @@ void BTCpuProcessInit() {
   FEX_CONFIG_OPT(StartupSleepProcName, STARTUPSLEEPPROCNAME);
 
   if (IsWine && ProfileStats()) {
-    StatAllocHandler = fextl::make_unique<FEX::Windows::StatAlloc>(FEXCore::Profiler::AppType::WIN_WOW64);
+    StatAllocHandler = fextl::make_unique<FEX::Windows::StatAlloc>(FEXCore::SHMStats::AppType::WIN_WOW64);
   }
 
   if (StartupSleep() && (StartupSleepProcName().empty() || ExecutablePath == StartupSleepProcName())) {


### PR DESCRIPTION
This option is free and only enabled if the config option is set. Enable it always at build time so that users can pick it up without enabling the full gpuviz/tracy paths.