### PR TITLE
WinAPI: Force WOW64 allocations to start >4GB

### DIFF
--- a/Source/Windows/include/winternl.h
+++ b/Source/Windows/include/winternl.h
@@ -452,6 +452,8 @@ typedef enum _MEMORY_INFORMATION_CLASS {
   MemoryFexStatsShm = 2000,
 } MEMORY_INFORMATION_CLASS;
 
+#define SystemEmulationBasicInformation (SYSTEM_INFORMATION_CLASS)62
+
 #define ProcessFexHardwareTso (PROCESSINFOCLASS)2000
 
 typedef enum _KEY_VALUE_INFORMATION_CLASS {


### PR DESCRIPTION
Avoids stealing address space from the guest, without wine patches