### PR TITLE
Disable 3DNow by default on WOW64 FEX

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -70,7 +70,9 @@
           "ENABLEPRESERVEALLABI": "enablepreserveallabi",
           "DISABLEPRESERVEALLABI": "disablepreserveallabi",
           "ENABLEWFXT": "enablewfxt",
-          "DISABLEWFXT": "disablewfxt"
+          "DISABLEWFXT": "disablewfxt",
+          "ENABLE3DNOW": "enable3dnow",
+          "DISABLE3DNOW": "disable3dnow"
         },
         "Desc": [
           "Allows controlling of the CPU features in the JIT.",
@@ -92,7 +94,8 @@
           "\t{enable,disable}rpres: Will force enable or disable rpres even if the host doesn't support it",
           "\t{enable,disable}svebitperm: Will force enable or disable svebitperm even if the host doesn't support it",
           "\t{enable,disable}preserveallabi: Will force enable or disable preserve_all abi even if the host doesn't support it",
-          "\t{enable,disable}wfxt: Will force enable or disable wfxt even if the host doesn't support it"
+          "\t{enable,disable}wfxt: Will force enable or disable wfxt even if the host doesn't support it",
+          "\t{enable,disable}3dnow: Will force enable or disable 3DNow even if the host doesn't support it"
         ]
       },
       "SmallTSCScale": {

--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -925,38 +925,38 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_8000_0001h(uint32_t Leaf) con
             (0 << 30) | // Reserved
             (0 << 31);  // Reserved
 
-  Res.edx = (1 << 0) |                // FPU
-            (1 << 1) |                // Virtual mode extensions
-            (1 << 2) |                // Debugging extensions
-            (1 << 3) |                // Page size extensions
-            (1 << 4) |                // TSC
-            (1 << 5) |                // MSR support
-            (1 << 6) |                // PAE
-            (1 << 7) |                // Machine Check Exception
-            (1 << 8) |                // CMPXCHG8B
-            (1 << 9) |                // APIC
-            (0 << 10) |               // Reserved
-            (1 << 11) |               // SYSCALL/SYSRET
-            (1 << 12) |               // MTRR
-            (1 << 13) |               // Page global extension
-            (1 << 14) |               // Machine Check architecture
-            (1 << 15) |               // CMOV
-            (1 << 16) |               // Page attribute table
-            (1 << 17) |               // Page-size extensions
-            (0 << 18) |               // Reserved
-            (0 << 19) |               // Reserved
-            (1 << 20) |               // NX
-            (0 << 21) |               // Reserved
-            (1 << 22) |               // MMXExt
-            (1 << 23) |               // MMX
-            (1 << 24) |               // FXSAVE/FXRSTOR
-            (1 << 25) |               // FXSAVE/FXRSTOR Optimizations
-            (0 << 26) |               // 1 gigabit pages
-            (SUPPORTS_RDTSCP << 27) | // RDTSCP
-            (0 << 28) |               // Reserved
-            (1 << 29) |               // Long Mode
-            (1 << 30) |               // 3DNow! Extensions
-            (1 << 31);                // 3DNow!
+  Res.edx = (1 << 0) |                                // FPU
+            (1 << 1) |                                // Virtual mode extensions
+            (1 << 2) |                                // Debugging extensions
+            (1 << 3) |                                // Page size extensions
+            (1 << 4) |                                // TSC
+            (1 << 5) |                                // MSR support
+            (1 << 6) |                                // PAE
+            (1 << 7) |                                // Machine Check Exception
+            (1 << 8) |                                // CMPXCHG8B
+            (1 << 9) |                                // APIC
+            (0 << 10) |                               // Reserved
+            (1 << 11) |                               // SYSCALL/SYSRET
+            (1 << 12) |                               // MTRR
+            (1 << 13) |                               // Page global extension
+            (1 << 14) |                               // Machine Check architecture
+            (1 << 15) |                               // CMOV
+            (1 << 16) |                               // Page attribute table
+            (1 << 17) |                               // Page-size extensions
+            (0 << 18) |                               // Reserved
+            (0 << 19) |                               // Reserved
+            (1 << 20) |                               // NX
+            (0 << 21) |                               // Reserved
+            (1 << 22) |                               // MMXExt
+            (1 << 23) |                               // MMX
+            (1 << 24) |                               // FXSAVE/FXRSTOR
+            (1 << 25) |                               // FXSAVE/FXRSTOR Optimizations
+            (0 << 26) |                               // 1 gigabit pages
+            (SUPPORTS_RDTSCP << 27) |                 // RDTSCP
+            (0 << 28) |                               // Reserved
+            (1 << 29) |                               // Long Mode
+            (CTX->HostFeatures.Supports3DNow << 30) | // 3DNow! Extensions
+            (CTX->HostFeatures.Supports3DNow << 31);  // 3DNow!
   return Res;
 }
 

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -39,6 +39,7 @@ struct HostFeatures {
   bool SupportsFRINTTS {};
   bool SupportsECV {};
   bool SupportsWFXT {};
+  bool Supports3DNow {};
 
   // Float exception behaviour
   bool SupportsAFP {};

--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -435,6 +435,7 @@ static void OverrideFeatures(FEXCore::HostFeatures* Features, uint64_t ForceSVEW
   ENABLE_DISABLE_OPTION(SupportsSVEBitPerm, SVEBITPERM, SVEBITPERM);
   ENABLE_DISABLE_OPTION(SupportsPreserveAllABI, PRESERVEALLABI, PRESERVEALLABI);
   ENABLE_DISABLE_OPTION(SupportsWFXT, WFXT, WFXT);
+  ENABLE_DISABLE_OPTION(Supports3DNow, 3DNOW, 3DNOW);
   GET_SINGLE_OPTION(Crypto, CRYPTO);
 
 #undef ENABLE_DISABLE_OPTION
@@ -496,6 +497,14 @@ FEXCore::HostFeatures FetchHostFeatures(FEX::CPUFeatures& Features, bool Support
   HostFeatures.SupportsSVE256 = Features.Supports(CPUFeatures::Feature::SVE2) && ReadSVEVectorLengthInBits() >= 256;
 #endif
   HostFeatures.SupportsAVX = true;
+
+#ifdef _WIN32
+  // Disable 3DNow! by default to better match the set of extensions exposed on modern CPUs
+  // Works around a bug breaking some uses of 3DNow in WOW64 FEX
+  HostFeatures.Supports3DNow = false;
+#else
+  HostFeatures.Supports3DNow = true;
+#endif
 
   HostFeatures.SupportsAES256 = HostFeatures.SupportsAVX && HostFeatures.SupportsAES;
 


### PR DESCRIPTION
Works around a bug in WOW64 FEX that occurs using MS d3d9x when 3DNow is enabled. 