### PR TITLE
RegisterAllocationPass: defer next-use analysis

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/AtomicOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/AtomicOps.cpp
@@ -138,108 +138,6 @@ DEF_OP(CAS) {
   }
 }
 
-DEF_OP(AtomicAdd) {
-  auto Op = IROp->C<IR::IROp_AtomicAdd>();
-  const auto EmitSize = ConvertSize(IROp);
-  const auto SubEmitSize = ConvertSubRegSize8(IROp->Size);
-
-  auto MemSrc = GetReg(Op->Addr);
-  auto Src = GetReg(Op->Value);
-
-  if (CTX->HostFeatures.SupportsAtomics) {
-    staddl(SubEmitSize, Src, MemSrc);
-  } else {
-    ARMEmitter::BackwardLabel LoopTop;
-    Bind(&LoopTop);
-    ldaxr(SubEmitSize, TMP2, MemSrc);
-    add(EmitSize, TMP2, TMP2, Src);
-    stlxr(SubEmitSize, TMP2, TMP2, MemSrc);
-    cbnz(EmitSize, TMP2, &LoopTop);
-  }
-}
-
-DEF_OP(AtomicSub) {
-  auto Op = IROp->C<IR::IROp_AtomicSub>();
-  const auto EmitSize = ConvertSize(IROp);
-  const auto SubEmitSize = ConvertSubRegSize8(IROp->Size);
-
-  auto MemSrc = GetReg(Op->Addr);
-  auto Src = GetReg(Op->Value);
-
-  if (CTX->HostFeatures.SupportsAtomics) {
-    neg(EmitSize, TMP2, Src);
-    staddl(SubEmitSize, TMP2, MemSrc);
-  } else {
-    ARMEmitter::BackwardLabel LoopTop;
-    Bind(&LoopTop);
-    ldaxr(SubEmitSize, TMP2, MemSrc);
-    sub(EmitSize, TMP2, TMP2, Src);
-    stlxr(SubEmitSize, TMP2, TMP2, MemSrc);
-    cbnz(EmitSize, TMP2, &LoopTop);
-  }
-}
-
-DEF_OP(AtomicAnd) {
-  auto Op = IROp->C<IR::IROp_AtomicAnd>();
-  const auto EmitSize = ConvertSize(IROp);
-  const auto SubEmitSize = ConvertSubRegSize8(IROp->Size);
-
-  auto MemSrc = GetReg(Op->Addr);
-  auto Src = GetReg(Op->Value);
-
-  if (CTX->HostFeatures.SupportsAtomics) {
-    mvn(EmitSize, TMP2, Src);
-    stclrl(SubEmitSize, TMP2, MemSrc);
-  } else {
-    ARMEmitter::BackwardLabel LoopTop;
-    Bind(&LoopTop);
-    ldaxr(SubEmitSize, TMP2, MemSrc);
-    and_(EmitSize, TMP2, TMP2, Src);
-    stlxr(SubEmitSize, TMP2, TMP2, MemSrc);
-    cbnz(EmitSize, TMP2, &LoopTop);
-  }
-}
-
-DEF_OP(AtomicCLR) {
-  auto Op = IROp->C<IR::IROp_AtomicCLR>();
-  const auto EmitSize = ConvertSize(IROp);
-  const auto SubEmitSize = ConvertSubRegSize8(IROp->Size);
-
-  auto MemSrc = GetReg(Op->Addr);
-  auto Src = GetReg(Op->Value);
-
-  if (CTX->HostFeatures.SupportsAtomics) {
-    stclrl(SubEmitSize, Src, MemSrc);
-  } else {
-    ARMEmitter::BackwardLabel LoopTop;
-    Bind(&LoopTop);
-    ldaxr(SubEmitSize, TMP2, MemSrc);
-    bic(EmitSize, TMP2, TMP2, Src);
-    stlxr(SubEmitSize, TMP2, TMP2, MemSrc);
-    cbnz(EmitSize, TMP2, &LoopTop);
-  }
-}
-
-DEF_OP(AtomicOr) {
-  auto Op = IROp->C<IR::IROp_AtomicOr>();
-  const auto EmitSize = ConvertSize(IROp);
-  const auto SubEmitSize = ConvertSubRegSize8(IROp->Size);
-
-  auto MemSrc = GetReg(Op->Addr);
-  auto Src = GetReg(Op->Value);
-
-  if (CTX->HostFeatures.SupportsAtomics) {
-    stsetl(SubEmitSize, Src, MemSrc);
-  } else {
-    ARMEmitter::BackwardLabel LoopTop;
-    Bind(&LoopTop);
-    ldaxr(SubEmitSize, TMP2, MemSrc);
-    orr(EmitSize, TMP2, TMP2, Src);
-    stlxr(SubEmitSize, TMP2, TMP2, MemSrc);
-    cbnz(EmitSize, TMP2, &LoopTop);
-  }
-}
-
 DEF_OP(AtomicXor) {
   auto Op = IROp->C<IR::IROp_AtomicXor>();
   const auto EmitSize = ConvertSize(IROp);
@@ -258,21 +156,6 @@ DEF_OP(AtomicXor) {
     stlxr(SubEmitSize, TMP2, TMP2, MemSrc);
     cbnz(EmitSize, TMP2, &LoopTop);
   }
-}
-
-DEF_OP(AtomicNeg) {
-  auto Op = IROp->C<IR::IROp_AtomicNeg>();
-  const auto EmitSize = ConvertSize(IROp);
-  const auto SubEmitSize = ConvertSubRegSize8(IROp->Size);
-
-  auto MemSrc = GetReg(Op->Addr);
-
-  ARMEmitter::BackwardLabel LoopTop;
-  Bind(&LoopTop);
-  ldaxr(SubEmitSize, TMP2, MemSrc);
-  neg(EmitSize, TMP3, TMP2);
-  stlxr(SubEmitSize, TMP4, TMP3, MemSrc);
-  cbnz(EmitSize, TMP4, &LoopTop);
 }
 
 DEF_OP(AtomicSwap) {

--- a/FEXCore/Source/Interface/IR/IR.h
+++ b/FEXCore/Source/Interface/IR/IR.h
@@ -141,8 +141,21 @@ struct FEX_PACKED NodeWrapperBase final {
   }
 
   [[nodiscard]]
+  bool HasKill() const {
+    return NodeOffset & (1u << 30);
+  }
+
+  void ClearKill() {
+    NodeOffset &= ~(1u << 30);
+  }
+
+  void SetKill() {
+    NodeOffset |= (1u << 30);
+  }
+
+  [[nodiscard]]
   bool IsPointer() const {
-    return !IsImmediate();
+    return !IsImmediate() && !HasKill();
   }
 
   [[nodiscard]]

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -826,69 +826,9 @@
           "Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
         ]
       },
-      "AtomicAdd OpSize:#Size, GPR:$Value, GPR:$Addr": {
-        "HasSideEffects": true,
-        "Desc": ["Atomic integer add",
-                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
-                ],
-        "DestSize": "Size",
-        "EmitValidation": [
-          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
-        ]
-      },
-      "AtomicSub OpSize:#Size, GPR:$Value, GPR:$Addr": {
-        "HasSideEffects": true,
-        "Desc": ["Atomic integer sub",
-                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
-                ],
-        "DestSize": "Size",
-        "EmitValidation": [
-          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
-        ]
-      },
-      "AtomicAnd OpSize:#Size, GPR:$Value, GPR:$Addr": {
-        "HasSideEffects": true,
-        "Desc": ["Atomic integer and",
-                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
-                ],
-        "DestSize": "Size",
-        "EmitValidation": [
-          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
-        ]
-      },
-      "AtomicCLR OpSize:#Size, GPR:$Value, GPR:$Addr": {
-        "HasSideEffects": true,
-        "Desc": ["Atomic integer binary clear",
-                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
-                ],
-        "DestSize": "Size",
-        "EmitValidation": [
-          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
-        ]
-      },
-      "AtomicOr OpSize:#Size, GPR:$Value, GPR:$Addr": {
-        "HasSideEffects": true,
-        "Desc": ["Atomic integer or",
-                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
-                ],
-        "DestSize": "Size",
-        "EmitValidation": [
-          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
-        ]
-      },
       "AtomicXor OpSize:#Size, GPR:$Value, GPR:$Addr": {
         "HasSideEffects": true,
         "Desc": ["Atomic integer xor",
-                 "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
-                ],
-        "DestSize": "Size",
-        "EmitValidation": [
-          "Size == FEXCore::IR::OpSize::i8Bit || Size == FEXCore::IR::OpSize::i16Bit || Size == FEXCore::IR::OpSize::i32Bit || Size == FEXCore::IR::OpSize::i64Bit"
-        ]
-      },
-      "AtomicNeg OpSize:#Size, GPR:$Addr": {
-        "HasSideEffects": true,
-        "Desc": ["Atomic integer two's complement negate",
                  "IR layout must match Fetch-variant, otherwise DCE IR optimization breaks!"
                 ],
         "DestSize": "Size",

--- a/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
@@ -452,35 +452,6 @@ bool DeadFlagCalculationEliminination::EliminateDeadCode(IREmitter* IREmit, Ref 
     return false;
   }
 
-  switch (IROp->Op) {
-  case OP_SYSCALL: {
-    auto Op = IROp->C<IR::IROp_Syscall>();
-    if ((Op->Flags & IR::SyscallFlags::NOSIDEEFFECTS) != IR::SyscallFlags::NOSIDEEFFECTS) {
-      return false;
-    }
-
-    break;
-  }
-  case OP_INLINESYSCALL: {
-    auto Op = IROp->C<IR::IROp_Syscall>();
-    if ((Op->Flags & IR::SyscallFlags::NOSIDEEFFECTS) != IR::SyscallFlags::NOSIDEEFFECTS) {
-      return false;
-    }
-
-    break;
-  }
-
-  // If the result of the atomic fetch is completely unused, convert it to a non-fetching atomic operation.
-  case OP_ATOMICFETCHADD: IROp->Op = OP_ATOMICADD; return true;
-  case OP_ATOMICFETCHSUB: IROp->Op = OP_ATOMICSUB; return true;
-  case OP_ATOMICFETCHAND: IROp->Op = OP_ATOMICAND; return true;
-  case OP_ATOMICFETCHCLR: IROp->Op = OP_ATOMICCLR; return true;
-  case OP_ATOMICFETCHOR: IROp->Op = OP_ATOMICOR; return true;
-  case OP_ATOMICFETCHXOR: IROp->Op = OP_ATOMICXOR; return true;
-  case OP_ATOMICFETCHNEG: IROp->Op = OP_ATOMICNEG; return true;
-  default: break;
-  }
-
   IREmit->Remove(CodeNode);
   return true;
 }

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -500,12 +500,14 @@ void ConstrainedRAPass::Run(IREmitter* IREmit_) {
   PreferredReg.resize(IR->GetSSACount(), PhysicalRegister::Invalid());
   SSAToReg.resize(IR->GetSSACount(), PhysicalRegister::Invalid());
   NextUses.resize(IR->GetSSACount(), 0);
-  AnySpilled = false;
 
   // Next-use distance relative to the block end of each source, last first.
   fextl::vector<uint32_t> SourcesNextUses;
 
   for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
+    // Spilling is local, so reset this per-block
+    AnySpilled = false;
+
     // At the start of each block, all registers are available.
     for (auto& Class : Classes) {
       Class.Available = (1u << Class.Count) - 1;

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -599,6 +599,8 @@ void ConstrainedRAPass::Run(IREmitter* IREmit_) {
 
     // Forward pass: Assign registers, spilling & optimizing as we go.
     for (auto [CodeNode, IROp] : IR->GetCode(BlockNode)) {
+      bool AnySpilledBeforeThisInstruction = AnySpilled;
+
       // These do not read or write registers, and must be skipped for merging.
       // Since we'd be doing this check anyway for merging, do the check now so
       // we can skip the rest of the logic too.
@@ -642,7 +644,7 @@ void ConstrainedRAPass::Run(IREmitter* IREmit_) {
       //
       // This happens before freeing killed sources, since we need all sources in
       // the register file simultaneously.
-      if (AnySpilled) {
+      if (AnySpilledBeforeThisInstruction) {
         for (auto s = 0; s < IR::GetRAArgs(IROp->Op); ++s) {
           if (!IsValidArg(IROp->Args[s])) {
             continue;

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -152,11 +152,13 @@ private:
     if (IROp->Op == OP_LOADREGISTER || IROp->Op == OP_LOADPF || IROp->Op == OP_LOADAF) {
       return Node;
     } else if (IROp->Op == OP_STOREREGISTER) {
-      const IROp_StoreRegister* Op = IROp->C<IR::IROp_StoreRegister>();
-      return IR->GetNode(Op->Value);
+      auto V = IROp->C<IR::IROp_StorePF>()->Value;
+      V.ClearKill();
+      return IR->GetNode(V);
     } else if (IROp->Op == OP_STOREPF || IROp->Op == OP_STOREAF) {
-      const IROp_StorePF* Op = IROp->C<IR::IROp_StorePF>();
-      return IR->GetNode(Op->Value);
+      auto V = IROp->C<IR::IROp_StorePF>()->Value;
+      V.ClearKill();
+      return IR->GetNode(V);
     }
 
     return nullptr;


### PR DESCRIPTION
    This is expensive and only needed for spilling, so only do it for spilling. This
    complicates the RA a bit but speeds us up on average since most blocks
    don't spill. Total results of this change (including the prep commits that
    slowed things down temporarily):
    
    Difference at 95.0% confidence
            -1.71952% +/- 0.455996%

(This requires us to introduce the notion of kill-bits to replace next-use info for the non-spilling code path)