### PR TITLE
asm_tests: Tests for fninit

### DIFF
--- a/unittests/ASM/X87/DB_E3.asm
+++ b/unittests/ASM/X87/DB_E3.asm
@@ -2,8 +2,7 @@
 {
   "RegData": {
     "RAX": "0x037F"
-  },
-  "Mode": "32BIT"
+  }
 }
 %endif
 

--- a/unittests/ASM/X87_F64/DB_E3.asm
+++ b/unittests/ASM/X87_F64/DB_E3.asm
@@ -3,7 +3,7 @@
   "RegData": {
     "RAX": "0x037F"
   },
-  "Mode": "32BIT"
+  "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
 }
 %endif
 


### PR DESCRIPTION
NFC.
These tests existed for 32bits but were missing for 64bits and reduced precision. Adjust 32bit test to match new tests.