### PR TITLE
HostRunner: Fixes bug with saving CSFSGS

### DIFF
--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.cpp
@@ -209,7 +209,7 @@ public:
 
 private:
   FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
-  int GlobalCodeSegmentEntry {};
+  uint64_t GlobalCodeSegmentEntry {};
   int CodeSegmentEntry {};
   uint64_t ReturningStackLocation;
 


### PR DESCRIPTION
We were failing to save the entire 64-bit register, cutting off the top 32-bits which contain SS and CS. This ...happened to not cause issues but is a bug that I encountered with far jump handling.