### PR TITLE
unittests/3DNow: Fix femms test

### DIFF
--- a/unittests/ASM/3DNow/0E.asm
+++ b/unittests/ASM/3DNow/0E.asm
@@ -23,6 +23,7 @@ femms
 mov rdx, 0xe0000000
 o32 fstenv [rdx]
 
-mov eax, dword [rdx + 8] ; Offset 8 in the structure has FTW
+mov eax, 0
+mov ax, word [rdx + 8] ; Offset 8 in the structure has FTW
 
 hlt


### PR DESCRIPTION
We are onyl wanting to test the FTW, which is 16-bit but we were reading a whole 32-bits. The upper 16-bits was ending up in the reserved section, which is undefined as to what it contains. In FEX it'll contain 0 but on a Zen 4 CPU it contains 0xFFFF.

Only read the bits we care about.