### PR TITLE
Reduce use of maybe_unused attributes

### DIFF
--- a/CodeEmitter/CodeEmitter/ALUOps.inl
+++ b/CodeEmitter/CodeEmitter/ALUOps.inl
@@ -174,7 +174,7 @@ public:
   // Logical immediate
   void and_(ARMEmitter::Size s, ARMEmitter::Register rd, ARMEmitter::Register rn, uint64_t Imm) {
     uint32_t n, immr, imms;
-    [[maybe_unused]] const auto IsImm = IsImmLogical(Imm, RegSizeInBits(s), &n, &imms, &immr);
+    const auto IsImm = IsImmLogical(Imm, RegSizeInBits(s), &n, &imms, &immr);
     LOGMAN_THROW_A_FMT(IsImm, "Couldn't encode immediate to logical op");
     and_(s, rd, rn, n, immr, imms);
   }
@@ -185,7 +185,7 @@ public:
 
   void ands(ARMEmitter::Size s, ARMEmitter::Register rd, ARMEmitter::Register rn, uint64_t Imm) {
     uint32_t n, immr, imms;
-    [[maybe_unused]] const auto IsImm = IsImmLogical(Imm, RegSizeInBits(s), &n, &imms, &immr);
+    const auto IsImm = IsImmLogical(Imm, RegSizeInBits(s), &n, &imms, &immr);
     LOGMAN_THROW_A_FMT(IsImm, "Couldn't encode immediate to logical op");
     ands(s, rd, rn, n, immr, imms);
   }
@@ -196,14 +196,14 @@ public:
 
   void orr(ARMEmitter::Size s, ARMEmitter::Register rd, ARMEmitter::Register rn, uint64_t Imm) {
     uint32_t n, immr, imms;
-    [[maybe_unused]] const auto IsImm = IsImmLogical(Imm, RegSizeInBits(s), &n, &imms, &immr);
+    const auto IsImm = IsImmLogical(Imm, RegSizeInBits(s), &n, &imms, &immr);
     LOGMAN_THROW_A_FMT(IsImm, "Couldn't encode immediate to logical op");
     orr(s, rd, rn, n, immr, imms);
   }
 
   void eor(ARMEmitter::Size s, ARMEmitter::Register rd, ARMEmitter::Register rn, uint64_t Imm) {
     uint32_t n, immr, imms;
-    [[maybe_unused]] const auto IsImm = IsImmLogical(Imm, RegSizeInBits(s), &n, &imms, &immr);
+    const auto IsImm = IsImmLogical(Imm, RegSizeInBits(s), &n, &imms, &immr);
     LOGMAN_THROW_A_FMT(IsImm, "Couldn't encode immediate to logical op");
     eor(s, rd, rn, n, immr, imms);
   }
@@ -333,7 +333,7 @@ public:
     bfi(s, rd, Reg::zr, lsb, width);
   }
   void bfxil(ARMEmitter::Size s, Register rd, Register rn, uint32_t lsb, uint32_t width) {
-    [[maybe_unused]] const auto reg_size_bits = RegSizeInBits(s);
+    const auto reg_size_bits = RegSizeInBits(s);
     const auto lsb_p_width = lsb + width;
 
     LOGMAN_THROW_A_FMT(width >= 1, "bfxil needs width >= 1");
@@ -977,7 +977,7 @@ private:
   }
 
   void xbfiz_helper(bool is_signed, ARMEmitter::Size s, Register rd, Register rn, uint32_t lsb, uint32_t width) {
-    [[maybe_unused]] const auto lsb_p_width = lsb + width;
+    const auto lsb_p_width = lsb + width;
     const auto reg_size_bits = RegSizeInBits(s);
 
     LOGMAN_THROW_A_FMT(lsb_p_width <= reg_size_bits, "lsb + width ({}) must be <= {}. lsb={}, width={}", lsb_p_width, reg_size_bits, lsb, width);

--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -1541,7 +1541,7 @@ public:
   void sqincp(SubRegSize size, XRegister rdn, PRegister pm) {
     SVEIncDecPredicateCountScalar(0, 1, 0b10, 0b00, size, rdn, pm);
   }
-  void sqincp(SubRegSize size, XRegister rdn, PRegister pm, [[maybe_unused]] WRegister wn) {
+  void sqincp(SubRegSize size, XRegister rdn, PRegister pm, WRegister wn) {
     LOGMAN_THROW_A_FMT(rdn.Idx() == wn.Idx(), "rdn and wn must be the same");
     SVEIncDecPredicateCountScalar(0, 1, 0b00, 0b00, size, rdn, pm);
   }
@@ -1554,7 +1554,7 @@ public:
   void sqdecp(SubRegSize size, XRegister rdn, PRegister pm) {
     SVEIncDecPredicateCountScalar(0, 1, 0b10, 0b10, size, rdn, pm);
   }
-  void sqdecp(SubRegSize size, XRegister rdn, PRegister pm, [[maybe_unused]] WRegister wn) {
+  void sqdecp(SubRegSize size, XRegister rdn, PRegister pm, WRegister wn) {
     LOGMAN_THROW_A_FMT(rdn.Idx() == wn.Idx(), "rdn and wn must be the same");
     SVEIncDecPredicateCountScalar(0, 1, 0b00, 0b10, size, rdn, pm);
   }
@@ -3296,7 +3296,7 @@ private:
     const auto log2_size_bytes = FEXCore::ilog2(size_bytes);
 
     // We can index up to 512-bit registers with dup
-    [[maybe_unused]] const auto max_index = (64U >> log2_size_bytes) - 1;
+    const auto max_index = (64U >> log2_size_bytes) - 1;
     LOGMAN_THROW_A_FMT(Index <= max_index, "dup index ({}) too large. Must be within [0, {}].", Index, max_index);
 
     // imm2:tsz make up a 7 bit wide field, with each increasing element size
@@ -3326,7 +3326,7 @@ private:
 
     uint32_t shift = 0;
     if (!is_uint8_imm) {
-      [[maybe_unused]] const bool is_uint16_imm = (imm >> 16) == 0;
+      const bool is_uint16_imm = (imm >> 16) == 0;
 
       LOGMAN_THROW_A_FMT(is_uint16_imm, "Immediate ({}) must be a 16-bit value within [256, 65280]", imm);
       LOGMAN_THROW_A_FMT((imm % 256) == 0, "Immediate ({}) must be a multiple of 256", imm);
@@ -4152,7 +4152,7 @@ private:
 
     const auto& op_data = mem_op.MetaType.ScalarVectorType;
     const bool is_scaled = op_data.scale != 0;
-    [[maybe_unused]] const auto msize_value = FEXCore::ToUnderlying(msize);
+    const auto msize_value = FEXCore::ToUnderlying(msize);
 
     LOGMAN_THROW_A_FMT(op_data.scale == 0 || op_data.scale == msize_value, "scale may only be 0 or {}", msize_value);
 
@@ -4266,7 +4266,7 @@ private:
     const auto msize_value = FEXCore::ToUnderlying(msize);
     const auto msize_bytes = 1U << msize_value;
 
-    [[maybe_unused]] const auto imm_limit = (32U << msize_value) - msize_bytes;
+    const auto imm_limit = (32U << msize_value) - msize_bytes;
     const auto imm = mem_op.MetaType.VectorImmType.Imm;
     const auto imm_to_encode = imm >> msize_value;
 
@@ -4332,8 +4332,8 @@ private:
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
     LOGMAN_THROW_A_FMT((imm % num_regs) == 0, "Offset must be a multiple of {}", num_regs);
 
-    [[maybe_unused]] const auto min_offset = -8 * num_regs;
-    [[maybe_unused]] const auto max_offset = 7 * num_regs;
+    const auto min_offset = -8 * num_regs;
+    const auto max_offset = 7 * num_regs;
     LOGMAN_THROW_A_FMT(imm >= min_offset && imm <= max_offset,
                        "Invalid load/store offset ({}). Offset must be a multiple of {} and be within [{}, {}]", imm, num_regs, min_offset,
                        max_offset);
@@ -4440,8 +4440,8 @@ private:
     LOGMAN_THROW_A_FMT(pg <= PReg::p7, "Can only use p0-p7 as a governing predicate");
 
     const auto esize = static_cast<int>(16 << ssz);
-    [[maybe_unused]] const auto max_imm = (esize << 3) - esize;
-    [[maybe_unused]] const auto min_imm = -(max_imm + esize);
+    const auto max_imm = (esize << 3) - esize;
+    const auto min_imm = -(max_imm + esize);
 
     LOGMAN_THROW_A_FMT((imm % esize) == 0, "imm ({}) must be a multiple of {}", imm, esize);
     LOGMAN_THROW_A_FMT(imm >= min_imm && imm <= max_imm, "imm ({}) must be within [{}, {}]", imm, min_imm, max_imm);
@@ -4485,7 +4485,7 @@ private:
     const auto msize_value = FEXCore::ToUnderlying(msize);
 
     const auto data_size_bytes = 1U << msize_value;
-    [[maybe_unused]] const auto max_imm = (64U << msize_value) - data_size_bytes;
+    const auto max_imm = (64U << msize_value) - data_size_bytes;
     LOGMAN_THROW_A_FMT((imm % data_size_bytes) == 0 && imm <= max_imm, "imm must be a multiple of {} and be within [0, {}]",
                        data_size_bytes, max_imm);
 
@@ -4861,7 +4861,7 @@ private:
                        "64-bit variants may only use Zm between z0-z15");
 
     const auto Underlying = FEXCore::ToUnderlying(size);
-    [[maybe_unused]] const uint32_t IndexMax = (16 / (1U << Underlying)) - 1;
+    const uint32_t IndexMax = (16 / (1U << Underlying)) - 1;
     LOGMAN_THROW_A_FMT(index <= IndexMax, "Index must be within 0-{}", IndexMax);
 
     // Can be bit 20 or 19 depending on whether or not the element size is 64-bit.
@@ -5117,12 +5117,13 @@ private:
   requires (std::is_same_v<T, float> || std::is_same_v<T, double>)
   using FloatToEquivalentUInt = std::conditional_t<std::is_same_v<T, float>, uint32_t, uint64_t>;
 
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
   // Determines if a floating-point value is capable of being converted
   // into an 8-bit immediate. See pseudocode definition of VFPExpandImm
   // in ARM A-profile reference manual for a general overview of how this was derived.
   template<typename T>
   requires (std::is_same_v<T, float> || std::is_same_v<T, double>)
-  [[nodiscard, maybe_unused]]
+  [[nodiscard]]
   static bool IsValidFPValueForImm8(T value) {
     const uint64_t bits = FEXCore::BitCast<FloatToEquivalentUInt<T>>(value);
     const uint64_t datasize_idx = FEXCore::ilog2(sizeof(T)) - 1;
@@ -5162,10 +5163,13 @@ private:
 
     return true;
   }
+#endif
 
 protected:
   static uint32_t FP32ToImm8(float value) {
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     LOGMAN_THROW_A_FMT(IsValidFPValueForImm8(value), "Value ({}) cannot be encoded into an 8-bit immediate", value);
+#endif
 
     const auto bits = FEXCore::BitCast<uint32_t>(value);
     const auto sign = (bits & 0x80000000) >> 24;
@@ -5176,7 +5180,9 @@ protected:
   }
 
   static uint32_t FP64ToImm8(double value) {
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     LOGMAN_THROW_A_FMT(IsValidFPValueForImm8(value), "Value ({}) cannot be encoded into an 8-bit immediate", value);
+#endif
 
     const auto bits = FEXCore::BitCast<uint64_t>(value);
     const auto sign = (bits & 0x80000000'00000000) >> 56;
@@ -5202,7 +5208,7 @@ private:
     uint32_t shift = 0;
     if (!is_int8_imm) {
       const int32_t imm16_limit = 32768;
-      [[maybe_unused]] const bool is_int16_imm = -imm16_limit <= imm && imm < imm16_limit;
+      const bool is_int16_imm = -imm16_limit <= imm && imm < imm16_limit;
 
       LOGMAN_THROW_A_FMT(is_int16_imm, "Immediate ({}) must be a 16-bit value within [-32768, 32512]", imm);
       LOGMAN_THROW_A_FMT((imm % 256) == 0, "Immediate ({}) must be a multiple of 256", imm);

--- a/CodeEmitter/CodeEmitter/ScalarOps.inl
+++ b/CodeEmitter/CodeEmitter/ScalarOps.inl
@@ -30,7 +30,7 @@ public:
     const uint32_t SizeImm = FEXCore::ToUnderlying(size);
     const uint32_t IndexShift = SizeImm + 1;
     const uint32_t ElementSize = 1U << SizeImm;
-    [[maybe_unused]] const uint32_t MaxIndex = 128U / (ElementSize * 8);
+    const uint32_t MaxIndex = 128U / (ElementSize * 8);
 
     LOGMAN_THROW_A_FMT(Index < MaxIndex, "Index too large. Index={}, Max Index: {}", Index, MaxIndex);
 
@@ -1381,7 +1381,7 @@ private:
   void ASIMDScalarXIndexedElement(uint32_t U, ScalarRegSize size, uint32_t opcode, VRegister rm, VRegister rn, VRegister rd, uint32_t index) {
     LOGMAN_THROW_A_FMT(size != ScalarRegSize::i8Bit, "Scalar size must not be 8-bit");
 
-    [[maybe_unused]] const auto invalid_bound = 16U >> FEXCore::ToUnderlying(size);
+    const auto invalid_bound = 16U >> FEXCore::ToUnderlying(size);
     LOGMAN_THROW_A_FMT(index < invalid_bound, "Index ({}) must be within [0-{}]", index, invalid_bound - 1);
 
     uint32_t Instr = 0b0101'1111'0000'0000'0000'0000'0000'0000;

--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -404,7 +404,7 @@ def print_ir_sizes():
     // Make sure our array maps directly to the IROps enum
     static_assert(IRSizes[IROps::OP_LAST] == -1ULL);
 
-    [[maybe_unused, nodiscard]] static size_t GetSize(IROps Op) { return IRSizes[Op]; }
+    [[nodiscard]] inline size_t GetSize(IROps Op) { return IRSizes[Op]; }
     [[nodiscard, gnu::const, gnu::visibility("default")]] std::string_view const& GetName(IROps Op);
     [[nodiscard, gnu::const, gnu::visibility("default")]] uint8_t GetArgs(IROps Op);
     [[nodiscard, gnu::const, gnu::visibility("default")]] uint8_t GetRAArgs(IROps Op);

--- a/FEXCore/Source/Common/StringConv.h
+++ b/FEXCore/Source/Common/StringConv.h
@@ -7,69 +7,58 @@
 #include <optional>
 
 namespace FEXCore::StrConv {
-[[maybe_unused]]
-static bool Conv(std::string_view Value, bool* Result) {
+inline bool Conv(std::string_view Value, bool* Result) {
   *Result = std::strtoull(Value.data(), nullptr, 0);
   return true;
 }
 
-[[maybe_unused]]
-static bool Conv(std::string_view Value, uint8_t* Result) {
+inline bool Conv(std::string_view Value, uint8_t* Result) {
   *Result = std::strtoul(Value.data(), nullptr, 0);
   return true;
 }
 
-[[maybe_unused]]
-static bool Conv(std::string_view Value, int8_t* Result) {
+inline bool Conv(std::string_view Value, int8_t* Result) {
   *Result = std::strtol(Value.data(), nullptr, 0);
   return true;
 }
 
-[[maybe_unused]]
-static bool Conv(std::string_view Value, uint16_t* Result) {
+inline bool Conv(std::string_view Value, uint16_t* Result) {
   *Result = std::strtoul(Value.data(), nullptr, 0);
   return true;
 }
 
-[[maybe_unused]]
-static bool Conv(std::string_view Value, int16_t* Result) {
+inline bool Conv(std::string_view Value, int16_t* Result) {
   *Result = std::strtol(Value.data(), nullptr, 0);
   return true;
 }
 
-[[maybe_unused]]
-static bool Conv(std::string_view Value, uint32_t* Result) {
+inline bool Conv(std::string_view Value, uint32_t* Result) {
   *Result = std::strtoul(Value.data(), nullptr, 0);
   return true;
 }
 
-[[maybe_unused]]
-static bool Conv(std::string_view Value, int32_t* Result) {
+inline bool Conv(std::string_view Value, int32_t* Result) {
   *Result = std::strtol(Value.data(), nullptr, 0);
   return true;
 }
 
-[[maybe_unused]]
-static bool Conv(std::string_view Value, uint64_t* Result) {
+inline bool Conv(std::string_view Value, uint64_t* Result) {
   *Result = std::strtoull(Value.data(), nullptr, 0);
   return true;
 }
 
-[[maybe_unused]]
-static bool Conv(std::string_view Value, int64_t* Result) {
+inline bool Conv(std::string_view Value, int64_t* Result) {
   *Result = std::strtoll(Value.data(), nullptr, 0);
   return true;
 }
 
 template<typename T, typename = std::enable_if<std::is_enum<T>::value, T>>
-[[maybe_unused]]
-static bool Conv(std::string_view Value, T* Result) {
+inline bool Conv(std::string_view Value, T* Result) {
   *Result = static_cast<T>(std::stoull(Value.data(), nullptr, 0));
   return true;
 }
 
-[[maybe_unused]]
-static bool Conv(std::string_view Value, fextl::string* Result) {
+inline bool Conv(std::string_view Value, fextl::string* Result) {
   *Result = Value;
   return true;
 }

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -712,7 +712,7 @@ void Arm64Emitter::SpillStaticRegs(ARMEmitter::Register TmpReg, bool FPRs, uint3
   // Now handle PF/AF
   if (PFAFSpillMask) {
     auto PFOffset = offsetof(FEXCore::Core::CpuStateFrame, State.pf_raw);
-    [[maybe_unused]] auto AFOffset = offsetof(FEXCore::Core::CpuStateFrame, State.af_raw);
+    auto AFOffset = offsetof(FEXCore::Core::CpuStateFrame, State.af_raw);
     LOGMAN_THROW_A_FMT(PFAFSpillMask == PFAFMask, "PF/AF not spilled together");
     LOGMAN_THROW_A_FMT(AFOffset == PFOffset + 4, "PF/AF are together");
 

--- a/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
@@ -1374,12 +1374,12 @@ DEF_OP(VExtractToGPR) {
   const auto Op = IROp->C<IR::IROp_VExtractToGPR>();
   const auto OpSize = IROp->Size;
 
-  [[maybe_unused]] constexpr auto AVXRegBitSize = Core::CPUState::XMM_AVX_REG_SIZE * 8;
+  constexpr auto AVXRegBitSize = Core::CPUState::XMM_AVX_REG_SIZE * 8;
   constexpr auto SSERegBitSize = Core::CPUState::XMM_SSE_REG_SIZE * 8;
   const auto ElementSizeBits = IR::OpSizeAsBits(Op->Header.ElementSize);
 
   const auto Offset = ElementSizeBits * Op->Index;
-  [[maybe_unused]] const auto Is256Bit = Offset >= SSERegBitSize;
+  const auto Is256Bit = Offset >= SSERegBitSize;
   LOGMAN_THROW_A_FMT(!Is256Bit || HostSupportsSVE256, "Need SVE256 support in order to use {} with 256-bit operation", __func__);
 
   const auto Dst = GetReg(Node);

--- a/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
@@ -217,8 +217,8 @@ DEF_OP(CondJump) {
   if (Op->FromNZCV) {
     b(MapCC(Op->Cond), TrueTargetLabel);
   } else {
-    [[maybe_unused]] uint64_t Const;
-    [[maybe_unused]] const bool isConst = IsInlineConstant(Op->Cmp2, &Const);
+    uint64_t Const;
+    const bool isConst = IsInlineConstant(Op->Cmp2, &Const);
 
     auto Reg = GetReg(Op->Cmp1);
     const auto Size = Op->CompareSize == IR::OpSize::i32Bit ? ARMEmitter::Size::i32Bit : ARMEmitter::Size::i64Bit;

--- a/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
@@ -16,7 +16,7 @@ DEF_OP(VAESImc) {
 
 DEF_OP(VAESEnc) {
   const auto Op = IROp->C<IR::IROp_VAESEnc>();
-  [[maybe_unused]] const auto OpSize = IROp->Size;
+  const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
   const auto Key = GetVReg(Op->Key);
@@ -41,7 +41,7 @@ DEF_OP(VAESEnc) {
 
 DEF_OP(VAESEncLast) {
   const auto Op = IROp->C<IR::IROp_VAESEncLast>();
-  [[maybe_unused]] const auto OpSize = IROp->Size;
+  const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
   const auto Key = GetVReg(Op->Key);
@@ -64,7 +64,7 @@ DEF_OP(VAESEncLast) {
 
 DEF_OP(VAESDec) {
   const auto Op = IROp->C<IR::IROp_VAESDec>();
-  [[maybe_unused]] const auto OpSize = IROp->Size;
+  const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
   const auto Key = GetVReg(Op->Key);
@@ -89,7 +89,7 @@ DEF_OP(VAESDec) {
 
 DEF_OP(VAESDecLast) {
   const auto Op = IROp->C<IR::IROp_VAESDecLast>();
-  [[maybe_unused]] const auto OpSize = IROp->Size;
+  const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
   const auto Key = GetVReg(Op->Key);
@@ -322,7 +322,7 @@ DEF_OP(VSha256U1) {
 
 DEF_OP(PCLMUL) {
   const auto Op = IROp->C<IR::IROp_PCLMUL>();
-  [[maybe_unused]] const auto OpSize = IROp->Size;
+  const auto OpSize = IROp->Size;
 
   const auto Dst = GetVReg(Node);
   const auto Src1 = GetVReg(Op->Src1);

--- a/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
@@ -140,7 +140,7 @@ DEF_OP(LoadRegister) {
 
     mov(GetReg(Node).X(), StaticRegisters[Op->Reg].X());
   } else if (Op->Class == IR::FPRClass) {
-    [[maybe_unused]] const auto regSize = HostSupportsAVX256 ? IR::OpSize::i256Bit : IR::OpSize::i128Bit;
+    const auto regSize = HostSupportsAVX256 ? IR::OpSize::i256Bit : IR::OpSize::i128Bit;
     LOGMAN_THROW_A_FMT(Op->Reg < StaticFPRegisters.size(), "out of range reg");
     LOGMAN_THROW_A_FMT(IROp->Size == regSize, "expected sized");
 
@@ -181,7 +181,7 @@ DEF_OP(StoreRegister) {
     // Always use 64-bit, it's faster. Upper bits ignored for 32-bit mode.
     mov(ARMEmitter::Size::i64Bit, GetReg(Reg), GetReg(Op->Value));
   } else if (Reg.Class == IR::FPRFixedClass) {
-    [[maybe_unused]] const auto regSize = HostSupportsAVX256 ? IR::OpSize::i256Bit : IR::OpSize::i128Bit;
+    const auto regSize = HostSupportsAVX256 ? IR::OpSize::i256Bit : IR::OpSize::i128Bit;
     LOGMAN_THROW_A_FMT(IROp->Size == regSize, "expected sized");
 
     const auto guest = GetVReg(Reg);
@@ -742,7 +742,7 @@ DEF_OP(LoadMemTSO) {
     const auto Dst = GetReg(Node);
     uint64_t Offset = 0;
     if (!Op->Offset.IsInvalid()) {
-      [[maybe_unused]] bool IsInline = IsInlineConstant(Op->Offset, &Offset);
+      bool IsInline = IsInlineConstant(Op->Offset, &Offset);
       LOGMAN_THROW_A_FMT(IsInline, "expected immediate");
     }
 
@@ -1750,7 +1750,7 @@ DEF_OP(StoreMemTSO) {
     const auto Src = GetZeroableReg(Op->Value);
     uint64_t Offset = 0;
     if (!Op->Offset.IsInvalid()) {
-      [[maybe_unused]] bool IsInline = IsInlineConstant(Op->Offset, &Offset);
+      bool IsInline = IsInlineConstant(Op->Offset, &Offset);
       LOGMAN_THROW_A_FMT(IsInline, "expected immediate");
     }
 
@@ -2586,7 +2586,7 @@ DEF_OP(VStoreNonTemporalPair) {
   const auto Op = IROp->C<IR::IROp_VStoreNonTemporalPair>();
   const auto OpSize = IROp->Size;
 
-  [[maybe_unused]] const auto Is128Bit = OpSize == IR::OpSize::i128Bit;
+  const auto Is128Bit = OpSize == IR::OpSize::i128Bit;
   LOGMAN_THROW_A_FMT(Is128Bit, "This IR operation only operates at 128-bit wide");
 
   const auto ValueLow = GetVReg(Op->ValueLow);

--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -1352,7 +1352,7 @@ DEF_OP(VFMin) {
 
   const auto ElementSize = Op->Header.ElementSize;
   const auto SubRegSize = ConvertSubRegSize248(IROp);
-  [[maybe_unused]] const auto IsScalar = ElementSize == OpSize;
+  const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == IR::OpSize::i256Bit;
   LOGMAN_THROW_A_FMT(!Is256Bit || HostSupportsSVE256, "Need SVE256 support in order to use {} with 256-bit operation", __func__);
 
@@ -1425,7 +1425,7 @@ DEF_OP(VFMax) {
 
   const auto ElementSize = Op->Header.ElementSize;
   const auto SubRegSize = ConvertSubRegSize248(IROp);
-  [[maybe_unused]] const auto IsScalar = ElementSize == OpSize;
+  const auto IsScalar = ElementSize == OpSize;
   const auto Is256Bit = OpSize == IR::OpSize::i256Bit;
   LOGMAN_THROW_A_FMT(!Is256Bit || HostSupportsSVE256, "Need SVE256 support in order to use {} with 256-bit operation", __func__);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3934,7 +3934,7 @@ void OpDispatchBuilder::Finalize() {
   // Node 0 is invalid node
   Ref RealNode = reinterpret_cast<Ref>(GetNode(1));
 
-  [[maybe_unused]] const FEXCore::IR::IROp_Header* IROp = RealNode->Op(DualListData.DataBegin());
+  const FEXCore::IR::IROp_Header* IROp = RealNode->Op(DualListData.DataBegin());
   LOGMAN_THROW_A_FMT(IROp->Op == OP_IRHEADER, "First op in function must be our header");
 
   // Let's walk the jump blocks and see if we have handled every block target

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -501,7 +501,7 @@ OpDispatchBuilder::RefPair OpDispatchBuilder::AVX128_LoadSource_WithOpSize(
     HighA.Offset += 16;
 
     if (Operand.IsSIB()) {
-      [[maybe_unused]] const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
+      const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
       LOGMAN_THROW_A_FMT(!IsVSIB, "VSIB uses LoadVSIB instead");
     }
 
@@ -515,7 +515,7 @@ OpDispatchBuilder::RefPair OpDispatchBuilder::AVX128_LoadSource_WithOpSize(
 
 OpDispatchBuilder::RefVSIB
 OpDispatchBuilder::AVX128_LoadVSIB(const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, uint32_t Flags, bool NeedsHigh) {
-  [[maybe_unused]] const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
+  const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
   LOGMAN_THROW_A_FMT(Operand.IsSIB() && IsVSIB, "Trying to load VSIB for something that isn't the correct type!");
 
   // VSIB is a very special case which has a ton of encoded data.
@@ -1038,7 +1038,7 @@ void OpDispatchBuilder::AVX128_InsertCVTGPR_To_FPR(OpcodeArgs) {
     Result.Low = _VSToFVectorInsert(DstSize, DstElementSize, DstElementSize, Src1.Low, Src2, false, false);
   }
 
-  [[maybe_unused]] const auto Is128Bit = DstSize == OpSize::i128Bit;
+  const auto Is128Bit = DstSize == OpSize::i128Bit;
   LOGMAN_THROW_A_FMT(Is128Bit, "Programming Error: This should never occur!");
   Result.High = LoadZeroVector(OpSize::i128Bit);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
@@ -177,7 +177,7 @@ void OpDispatchBuilder::AESEncOp(OpcodeArgs) {
 
 void OpDispatchBuilder::VAESEncOp(OpcodeArgs) {
   const auto DstSize = OpSizeFromDst(Op);
-  [[maybe_unused]] const auto Is128Bit = DstSize == OpSize::i128Bit;
+  const auto Is128Bit = DstSize == OpSize::i128Bit;
 
   // TODO: Handle 256-bit VAESENC.
   LOGMAN_THROW_A_FMT(Is128Bit, "256-bit VAESENC unimplemented");
@@ -198,7 +198,7 @@ void OpDispatchBuilder::AESEncLastOp(OpcodeArgs) {
 
 void OpDispatchBuilder::VAESEncLastOp(OpcodeArgs) {
   const auto DstSize = OpSizeFromDst(Op);
-  [[maybe_unused]] const auto Is128Bit = DstSize == OpSize::i128Bit;
+  const auto Is128Bit = DstSize == OpSize::i128Bit;
 
   // TODO: Handle 256-bit VAESENCLAST.
   LOGMAN_THROW_A_FMT(Is128Bit, "256-bit VAESENCLAST unimplemented");
@@ -219,7 +219,7 @@ void OpDispatchBuilder::AESDecOp(OpcodeArgs) {
 
 void OpDispatchBuilder::VAESDecOp(OpcodeArgs) {
   const auto DstSize = OpSizeFromDst(Op);
-  [[maybe_unused]] const auto Is128Bit = DstSize == OpSize::i128Bit;
+  const auto Is128Bit = DstSize == OpSize::i128Bit;
 
   // TODO: Handle 256-bit VAESDEC.
   LOGMAN_THROW_A_FMT(Is128Bit, "256-bit VAESDEC unimplemented");
@@ -240,7 +240,7 @@ void OpDispatchBuilder::AESDecLastOp(OpcodeArgs) {
 
 void OpDispatchBuilder::VAESDecLastOp(OpcodeArgs) {
   const auto DstSize = OpSizeFromDst(Op);
-  [[maybe_unused]] const auto Is128Bit = DstSize == OpSize::i128Bit;
+  const auto Is128Bit = DstSize == OpSize::i128Bit;
 
   // TODO: Handle 256-bit VAESDECLAST.
   LOGMAN_THROW_A_FMT(Is128Bit, "256-bit VAESDECLAST unimplemented");

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -5001,7 +5001,7 @@ void OpDispatchBuilder::VFMAddSubImpl(OpcodeArgs, bool AddSub, uint8_t Src1Idx, 
 }
 
 OpDispatchBuilder::RefVSIB OpDispatchBuilder::LoadVSIB(const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, uint32_t Flags) {
-  [[maybe_unused]] const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
+  const bool IsVSIB = (Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0;
   LOGMAN_THROW_A_FMT(Operand.IsSIB() && IsVSIB, "Trying to load VSIB for something that isn't the correct type!");
 
   // VSIB is a very special case which has a ton of encoded data.

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -267,7 +267,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::S
   }
 }
 
-static void PrintArg(fextl::stringstream* out, [[maybe_unused]] const IRListView* IR, FEXCore::IR::BranchHint Arg) {
+static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::BranchHint Arg) {
   switch (Arg) {
   case BranchHint::None: *out << "None"; break;
   case BranchHint::Call: *out << "Call"; break;

--- a/FEXCore/Source/Interface/IR/IREmitter.h
+++ b/FEXCore/Source/Interface/IR/IREmitter.h
@@ -396,12 +396,10 @@ public:
    * @{ */
   /**  @} */
   void LinkCodeBlocks(Ref CodeNode, Ref Next) {
+    [[maybe_unused]] auto CurrentIROp = CodeNode->Op(DualListData.DataBegin())->CW<FEXCore::IR::IROp_CodeBlock>();
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
-    FEXCore::IR::IROp_CodeBlock* CurrentIROp =
-#endif
-      CodeNode->Op(DualListData.DataBegin())->CW<FEXCore::IR::IROp_CodeBlock>();
-
     LOGMAN_THROW_A_FMT(CurrentIROp->Header.Op == IROps::OP_CODEBLOCK, "Invalid");
+#endif
 
     CodeNode->append(DualListData.ListBegin(), Next);
   }

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -278,7 +278,7 @@ private:
     // next-use has the /smallest/ unsigned IP.
     Ref Candidate = nullptr;
     uint32_t BestDistance = UINT32_MAX;
-    [[maybe_unused]] uint8_t BestReg = ~0;
+    uint8_t BestReg = ~0;
     uint32_t Allocated = ((1u << Class->Count) - 1) & ~Class->Available;
 
     foreach_bit(i, Allocated) {

--- a/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -164,11 +164,8 @@ private:
       FEXCore::AlignUp(LiveVMARegion::GetFEXManagedVMARegionSize(ReservedRegion->RegionSize), FEXCore::Utils::FEX_PAGE_SIZE);
     size_t SizePlusManagedData = UsedSize + SizeOfLiveRegion;
 
-    [[maybe_unused]] auto Res = mprotect(reinterpret_cast<void*>(ReservedRegion->Base), SizePlusManagedData, PROT_READ | PROT_WRITE);
-
-    if (Res == -1) {
-      LOGMAN_MSG_A_FMT("Couldn't mprotect region: {} '{}' Likely occurs when running out of memory or Maximum VMAs", errno, strerror(errno));
-    }
+    auto Res = mprotect(reinterpret_cast<void*>(ReservedRegion->Base), SizePlusManagedData, PROT_READ | PROT_WRITE);
+    LOGMAN_THROW_A_FMT(Res != -1, "Couldn't mprotect region: {} '{}' Likely occurs when running out of memory or Maximum VMAs", errno, strerror(errno));
 
     LiveVMARegion* LiveRange = new (reinterpret_cast<void*>(ReservedRegion->Base)) LiveVMARegion();
 

--- a/FEXCore/include/FEXCore/Utils/EnumOperators.h
+++ b/FEXCore/include/FEXCore/Utils/EnumOperators.h
@@ -3,20 +3,20 @@
 #include <type_traits>
 
 #define FEX_DEF_ENUM_CLASS_BIN_OP(Enum, Op)                                        \
-  [[maybe_unused]] static constexpr Enum operator Op(Enum lhs, Enum rhs) {         \
+  inline constexpr Enum operator Op(Enum lhs, Enum rhs) {         \
     using Type = std::underlying_type_t<Enum>;                                     \
     Type _lhs = static_cast<Type>(lhs);                                            \
     Type _rhs = static_cast<Type>(rhs);                                            \
     return static_cast<Enum>(_lhs Op _rhs);                                        \
   }                                                                                \
-  [[maybe_unused]] static constexpr uint64_t operator Op(uint64_t lhs, Enum rhs) { \
+  inline constexpr uint64_t operator Op(uint64_t lhs, Enum rhs) { \
     using Type = std::underlying_type_t<Enum>;                                     \
     Type _rhs = static_cast<Type>(rhs);                                            \
     return lhs Op _rhs;                                                            \
   }
 
 #define FEX_DEF_ENUM_CLASS_UNARY_OP(Enum, Op)                    \
-  [[maybe_unused]] static constexpr Enum operator Op(Enum rhs) { \
+  inline constexpr Enum operator Op(Enum rhs) { \
     using Type = std::underlying_type_t<Enum>;                   \
     Type _rhs = static_cast<Type>(rhs);                          \
     return static_cast<Enum>(Op _rhs);                           \

--- a/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -68,6 +68,7 @@ namespace Throw {
   static inline void AFmt(bool, const char*, ...) {}
 #define LOGMAN_THROW_A_FMT(pred, ...) \
   do {                                \
+    (void)(pred);                     \
   } while (0)
 #endif
 

--- a/FEXCore/include/FEXCore/Utils/Profiler.h
+++ b/FEXCore/include/FEXCore/Utils/Profiler.h
@@ -50,16 +50,11 @@ private:
 #endif
 
 #else
-[[maybe_unused]]
-static void Init(std::string_view ProgramName, std::string_view ProgramPath) {}
-[[maybe_unused]]
-static void PostForkAction(bool IsChild) {}
-[[maybe_unused]]
-static void Shutdown() {}
-[[maybe_unused]]
-static void TraceObject(const std::string_view Format) {}
-[[maybe_unused]]
-static void TraceObject(const std::string_view, uint64_t) {}
+inline void Init(std::string_view ProgramName, std::string_view ProgramPath) {}
+inline void PostForkAction(bool IsChild) {}
+inline void Shutdown() {}
+inline void TraceObject(const std::string_view Format) {}
+inline void TraceObject(const std::string_view, uint64_t) {}
 
 #define FEXCORE_PROFILE_INSTANT(...) \
   do {                               \

--- a/FEXCore/include/FEXCore/Utils/SignalScopeGuards.h
+++ b/FEXCore/include/FEXCore/Utils/SignalScopeGuards.h
@@ -32,11 +32,11 @@ public:
   ForkableUniqueMutex& operator=(ForkableUniqueMutex&&) = default;
 
   void lock() {
-    [[maybe_unused]] const auto Result = pthread_mutex_lock(&Mutex);
+    const auto Result = pthread_mutex_lock(&Mutex);
     LOGMAN_THROW_A_FMT(Result == 0, "{} failed to lock with {}", __func__, Result);
   }
   void unlock() {
-    [[maybe_unused]] const auto Result = pthread_mutex_unlock(&Mutex);
+    const auto Result = pthread_mutex_unlock(&Mutex);
     LOGMAN_THROW_A_FMT(Result == 0, "{} failed to unlock with {}", __func__, Result);
   }
   // Initialize the internal pthread object to its default initializer state.
@@ -47,7 +47,7 @@ public:
 
   // Asserts that the mutex isn't exclusively owned by the calling thread.
   void check_lock_owned_by_self() {
-    [[maybe_unused]] const auto Result = pthread_mutex_lock(&Mutex);
+    const auto Result = pthread_mutex_lock(&Mutex);
     LOGMAN_THROW_A_FMT(Result == EDEADLK, "User of unique lock must have already locked mutex as write!");
   }
 
@@ -67,15 +67,15 @@ public:
   ForkableSharedMutex& operator=(ForkableSharedMutex&&) = default;
 
   void lock() {
-    [[maybe_unused]] const auto Result = pthread_rwlock_wrlock(&Mutex);
+    const auto Result = pthread_rwlock_wrlock(&Mutex);
     LOGMAN_THROW_A_FMT(Result == 0, "{} failed to lock with {}", __func__, Result);
   }
   void unlock() {
-    [[maybe_unused]] const auto Result = pthread_rwlock_unlock(&Mutex);
+    const auto Result = pthread_rwlock_unlock(&Mutex);
     LOGMAN_THROW_A_FMT(Result == 0, "{} failed to unlock with {}", __func__, Result);
   }
   void lock_shared() {
-    [[maybe_unused]] const auto Result = pthread_rwlock_rdlock(&Mutex);
+    const auto Result = pthread_rwlock_rdlock(&Mutex);
     LOGMAN_THROW_A_FMT(Result == 0, "{} failed to lock with {}", __func__, Result);
   }
 
@@ -95,7 +95,7 @@ public:
 
   // Asserts that the rwlock isn't exclusively owned by the calling thread.
   void check_lock_owned_by_self_as_write() {
-    [[maybe_unused]] const auto Result = pthread_rwlock_wrlock(&Mutex);
+    const auto Result = pthread_rwlock_wrlock(&Mutex);
     LOGMAN_THROW_A_FMT(Result == EDEADLK, "User of rwlock must have already locked mutex as write!");
   }
 

--- a/FEXCore/include/FEXCore/Utils/StringUtils.h
+++ b/FEXCore/include/FEXCore/Utils/StringUtils.h
@@ -4,8 +4,7 @@
 
 namespace FEXCore::StringUtils {
 // Trim the left side of the string of whitespace and new lines
-[[maybe_unused]]
-static fextl::string LeftTrim(fextl::string String, std::string_view TrimTokens = " \t\n\r") {
+inline fextl::string LeftTrim(fextl::string String, std::string_view TrimTokens = " \t\n\r") {
   size_t pos = fextl::string::npos;
   if ((pos = String.find_first_not_of(TrimTokens)) != fextl::string::npos) {
     String.erase(0, pos);
@@ -15,8 +14,7 @@ static fextl::string LeftTrim(fextl::string String, std::string_view TrimTokens 
 }
 
 // Trim the right side of the string of whitespace and new lines
-[[maybe_unused]]
-static fextl::string RightTrim(fextl::string String, std::string_view TrimTokens = " \t\n\r") {
+inline fextl::string RightTrim(fextl::string String, std::string_view TrimTokens = " \t\n\r") {
   size_t pos = fextl::string::npos;
   if ((pos = String.find_last_not_of(TrimTokens)) != fextl::string::npos) {
     String.erase(String.begin() + pos + 1, String.end());
@@ -26,8 +24,7 @@ static fextl::string RightTrim(fextl::string String, std::string_view TrimTokens
 }
 
 // Trim both the left and right of the string of whitespace and new lines
-[[maybe_unused]]
-static fextl::string Trim(fextl::string String, std::string_view TrimTokens = " \t\n\r") {
+inline fextl::string Trim(fextl::string String, std::string_view TrimTokens = " \t\n\r") {
   return RightTrim(LeftTrim(std::move(String), TrimTokens), TrimTokens);
 }
 

--- a/Source/Tools/LinuxEmulation/ArchHelpers/MContext.h
+++ b/Source/Tools/LinuxEmulation/ArchHelpers/MContext.h
@@ -256,7 +256,9 @@ static inline void BackupContext(void* ucontext, T* Backup) {
 template<typename T>
 static inline void RestoreContext(void* ucontext, T* Backup) {
   if constexpr (std::is_same<T, ArmContextBackup>::value) {
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     LOGMAN_THROW_A_FMT(Backup->StackCookie == STACK_COOKIE_MAGIC, "Stack cookie didn't match! 0x{:x}", Backup->StackCookie);
+#endif
 
     auto _ucontext = GetUContext(ucontext);
     auto _mcontext = GetMContext(ucontext);
@@ -365,7 +367,9 @@ static inline void BackupContext(void* ucontext, T* Backup) {
 template<typename T>
 static inline void RestoreContext(void* ucontext, T* Backup) {
   if constexpr (std::is_same<T, X86ContextBackup>::value) {
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     LOGMAN_THROW_A_FMT(Backup->StackCookie == STACK_COOKIE_MAGIC, "Stack cookie didn't match! 0x{:x}", Backup->StackCookie);
+#endif
 
     auto _ucontext = GetUContext(ucontext);
     auto _mcontext = GetMContext(ucontext);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -455,8 +455,10 @@ bool SignalDelegator::HandleSignalPause(FEXCore::Core::InternalThreadState* Thre
       ArchHelpers::Context::SetPc(ucontext, Config.ThreadPauseHandlerAddressSpillSRA);
     } else {
       // We are in non-jit, SRA is already spilled
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       LOGMAN_THROW_A_FMT(!IsAddressInDispatcher(ArchHelpers::Context::GetPc(ucontext)), "Signals in dispatcher have unsynchronized "
                                                                                         "context");
+#endif
       ArchHelpers::Context::SetPc(ucontext, Config.ThreadPauseHandlerAddress);
     }
 
@@ -486,8 +488,10 @@ bool SignalDelegator::HandleSignalPause(FEXCore::Core::InternalThreadState* Thre
       ArchHelpers::Context::SetPc(ucontext, Config.ThreadStopHandlerAddressSpillSRA);
     } else {
       // We are in non-jit, SRA is already spilled
+#if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
       LOGMAN_THROW_A_FMT(!IsAddressInDispatcher(ArchHelpers::Context::GetPc(ucontext)), "Signals in dispatcher have unsynchronized "
                                                                                         "context");
+#endif
       ArchHelpers::Context::SetPc(ucontext, Config.ThreadStopHandlerAddress);
     }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -720,7 +720,7 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame* Frame, void* Ad
 
         uint64_t RemainingSize = DataSpaceMaxSize - NewSizeAligned;
         // We have pages we can unmap
-        [[maybe_unused]] auto ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(DataSpace + NewSizeAligned), RemainingSize);
+        auto ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(DataSpace + NewSizeAligned), RemainingSize);
         LOGMAN_THROW_A_FMT(ok != -1, "Munmap failed");
 
         DataSpaceMaxSize = NewSizeAligned;
@@ -739,7 +739,7 @@ uint64_t SyscallHandler::HandleBRK(FEXCore::Core::CpuStateFrame* Frame, void* Ad
         if (!FEX::HLE::HasSyscallError(NewBRK) && NewBRK != (DataSpace + DataSpaceMaxSize)) {
           // Couldn't allocate that the region we wanted
           // Can happen if MAP_FIXED_NOREPLACE isn't understood by the kernel
-          [[maybe_unused]] int ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(NewBRK), AllocateNewSize);
+          int ok = GuestMunmap(Frame->Thread, reinterpret_cast<void*>(NewBRK), AllocateNewSize);
           LOGMAN_THROW_A_FMT(ok != -1, "Munmap failed");
           NewBRK = ~0ULL;
         }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -330,7 +330,7 @@ uint64_t SyscallHandler::GuestShmat(bool Is64Bit, FEXCore::Core::InternalThreadS
 
     shmid_ds stat;
 
-    [[maybe_unused]] auto res = shmctl(shmid, IPC_STAT, &stat);
+    auto res = shmctl(shmid, IPC_STAT, &stat);
     LOGMAN_THROW_A_FMT(res != -1, "shmctl IPC_STAT failed");
 
     Length = stat.shm_segsz;


### PR DESCRIPTION
A prevalent pattern in the FEX codebase is to compute some data and store it in a maybe_unused variable that's only ever passed to LOGMAN_THROW_A_FMT:
```cpp
    const auto IsImm = IsImmLogical(Imm, RegSizeInBits(s), &n, &imms, &immr);
    LOGMAN_THROW_A_FMT(IsImm, "Couldn't encode immediate to logical op");
```

Besides few exceptions, we never compute expensive data in the macro arguments themselves, so we can remove a lot of code noise by unconditionally evaluating the condition even in assertion-disabled builds (and explicitly wrapping the rest in `ASSERTIONS_ENABLED` checks). Dead code elimination will trivially prevent any overhead from doing so.

Additionally, this PR includes two very minor changes to drop even more uses of `maybe_unused`.