### PR TITLE
ArchHelpers: Remove pair usage in unaligned handler

### DIFF
--- a/FEXCore/Source/Utils/ArchHelpers/Arm64_stubs.cpp
+++ b/FEXCore/Source/Utils/ArchHelpers/Arm64_stubs.cpp
@@ -11,7 +11,7 @@ namespace FEXCore::ArchHelpers::Arm64 {
 
 // Obvously such a configuration can't do the actual arm64-specific stuff
 
-std::pair<bool, int32_t>
+std::optional<int32_t>
 HandleUnalignedAccess(FEXCore::Core::InternalThreadState* Thread, UnalignedHandlerType HandleType, uintptr_t ProgramCounter, uint64_t* GPRs) {
   ERROR_AND_DIE_FMT("HandleAtomicMemOp Not Implemented");
 }

--- a/FEXCore/include/FEXCore/Utils/ArchHelpers/Arm64.h
+++ b/FEXCore/include/FEXCore/Utils/ArchHelpers/Arm64.h
@@ -4,7 +4,7 @@
 #include <FEXCore/Utils/CompilerDefs.h>
 
 #include <stdint.h>
-#include <utility>
+#include <optional>
 
 namespace FEXCore::Core {
 struct InternalThreadState;
@@ -30,10 +30,10 @@ enum class UnalignedHandlerType {
  * @param ProgramCounter The location in memory for the instruction that did the access
  * @param GPRs The array of GPRs from the signal context. This will be modified and the host context needs to be updated on signal return.
  *
- * @return A pair where the first element is if the unaligned access has been handle and the second element is how many bytes to modify the host PC
+ * @return Returns a value if the unaligned access has been handled with how many bytes to modify the host PC
  * by. FEXCore will return a positive or negative offset depending on internal handling.
  */
 [[nodiscard]]
-FEX_DEFAULT_VISIBILITY std::pair<bool, int32_t>
+FEX_DEFAULT_VISIBILITY std::optional<int32_t>
 HandleUnalignedAccess(FEXCore::Core::InternalThreadState* Thread, UnalignedHandlerType HandleType, uintptr_t ProgramCounter, uint64_t* GPRs);
 } // namespace FEXCore::ArchHelpers::Arm64

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -945,8 +945,8 @@ SignalDelegator::SignalDelegator(FEXCore::Context::Context* _CTX, const std::str
     const auto Delegator = FEX::HLE::ThreadManager::GetStateObjectFromFEXCoreThread(Thread)->SignalInfo.Delegator;
     const auto Result = FEXCore::ArchHelpers::Arm64::HandleUnalignedAccess(Thread, Delegator->GetUnalignedHandlerType(), PC,
                                                                            ArchHelpers::Context::GetArmGPRs(ucontext));
-    ArchHelpers::Context::SetPc(ucontext, PC + Result.second);
-    return Result.first;
+    ArchHelpers::Context::SetPc(ucontext, PC + Result.value_or(0));
+    return Result.has_value();
   };
 
   RegisterHostSignalHandler(SIGBUS, SigbusHandler, true);

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -153,8 +153,8 @@ LONG WINAPI VectoredExceptionHandler(struct _EXCEPTION_POINTERS* ExceptionInfo) 
     }
 
     const auto Result = FEXCore::ArchHelpers::Arm64::HandleUnalignedAccess(true, PC, FEX::ArchHelpers::Context::GetArmGPRs(Context));
-    FEX::ArchHelpers::Context::SetPc(Context, PC + Result.second);
-    return Result.first ? EXCEPTION_CONTINUE_EXECUTION : EXCEPTION_CONTINUE_SEARCH;
+    FEX::ArchHelpers::Context::SetPc(Context, PC + Result.value_or(0));
+    return Result ? EXCEPTION_CONTINUE_EXECUTION : EXCEPTION_CONTINUE_SEARCH;
   }
   case STATUS_ACCESS_VIOLATION: {
     constexpr uint8_t HLT = 0xF4;

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -335,12 +335,8 @@ static bool HandleUnalignedAccess(ARM64_NT_CONTEXT& Context) {
   FEXCORE_PROFILE_INSTANT_INCREMENT(Thread, AccumulatedSIGBUSCount, 1);
   const auto Result =
     FEXCore::ArchHelpers::Arm64::HandleUnalignedAccess(Thread, HandlerConfig->GetUnalignedHandlerType(), Context.Pc, &Context.X0);
-  if (!Result.first) {
-    return false;
-  }
-
-  Context.Pc += Result.second;
-  return true;
+  Context.Pc += Result.value_or(0);
+  return Result.has_value();
 }
 
 static void LoadStateFromECContext(FEXCore::Core::InternalThreadState* Thread, CONTEXT& Context) {

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -318,12 +318,8 @@ bool HandleUnalignedAccess(CONTEXT* Context) {
 
   const auto Result =
     FEXCore::ArchHelpers::Arm64::HandleUnalignedAccess(Thread, HandlerConfig->GetUnalignedHandlerType(), Context->Pc, &Context->X0);
-  if (!Result.first) {
-    return false;
-  }
-
-  Context->Pc += Result.second;
-  return true;
+  Context->Pc += Result.value_or(0);
+  return Result.has_value();
 }
 
 void LockJITContext() {


### PR DESCRIPTION
It's being treated like optional, where a value means it has been handled, and no value means it hasn't been handled. Stop using pair in this case.