### PR TITLE
OpcodeDispatcher: Implement support for far jump

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -348,6 +348,7 @@ public:
   void LoopOp(OpcodeArgs);
   void JUMPOp(OpcodeArgs);
   void JUMPAbsoluteOp(OpcodeArgs);
+  void JUMPFARIndirectOp(OpcodeArgs);
   void TESTOp(OpcodeArgs, uint32_t SrcIndex);
   void MOVSXDOp(OpcodeArgs);
   void MOVSXOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/PrimaryGroupTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/PrimaryGroupTables.h
@@ -118,6 +118,7 @@ constexpr DispatchTableEntry OpDispatch_PrimaryGroupTables[] = {
   {OPD(FEXCore::X86Tables::TYPE_GROUP_5, OpToIndex(0xFF), 1), 1, &OpDispatchBuilder::DECOp}, // DEC
   {OPD(FEXCore::X86Tables::TYPE_GROUP_5, OpToIndex(0xFF), 2), 1, &OpDispatchBuilder::CALLAbsoluteOp},
   {OPD(FEXCore::X86Tables::TYPE_GROUP_5, OpToIndex(0xFF), 4), 1, &OpDispatchBuilder::JUMPAbsoluteOp},
+  {OPD(FEXCore::X86Tables::TYPE_GROUP_5, OpToIndex(0xFF), 5), 1, &OpDispatchBuilder::JUMPFARIndirectOp},
   {OPD(FEXCore::X86Tables::TYPE_GROUP_5, OpToIndex(0xFF), 6), 1, &OpDispatchBuilder::PUSHOp},
 
   // GROUP 11

--- a/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
@@ -131,7 +131,7 @@ std::array<X86InstInfo, MAX_INST_GROUP_TABLE_SIZE> PrimaryInstGroupOps = []() co
     {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 2), 1, X86InstInfo{"CALL",  TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_MODRM | FLAGS_BLOCK_END | FLAGS_CALL , 0, nullptr}},
     {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 3), 1, X86InstInfo{"CALLF", TYPE_INST, FLAGS_SETS_RIP | FLAGS_MODRM | FLAGS_BLOCK_END,                  0, nullptr}},
     {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 4), 1, X86InstInfo{"JMP",   TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_SETS_RIP | FLAGS_MODRM | FLAGS_BLOCK_END , 0, nullptr}},
-    {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 5), 1, X86InstInfo{"JMPF",  TYPE_INST, FLAGS_SETS_RIP | FLAGS_MODRM | FLAGS_BLOCK_END,                  0, nullptr}},
+    {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 5), 1, X86InstInfo{"JMPF",  TYPE_INST, FLAGS_SETS_RIP | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_MEM_ONLY | FLAGS_BLOCK_END,                  0, nullptr}},
     {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 6), 1, X86InstInfo{"PUSH",  TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_DEBUG_MEM_ACCESS | FLAGS_MODRM,                                                     0, nullptr}},
     {OPD(TYPE_GROUP_5, OpToIndex(0xFF), 7), 1, X86InstInfo{"",      TYPE_INVALID, FLAGS_NONE,                                                       0, nullptr}},
 

--- a/unittests/ASM/PrimaryGroup/5_FF_05.asm
+++ b/unittests/ASM/PrimaryGroup/5_FF_05.asm
@@ -1,0 +1,24 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "1"
+  }
+}
+%endif
+
+mov rsp, 0xe000_1000
+mov ax, cs
+lea edi, [rel .success]
+
+sub rsp, 16
+mov [rsp], edi
+mov [rsp+4], cs
+
+mov rax, 0
+jmp far [rsp]
+
+hlt
+
+.success:
+mov rax, 1
+hlt

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -2980,6 +2980,25 @@
         "str x4, [x8, #-8]!"
       ]
     },
+    "jmp far [rsp]": {
+      "ExpectedInstructionCount": 13,
+      "Comment": "GROUP5 0xff /5",
+      "ExpectedArm64ASM": [
+        "ldr w20, [x8]",
+        "ldrh w21, [x8, #4]",
+        "strh w21, [x28, #930]",
+        "ubfx w22, w21, #2, #1",
+        "and w21, w21, #0xfff8",
+        "add x0, x28, x22, lsl #3",
+        "ldr x22, [x0, #1168]",
+        "ldr x21, [x22, w21, uxtw]",
+        "lsr x22, x21, #32",
+        "and w23, w22, #0xff000000",
+        "orr w21, w23, w21, lsr #16",
+        "bfi w21, w22, #16, #8",
+        "str w21, [x28, #948]"
+      ]
+    },
     "mov byte [rax], 0": {
       "ExpectedInstructionCount": 1,
       "Comment": "GROUP11 0xc6 /0",


### PR DESCRIPTION
If anything actually attempts to use this to change CS then it'll very
quickly hit some other asserts, but it gets one more change off my list.