### PR TITLE
Implement inline SMC handling for linux FEX

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -92,9 +92,6 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
   // GDB signal information
   struct GdbInfoStruct {
     int Signal {};
-    uint64_t SignalPC {};
-    uint64_t GPRs[32];
-    uint64_t PState {};
   };
   std::optional<GdbInfoStruct> GdbInfo;
 

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -301,9 +301,11 @@ int main(int argc, char** argv, char** const envp) {
                                                  FEX::HLE::x32::CreateHandler(CTX.get(), SignalDelegation.get(), nullptr, std::move(Allocator));
 
     auto DoMmap = [&](uint64_t Address, size_t Size) -> void* {
-      void* Result = SyscallHandler->GuestMmap(nullptr, (void*)Address, Size, PROT_READ | PROT_WRITE | PROT_EXEC,
-                                               MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
+      // Map as R-X, then protect as RWX without informing the frontend to avoid unwanted SMC detection
+      void* Result =
+        SyscallHandler->GuestMmap(nullptr, (void*)Address, Size, PROT_READ | PROT_EXEC, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
       LOGMAN_THROW_A_FMT(Result == reinterpret_cast<void*>(Address), "Map Memory mmap failed");
+      ::mprotect(Result, Size, PROT_READ | PROT_WRITE | PROT_EXEC);
       return Result;
     };
 


### PR DESCRIPTION
Works the same as ARM64EC/WOW64, recovering the context for SMC insts in non-single-instruction and recompiling them as ones.

Closes #4706

Needs testing in peggle/crysis/denuvo games. Theoretically should work though