### PR TITLE
Frontend: Force acq/rel semantics for known Unity ringbuffer offsets

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -602,11 +602,17 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
           auto Fn = TableInfo->OpcodeDispatcher.OpDispatch;
           Thread->OpDispatcher->ResetHandledLock();
           Thread->OpDispatcher->ResetDecodeFailure();
-          IR::ForceTSOMode ForceTSO =
-            BlockInForceTSOValidRange ?
-              (InstForceTSOIt != ForceTSOInstructions.end() && *InstForceTSOIt == InstAddress ? IR::ForceTSOMode::ForceEnabled :
-                                                                                                IR::ForceTSOMode::ForceDisabled) :
-              IR::ForceTSOMode::NoOverride;
+          IR::ForceTSOMode ForceTSO = IR::ForceTSOMode::NoOverride;
+          if (BlockInForceTSOValidRange) {
+            if (InstForceTSOIt != ForceTSOInstructions.end() && *InstForceTSOIt == InstAddress) {
+              ForceTSO = IR::ForceTSOMode::ForceEnabled;
+            } else {
+              ForceTSO = IR::ForceTSOMode::ForceDisabled;
+            }
+          } else if (DecodedInfo->ForceTSO) {
+            ForceTSO = IR::ForceTSOMode::ForceEnabled;
+          }
+
           Thread->OpDispatcher->SetForceTSO(ForceTSO);
           std::invoke(Fn, Thread->OpDispatcher, DecodedInfo);
           if (Thread->OpDispatcher->HadDecodeFailure()) {

--- a/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -199,6 +199,7 @@ struct DecodedInst {
   uint8_t LastEscapePrefix;
   bool DecodedModRM;
   bool DecodedSIB;
+  bool ForceTSO;
 };
 
 union ModRMDecoded {


### PR DESCRIPTION
Unity games crash with TSO disabled due to the SPSC GfxDevice ThreadedStreamBuffer read/write pointer updates missing acq/rel semantics. Rather than attempting to use heuristics to match cases like this, which could be overzealous and hit more accesses than necessary, just target the problem directly as this is consist across 32/64 bit Unity versions for at least the past 10 years. Gate this behind the existing Unity mono hacks to avoid false-positives in non-Unity games.


Draft - do we want this? should this be some sort of config for volatile displacements? this gives a 1.5-3x FPS improvement vs TSO enabled or any reasonable heuristic that could catch all of these without hardcoding the offsets.