### PR TITLE
Frontend: Remove arbitrary check

### DIFF
--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -962,9 +962,6 @@ bool Decoder::DecodeInstructionImpl(uint64_t PC) {
         auto Info = &FEXCore::X86Tables::BaseOps[Op];
 
         if (Info->Type == FEXCore::X86Tables::TYPE_REX_PREFIX) {
-          if (!BlockInfo.Is64BitMode) {
-            return false;
-          }
           DecodeInst->Flags |= DecodeFlags::FLAG_REX_PREFIX;
 
           // Widening displacement


### PR DESCRIPTION
REX prefix isn't even encoded in to the instruction tables if a 32-bit process is running. Just remove this.