### PR TITLE
CMake: Work around QCom disabling SVE in their chips

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,13 @@ if (TUNE_CPU STREQUAL "native")
 
       string(STRIP ${AARCH64_CPU} AARCH64_CPU)
 
+      execute_process(COMMAND python3 "${PROJECT_SOURCE_DIR}/Scripts/NeedDisabledSVE.py"
+        RESULT_VARIABLE NEEDS_SVE_DISABLED)
+      if (NEEDS_SVE_DISABLED)
+        message(STATUS "Platform has bugged SVE. Disabling")
+        set(AARCH64_CPU "cortex-a78")
+      endif()
+
       check_cxx_compiler_flag("-mcpu=${AARCH64_CPU}" COMPILER_SUPPORTS_CPU_TYPE)
       if(COMPILER_SUPPORTS_CPU_TYPE)
         list(APPEND FEX_TUNE_COMPILE_FLAGS "-mcpu=${AARCH64_CPU}")

--- a/Scripts/NeedDisabledSVE.py
+++ b/Scripts/NeedDisabledSVE.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+
+# Qualcomm in their infinite wisdom decided to disable SVE in a handful of SoCs.
+# When compiling for a specific CPU architecture or `-mcpu=native`, we need to ensure
+# that SVE is disabled on these platforms that had the feature disabled.
+# Check for the handful of Cortex CPUs that support SVE in hardware, but are disabled
+# in software.
+import re
+import sys
+
+def GetCPUFeatures():
+    File = open("/proc/cpuinfo", "r")
+    Lines = File.readlines()
+    File.close()
+
+    for Line in Lines:
+        if "Features" in Line:
+            Features = Line.split(":")[1].strip().split(" ")
+            return Features
+
+SnapdragonIDsWithDisabledSVE = {
+    # Snapdragon 8 Gen 3
+    tuple([0x41, 0xd82]): True, # Cortex-X4
+    tuple([0x41, 0xd81]): True, # Cortex-A720
+    tuple([0x41, 0xd80]): True, # Cortex-A520
+
+    # Snapdragon 8 Gen 2
+    tuple([0x41, 0xd4e]): True, # Cortex-X3
+    tuple([0x41, 0xd4d]): True, # Cortex-A715
+    tuple([0x41, 0xd47]): True, # Cortex-A710
+    tuple([0x41, 0xd46]): True, # Cortex-A510
+
+    # Snapdragon 8 Gen 1
+    tuple([0x41, 0xd48]): True, # Cortex-X2
+    # A710
+    # A510
+}
+
+def IsAffectedSnapdragon():
+    cpuinfo = []
+
+    with open("/proc/cpuinfo") as cpuinfo_file:
+        current_implementer = 0
+        current_part = 0
+        for line in cpuinfo_file:
+            line = line.strip()
+            if "CPU implementer" in line:
+                current_implementer = int(re.findall(r'0x[0-9A-F]+', line, re.I)[0], 16)
+            if "CPU part" in line:
+                current_part = int(re.findall(r'0x[0-9A-F]+', line, re.I)[0], 16)
+                cpuinfo += {tuple([current_implementer, current_part])}
+
+    for core in cpuinfo:
+        if SnapdragonIDsWithDisabledSVE.get(core):
+            return True
+
+    return False
+
+
+def main():
+    Features = GetCPUFeatures()
+
+    # If SVE is reported from cpuinfo just return.
+    if "sve" in Features:
+        return 0
+
+    if IsAffectedSnapdragon():
+        return 1
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #4124

clang feature checking can't check beyond MIDR, so compiling for a specific cortex version means compiling SVE on these CPUs that disabled them.

Just detect the particular situation in-which SVE isn't inside proc/cpuinfo and is one of the snapdragon cores that are supposed to support SVE. Then compile for Cortex-a78 instead.