### PR TITLE
FEXConfig: Fix RootFS override in muvm-based setups

### DIFF
--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -406,6 +406,12 @@ ConfigRuntime::ConfigRuntime(const QString& ConfigFilename) {
 }
 
 void ConfigRuntime::onSave(const QUrl& Filename) {
+  // If no RootFS is selected, assume another Config layer is setting it up and drop it from the local configuration
+  auto RootFS = LoadedConfig->Get(FEXCore::Config::ConfigOption::CONFIG_ROOTFS).value_or(nullptr);
+  if (RootFS && RootFS->empty()) {
+    LoadedConfig->Erase(FEXCore::Config::ConfigOption::CONFIG_ROOTFS);
+  }
+
   qInfo() << "Saving to" << Filename.toLocalFile().toStdString().c_str();
   FEX::Config::SaveLayerToJSON(Filename.toLocalFile().toStdString().c_str(), LoadedConfig.get(), HostLibs.HostLibsDB);
 }


### PR DESCRIPTION
The `~/.fex-emu/Config.json` file previously written by FEXConfig breaks muvm-based setups like Fedora Asahi Remix: These setups use a muvm-internal `/usr/share/fex-emu/Config.json` to point the RootFS to `/run/fex-emu/rootfs/`, which a user-local Config.json will override however. Instead, the RootFS entry is omitted from the local Config.json if it's not set now.

This fix isn't ideal:
* It would be better if muvm could apply an overlay *after* loading the local config, not before
* FEXConfig should completely prohibit changing "distributor-provided" settings like these
* Upstream should set up FEXConfig to run in an environment where it can automatically discover the Fedora-provided RootFS. (Running in muvm is not an option currently since it fails to launch FEXConfig)

This change is not a hack either though, so let's roll with the pragmatic fix here.
