### PR TITLE
Windows: Ignore MEM_RESET(_UNDO) allocation protection notifications

### DIFF
--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -804,6 +804,8 @@ void NotifyMemoryAlloc(void* Address, SIZE_T Size, ULONG Type, ULONG Prot, BOOL 
   if (!After) {
     ThreadCreationMutex.lock();
   } else {
+    // MEM_RESET(_UNDO) ignores the passed permissions
+    if (!Status && !(Type & (MEM_RESET | MEM_RESET_UNDO))) {
       InvalidationTracker->HandleMemoryProtectionNotification(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), Prot);
     }
     ThreadCreationMutex.unlock();

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -804,8 +804,6 @@ void NotifyMemoryAlloc(void* Address, SIZE_T Size, ULONG Type, ULONG Prot, BOOL 
   if (!After) {
     ThreadCreationMutex.lock();
   } else {
-    if (!Status) {
-      std::scoped_lock Lock(ThreadCreationMutex);
       InvalidationTracker->HandleMemoryProtectionNotification(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), Prot);
     }
     ThreadCreationMutex.unlock();
@@ -838,7 +836,6 @@ void NotifyMemoryProtect(void* Address, SIZE_T Size, ULONG NewProt, BOOL After, 
     ThreadCreationMutex.lock();
   } else {
     if (!Status) {
-      std::scoped_lock Lock(ThreadCreationMutex);
       InvalidationTracker->HandleMemoryProtectionNotification(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), NewProt);
     }
     ThreadCreationMutex.unlock();
@@ -866,7 +863,6 @@ void NotifyUnmapViewOfSection(void* Address, BOOL After, NTSTATUS Status) {
 
   if (!After) {
     ThreadCreationMutex.lock();
-    std::scoped_lock Lock(ThreadCreationMutex);
     auto [Start, Size] = InvalidationTracker->InvalidateContainingSection(reinterpret_cast<uint64_t>(Address), true);
     if (Size) {
       std::scoped_lock Lock(CTX->GetCodeInvalidationMutex());

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -876,7 +876,8 @@ void BTCpuNotifyMemoryAlloc(void* Address, SIZE_T Size, ULONG Type, ULONG Prot, 
   if (!After) {
     ThreadCreationMutex.lock();
   } else {
-    if (!Status) {
+    // MEM_RESET(_UNDO) ignores the passed permissions
+    if (!Status && !(Type & (MEM_RESET | MEM_RESET_UNDO))) {
       InvalidationTracker->HandleMemoryProtectionNotification(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), Prot);
     }
     ThreadCreationMutex.unlock();


### PR DESCRIPTION
When these are set the allocation permissions aren't actually updated. Fixes steam under wine

Closes #4493 