### PR TITLE
LogManager: Evaluate non-predicate arguments for assertions lazily

### DIFF
--- a/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -60,9 +60,11 @@ namespace Throw {
     MFmt(fmt, fmt::make_format_args(args...));
   }
 
-#define LOGMAN_THROW_A_FMT(pred, format, ...)                                                                            \
-  do {                                                                                                                   \
-    LogMan::Throw::AFmt((pred), "{}:{}, {}: " format, __FILE_NAME__, __LINE__, __FUNCTION__ __VA_OPT__(, ) __VA_ARGS__); \
+#define LOGMAN_THROW_A_FMT(pred, format, ...)                                                                             \
+  do {                                                                                                                    \
+    if (!(pred)) {                                                                                                        \
+      LogMan::Throw::AFmt(false, "{}:{}, {}: " format, __FILE_NAME__, __LINE__, __FUNCTION__ __VA_OPT__(, ) __VA_ARGS__); \
+    }                                                                                                                     \
   } while (0)
 #else
   static inline void AFmt(bool, const char*, ...) {}


### PR DESCRIPTION
This allows assertions like "some_iterator == end()" to dereference the unexpected iterator value when formatting the log message on failure.