### PR TITLE
FEXCore: Move LDT/GDT management to the frontend

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -451,28 +451,6 @@ ContextImpl::CreateThread(uint64_t InitialRIP, uint64_t StackPointer, const FEXC
     memcpy(&Thread->CurrentFrame->State, NewThreadState, sizeof(FEXCore::Core::CPUState));
   }
 
-  Thread->CurrentFrame->State.segment_arrays[0] = &Thread->CurrentFrame->State.private_gdt[0];
-  // TODO: LDTs are currently unsupported, mirror them to GDT.
-  Thread->CurrentFrame->State.segment_arrays[1] = &Thread->CurrentFrame->State.private_gdt[0];
-
-  // Set up default code segment.
-  // Default code segment indexes match the numbers that the Linux kernel uses.
-  Thread->CurrentFrame->State.cs_idx = Core::CPUState::DEFAULT_USER_CS << 3;
-
-  // TODO: Segment management should be moved to the frontend.
-  auto GDT = Thread->CurrentFrame->State.GetSegmentFromIndex(Thread->CurrentFrame->State, Thread->CurrentFrame->State.cs_idx);
-  Core::CPUState::SetGDTBase(GDT, 0);
-  Core::CPUState::SetGDTLimit(GDT, 0xF'FFFFU);
-
-  if (Config.Is64BitMode) {
-    GDT->L = 1; // L = Long Mode = 64-bit
-    GDT->D = 0; // D = Default Operand SIze = Reserved
-  }
-  else {
-    GDT->L = 0; // L = Long Mode = 32-bit
-    GDT->D = 1; // D = Default Operand Size = 32-bit
-  }
-
   // Set up the thread manager state
   Thread->CurrentFrame->Thread = Thread;
 

--- a/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/FEXCore/include/FEXCore/Core/CoreState.h
@@ -234,6 +234,10 @@ struct CPUState {
 
   // TODO: This should be moved to the frontend.
   constexpr static uint32_t DEFAULT_USER_CS = 6;
+
+  // Follows encoding of the TI bit in segment selector encoding.
+  constexpr static uint32_t SEGMENT_ARRAY_INDEX_GDT = 0;
+  constexpr static uint32_t SEGMENT_ARRAY_INDEX_LDT = 1;
   Core::CPUState::gdt_segment private_gdt[32] {};
 };
 static_assert(std::is_trivially_copyable_v<CPUState>, "Needs to be trivial");

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -109,6 +109,9 @@ struct ThreadStateObject : public FEXCore::Allocator::FEXAllocOperators {
     return {Base - FEXCore::Utils::FEX_PAGE_SIZE, Base + FEXCore::Core::InternalThreadState::CALLRET_STACK_SIZE + FEXCore::Utils::FEX_PAGE_SIZE,
             Base + FEXCore::Core::InternalThreadState::CALLRET_STACK_SIZE / 4};
   }
+
+  // GDT and LDT tracking
+  FEXCore::Core::CPUState::gdt_segment gdt[32] {};
 };
 
 class ThreadManager final {
@@ -239,6 +242,7 @@ private:
   void HandleThreadDeletion(FEX::HLE::ThreadStateObject* Thread, bool NeedsTLSUninstall = false);
   void NotifyPause();
   FEX_CONFIG_OPT(ProfileStats, PROFILESTATS);
+  FEX_CONFIG_OPT(Is64BitMode, IS64BIT_MODE);
 };
 
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Thread.cpp
@@ -53,7 +53,7 @@ uint64_t SetThreadArea(FEXCore::Core::CpuStateFrame* Frame, void* tls) {
 
   if (u_info->entry_number == -1) {
     for (uint32_t i = TLS_NextEntry; i < TLS_MaxEntry; ++i) {
-      auto GDT = &Frame->State.segment_arrays[0][i];
+      auto GDT = &Frame->State.segment_arrays[FEXCore::Core::CPUState::SEGMENT_ARRAY_INDEX_GDT][i];
       if (Frame->State.CalculateGDTLimit(*GDT) == 0) {
         // If the limit is zero then it isn't present with our setup
         u_info->entry_number = i;
@@ -68,7 +68,7 @@ uint64_t SetThreadArea(FEXCore::Core::CpuStateFrame* Frame, void* tls) {
   }
 
   // Now we need to update the thread's GDT to handle this change
-  auto GDT = &Frame->State.segment_arrays[0][u_info->entry_number];
+  auto GDT = &Frame->State.segment_arrays[FEXCore::Core::CPUState::SEGMENT_ARRAY_INDEX_GDT][u_info->entry_number];
   Frame->State.SetGDTBase(GDT, u_info->base_addr);
   Frame->State.SetGDTLimit(GDT, 0xF'FFFFU);
 
@@ -160,7 +160,7 @@ void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
 
     FaultSafeUserMemAccess::VerifyIsWritable(u_info, sizeof(*u_info));
 
-    const auto& GDT = &Frame->State.segment_arrays[0][Entry];
+    const auto& GDT = &Frame->State.segment_arrays[FEXCore::Core::CPUState::SEGMENT_ARRAY_INDEX_GDT][Entry];
 
     memset(u_info, 0, sizeof(*u_info));
 

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -644,6 +644,7 @@ NTSTATUS ProcessInit() {
   CTX->SetSignalDelegator(SignalDelegator.get());
   CTX->SetSyscallHandler(SyscallHandler.get());
   CTX->InitCore();
+
   InvalidationTracker.emplace(*CTX, Threads);
 
   HandleImageMap(NtDllBase);
@@ -924,6 +925,24 @@ NTSTATUS ThreadInit() {
 
   auto* Thread = CTX->CreateThread(0, 0);
 
+  // Default segment setup.
+  auto Frame = Thread->CurrentFrame;
+  auto NewSegments = new FEXCore::Core::CPUState::gdt_segment[32];
+
+  // Setup initial code-segment GDT
+  auto &GDT = NewSegments[FEXCore::Core::CPUState::DEFAULT_USER_CS];
+  FEXCore::Core::CPUState::SetGDTBase(&GDT, 0);
+  FEXCore::Core::CPUState::SetGDTLimit(&GDT, 0xF'FFFFU);
+  GDT.L = 1; // L = Long Mode = 64-bit
+  GDT.D = 0; // D = Default Operand SIze = Reserved
+
+  Frame->State.segment_arrays[FEXCore::Core::CPUState::SEGMENT_ARRAY_INDEX_GDT] = &NewSegments[0];
+  // TODO: LDTs are currently unsupported, mirror them to GDT.
+  Frame->State.segment_arrays[FEXCore::Core::CPUState::SEGMENT_ARRAY_INDEX_LDT] = &NewSegments[0];
+
+  Frame->State.cs_idx = FEXCore::Core::CPUState::DEFAULT_USER_CS << 3;
+  Frame->State.cs_cached = FEXCore::Core::CPUState::CalculateGDTBase(GDT);
+
   FEX::Windows::CallRetStack::InitializeThread(Thread);
   Thread->CurrentFrame->Pointers.Common.ExitFunctionEC = reinterpret_cast<uintptr_t>(&ExitFunctionEC);
   CPUArea.StateFrame() = Thread->CurrentFrame;
@@ -935,7 +954,7 @@ NTSTATUS ThreadInit() {
   CPUArea.DispatcherLoopTopEnterECFillSRA() = EnterECFillSRA;
 
   CPUArea.ContextAmd64() = {.ContextFlags = CONTEXT_CONTROL | CONTEXT_SEGMENTS | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT,
-                            .AMD64_SegCs = 0x33,
+                            .AMD64_SegCs = (FEXCore::Core::CPUState::DEFAULT_USER_CS << 3) | 3,
                             .AMD64_SegDs = 0x2b,
                             .AMD64_SegEs = 0x2b,
                             .AMD64_SegFs = 0x53,
@@ -1000,9 +1019,13 @@ NTSTATUS ThreadTerm(HANDLE Thread, LONG ExitCode) {
       StatAllocHandler->DeallocateSlot(CPUArea.ThreadState()->ThreadStats);
     }
   }
+  auto ThreadState = CPUArea.ThreadState();
 
-  FEX::Windows::CallRetStack::DestroyThread(CPUArea.ThreadState());
-  CTX->DestroyThread(CPUArea.ThreadState());
+  // GDT and LDT are mirrored, only free one.
+  delete [] ThreadState->CurrentFrame->State.segment_arrays[FEXCore::Core::CPUState::SEGMENT_ARRAY_INDEX_GDT];
+
+  FEX::Windows::CallRetStack::DestroyThread(ThreadState);
+  CTX->DestroyThread(ThreadState);
   ::VirtualFree(reinterpret_cast<void*>(CPUArea.EmulatorStackLimit()), 0, MEM_RELEASE);
   if (ThreadTID == GetCurrentThreadId()) {
     FEX::Windows::DeinitCRTThread();

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -508,6 +508,7 @@ void BTCpuProcessInit() {
   CTX->SetSignalDelegator(SignalDelegator.get());
   CTX->SetSyscallHandler(SyscallHandler.get());
   CTX->InitCore();
+
   InvalidationTracker.emplace(*CTX, Threads);
 
   auto NtDllX86 = reinterpret_cast<SYSTEM_DLL_INIT_BLOCK*>(GetProcAddress(NtDll, "LdrSystemDllInitBlock"))->ntdll_handle;
@@ -565,10 +566,29 @@ void BTCpuThreadInit() {
   FEX::Windows::InitCRTThread();
   auto* Thread = CTX->CreateThread(0, 0);
 
+  // Default segment setup.
+  auto Frame = Thread->CurrentFrame;
+  auto NewSegments = new FEXCore::Core::CPUState::gdt_segment[32];
+
+  // Setup initial code-segment GDT
+  auto &GDT = NewSegments[FEXCore::Core::CPUState::DEFAULT_USER_CS];
+  FEXCore::Core::CPUState::SetGDTBase(&GDT, 0);
+  FEXCore::Core::CPUState::SetGDTLimit(&GDT, 0xF'FFFFU);
+  GDT.L = 0; // L = Long Mode = 32-bit
+  GDT.D = 1; // D = Default Operand Size = 32-bit
+
+  Frame->State.segment_arrays[FEXCore::Core::CPUState::SEGMENT_ARRAY_INDEX_GDT] = &NewSegments[0];
+  // TODO: LDTs are currently unsupported, mirror them to GDT.
+  Frame->State.segment_arrays[FEXCore::Core::CPUState::SEGMENT_ARRAY_INDEX_LDT] = &NewSegments[0];
+
+  Frame->State.cs_idx = FEXCore::Core::CPUState::DEFAULT_USER_CS << 3;
+  Frame->State.cs_cached = FEXCore::Core::CPUState::CalculateGDTBase(GDT);
+
   FEX::Windows::CallRetStack::InitializeThread(Thread);
 
-  GetTLS().ThreadState() = Thread;
-  GetTLS().ControlWord().fetch_or(ControlBits::WOW_CPU_AREA_DIRTY, std::memory_order::relaxed);
+  auto TLS = GetTLS();
+  TLS.ThreadState() = Thread;
+  TLS.ControlWord().fetch_or(ControlBits::WOW_CPU_AREA_DIRTY, std::memory_order::relaxed);
 
   auto ThreadTID = GetCurrentThreadId();
   Threads.emplace(ThreadTID, Thread);
@@ -614,9 +634,13 @@ void BTCpuThreadTerm(HANDLE Thread, LONG ExitCode) {
       StatAllocHandler->DeallocateSlot(TLS.ThreadState()->ThreadStats);
     }
   }
+  auto ThreadState = TLS.ThreadState();
 
-  FEX::Windows::CallRetStack::DestroyThread(TLS.ThreadState());
-  CTX->DestroyThread(TLS.ThreadState());
+  // GDT and LDT are mirrored, only free one.
+  delete [] ThreadState->CurrentFrame->State.segment_arrays[FEXCore::Core::CPUState::SEGMENT_ARRAY_INDEX_GDT];
+
+  FEX::Windows::CallRetStack::DestroyThread(ThreadState);
+  CTX->DestroyThread(ThreadState);
   if (Self) {
     FEX::Windows::DeinitCRTThread();
   }


### PR DESCRIPTION
This will allow the frontend to manage LDT and GDT so that Linux will be
able to install 32-bit code segments.

A slight behaviour change on wow64 and arm64ec where threads are now sharing their gdt entries, but because we don't yet support having the guest modify those it should be a non-issue? I need to some testing with arm64ec/wow64 still to ensure this doesn't break things, but this is the probably the scariest change in this series.