### PR TITLE
Remove visibility on functions that is no longer necessary

### DIFF
--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -405,15 +405,15 @@ def print_ir_sizes():
     static_assert(IRSizes[IROps::OP_LAST] == -1ULL);
 
     [[nodiscard]] inline size_t GetSize(IROps Op) { return IRSizes[Op]; }
-    [[nodiscard, gnu::const, gnu::visibility("default")]] std::string_view const& GetName(IROps Op);
-    [[nodiscard, gnu::const, gnu::visibility("default")]] uint8_t GetArgs(IROps Op);
-    [[nodiscard, gnu::const, gnu::visibility("default")]] uint8_t GetRAArgs(IROps Op);
-    [[nodiscard, gnu::const, gnu::visibility("default")]] FEXCore::IR::RegisterClassType GetRegClass(IROps Op);
-    [[nodiscard, gnu::const, gnu::visibility("default")]] bool HasSideEffects(IROps Op);
-    [[nodiscard, gnu::const, gnu::visibility("default")]] bool ImplicitFlagClobber(IROps Op);
-    [[nodiscard, gnu::const, gnu::visibility("default")]] bool GetHasDest(IROps Op);
-    [[nodiscard, gnu::const, gnu::visibility("default")]] bool LoweredX87(IROps Op);
-    [[nodiscard, gnu::const, gnu::visibility("default")]] int8_t TiedSource(IROps Op);
+    [[nodiscard, gnu::const]] std::string_view const& GetName(IROps Op);
+    [[nodiscard, gnu::const]] uint8_t GetArgs(IROps Op);
+    [[nodiscard, gnu::const]] uint8_t GetRAArgs(IROps Op);
+    [[nodiscard, gnu::const]] FEXCore::IR::RegisterClassType GetRegClass(IROps Op);
+    [[nodiscard, gnu::const]] bool HasSideEffects(IROps Op);
+    [[nodiscard, gnu::const]] bool ImplicitFlagClobber(IROps Op);
+    [[nodiscard, gnu::const]] bool GetHasDest(IROps Op);
+    [[nodiscard, gnu::const]] bool LoweredX87(IROps Op);
+    [[nodiscard, gnu::const]] int8_t TiedSource(IROps Op);
 
     #undef IROP_SIZES
     #endif

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -22,3 +22,9 @@ endif()
 add_library(${NAME} STATIC ${SRCS})
 target_link_libraries(${NAME} FEXCore_Base cpp-optparse tiny-json FEXHeaderUtils range-v3::range-v3)
 target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)
+
+set_target_properties(${NAME} PROPERTIES
+  C_VISIBILITY_PRESET hidden
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN TRUE
+)

--- a/Source/Tools/FEXLoader/CMakeLists.txt
+++ b/Source/Tools/FEXLoader/CMakeLists.txt
@@ -13,7 +13,12 @@ function(GenerateInterpreter NAME AsInterpreter)
   target_compile_definitions(${NAME} PRIVATE ${DEFINES})
 
   # Enable FEX APIs to be used by targets that use target_link_libraries on FEXLoader
-  set_target_properties(${NAME} PROPERTIES ENABLE_EXPORTS 1)
+  set_target_properties(${NAME} PROPERTIES
+    ENABLE_EXPORTS 1
+    C_VISIBILITY_PRESET hidden
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN TRUE
+  )
 
   target_include_directories(${NAME}
     PRIVATE

--- a/Source/Tools/LinuxEmulation/CMakeLists.txt
+++ b/Source/Tools/LinuxEmulation/CMakeLists.txt
@@ -73,6 +73,12 @@ PRIVATE
   -fwrapv
 )
 
+set_target_properties(LinuxEmulation PROPERTIES
+  C_VISIBILITY_PRESET hidden
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN TRUE
+)
+
 target_include_directories(LinuxEmulation
 PRIVATE
   ${CMAKE_BINARY_DIR}/generated


### PR DESCRIPTION
These used to be required because we leaked IR semantics across the API boundary. Since we no longer do, we can remove the visibility from these.

Other bits also can use hidden visibility.