### PR TITLE
Github: Force FEX portable config

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,6 +13,7 @@ env:
   BUILD_TYPE: Release
   CC: clang
   CXX: clang++
+  FEX_PORTABLE: 1
 
 jobs:
   build_plus_test:

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -20,6 +20,7 @@ env:
   BUILD_TYPE: Release
   CC: clang
   CXX: clang++
+  FEX_PORTABLE: 1
 
 jobs:
   glibc_fault_test:

--- a/.github/workflows/hostrunner.yml
+++ b/.github/workflows/hostrunner.yml
@@ -13,6 +13,7 @@ env:
   BUILD_TYPE: Release
   CC: clang
   CXX: clang++
+  FEX_PORTABLE: 1
 
 jobs:
   hostrunner_tests:

--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -13,6 +13,7 @@ env:
   BUILD_TYPE: Release
   CC: clang
   CXX: clang++
+  FEX_PORTABLE: 1
 
 jobs:
   vixl_simulator:


### PR DESCRIPTION
Noticed some runners had generated a .fex-emu/Config.json, run the tests in portable mode to ensure they don't pick up a spurious config option.