### PR TITLE
LinuxSyscalls: Save and restore segment registers on signal

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator/GuestFramesManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator/GuestFramesManagement.cpp
@@ -127,6 +127,15 @@ void SignalDelegator::RestoreFrame_x64(FEXCore::Core::InternalThreadState* Threa
     ArchHelpers::Context::SetState(ucontext, reinterpret_cast<uint64_t>(Frame));
 
     Frame->State.rip = guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_RIP];
+
+    // Restore segments.
+    // FS and GS are explicitly ignored here, as WRFSGSbase is used instead.
+    Frame->State.cs_idx = (guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_CSGSFS] >> 0)  & 0xffff;
+    Frame->State.ss_idx = (guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_CSGSFS] >> 48) & 0xffff;
+
+    Frame->State.cs_cached = Frame->State.CalculateGDTBase(*Frame->State.GetSegmentFromIndex(Frame->State, Frame->State.cs_idx));
+    Frame->State.ss_cached = Frame->State.CalculateGDTBase(*Frame->State.GetSegmentFromIndex(Frame->State, Frame->State.ss_idx));
+
     // XXX: Full context setting
     CTX->SetFlagsFromCompactedEFLAGS(Thread, guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_EFL]);
 
@@ -377,7 +386,13 @@ uint64_t SignalDelegator::SetupFrame_x64(FEXCore::Core::InternalThreadState* Thr
 
   guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_RIP] = ContextBackup->OriginalRIP;
   guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_EFL] = eflags;
-  guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_CSGSFS] = 0;
+  // This stores the CS/GS/FS selectors. It ALSO stores the SS selector in the top 16 bits...For some reason.
+  // Despite the naming, the endianness is swapped from what you'd expect.
+  guest_uctx->uc_mcontext.gregs[FEXCore::x86_64::FEX_REG_CSGSFS] =
+    ((uint64_t)Frame->State.ss_idx << 48) |
+    ((uint64_t)Frame->State.fs_idx << 32) |
+    ((uint64_t)Frame->State.gs_idx << 16) |
+    ((uint64_t)Frame->State.cs_idx << 0);
 
   // aarch64 and x86_64 siginfo_t matches. We can just copy this over
   // SI_USER could also potentially have random data in it, needs to be bit perfect


### PR DESCRIPTION
Effectively NFC today while we don't allow installing LDT entries, but is required to have signal handlers execute in the correct bitness if 32-bit code segments are enabled.

Nothing too crazy, just that four segments are stuffed in to the `REG_CSGSFS` data value, and then CS/SS gets restored on restore. FS and GS are ignored in this instance because edge case behaviour where those don't get reset on signal entry, so if they get changed then it is on the userspace application to fix it.

Gets another change out of my stashes.