### PR TITLE
Scripts: Fix use of removed helper script

### DIFF
--- a/Scripts/reformat.sh
+++ b/Scripts/reformat.sh
@@ -38,13 +38,13 @@ if [ "$CHANGED_ONLY" = true ]; then
 
     CHANGED_FILES=$(git ls-files -m '*.cpp' '*.h' '*.inl')
     if [ -n "$CHANGED_FILES" ]; then
-        echo "$CHANGED_FILES" | xargs -d '\n' -n 1 -P $(nproc) python3 "$SCRIPT_DIR/clang-format.py" -i
+        echo "$CHANGED_FILES" | xargs -d '\n' -n 1 -P $(nproc) clang-format-19 -i
     else
         echo "No changed files to format."
     fi
 else
     # Reformat whole tree (original behavior)
-    git ls-files -z '*.cpp' '*.h' '*.inl' | xargs -0 -n 1 -P $(nproc) python3 "$SCRIPT_DIR/clang-format.py" -i
+    git ls-files -z '*.cpp' '*.h' '*.inl' | xargs -0 -n 1 -P $(nproc) clang-format-19 -i
 fi
 
 cd $DIR


### PR DESCRIPTION
This was accidentally changed back to clang-format.py in 3b322d8f375b32f08ea4c5824af4536ba7fde98a.