### PR TITLE
ASIMDOps: Move remaining base opcodes into implementing function

### DIFF
--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -332,20 +332,6 @@ public:
     ASIMDScalarCopy(Q, 0, imm5, 0b0111, ToVReg(rd), rn);
   }
 
-  template<SubRegSize size>
-  void ins(VRegister rd, uint32_t Index, Register rn) {
-    constexpr uint32_t SizeImm = FEXCore::ToUnderlying(size);
-    constexpr uint32_t IndexShift = SizeImm + 1;
-    constexpr uint32_t ElementSize = 1U << SizeImm;
-    [[maybe_unused]] constexpr uint32_t MaxIndex = 128U / (ElementSize * 8);
-
-    LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
-
-    const uint32_t imm5 = (Index << IndexShift) | ElementSize;
-
-    ASIMDScalarCopy(1, 0, imm5, 0b0011, rd, ToVReg(rn));
-  }
-
   void ins(SubRegSize size, VRegister rd, uint32_t Index, Register rn) {
     const uint32_t SizeImm = FEXCore::ToUnderlying(size);
     const uint32_t IndexShift = SizeImm + 1;

--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -3910,195 +3910,150 @@ public:
   }
 
   // Conversion between floating-point and integer
-  void fcvtns(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtns(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b00, 0b000, rd, ToReg(rn));
   }
-  void fcvtns(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtns(ARMEmitter::Size size, Register rd, SRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b00, 0b000, rd, ToReg(rn));
   }
-  void fcvtns(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtns(ARMEmitter::Size size, Register rd, DRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b00, 0b000, rd, ToReg(rn));
   }
-  void fcvtnu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtnu(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b00, 0b001, rd, ToReg(rn));
   }
-  void fcvtnu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtnu(ARMEmitter::Size size, Register rd, SRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b00, 0b001, rd, ToReg(rn));
   }
-  void fcvtnu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtnu(ARMEmitter::Size size, Register rd, DRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b00, 0b001, rd, ToReg(rn));
   }
-  void scvtf(ARMEmitter::Size size, ARMEmitter::HRegister rd, ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b010, ARMEmitter::ToReg(rd), rn);
+  void scvtf(ARMEmitter::Size size, HRegister rd, Register rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b00, 0b010, ToReg(rd), rn);
   }
-  void scvtf(ARMEmitter::Size size, ARMEmitter::SRegister rd, ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b010, ARMEmitter::ToReg(rd), rn);
+  void scvtf(ARMEmitter::Size size, SRegister rd, Register rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b00, 0b010, ToReg(rd), rn);
   }
-  void scvtf(ARMEmitter::Size size, ARMEmitter::DRegister rd, ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b010, ARMEmitter::ToReg(rd), rn);
+  void scvtf(ARMEmitter::Size size, DRegister rd, Register rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b00, 0b010, ToReg(rd), rn);
   }
-  void ucvtf(ARMEmitter::Size size, ARMEmitter::HRegister rd, ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b011, ARMEmitter::ToReg(rd), rn);
+  void ucvtf(ARMEmitter::Size size, HRegister rd, Register rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b00, 0b011, ToReg(rd), rn);
   }
-  void ucvtf(ARMEmitter::Size size, ARMEmitter::SRegister rd, ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b011, ARMEmitter::ToReg(rd), rn);
+  void ucvtf(ARMEmitter::Size size, SRegister rd, Register rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b00, 0b011, ToReg(rd), rn);
   }
-  void ucvtf(ARMEmitter::Size size, ARMEmitter::DRegister rd, ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b011, ARMEmitter::ToReg(rd), rn);
+  void ucvtf(ARMEmitter::Size size, DRegister rd, Register rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b00, 0b011, ToReg(rd), rn);
   }
-  void fcvtas(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b100, rd, ARMEmitter::ToReg(rn));
+  void fcvtas(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b00, 0b100, rd, ToReg(rn));
   }
-  void fcvtas(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b100, rd, ARMEmitter::ToReg(rn));
+  void fcvtas(ARMEmitter::Size size, Register rd, SRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b00, 0b100, rd, ToReg(rn));
   }
-  void fcvtas(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b100, rd, ARMEmitter::ToReg(rn));
+  void fcvtas(ARMEmitter::Size size, Register rd, DRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b00, 0b100, rd, ToReg(rn));
   }
-  void fcvtau(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b101, rd, ARMEmitter::ToReg(rn));
+  void fcvtau(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b00, 0b101, rd, ToReg(rn));
   }
-  void fcvtau(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b101, rd, ARMEmitter::ToReg(rn));
+  void fcvtau(ARMEmitter::Size size, Register rd, SRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b00, 0b101, rd, ToReg(rn));
   }
-  void fcvtau(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b101, rd, ARMEmitter::ToReg(rn));
+  void fcvtau(ARMEmitter::Size size, Register rd, DRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b00, 0b101, rd, ToReg(rn));
   }
-  void fmov(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b110, rd, ARMEmitter::ToReg(rn));
+  void fmov(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b00, 0b110, rd, ToReg(rn));
   }
-  void fmov(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
+  void fmov(ARMEmitter::Size size, Register rd, SRegister rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::Size::i64Bit, "Can't move SReg to 64-bit");
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b110, rd, ARMEmitter::ToReg(rn));
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b00, 0b110, rd, ToReg(rn));
   }
-  void fmov(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
+  void fmov(ARMEmitter::Size size, Register rd, DRegister rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::Size::i32Bit, "Can't move DReg to 32-bit");
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b110, rd, ARMEmitter::ToReg(rn));
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b00, 0b110, rd, ToReg(rn));
   }
-  void fmov(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::VRegister rn, bool Upper) {
+  void fmov(ARMEmitter::Size size, Register rd, VRegister rn, bool Upper) {
     if (Upper) {
       LOGMAN_THROW_A_FMT(size == ARMEmitter::Size::i64Bit, "Can only move upper with 64-bit elements");
     }
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, Upper ? 0b10 : 0b01, Upper ? 0b01 : 0b00, 0b110, rd, ARMEmitter::ToReg(rn));
+    ASIMDFloatConvBetweenInt(size, 0, Upper ? 0b10 : 0b01, Upper ? 0b01 : 0b00, 0b110, rd, ToReg(rn));
   }
-  void fmov(ARMEmitter::Size size, ARMEmitter::HRegister rd, ARMEmitter::Register rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b00, 0b111, ARMEmitter::ToReg(rd), rn);
+  void fmov(ARMEmitter::Size size, HRegister rd, Register rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b00, 0b111, ToReg(rd), rn);
   }
-  void fmov(ARMEmitter::Size size, ARMEmitter::SRegister rd, ARMEmitter::Register rn) {
+  void fmov(ARMEmitter::Size size, SRegister rd, Register rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::Size::i64Bit, "Can't move SReg to 64-bit");
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b00, 0b111, ARMEmitter::ToReg(rd), rn);
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b00, 0b111, ToReg(rd), rn);
   }
-  void fmov(ARMEmitter::Size size, ARMEmitter::DRegister rd, ARMEmitter::Register rn) {
+  void fmov(ARMEmitter::Size size, DRegister rd, Register rn) {
     LOGMAN_THROW_A_FMT(size != ARMEmitter::Size::i32Bit, "Can't move DReg to 32-bit");
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b00, 0b111, ARMEmitter::ToReg(rd), rn);
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b00, 0b111, ToReg(rd), rn);
   }
-  void fmov(ARMEmitter::Size size, ARMEmitter::VRegister rd, ARMEmitter::Register rn, bool Upper) {
+  void fmov(ARMEmitter::Size size, VRegister rd, Register rn, bool Upper) {
     if (Upper) {
       LOGMAN_THROW_A_FMT(size == ARMEmitter::Size::i64Bit, "Can only move upper with 64-bit elements");
     }
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, Upper ? 0b10 : 0b01, Upper ? 0b01 : 0b00, 0b111, ARMEmitter::ToReg(rd), rn);
+    ASIMDFloatConvBetweenInt(size, 0, Upper ? 0b10 : 0b01, Upper ? 0b01 : 0b00, 0b111, ToReg(rd), rn);
   }
-  void fcvtps(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b01, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtps(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b01, 0b000, rd, ToReg(rn));
   }
-  void fcvtps(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b01, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtps(ARMEmitter::Size size, Register rd, SRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b01, 0b000, rd, ToReg(rn));
   }
-  void fcvtps(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b01, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtps(ARMEmitter::Size size, Register rd, DRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b01, 0b000, rd, ToReg(rn));
   }
-  void fcvtpu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b01, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtpu(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b01, 0b001, rd, ToReg(rn));
   }
-  void fcvtpu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b01, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtpu(ARMEmitter::Size size, Register rd, SRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b01, 0b001, rd, ToReg(rn));
   }
-  void fcvtpu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b01, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtpu(ARMEmitter::Size size, Register rd, DRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b01, 0b001, rd, ToReg(rn));
   }
-  void fcvtms(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b10, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtms(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b10, 0b000, rd, ToReg(rn));
   }
-  void fcvtms(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b10, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtms(ARMEmitter::Size size, Register rd, SRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b10, 0b000, rd, ToReg(rn));
   }
-  void fcvtms(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b10, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtms(ARMEmitter::Size size, Register rd, DRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b10, 0b000, rd, ToReg(rn));
   }
-  void fcvtmu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b10, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtmu(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b10, 0b001, rd, ToReg(rn));
   }
-  void fcvtmu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b10, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtmu(ARMEmitter::Size size, Register rd, SRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b10, 0b001, rd, ToReg(rn));
   }
-  void fcvtmu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b10, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtmu(ARMEmitter::Size size, Register rd, DRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b10, 0b001, rd, ToReg(rn));
   }
-  void fcvtzs(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b11, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtzs(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b11, 0b000, rd, ToReg(rn));
   }
-  void fcvtzs(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b11, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtzs(ARMEmitter::Size size, Register rd, SRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b11, 0b000, rd, ToReg(rn));
   }
-  void fcvtzs(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b11, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtzs(ARMEmitter::Size size, Register rd, DRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b11, 0b000, rd, ToReg(rn));
   }
-  void fcvtzs(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::VRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b11, 0b000, rd, ARMEmitter::ToReg(rn));
+  void fcvtzs(ARMEmitter::Size size, Register rd, VRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b11, 0b000, rd, ToReg(rn));
   }
-  void fcvtzu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::HRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b11, 0b11, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtzu(ARMEmitter::Size size, Register rd, HRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b11, 0b11, 0b001, rd, ToReg(rn));
   }
-  void fcvtzu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::SRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b00, 0b11, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtzu(ARMEmitter::Size size, Register rd, SRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b00, 0b11, 0b001, rd, ToReg(rn));
   }
-  void fcvtzu(ARMEmitter::Size size, ARMEmitter::Register rd, ARMEmitter::DRegister rn) {
-    constexpr uint32_t Op = 0b0001'1110'001 << 21;
-    ASIMDFloatConvBetweenInt(Op, size, 0, 0b01, 0b11, 0b001, rd, ARMEmitter::ToReg(rn));
+  void fcvtzu(ARMEmitter::Size size, Register rd, DRegister rn) {
+    ASIMDFloatConvBetweenInt(size, 0, 0b01, 0b11, 0b001, rd, ToReg(rn));
   }
 
 private:
@@ -4403,12 +4358,10 @@ private:
   }
 
   // Conversion between floating-point and integer
-  void ASIMDFloatConvBetweenInt(uint32_t Op, ARMEmitter::Size s, uint32_t S, uint32_t ptype, uint32_t rmode, uint32_t opcode,
-                                ARMEmitter::Register rd, ARMEmitter::Register rn) {
+  void ASIMDFloatConvBetweenInt(ARMEmitter::Size s, uint32_t S, uint32_t ptype, uint32_t rmode, uint32_t opcode, Register rd, Register rn) {
     const uint32_t SF = s == ARMEmitter::Size::i64Bit ? (1U << 31) : 0;
 
-    uint32_t Instr = Op;
-
+    uint32_t Instr = 0b0001'1110'001U << 21;
     Instr |= SF;
     Instr |= S << 29;
     Instr |= ptype << 22;

--- a/CodeEmitter/CodeEmitter/ASIMDOps.inl
+++ b/CodeEmitter/CodeEmitter/ASIMDOps.inl
@@ -253,7 +253,6 @@ public:
     }
 
     constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
-    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
 
     const uint32_t SizeImm = FEXCore::ToUnderlying(size);
     const uint32_t IndexShift = SizeImm + 1;
@@ -264,7 +263,7 @@ public:
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
-    ASIMDScalarCopy(Op, Q, imm5, 0b0000, rd.V(), rn.V());
+    ASIMDScalarCopy(Q, 0, imm5, 0b0000, rd.V(), rn.V());
   }
 
   template<IsQOrDRegister T>
@@ -274,12 +273,11 @@ public:
     }
 
     constexpr uint32_t Q = std::is_same_v<QRegister, T> ? 1 : 0;
-    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
 
     // Upper bits of imm5 are ignored for GPR dup
     const uint32_t imm5 = 1U << FEXCore::ToUnderlying(size);
 
-    ASIMDScalarCopy(Op, Q, imm5, 0b0001, rd, ToVReg(rn));
+    ASIMDScalarCopy(Q, 0, imm5, 0b0001, rd, ToVReg(rn));
   }
 
   template<SubRegSize size>
@@ -287,8 +285,6 @@ public:
   void smov(XRegister rd, VRegister rn, uint32_t Index) {
     static_assert(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit, "Unsupported smov size");
 
-    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
-
     constexpr uint32_t SizeImm = FEXCore::ToUnderlying(size);
     constexpr uint32_t IndexShift = SizeImm + 1;
     constexpr uint32_t ElementSize = 1U << SizeImm;
@@ -298,15 +294,13 @@ public:
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
-    ASIMDScalarCopy(Op, 1, imm5, 0b0101, ToVReg(rd), rn);
+    ASIMDScalarCopy(1, 0, imm5, 0b0101, ToVReg(rd), rn);
   }
   template<SubRegSize size>
   requires (size == SubRegSize::i8Bit || size == SubRegSize::i16Bit)
   void smov(WRegister rd, VRegister rn, uint32_t Index) {
     static_assert(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit, "Unsupported smov size");
 
-    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
-
     constexpr uint32_t SizeImm = FEXCore::ToUnderlying(size);
     constexpr uint32_t IndexShift = SizeImm + 1;
     constexpr uint32_t ElementSize = 1U << SizeImm;
@@ -316,7 +310,7 @@ public:
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
-    ASIMDScalarCopy(Op, 0, imm5, 0b0101, ToVReg(rd), rn);
+    ASIMDScalarCopy(0, 0, imm5, 0b0101, ToVReg(rd), rn);
   }
 
   template<SubRegSize size>
@@ -324,8 +318,6 @@ public:
     static_assert(size == SubRegSize::i8Bit || size == SubRegSize::i16Bit || size == SubRegSize::i32Bit || size == SubRegSize::i64Bit,
                   "Unsupported umov size");
 
-
-    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
     constexpr uint32_t Q = size == SubRegSize::i64Bit ? 1 : 0;
 
     constexpr uint32_t SizeImm = FEXCore::ToUnderlying(size);
@@ -337,13 +329,11 @@ public:
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
-    ASIMDScalarCopy(Op, Q, imm5, 0b0111, ToVReg(rd), rn);
+    ASIMDScalarCopy(Q, 0, imm5, 0b0111, ToVReg(rd), rn);
   }
 
   template<SubRegSize size>
   void ins(VRegister rd, uint32_t Index, Register rn) {
-    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
-
     constexpr uint32_t SizeImm = FEXCore::ToUnderlying(size);
     constexpr uint32_t IndexShift = SizeImm + 1;
     constexpr uint32_t ElementSize = 1U << SizeImm;
@@ -353,12 +343,10 @@ public:
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
-    ASIMDScalarCopy(Op, 1, imm5, 0b0011, rd, ToVReg(rn));
+    ASIMDScalarCopy(1, 0, imm5, 0b0011, rd, ToVReg(rn));
   }
 
   void ins(SubRegSize size, VRegister rd, uint32_t Index, Register rn) {
-    constexpr uint32_t Op = 0b0000'1110'0000'0000'0000'01 << 10;
-
     const uint32_t SizeImm = FEXCore::ToUnderlying(size);
     const uint32_t IndexShift = SizeImm + 1;
     const uint32_t ElementSize = 1U << SizeImm;
@@ -368,12 +356,10 @@ public:
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
-    ASIMDScalarCopy(Op, 1, imm5, 0b0011, rd, ToVReg(rn));
+    ASIMDScalarCopy(1, 0, imm5, 0b0011, rd, ToVReg(rn));
   }
 
   void ins(SubRegSize size, VRegister rd, uint32_t Index, VRegister rn, uint32_t Index2) {
-    constexpr uint32_t Op = 0b0110'1110'0000'0000'0000'01 << 10;
-
     const uint32_t SizeImm = FEXCore::ToUnderlying(size);
     const uint32_t IndexShift = SizeImm + 1;
     const uint32_t ElementSize = 1U << SizeImm;
@@ -385,7 +371,7 @@ public:
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
     const uint32_t imm4 = Index2 << SizeImm;
 
-    ASIMDScalarCopy(Op, 1, imm5, imm4, rd, rn);
+    ASIMDScalarCopy(1, 0b10, imm5, imm4, rd, rn);
   }
 
   // Advanced SIMD three-register extension

--- a/CodeEmitter/CodeEmitter/ScalarOps.inl
+++ b/CodeEmitter/CodeEmitter/ScalarOps.inl
@@ -27,8 +27,6 @@ struct EmitterOps : Emitter {
 public:
   // Advanced SIMD scalar copy
   void dup(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Index) {
-    constexpr uint32_t Op = 0b0101'1110'0000'0000'0000'01 << 10;
-
     const uint32_t SizeImm = FEXCore::ToUnderlying(size);
     const uint32_t IndexShift = SizeImm + 1;
     const uint32_t ElementSize = 1U << SizeImm;
@@ -38,10 +36,10 @@ public:
 
     const uint32_t imm5 = (Index << IndexShift) | ElementSize;
 
-    ASIMDScalarCopy(Op, 1, imm5, 0b0000, rd, rn);
+    ASIMDScalarCopy(1, 1, imm5, 0b0000, rd, rn);
   }
 
-  void mov(ARMEmitter::ScalarRegSize size, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn, uint32_t Index) {
+  void mov(ScalarRegSize size, VRegister rd, VRegister rn, uint32_t Index) {
     dup(size, rd, rn, Index);
   }
 
@@ -1282,10 +1280,10 @@ public:
 
 private:
   // Advanced SIMD scalar copy
-  void ASIMDScalarCopy(uint32_t Op, uint32_t Q, uint32_t imm5, uint32_t imm4, ARMEmitter::VRegister rd, ARMEmitter::VRegister rn) {
-    uint32_t Instr = Op;
-
+  void ASIMDScalarCopy(uint32_t Q, uint32_t b28, uint32_t imm5, uint32_t imm4, VRegister rd, VRegister rn) {
+    uint32_t Instr = 0b0000'1110'0000'0000'0000'01U << 10;
     Instr |= Q << 30;
+    Instr |= b28 << 28;
     Instr |= imm5 << 16;
     Instr |= imm4 << 11;
     Instr |= Encode_rn(rn);

--- a/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
+++ b/FEXCore/unittests/Emitter/ASIMD_Tests.cpp
@@ -234,15 +234,6 @@ TEST_CASE_METHOD(TestDisassembler, "Emitter: ASIMD: Advanced SIMD copy") {
   TEST_SINGLE(umov<SubRegSize::i64Bit>(Reg::r29, VReg::v30, 0), "mov x29, v30.d[0]");
   TEST_SINGLE(umov<SubRegSize::i64Bit>(Reg::r29, VReg::v30, 1), "mov x29, v30.d[1]");
 
-  TEST_SINGLE(ins<SubRegSize::i8Bit>(VReg::v30, 0, Reg::r29), "mov v30.b[0], w29");
-  TEST_SINGLE(ins<SubRegSize::i16Bit>(VReg::v30, 0, Reg::r29), "mov v30.h[0], w29");
-  TEST_SINGLE(ins<SubRegSize::i32Bit>(VReg::v30, 0, Reg::r29), "mov v30.s[0], w29");
-  TEST_SINGLE(ins<SubRegSize::i64Bit>(VReg::v30, 0, Reg::r29), "mov v30.d[0], x29");
-  TEST_SINGLE(ins<SubRegSize::i8Bit>(VReg::v30, 15, Reg::r29), "mov v30.b[15], w29");
-  TEST_SINGLE(ins<SubRegSize::i16Bit>(VReg::v30, 7, Reg::r29), "mov v30.h[7], w29");
-  TEST_SINGLE(ins<SubRegSize::i32Bit>(VReg::v30, 3, Reg::r29), "mov v30.s[3], w29");
-  TEST_SINGLE(ins<SubRegSize::i64Bit>(VReg::v30, 1, Reg::r29), "mov v30.d[1], x29");
-
   TEST_SINGLE(ins(SubRegSize::i8Bit, VReg::v30, 0, Reg::r29), "mov v30.b[0], w29");
   TEST_SINGLE(ins(SubRegSize::i16Bit, VReg::v30, 0, Reg::r29), "mov v30.h[0], w29");
   TEST_SINGLE(ins(SubRegSize::i32Bit, VReg::v30, 0, Reg::r29), "mov v30.s[0], w29");


### PR DESCRIPTION
Now we have all of the base opcodes in ASIMDOps deduplicated.