### PR TITLE
General: Replace usages of .at(0) with .data() where applicable

### DIFF
--- a/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -33,7 +33,7 @@ X86GeneratedCode::X86GeneratedCode() {
 
   CallbackReturn = reinterpret_cast<uint64_t>(CodePtr);
 
-  memcpy(reinterpret_cast<void*>(CallbackReturn), &SignalReturnCode.at(0), SignalReturnCode.size());
+  memcpy(reinterpret_cast<void*>(CallbackReturn), SignalReturnCode.data(), SignalReturnCode.size());
 
   mprotect(CodePtr, CODE_SIZE, PROT_READ);
 #endif

--- a/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -429,7 +429,7 @@ const std::array<X86InstInfo, MAX_PRIMARY_TABLE_SIZE> BaseOps = []() consteval {
     {0xC4, 2, X86InstInfo{"",   TYPE_VEX_TABLE_PREFIX, FLAGS_NONE, 0}},
   };
 
-  GenerateTable(&Table.at(0), BaseOpTable, std::size(BaseOpTable));
+  GenerateTable(Table.data(), BaseOpTable, std::size(BaseOpTable));
   IR::InstallToTable(Table, IR::OpDispatch_BaseOpTable);
 
   return Table;

--- a/FEXCore/Source/Interface/Core/X86Tables/DDDTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/DDDTables.cpp
@@ -54,7 +54,7 @@ constexpr std::array<X86InstInfo, MAX_3DNOW_TABLE_SIZE> DDDNowOps = []() constev
     {0xBF, 1, X86InstInfo{"PAVGUSB",  TYPE_INST, GenFlagsSameSize(SIZE_64BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_MMX, 0}},
   };
 
-  GenerateTable(&Table.at(0), DDDNowOpTable, std::size(DDDNowOpTable));
+  GenerateTable(Table.data(), DDDNowOpTable, std::size(DDDNowOpTable));
 
   IR::InstallToTable(Table, IR::OpDispatch_DDDTable);
   return Table;

--- a/FEXCore/Source/Interface/Core/X86Tables/H0F38Tables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/H0F38Tables.cpp
@@ -119,7 +119,7 @@ constexpr std::array<X86InstInfo, MAX_0F_38_TABLE_SIZE> H0F38TableOps = []() con
   };
 #undef OPD
 
-  GenerateTable(&Table.at(0), H0F38Table, std::size(H0F38Table));
+  GenerateTable(Table.data(), H0F38Table, std::size(H0F38Table));
 
   IR::InstallToTable(Table, IR::OpDispatch_H0F38Table);
   return Table;

--- a/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/H0F3ATables.cpp
@@ -77,20 +77,20 @@ constexpr std::array<X86InstInfo, MAX_0F_3A_TABLE_SIZE> H0F3ATableOps = []() con
   constexpr auto H0F3ATable_IgnoresREX0 = TableGen.template operator()<0>();
   constexpr auto H0F3ATable_IgnoresREX1 = TableGen.template operator()<1>();
 
-  GenerateTable(&Table.at(0), &H0F3ATable_IgnoresREX0.at(0), H0F3ATable_IgnoresREX0.size());
-  GenerateTable(&Table.at(0), &H0F3ATable_IgnoresREX1.at(0), H0F3ATable_IgnoresREX1.size());
+  GenerateTable(Table.data(), H0F3ATable_IgnoresREX0.data(), H0F3ATable_IgnoresREX0.size());
+  GenerateTable(Table.data(), H0F3ATable_IgnoresREX1.data(), H0F3ATable_IgnoresREX1.size());
 
   constexpr U16U8InfoStruct TableNeedsREX0[] = {
     {OPD(0, PF_3A_66,   0x16), 1, X86InstInfo{"PEXTRD",          TYPE_INST, GenFlagsSizes(SIZE_32BIT, SIZE_128BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_DST_GPR | FLAGS_XMM_FLAGS, 1}},
     {OPD(0, PF_3A_66,   0x22), 1, X86InstInfo{"PINSRD",          TYPE_INST, GenFlagsSizes(SIZE_128BIT, SIZE_32BIT) | FLAGS_MODRM | FLAGS_XMM_FLAGS | FLAGS_SF_SRC_GPR,           1}},
   };
-  GenerateTable(&Table.at(0), TableNeedsREX0, std::size(TableNeedsREX0));
+  GenerateTable(Table.data(), TableNeedsREX0, std::size(TableNeedsREX0));
 
   constexpr U16U8InfoStruct TableNeedsREX1[] = {
     {OPD(1, PF_3A_66,   0x16), 1, X86InstInfo{"", TYPE_ARCH_DISPATCHER, FLAGS_NONE, 0, { .Indirect = H0F3A_ArchSelect_LUT[ENTRY_1_3A_66_16] }}},
     {OPD(1, PF_3A_66,   0x22), 1, X86InstInfo{"", TYPE_ARCH_DISPATCHER, FLAGS_NONE, 0, { .Indirect = H0F3A_ArchSelect_LUT[ENTRY_1_3A_66_22] }}},
   };
-  GenerateTable(&Table.at(0), TableNeedsREX1, std::size(TableNeedsREX1));
+  GenerateTable(Table.data(), TableNeedsREX1, std::size(TableNeedsREX1));
 
   IR::InstallToTable(Table, IR::OpDispatch_H0F3ATableIgnoreREX);
   IR::InstallToTable(Table, IR::OpDispatch_H0F3ATableNeedsREX0);

--- a/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/PrimaryGroupTables.cpp
@@ -201,7 +201,7 @@ constexpr std::array<X86InstInfo, MAX_INST_GROUP_TABLE_SIZE> PrimaryInstGroupOps
     {OPD(TYPE_GROUP_11, OpToIndex(0xC7), 7), 1, X86InstInfo{"XBEGIN", TYPE_INST, FLAGS_MODRM | FLAGS_SRC_SEXT | FLAGS_SETS_RIP | FLAGS_DISPLACE_SIZE_DIV_2,                                                       4}},
   };
 
-  GenerateTable(&Table.at(0), PrimaryGroupOpTable, std::size(PrimaryGroupOpTable));
+  GenerateTable(Table.data(), PrimaryGroupOpTable, std::size(PrimaryGroupOpTable));
 
   IR::InstallToTable(Table, IR::OpDispatch_PrimaryGroupTables);
   return Table;

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryGroupTables.cpp
@@ -519,7 +519,7 @@ constexpr auto SecondInstGroupOps = []() consteval {
   };
 #undef OPD
 
-  GenerateTable(&Table.at(0), SecondaryExtensionOpTable, std::size(SecondaryExtensionOpTable));
+  GenerateTable(Table.data(), SecondaryExtensionOpTable, std::size(SecondaryExtensionOpTable));
 
   IR::InstallToTable(Table, IR::OpDispatch_SecondaryGroupTables);
   return Table;

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryModRMTables.cpp
@@ -56,7 +56,7 @@ constexpr std::array<X86InstInfo, MAX_SECOND_MODRM_TABLE_SIZE> SecondModRMTableO
     {((3 << 3) | 7), 1, X86InstInfo{"",         TYPE_INVALID, FLAGS_NONE, 0}},
   };
 
-  GenerateTable(&Table.at(0), SecondaryModRMExtensionOpTable, std::size(SecondaryModRMExtensionOpTable));
+  GenerateTable(Table.data(), SecondaryModRMExtensionOpTable, std::size(SecondaryModRMExtensionOpTable));
 
   IR::InstallToTable(Table, IR::OpDispatch_SecondaryModRMTables);
   return Table;

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -306,7 +306,7 @@ constexpr std::array<X86InstInfo, MAX_SECOND_TABLE_SIZE> SecondBaseOps = []() co
 #endif
   };
 
-  GenerateTable(&Table.at(0), TwoByteOpTable, std::size(TwoByteOpTable));
+  GenerateTable(Table.data(), TwoByteOpTable, std::size(TwoByteOpTable));
 
   IR::InstallToTable(Table, IR::OpDispatch_TwoByteOpTable);
 
@@ -396,7 +396,7 @@ constexpr std::array<X86InstInfo, MAX_REP_MOD_TABLE_SIZE> RepModOps = []() const
     {0xFF, 1, X86InstInfo{"",          TYPE_COPY_OTHER, FLAGS_NONE,                                     0}},
   };
 
-  GenerateTableWithCopy(&Table.at(0), RepModOpTable, std::size(RepModOpTable), &SecondBaseOps.at(0));
+  GenerateTableWithCopy(Table.data(), RepModOpTable, std::size(RepModOpTable), SecondBaseOps.data());
 
   IR::InstallToTable(Table, IR::OpDispatch_SecondaryRepModTables);
   return Table;
@@ -478,7 +478,7 @@ constexpr std::array<X86InstInfo, MAX_REPNE_MOD_TABLE_SIZE> RepNEModOps = []() c
     {0xF8, 8, X86InstInfo{"",          TYPE_INVALID, FLAGS_NONE,                                                         0}},
   };
 
-  GenerateTableWithCopy(&Table.at(0), RepNEModOpTable,   std::size(RepNEModOpTable), &SecondBaseOps.at(0));
+  GenerateTableWithCopy(Table.data(), RepNEModOpTable,   std::size(RepNEModOpTable), SecondBaseOps.data());
 
   IR::InstallToTable(Table, IR::OpDispatch_SecondaryRepNEModTables);
   return Table;
@@ -634,7 +634,7 @@ constexpr std::array<X86InstInfo, MAX_OPSIZE_MOD_TABLE_SIZE> OpSizeModOps = []()
     {0xFF, 1, X86InstInfo{"",           TYPE_COPY_OTHER, FLAGS_NONE,                                                            0}},
   };
 
-  GenerateTableWithCopy(&Table.at(0), OpSizeModOpTable, std::size(OpSizeModOpTable), &SecondBaseOps.at(0));
+  GenerateTableWithCopy(Table.data(), OpSizeModOpTable, std::size(OpSizeModOpTable), SecondBaseOps.data());
 
   IR::InstallToTable(Table, IR::OpDispatch_SecondaryOpSizeModTables);
   return Table;

--- a/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -1362,7 +1362,7 @@ auto BaseTableLambda = [](const auto RuntimeTable) consteval {
   };
 #undef OPD
 
-  GenerateTable(&Table.at(0), VEXTable, std::size(VEXTable));
+  GenerateTable(Table.data(), VEXTable, std::size(VEXTable));
 
   IR::InstallToTable(Table, IR::OpDispatch_VEXTable);
   IR::InstallToTable(Table, RuntimeTable);
@@ -1396,7 +1396,7 @@ auto GroupTableLambda = [](const auto RuntimeTable) consteval {
   };
 #undef OPD
 
-  GenerateTable(&Table.at(0), VEXGroupTable, std::size(VEXGroupTable));
+  GenerateTable(Table.data(), VEXGroupTable, std::size(VEXGroupTable));
 
   IR::InstallToTable(Table, IR::OpDispatch_VEXGroupTable);
   IR::InstallToTable(Table, RuntimeTable);

--- a/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
@@ -809,7 +809,7 @@ auto GenerateX87TableLambda = [](const auto DispatchTable) consteval {
     }
   };
 
-  GenerateX87Table(&Table.at(0), X87OpTable, std::size(X87OpTable));
+  GenerateX87Table(Table.data(), X87OpTable, std::size(X87OpTable));
   InstallToX87Table(Table, DispatchTable);
   return Table;
 };

--- a/FEXCore/Source/Interface/GDBJIT/GDBJIT.cpp
+++ b/FEXCore/Source/Interface/GDBJIT/GDBJIT.cpp
@@ -90,7 +90,7 @@ void GDBJITRegister(FEXCore::IR::AOTIRCacheEntry* Entry, uintptr_t VAFileStart, 
     mem += info->nlines * sizeof(gdb_line_mapping);
 
     if (info->nlines) {
-      memcpy(lines, &Lines.at(0), info->nlines * sizeof(gdb_line_mapping));
+      memcpy(lines, Lines.data(), info->nlines * sizeof(gdb_line_mapping));
     }
 
     auto entry = new jit_code_entry {0, 0, 0, 0};

--- a/Source/Tools/CommonTools/Linux/Utils/ELFContainer.cpp
+++ b/Source/Tools/CommonTools/Linux/Utils/ELFContainer.cpp
@@ -81,13 +81,13 @@ ELFContainer::ELFType ELFContainer::GetELFType(int FD) {
 
   // Read the header so we can tell if it is a supported ELF file.
   // Can't adjust file offset, so use pread.
-  if (pread(FD, &RawFile.at(0), RawFile.size(), 0) != RawFile.size()) {
+  if (pread(FD, RawFile.data(), RawFile.size(), 0) != RawFile.size()) {
     // Couldn't read
     LogMan::Msg::EFmt("Couldn't read potential ELF FD");
     return ELFType::TYPE_NONE;
   }
 
-  return CheckELFType(reinterpret_cast<uint8_t*>(&RawFile.at(0)));
+  return CheckELFType(reinterpret_cast<uint8_t*>(RawFile.data()));
 }
 
 ELFContainer::ELFContainer(const fextl::string& Filename, const fextl::string& RootFS, bool CustomInterpreter) {
@@ -159,7 +159,7 @@ bool ELFContainer::LoadELF(const fextl::string& Filename) {
   SectionHeaders.clear();
   ProgramHeaders.clear();
 
-  uint8_t* Ident = reinterpret_cast<uint8_t*>(&RawFile.at(0));
+  uint8_t* Ident = reinterpret_cast<uint8_t*>(RawFile.data());
 
   if (Ident[EI_MAG0] != ELFMAG0 || Ident[EI_MAG1] != ELFMAG1 || Ident[EI_MAG2] != ELFMAG2 || Ident[EI_MAG3] != ELFMAG3) {
     LogMan::Msg::EFmt("ELF missing magic cookie");
@@ -179,7 +179,7 @@ bool ELFContainer::LoadELF(const fextl::string& Filename) {
 bool ELFContainer::LoadELF_32() {
   Mode = MODE_32BIT;
 
-  memcpy(&Header, reinterpret_cast<Elf32_Ehdr*>(&RawFile.at(0)), sizeof(Elf32_Ehdr));
+  memcpy(&Header, reinterpret_cast<Elf32_Ehdr*>(RawFile.data()), sizeof(Elf32_Ehdr));
   LOGMAN_THROW_A_FMT(Header._32.e_phentsize == sizeof(Elf32_Phdr), "PH Entry size wasn't correct size");
   LOGMAN_THROW_A_FMT(Header._32.e_shentsize == sizeof(Elf32_Shdr), "PH Entry size wasn't correct size");
 
@@ -217,7 +217,7 @@ bool ELFContainer::LoadELF_32() {
 bool ELFContainer::LoadELF_64() {
   Mode = MODE_64BIT;
 
-  memcpy(&Header, reinterpret_cast<Elf64_Ehdr*>(&RawFile.at(0)), sizeof(Elf64_Ehdr));
+  memcpy(&Header, reinterpret_cast<Elf64_Ehdr*>(RawFile.data()), sizeof(Elf64_Ehdr));
   LOGMAN_THROW_A_FMT(Header._64.e_phentsize == 56, "PH Entry size wasn't 56");
   LOGMAN_THROW_A_FMT(Header._64.e_shentsize == 64, "PH Entry size wasn't 64");
 

--- a/Source/Tools/FEXBash/FEXBash.cpp
+++ b/Source/Tools/FEXBash/FEXBash.cpp
@@ -95,5 +95,5 @@ int main(int argc, char** argv, char** const envp) {
   Envp.emplace_back(PS1.c_str());
   Envp.emplace_back(nullptr);
 
-  return execve(Argv[0], const_cast<char* const*>(&Argv.at(0)), const_cast<char* const*>(&Envp[0]));
+  return execve(Argv[0], const_cast<char* const*>(Argv.data()), const_cast<char* const*>(&Envp[0]));
 }

--- a/Source/Tools/FEXLoader/ELFCodeLoader.h
+++ b/Source/Tools/FEXLoader/ELFCodeLoader.h
@@ -672,7 +672,7 @@ public:
       ArgumentPointers[i] = ArgumentBackingBaseGuest + CurrentOffset;
       if (ArgSize > 0) {
         // Copy the string in to the final location
-        memcpy(reinterpret_cast<void*>(ArgumentBackingBase + CurrentOffset), &Args[i].at(0), ArgSize);
+        memcpy(reinterpret_cast<void*>(ArgumentBackingBase + CurrentOffset), Args[i].data(), ArgSize);
       }
 
       // Set the null terminator for the string
@@ -689,7 +689,7 @@ public:
 
       // Copy the string in to the final location
       if (EnvpSize) {
-        memcpy(reinterpret_cast<void*>(EnvpBackingBase + CurrentOffset), &EnvironmentVariables[i].at(0), EnvpSize);
+        memcpy(reinterpret_cast<void*>(EnvpBackingBase + CurrentOffset), EnvironmentVariables[i].data(), EnvpSize);
       }
 
       // Set the null terminator for the string

--- a/Source/Tools/FEXLoader/FEXLoader.cpp
+++ b/Source/Tools/FEXLoader/FEXLoader.cpp
@@ -113,7 +113,7 @@ bool InterpreterHandler(fextl::string* Filename, const fextl::string& RootFS, fe
 
   std::array<char, 257> Header;
   const auto ChunkSize = 257l;
-  const auto ReadSize = pread(FD, &Header.at(0), ChunkSize, 0);
+  const auto ReadSize = pread(FD, Header.data(), ChunkSize, 0);
   close(FD);
 
   const auto Data = std::span<char>(Header.data(), ReadSize);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -521,7 +521,7 @@ EmulatedFDManager::EmulatedFDManager(FEXCore::Context::Context* ctx)
     std::call_once(cpu_info_initialized, [&]() { cpu_info = GenerateCPUInfo(ctx, ThreadsConfig); });
 
     int FD = GenTmpFD(pathname, flags);
-    write(FD, (void*)&cpu_info.at(0), cpu_info.size());
+    write(FD, cpu_info.data(), cpu_info.size());
     lseek(FD, 0, SEEK_SET);
     SealTmpFD(FD);
     return FD;
@@ -572,7 +572,7 @@ EmulatedFDManager::EmulatedFDManager(FEXCore::Context::Context* ctx)
 
   auto NumCPUCores = [&](FEXCore::Context::Context* ctx, int32_t fd, const char* pathname, int32_t flags, mode_t mode) -> int32_t {
     int FD = GenTmpFD(pathname, flags);
-    write(FD, (void*)&cpus_online.at(0), cpus_online.size());
+    write(FD, cpus_online.data(), cpus_online.size());
     lseek(FD, 0, SEEK_SET);
     SealTmpFD(FD);
     return FD;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -178,7 +178,7 @@ static fextl::string GetShebangInterpFD(int FD) {
   // The maximum length of the shebang line is `#!` + 255 chars
   std::array<char, 257> Header;
   const auto ChunkSize = 257l;
-  const auto ReadSize = pread(FD, &Header.at(0), ChunkSize, 0);
+  const auto ReadSize = pread(FD, Header.data(), ChunkSize, 0);
 
   return GetShebangInterpFile(std::span<char>(Header.data(), ReadSize));
 }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
@@ -192,7 +192,7 @@ uint64_t _ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first
   case OP_MSGSND: {
     // Requires a temporary buffer
     fextl::vector<uint8_t> Tmp(second + sizeof(size_t));
-    struct msgbuf* TmpMsg = reinterpret_cast<struct msgbuf*>(&Tmp.at(0));
+    struct msgbuf* TmpMsg = reinterpret_cast<struct msgbuf*>(Tmp.data());
     msgbuf_32* src = reinterpret_cast<msgbuf_32*>(ptr);
     FaultSafeUserMemAccess::VerifyIsReadable(src, sizeof(*src));
     FaultSafeUserMemAccess::VerifyIsReadable(src->mtext, second);
@@ -204,7 +204,7 @@ uint64_t _ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first
   }
   case OP_MSGRCV: {
     fextl::vector<uint8_t> Tmp(second + sizeof(size_t));
-    struct msgbuf* TmpMsg = reinterpret_cast<struct msgbuf*>(&Tmp.at(0));
+    struct msgbuf* TmpMsg = reinterpret_cast<struct msgbuf*>(Tmp.data());
 
     if (Version != 0) {
       Result = ::syscall(SYSCALL_DEF(msgrcv), first, TmpMsg, second, fifth, third);

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
@@ -712,8 +712,8 @@ void LoadUnique32BitSigreturn(VDSOMapping* Mapping, FEX::HLE::SyscallHandler* co
   VDSOPointers.VDSO_kernel_rt_sigreturn =
     reinterpret_cast<void*>(reinterpret_cast<uint64_t>(Mapping->OptionalSigReturnMapping) + sigreturn_32_code.size());
 
-  memcpy(reinterpret_cast<void*>(VDSOPointers.VDSO_kernel_sigreturn), &sigreturn_32_code.at(0), sigreturn_32_code.size());
-  memcpy(reinterpret_cast<void*>(VDSOPointers.VDSO_kernel_rt_sigreturn), &rt_sigreturn_32_code.at(0), rt_sigreturn_32_code.size());
+  memcpy(VDSOPointers.VDSO_kernel_sigreturn, sigreturn_32_code.data(), sigreturn_32_code.size());
+  memcpy(VDSOPointers.VDSO_kernel_rt_sigreturn, rt_sigreturn_32_code.data(), rt_sigreturn_32_code.size());
 
   mprotect(Mapping->OptionalSigReturnMapping, Mapping->OptionalMappingSize, PROT_READ | PROT_EXEC);
   {


### PR DESCRIPTION
This is generally more straightforward in cases where bounds checking isn't necessary.