### PR TITLE
Implement support for additional provided volatile metadata

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -522,6 +522,27 @@
         "Desc": [
           "Disables inline syscalls in order to support seccomp handling"
         ]
+      },
+      "ExtendedVolatileMetadata": {
+        "Type": "str",
+        "Default": "",
+        "Desc": [
+          "Configuration provided volatile metadata. Only implemented for WoW64/arm64ec.",
+          "Limited in its use but can be handy.",
+          "Extends on top of what Microsoft has for volatile metadata, but also supported for WoW64.",
+          "Colon delimited modules, then semi-colon delimited instructions, then comma delimited ranges",
+          "Default disables TSO in the module, unless instructions overlap the range",
+          "<module>;<offset begin>-<offset-end>,...;<instruction offset to force TSO>,...:<another>",
+          "examples:",
+          "  * Disable TSO for a full module: Just provide the module name:",
+          "      `hl2_linux`",
+          "  * Disable TSO for a part of the module:",
+          "      `hl2_linux;<offset begin>-<offset-end>`",
+          "  * Disable TSO for a part of the module, but enable TSO for some instructions within the module",
+          "      `hl2_linux;<offset begin>-<offset-end>;<instruction offset>,<instruction offset>`",
+          "  * Disable TSO for multiple modules",
+          "      `hl2_linux:libsdl2.so`"
+        ]
       }
     }
   },

--- a/FEXCore/include/FEXCore/Utils/IntervalList.h
+++ b/FEXCore/include/FEXCore/Utils/IntervalList.h
@@ -34,8 +34,21 @@ public:
     Interval Interval;   ///< The interval that the query offset is enclosed by, or the next interval if `Enclosed` is false
   };
 
+  using const_iterator = typename fextl::vector<Interval>::const_iterator;
+
+  const_iterator begin() const {
+    return Intervals.begin();
+  }
+  const_iterator end() const {
+    return Intervals.end();
+  }
+
   void Clear() {
     Intervals.clear();
+  }
+
+  bool Empty() const {
+    return Intervals.empty();
   }
 
   void Insert(Interval Entry) {

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -9,7 +9,9 @@ set(SRCS
   HostFeatures.cpp
   JSONPool.cpp
   StringUtil.cpp
-  SHMStats.cpp)
+  SHMStats.cpp
+  VolatileMetadata.cpp
+  )
 
 if (NOT MINGW_BUILD)
   list (APPEND SRCS

--- a/Source/Common/VolatileMetadata.cpp
+++ b/Source/Common/VolatileMetadata.cpp
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+#include "Common/VolatileMetadata.h"
+
+namespace FEX::VolatileMetadata {
+fextl::unordered_map<fextl::string, ExtendedVolatileMetadata> ParseExtendedVolatileMetadata(std::string_view ListOfDescriptors) {
+  // Parsing: `<module>;<address begin>-<address-end>,<more addresses>;<instruction offset to force TSO>:`
+  if (ListOfDescriptors.empty()) {
+    return {};
+  }
+
+  fextl::unordered_map<fextl::string, ExtendedVolatileMetadata> ExtendedMetaData {};
+
+  auto current_module = ExtendedMetaData.end();
+
+  for (size_t module_offset = 0; module_offset != ListOfDescriptors.npos;) {
+    size_t end_of_module = ListOfDescriptors.find(":", module_offset);
+    std::string_view module_config = ListOfDescriptors.substr(module_offset, end_of_module - module_offset);
+
+    if (module_config.empty()) {
+      module_offset = end_of_module == ListOfDescriptors.npos ? ListOfDescriptors.npos : end_of_module + 1;
+      continue;
+    }
+
+    size_t end_of_name = module_config.find(";");
+    size_t end_of_address_ranges = module_config.npos;
+    size_t end_of_individual_inst = module_config.npos;
+
+    // Module name handling
+    {
+      std::string_view section_str = module_config.substr(0, end_of_name);
+
+      if (section_str.empty()) {
+        module_offset = end_of_module == ListOfDescriptors.npos ? ListOfDescriptors.npos : end_of_module + 1;
+        continue;
+      }
+
+      current_module = ExtendedMetaData
+                         .insert_or_assign(fextl::string(section_str),
+                                           ExtendedVolatileMetadata {
+                                             .ModuleTSODisabled = true,
+                                           })
+                         .first;
+    }
+
+    // Address range handling
+    if (end_of_name != module_config.npos) {
+      end_of_address_ranges = module_config.find(";", end_of_name + 1);
+      std::string_view section_str = module_config.substr(end_of_name + 1, end_of_address_ranges - (end_of_name + 1));
+
+      if (section_str.empty()) {
+        module_offset = end_of_module == ListOfDescriptors.npos ? ListOfDescriptors.npos : end_of_module + 1;
+        continue;
+      }
+
+      current_module->second.ModuleTSODisabled = false;
+
+      // Walk all the address ranges provided.
+      for (size_t non_tso_region_offset = 0; non_tso_region_offset != section_str.npos;) {
+        size_t end_of_region_substr = section_str.find(",", non_tso_region_offset);
+        std::string_view tso_region_view = section_str.substr(non_tso_region_offset, end_of_region_substr - non_tso_region_offset);
+
+        if (tso_region_view.empty()) {
+          non_tso_region_offset = end_of_region_substr == section_str.npos ? section_str.npos : end_of_region_substr + 1;
+          continue;
+        }
+
+        uint64_t begin {}, end {};
+        char* str_end;
+        begin = std::strtoull(tso_region_view.data(), &str_end, 16);
+        LOGMAN_THROW_A_FMT(tso_region_view.data() != str_end, "Couldn't parse begin {}", tso_region_view);
+
+        // Skip `-` separator.
+        ++str_end;
+
+        LOGMAN_THROW_A_FMT(str_end != tso_region_view.end(), "Couldn't parse end {}", tso_region_view);
+        auto str_begin = str_end;
+        end = std::strtoull(str_begin, &str_end, 16);
+        LOGMAN_THROW_A_FMT(str_begin != str_end, "Couldn't parse end {}", tso_region_view);
+
+        current_module->second.VolatileValidRanges.Insert({begin, end});
+        non_tso_region_offset = end_of_region_substr == section_str.npos ? section_str.npos : end_of_region_substr + 1;
+      }
+    }
+
+    // Individual instruction handling
+    if (end_of_address_ranges != module_config.npos) {
+      end_of_individual_inst = module_config.find(";", end_of_address_ranges + 1);
+      std::string_view section_str = module_config.substr(end_of_address_ranges + 1, end_of_individual_inst);
+
+      if (section_str.empty()) {
+        module_offset = end_of_module == ListOfDescriptors.npos ? ListOfDescriptors.npos : end_of_module + 1;
+        continue;
+      }
+
+      for (size_t force_tso_region_offset = 0; force_tso_region_offset != section_str.npos;) {
+        size_t end_of_region_substr = section_str.find(",", force_tso_region_offset);
+        std::string_view tso_region_view = section_str.substr(force_tso_region_offset, end_of_region_substr - force_tso_region_offset);
+
+        if (tso_region_view.empty()) {
+          force_tso_region_offset = end_of_region_substr == section_str.npos ? section_str.npos : end_of_region_substr + 1;
+          continue;
+        }
+
+        uint64_t offset {};
+        char* str_end;
+        offset = std::strtoull(tso_region_view.data(), &str_end, 16);
+        LOGMAN_THROW_A_FMT(tso_region_view.data() != str_end, "Couldn't parse offset {}", tso_region_view);
+
+        current_module->second.VolatileInstructions.insert(offset);
+
+        force_tso_region_offset = end_of_region_substr == section_str.npos ? section_str.npos : end_of_region_substr + 1;
+      }
+    }
+
+    module_offset = end_of_module == ListOfDescriptors.npos ? ListOfDescriptors.npos : end_of_module + 1;
+  }
+
+  return ExtendedMetaData;
+}
+} // namespace FEX::VolatileMetadata

--- a/Source/Common/VolatileMetadata.h
+++ b/Source/Common/VolatileMetadata.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include <FEXCore/Utils/IntervalList.h>
+#include <FEXCore/fextl/unordered_map.h>
+#include <FEXCore/fextl/set.h>
+#include <FEXCore/fextl/string.h>
+
+namespace FEX::VolatileMetadata {
+struct ExtendedVolatileMetadata {
+  FEXCore::IntervalList<uint64_t> VolatileValidRanges;
+  fextl::set<uint64_t> VolatileInstructions;
+  bool ModuleTSODisabled;
+};
+
+fextl::unordered_map<fextl::string, ExtendedVolatileMetadata> ParseExtendedVolatileMetadata(std::string_view ListOfDescriptors);
+} // namespace FEX::VolatileMetadata

--- a/Source/Windows/Common/VolatileMetadata.h
+++ b/Source/Windows/Common/VolatileMetadata.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "Common/VolatileMetadata.h"
+
+#include <FEXCore/fextl/unordered_map.h>
+#include <FEXCore/fextl/string.h>
+#include <FEXCore/fextl/set.h>
+#include <FEXCore/Utils/IntervalList.h>
+
+namespace FEX::Windows {
+inline void ApplyFEXExtendedVolatileMetadata(FEX::VolatileMetadata::ExtendedVolatileMetadata& ExtendedMetaData,
+                                             fextl::set<uint64_t>& VolatileInstructions,
+                                             FEXCore::IntervalList<uint64_t>& VolatileValidRanges, uint64_t Address, uint64_t EndAddress) {
+  // Load FEX extended volatile metadata.
+  // Walk the volatile instructions first if they exist.
+  for (const auto it_inst : ExtendedMetaData.VolatileInstructions) {
+    const auto inst_address = it_inst + Address;
+    if (inst_address < EndAddress) {
+      VolatileInstructions.emplace(Address + it_inst);
+    } else {
+      LogMan::Msg::DFmt("Volatile instruction 0x{:x} couldn't fit in to module range [0x{:x}, 0x{:x}). Not adding anymore volatile "
+                        "instructions. Inspect your config!",
+                        inst_address, Address, EndAddress);
+      return;
+    }
+  }
+
+  // Walk the volatile list
+  for (const auto it_ranges : ExtendedMetaData.VolatileValidRanges) {
+    VolatileValidRanges.Insert({Address + it_ranges.Offset, Address + it_ranges.End});
+  }
+
+  // If it is fully disabled, then set the entire module range
+  if (ExtendedMetaData.ModuleTSODisabled) {
+    VolatileValidRanges.Clear();
+    VolatileValidRanges.Insert({Address, EndAddress});
+  }
+}
+
+
+} // namespace FEX::Windows

--- a/unittests/APITests/CMakeLists.txt
+++ b/unittests/APITests/CMakeLists.txt
@@ -5,6 +5,7 @@ set (TESTS
   Filesystem
   StringUtils
   fextl_function
+  ExtendedVolatileMetadata
   )
 
 list(APPEND LIBS Common FEXCore JemallocLibs)

--- a/unittests/APITests/ExtendedVolatileMetadata.cpp
+++ b/unittests/APITests/ExtendedVolatileMetadata.cpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+#include <catch2/catch_all.hpp>
+#include "Common/VolatileMetadata.h"
+
+TEST_CASE("Basic - Empty") {
+  const auto String = "";
+  const auto Result = FEX::VolatileMetadata::ParseExtendedVolatileMetadata(String);
+  REQUIRE(Result.empty());
+}
+
+TEST_CASE("Basic - Empty - modules") {
+  const auto String = ":::::";
+  const auto Result = FEX::VolatileMetadata::ParseExtendedVolatileMetadata(String);
+  REQUIRE(Result.empty());
+}
+
+TEST_CASE("Basic - Single") {
+  const auto String = "hl2_linux";
+  const auto Result = FEX::VolatileMetadata::ParseExtendedVolatileMetadata(String);
+  REQUIRE(Result.size() == 1);
+
+  REQUIRE(Result.contains("hl2_linux"));
+  CHECK(Result.at("hl2_linux").ModuleTSODisabled == true);
+  CHECK(Result.at("hl2_linux").VolatileInstructions.empty());
+  CHECK(Result.at("hl2_linux").VolatileValidRanges.Empty());
+}
+
+TEST_CASE("Basic - Multiple") {
+  const auto String = "hl2_linux:DeckJob";
+  const auto Result = FEX::VolatileMetadata::ParseExtendedVolatileMetadata(String);
+  REQUIRE(Result.size() == 2);
+
+  REQUIRE(Result.contains("hl2_linux"));
+  CHECK(Result.at("hl2_linux").ModuleTSODisabled == true);
+  CHECK(Result.at("hl2_linux").VolatileInstructions.empty());
+  CHECK(Result.at("hl2_linux").VolatileValidRanges.Empty());
+
+  REQUIRE(Result.contains("DeckJob"));
+  CHECK(Result.at("DeckJob").ModuleTSODisabled == true);
+  CHECK(Result.at("DeckJob").VolatileInstructions.empty());
+  CHECK(Result.at("DeckJob").VolatileValidRanges.Empty());
+}
+
+TEST_CASE("Basic - Single plus empty") {
+  const auto String = "hl2_linux:::::";
+  const auto Result = FEX::VolatileMetadata::ParseExtendedVolatileMetadata(String);
+  REQUIRE(Result.size() == 1);
+  REQUIRE(Result.contains("hl2_linux"));
+  CHECK(Result.at("hl2_linux").ModuleTSODisabled == true);
+  CHECK(Result.at("hl2_linux").VolatileInstructions.empty());
+  CHECK(Result.at("hl2_linux").VolatileValidRanges.Empty());
+}
+
+static inline bool ContainsRange(std::pair<uint64_t, uint64_t> Range, const std::vector<std::pair<uint64_t, uint64_t>>& ValidRanges) {
+  return std::ranges::find(ValidRanges, Range) != ValidRanges.end();
+}
+
+TEST_CASE("Basic - Single - offset") {
+  const auto String = "hl2_linux;0x0-0x1000";
+  const auto Result = FEX::VolatileMetadata::ParseExtendedVolatileMetadata(String);
+  REQUIRE(Result.size() == 1);
+
+  REQUIRE(Result.contains("hl2_linux"));
+  CHECK(Result.at("hl2_linux").ModuleTSODisabled == false);
+  CHECK(Result.at("hl2_linux").VolatileInstructions.empty());
+  CHECK(Result.at("hl2_linux").VolatileValidRanges.Empty() == false);
+
+  const std::vector<std::pair<uint64_t, uint64_t>> ValidRanges = {
+    {0, 0x1000},
+  };
+
+  for (auto it : Result.at("hl2_linux").VolatileValidRanges) {
+    CHECK(ContainsRange(std::make_pair(it.Offset, it.End), ValidRanges));
+  }
+}
+
+TEST_CASE("Basic - Single - offset x2") {
+  const auto String = "hl2_linux;0x0-0x1000,0x2000-0x3000";
+  const auto Result = FEX::VolatileMetadata::ParseExtendedVolatileMetadata(String);
+  REQUIRE(Result.size() == 1);
+  REQUIRE(Result.contains("hl2_linux"));
+  CHECK(Result.at("hl2_linux").ModuleTSODisabled == false);
+  CHECK(Result.at("hl2_linux").VolatileInstructions.empty());
+  CHECK(Result.at("hl2_linux").VolatileValidRanges.Empty() == false);
+
+  const std::vector<std::pair<uint64_t, uint64_t>> ValidRanges = {
+    {0, 0x1000},
+    {0x2000, 0x3000},
+  };
+
+  for (auto it : Result.at("hl2_linux").VolatileValidRanges) {
+    CHECK(ContainsRange(std::make_pair(it.Offset, it.End), ValidRanges));
+  }
+}
+
+TEST_CASE("Basic - Single - offset plus instruction") {
+  const auto String = "hl2_linux;0x0-0x1000;0x1,0x2,0x3";
+  const auto Result = FEX::VolatileMetadata::ParseExtendedVolatileMetadata(String);
+  REQUIRE(Result.size() == 1);
+  REQUIRE(Result.contains("hl2_linux"));
+  CHECK(Result.at("hl2_linux").ModuleTSODisabled == false);
+  CHECK(Result.at("hl2_linux").VolatileInstructions.empty() == false);
+  CHECK(Result.at("hl2_linux").VolatileValidRanges.Empty() == false);
+
+  const std::vector<std::pair<uint64_t, uint64_t>> ValidRanges = {
+    {0, 0x1000},
+  };
+
+  const std::vector<uint64_t> ValidInsts = {
+    1,
+    2,
+    3,
+  };
+
+  for (auto it : Result.at("hl2_linux").VolatileValidRanges) {
+    CHECK(ContainsRange(std::make_pair(it.Offset, it.End), ValidRanges));
+  }
+
+  for (auto it : Result.at("hl2_linux").VolatileInstructions) {
+    CHECK_THAT(ValidInsts, Catch::Matchers::Contains(it));
+  }
+}
+
+TEST_CASE("Basic - Double - offset") {
+  const auto String = "hl2_linux;0x0-0x1000:DeckJob;0x2000-0x3000";
+  const auto Result = FEX::VolatileMetadata::ParseExtendedVolatileMetadata(String);
+  REQUIRE(Result.size() == 2);
+
+  {
+    REQUIRE(Result.contains("hl2_linux"));
+    CHECK(Result.at("hl2_linux").ModuleTSODisabled == false);
+    CHECK(Result.at("hl2_linux").VolatileInstructions.empty());
+    CHECK(Result.at("hl2_linux").VolatileValidRanges.Empty() == false);
+
+    const std::vector<std::pair<uint64_t, uint64_t>> ValidRanges = {
+      {0, 0x1000},
+    };
+
+    for (auto it : Result.at("hl2_linux").VolatileValidRanges) {
+      CHECK(ContainsRange(std::make_pair(it.Offset, it.End), ValidRanges));
+    }
+  }
+
+  {
+    REQUIRE(Result.contains("DeckJob"));
+    CHECK(Result.at("DeckJob").ModuleTSODisabled == false);
+    CHECK(Result.at("DeckJob").VolatileInstructions.empty());
+    CHECK(Result.at("DeckJob").VolatileValidRanges.Empty() == false);
+
+    const std::vector<std::pair<uint64_t, uint64_t>> ValidRanges = {
+      {0x2000, 0x3000},
+    };
+
+    for (auto it : Result.at("DeckJob").VolatileValidRanges) {
+      CHECK(ContainsRange(std::make_pair(it.Offset, it.End), ValidRanges));
+    }
+  }
+}


### PR DESCRIPTION
Only wired up for wow64 and arm64ec. Gives more granular control over
TSO enabling and disabling. Matches arm64ec volatile metadata except
with one more additional feature that whole modules can be disabled at a
time.

Once we know the mapped size of files in Linux then we'll be able to do
the same thing there, but there's not a full mechanism wired up for that
yet.