### PR TITLE
OpDispatcher: Force a recheck of TF after POPF

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3604,6 +3604,10 @@ void OpDispatchBuilder::POPFOp(OpcodeArgs) {
   Src = _Or(OpSize::i64Bit, Src, Constant(0x202));
 
   SetPackedRFLAG(false, Src);
+
+  auto NewRIP = GetRelocatedPC(Op);
+  ExitFunction(NewRIP, BranchHint::CheckTF);
+  BlockSetRIP = true;
 }
 
 void OpDispatchBuilder::NEGOp(OpcodeArgs) {

--- a/FEXCore/Source/Interface/IR/IR.h
+++ b/FEXCore/Source/Interface/IR/IR.h
@@ -621,11 +621,7 @@ enum class ShiftType : uint8_t {
   ROR,
 };
 
-enum class BranchHint : uint8_t {
-  None = 0,
-  Call,
-  Return,
-};
+enum class BranchHint : uint8_t { None = 0, Call, Return, CheckTF };
 
 
 // Converts a size stored as an integer in to an OpSize enum.

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -1752,7 +1752,7 @@
       ]
     },
     "popf": {
-      "ExpectedInstructionCount": 39,
+      "ExpectedInstructionCount": 40,
       "Comment": "0x9d",
       "ExpectedArm64ASM": [
         "ldr x20, [x8], #8",
@@ -1793,6 +1793,7 @@
         "strb w21, [x28, #996]",
         "ubfx w21, w27, #21, #1",
         "strb w21, [x28, #997]",
+        "mov w21, #0x10001",
         "strb w20, [x28, #986]"
       ]
     },

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -2733,7 +2733,7 @@
       ]
     },
     "popf": {
-      "ExpectedInstructionCount": 43,
+      "ExpectedInstructionCount": 44,
       "Comment": "0x9d",
       "ExpectedArm64ASM": [
         "ldr x20, [x8], #8",
@@ -2777,6 +2777,7 @@
         "strb w21, [x28, #996]",
         "ubfx w21, w27, #21, #1",
         "strb w21, [x28, #997]",
+        "mov w21, #0x10001",
         "msr nzcv, x22",
         "strb w20, [x28, #986]"
       ]


### PR DESCRIPTION
The dispatcher/block linker will handle this, but if the instruction following a POPF flag doesn't otherwise trigger one of those the interrupt would be missed.