### PR TITLE
More BRK fixes

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -763,7 +763,6 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame* Frame, void* Ad
 void SyscallHandler::DefaultProgramBreak(uint64_t Base, uint64_t Size) {
   DataSpace = Base;
   DataSpaceMaxSize = Size;
-  DataSpaceStartingSize = Size;
 }
 
 SyscallHandler::SyscallHandler(FEXCore::Context::Context* _CTX, FEX::HLE::SignalDelegator* _SignalDelegation, FEX::HLE::ThunkHandler* ThunkHandler)

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -709,6 +709,11 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame* Frame, void* Ad
       // Not allowed to move brk end below original start
       // Set the size to zero
       DataSpaceSize = 0;
+
+      // Munmap the whole space.
+      [[maybe_unused]] auto ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(DataSpace), DataSpaceMappedSize);
+      LOGMAN_THROW_A_FMT(ok != -1, "Munmap failed");
+      DataSpaceMappedSize = 0;
     } else {
       uint64_t NewSize = NewEnd - DataSpace;
       uint64_t NewSizeAligned = FEXCore::AlignUp(NewSize, 4096);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -740,14 +740,6 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame* Frame, void* Ad
         NewBRK = (uint64_t)GuestMmap(Frame->Thread, (void*)(DataSpace + DataSpaceMappedSize), AllocateNewSize, PROT_READ | PROT_WRITE,
                                      MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
-        if (!FEX::HLE::HasSyscallError(NewBRK) && NewBRK != (DataSpace + DataSpaceMappedSize)) {
-          // Couldn't allocate that the region we wanted
-          // Can happen if MAP_FIXED_NOREPLACE isn't understood by the kernel
-          [[maybe_unused]] int ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(NewBRK), AllocateNewSize);
-          LOGMAN_THROW_A_FMT(ok != -1, "Munmap failed");
-          NewBRK = ~0ULL;
-        }
-
         if (FEX::HLE::HasSyscallError(NewBRK)) {
           // If we couldn't allocate a new region then out of memory
           return DataSpace + DataSpaceSize;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -713,30 +713,30 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame* Frame, void* Ad
       uint64_t NewSize = NewEnd - DataSpace;
       uint64_t NewSizeAligned = FEXCore::AlignUp(NewSize, 4096);
 
-      if (NewSizeAligned < DataSpaceMaxSize) {
+      if (NewSizeAligned < DataSpaceMappedSize) {
         // If we are shrinking the brk then munmap the ranges
         // That way we gain the memory back and also give the application zero pages if it allocates again
         // DataspaceMaxSize is always page aligned
 
-        uint64_t RemainingSize = DataSpaceMaxSize - NewSizeAligned;
+        uint64_t RemainingSize = DataSpaceMappedSize - NewSizeAligned;
         // We have pages we can unmap
         [[maybe_unused]] auto ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(DataSpace + NewSizeAligned), RemainingSize);
         LOGMAN_THROW_A_FMT(ok != -1, "Munmap failed");
 
-        DataSpaceMaxSize = NewSizeAligned;
-      } else if (NewSize > DataSpaceMaxSize) {
+        DataSpaceMappedSize = NewSizeAligned;
+      } else if (NewSize > DataSpaceMappedSize) {
         constexpr static uint64_t SizeAlignment = 8 * 1024 * 1024;
-        uint64_t AllocateNewSize = FEXCore::AlignUp(NewSize, SizeAlignment) - DataSpaceMaxSize;
-        if (!Is64BitMode() && (DataSpace + DataSpaceMaxSize + AllocateNewSize > 0x1'0000'0000ULL)) {
+        uint64_t AllocateNewSize = FEXCore::AlignUp(NewSize, SizeAlignment) - DataSpaceMappedSize;
+        if (!Is64BitMode() && (DataSpace + DataSpaceMappedSize + AllocateNewSize > 0x1'0000'0000ULL)) {
           // If we are 32bit and we tried going about the 32bit limit then out of memory
           return DataSpace + DataSpaceSize;
         }
 
         uint64_t NewBRK {};
-        NewBRK = (uint64_t)GuestMmap(Frame->Thread, (void*)(DataSpace + DataSpaceMaxSize), AllocateNewSize, PROT_READ | PROT_WRITE,
+        NewBRK = (uint64_t)GuestMmap(Frame->Thread, (void*)(DataSpace + DataSpaceMappedSize), AllocateNewSize, PROT_READ | PROT_WRITE,
                                      MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
-        if (!FEX::HLE::HasSyscallError(NewBRK) && NewBRK != (DataSpace + DataSpaceMaxSize)) {
+        if (!FEX::HLE::HasSyscallError(NewBRK) && NewBRK != (DataSpace + DataSpaceMappedSize)) {
           // Couldn't allocate that the region we wanted
           // Can happen if MAP_FIXED_NOREPLACE isn't understood by the kernel
           [[maybe_unused]] int ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(NewBRK), AllocateNewSize);
@@ -749,7 +749,7 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame* Frame, void* Ad
           return DataSpace + DataSpaceSize;
         } else {
           // Increase our BRK size
-          DataSpaceMaxSize += AllocateNewSize;
+          DataSpaceMappedSize += AllocateNewSize;
         }
       }
 
@@ -762,7 +762,7 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame* Frame, void* Ad
 
 void SyscallHandler::DefaultProgramBreak(uint64_t Base, uint64_t Size) {
   DataSpace = Base;
-  DataSpaceMaxSize = Size;
+  DataSpaceMappedSize = Size;
 }
 
 SyscallHandler::SyscallHandler(FEXCore::Context::Context* _CTX, FEX::HLE::SignalDelegator* _SignalDelegation, FEX::HLE::ThunkHandler* ThunkHandler)
@@ -781,7 +781,7 @@ SyscallHandler::SyscallHandler(FEXCore::Context::Context* _CTX, FEX::HLE::Signal
 }
 
 SyscallHandler::~SyscallHandler() {
-  FEXCore::Allocator::munmap(reinterpret_cast<void*>(DataSpace), DataSpaceMaxSize);
+  FEXCore::Allocator::munmap(reinterpret_cast<void*>(DataSpace), DataSpaceMappedSize);
 }
 
 uint32_t SyscallHandler::CalculateHostKernelVersion() {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -339,7 +339,7 @@ protected:
   // BRK management
   uint64_t DataSpace {};
   uint64_t DataSpaceSize {};
-  uint64_t DataSpaceMaxSize {};
+  uint64_t DataSpaceMappedSize {};
 
   // (Major << 24) | (Minor << 16) | Patch
   uint32_t HostKernelVersion {};

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -340,7 +340,6 @@ protected:
   uint64_t DataSpace {};
   uint64_t DataSpaceSize {};
   uint64_t DataSpaceMaxSize {};
-  uint64_t DataSpaceStartingSize {};
 
   // (Major << 24) | (Minor << 16) | Patch
   uint32_t HostKernelVersion {};


### PR DESCRIPTION
This fixes some minor edge cases in FEX's BRK emulation, with these changes in place, FEXInterpreter can self-host the TestHarnessRunner built for x86-64.

Specifically fixes a couple of things:
* Unmap the whole BRK space at startup
  * Needs to be initially reserved to ensure nothing gets mapped in the space, but then unmapped to ensure the VA is free
  * Technically gives ~8MB more VA space to 32-bit applications
  * Required to support the visibility rules that Linux imposes on brk
* Changes brk map granularity to a page
  * Again required for VA mapping visibility rules
* Fixes a bug where I forgot to munmap the brk region if it was set to 0 length
* Removes a workaround for old kernels that don't support `MAP_FIXED_NOREPLACE`   