### PR TITLE
FEXCore: Fixes 32-bit zero-extend semantics on cmpxchg 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3733,7 +3733,11 @@ void OpDispatchBuilder::CMPXCHGOp(OpcodeArgs) {
     // Op1 = RAX == Op1 ? Op2 : Op1
     // If they match then set the rm operand to the input
     // else don't set the rm operand
-    Ref DestResult = Trivial ? Src2 : NZCVSelect(OpSize::i64Bit, CondClassType {COND_EQ}, Src2, Src1);
+    Ref Src2Lower = Src2;
+    if (GPRSize == OpSize::i64Bit && Size == OpSize::i32Bit) {
+      Src2Lower = _Bfe(GPRSize, IR::OpSizeAsBits(Size), 0, Src2);
+    }
+    Ref DestResult = Trivial ? Src2 : NZCVSelect(OpSize::i64Bit, CondClassType {COND_EQ}, Src2Lower, Src1);
 
     // Store in to GPR Dest
     if (GPRSize == OpSize::i64Bit && Size == OpSize::i32Bit) {

--- a/unittests/ASM/FEX_bugs/cmpxchg.asm
+++ b/unittests/ASM/FEX_bugs/cmpxchg.asm
@@ -1,0 +1,23 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x41424344fbca7654",
+    "RBX": "0x00000000fbca7654",
+    "RCX": "0x61626364fbca7654"
+  }
+}
+%endif
+
+; FEX-Emu had a but where it was failing to follow zero-extend semantics on
+; the destination register when cmpxchg was a success as a 32-bit operation.
+; A simple test that does a 32-bit compare exchange with success as 32-bit.
+mov rax, [rel .data + (8 * 0)]
+mov rbx, [rel .data + (8 * 0)]
+mov rcx, [rel .data + (8 * 1)]
+
+cmpxchg ebx, ecx
+hlt
+
+.data:
+dq 0x41424344_fbca7654
+dq 0x61626364_fbca7654

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -1054,13 +1054,14 @@
       ]
     },
     "cmpxchg ecx, ebx": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 6,
       "ExpectedArm64ASM": [
         "mov w20, w7",
         "eor x27, x4, x20",
         "subs w26, w4, w20",
         "csel x4, x4, x20, eq",
-        "csel x7, x6, x7, eq"
+        "mov w20, w6",
+        "csel x7, x20, x7, eq"
       ]
     },
     "cmpxchg rcx, rbx": {


### PR DESCRIPTION
We were missing the semantics when the result was a success.