### PR TITLE
CPUID: Support spoofing using a constexpr set of generated tables

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -509,6 +509,13 @@
           "  * Disable TSO for multiple modules",
           "      `hl2_linux:libsdl2.so`"
         ]
+      },
+      "SpoofCPUID": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Spoof to hardcoded list in program"
+        ]
       }
     }
   },

--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -38,15 +38,15 @@ void FEXCore::Context::ContextImpl::SetThunkHandler(FEXCore::ThunkHandler* Handl
 }
 
 FEXCore::CPUID::FunctionResults FEXCore::Context::ContextImpl::RunCPUIDFunction(uint32_t Function, uint32_t Leaf) {
-  return CPUID.RunFunction(Function, Leaf);
+  return CPUID->RunFunction(Function, Leaf);
 }
 
 FEXCore::CPUID::XCRResults FEXCore::Context::ContextImpl::RunXCRFunction(uint32_t Function) {
-  return CPUID.RunXCRFunction(Function);
+  return CPUID->RunXCRFunction(Function);
 }
 
 FEXCore::CPUID::FunctionResults FEXCore::Context::ContextImpl::RunCPUIDFunctionName(uint32_t Function, uint32_t Leaf, uint32_t CPU) {
-  return CPUID.RunFunctionName(Function, Leaf, CPU);
+  return CPUID->RunFunctionName(Function, Leaf, CPU);
 }
 
 bool FEXCore::Context::ContextImpl::IsAddressInCodeBuffer(FEXCore::Core::InternalThreadState* Thread, uintptr_t Address) const {

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -221,7 +221,7 @@ public:
 
   FEXCore::HostFeatures HostFeatures;
   // CPUID depends on HostFeatures so needs to be initialized after that.
-  FEXCore::CPUIDEmu CPUID;
+  fextl::unique_ptr<FEXCore::CPUIDBase> CPUID;
   FEXCore::HLE::SyscallHandler* SyscallHandler {};
   FEXCore::HLE::SourcecodeResolver* SourcecodeResolver {};
   FEXCore::ThunkHandler* ThunkHandler {};

--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -19,7 +19,203 @@ uint32_t GetCycleCounterFrequency();
 // Debugging define to switch what family of CPU we execute as.
 // Might be useful if an application makes an assumption about a CPU.
 // #define CPUID_AMD
-class CPUIDEmu final {
+class CPUIDBase {
+  public:
+    virtual ~CPUIDBase() = default;
+    enum class SupportsConstant {
+      CONSTANT,
+      NONCONSTANT,
+    };
+    enum class NeedsLeafConstant {
+      NEEDSLEAFCONSTANT,
+      NOLEAFCONSTANT,
+    };
+    struct FunctionConstant {
+      SupportsConstant SupportsConstantFunction;
+      NeedsLeafConstant NeedsLeaf;
+    };
+
+    virtual FEXCore::CPUID::FunctionResults RunFunction(uint32_t Function, uint32_t Leaf) const = 0;
+    virtual FEXCore::CPUID::XCRResults RunXCRFunction(uint32_t Function) const = 0;
+    virtual FEXCore::CPUID::FunctionResults RunFunctionName(uint32_t Function, uint32_t Leaf, uint32_t CPU) const = 0;
+    virtual bool DoesXCRFunctionReportConstantData(uint32_t Function) const = 0;
+    virtual FunctionConstant DoesFunctionReportConstantData(uint32_t Function) const = 0;
+};
+
+class SirSpoofingtonTheThird final : public CPUIDBase {
+  public:
+    FEXCore::CPUID::FunctionResults RunFunction(uint32_t Function, uint32_t Leaf) const override {
+      auto Result = GetKeyFromTable(BaseTable, Function, Leaf);
+      if (Result.has_value()) {
+        return *Result;
+      }
+
+      Result = GetKeyFromTable(VMTable, Function, Leaf);
+      if (Result.has_value()) {
+        return *Result;
+      }
+
+      Result = GetKeyFromTable(ExtendedTable, Function, Leaf);
+      if (Result.has_value()) {
+        return *Result;
+      }
+
+      return {};
+    }
+
+    FEXCore::CPUID::XCRResults RunXCRFunction(uint32_t Function) const override {
+      auto Result = GetKeyFromTable(XCRTable, Function, 0);
+      if (Result.has_value()) {
+        return FEXCore::CPUID::XCRResults {
+          .eax = Result->eax,
+          .edx = Result->ebx,
+        };
+      }
+
+      return {};
+    }
+
+    FEXCore::CPUID::FunctionResults RunFunctionName(uint32_t Function, uint32_t Leaf, uint32_t CPU) const override {
+      auto Result = GetKeyFromTable(BaseTable, Function, Leaf);
+      if (Result.has_value()) {
+        return *Result;
+      }
+
+      Result = GetKeyFromTable(VMTable, Function, Leaf);
+      if (Result.has_value()) {
+        return *Result;
+      }
+
+      Result = GetKeyFromTable(ExtendedTable, Function, Leaf);
+      if (Result.has_value()) {
+        return *Result;
+      }
+
+      return {};
+    }
+
+    bool DoesXCRFunctionReportConstantData(uint32_t Function) const override {
+      // Never optimize.
+      return false;
+    }
+
+    FunctionConstant DoesFunctionReportConstantData(uint32_t Function) const override {
+      // Never optimize.
+      return {SupportsConstant::NONCONSTANT, NeedsLeafConstant::NEEDSLEAFCONSTANT};
+    }
+
+private:
+    std::optional<FEXCore::CPUID::FunctionResults> GetKeyFromTable(auto &Table, uint32_t Function, uint32_t Leaf) const {
+      for (auto &Entry : Table) {
+        if (Entry.Key == Function && (Entry.Leaf == Leaf || Entry.IgnoreLeaf)) {
+          return Entry.Res;
+        }
+      }
+
+      return std::nullopt;
+    }
+
+    struct CPUIDData {
+      uint32_t Key, Leaf;
+      FEXCore::CPUID::FunctionResults Res;
+      bool XCR; // Only uses EAX/EDX in this case.
+      bool IgnoreLeaf;
+    };
+
+    constexpr static CPUIDData DataArray[] = {
+      {0x00000000, 0x00000000, {0x00000006, 0x68747541, 0x444d4163, 0x69746e65}, false, true},
+      {0x00000001, 0x00000000, {0x00100fa0, 0x04060800, 0x00802009, 0x178bfbff}, false, true},
+      {0x00000002, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x00000003, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x00000004, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x00000005, 0x00000000, {0x00000040, 0x00000040, 0x00000003, 0x00000000}, false, true},
+      {0x00000006, 0x00000000, {0x00000000, 0x00000000, 0x00000001, 0x00000000}, false, true},
+      {0x80000000, 0x00000000, {0x8000001b, 0x68747541, 0x444d4163, 0x69746e65}, false, true},
+      {0x80000001, 0x00000000, {0x00100fa0, 0x100000a1, 0x000837ff, 0xefd3fbff}, false, true},
+      {0x80000002, 0x00000000, {0x20444d41, 0x6e656850, 0x74286d6f, 0x4920296d}, false, true},
+      {0x80000003, 0x00000000, {0x36582049, 0x30313120, 0x50205430, 0x65636f72}, false, true},
+      {0x80000004, 0x00000000, {0x726f7373, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000005, 0x00000000, {0xff30ff10, 0xff30ff20, 0x40020140, 0x40020140}, false, true},
+      {0x80000006, 0x00000000, {0x20800000, 0x42004200, 0x02008140, 0x0030b140}, false, true},
+      {0x80000007, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x000003f9}, false, true},
+      {0x80000008, 0x00000000, {0x00003030, 0x00000000, 0x00003005, 0x00000000}, false, true},
+      {0x80000009, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x8000000a, 0x00000000, {0x00000001, 0x00000040, 0x00000000, 0x0000040f}, false, true},
+      {0x8000000b, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x8000000c, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x8000000d, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x8000000e, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x8000000f, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000010, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000011, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000012, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000013, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000014, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000015, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000016, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000017, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000018, 0x00000000, {0x00000000, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x80000019, 0x00000000, {0xf0300000, 0x60100000, 0x00000000, 0x00000000}, false, true},
+      {0x8000001a, 0x00000000, {0x00000003, 0x00000000, 0x00000000, 0x00000000}, false, true},
+      {0x8000001b, 0x00000000, {0x0000001f, 0x00000000, 0x00000000, 0x00000000}, false, true},
+    };
+
+    constexpr static auto MaxKeyInRange = [](size_t Min, size_t Max, bool XCR = false) consteval -> uint32_t {
+      uint32_t Maximum {};
+      for (auto &Data : DataArray) {
+        if (Data.XCR != XCR) {
+          // Skip XCR
+          continue;
+        }
+
+        if (Data.Key < Min || Data.Key > Max) {
+          // Skip out of range
+          continue;
+        }
+
+        // Leafs count.
+        ++Maximum;
+      }
+      return Maximum;
+    };
+
+    constexpr static auto GenerateArrayInRange = []<size_t Min, size_t Max, bool XCR = false>() consteval {
+      std::array<CPUIDData, MaxKeyInRange(Min, Max, XCR)> ArrayData;
+
+      size_t CurrentKey {};
+      for (auto &Data : DataArray) {
+        if (Data.XCR != XCR) {
+          // Skip XCR
+          continue;
+        }
+
+        if (Data.Key < Min || Data.Key > Max) {
+          // Skip out of range
+          continue;
+        }
+
+        CPUIDData &GenData = ArrayData[CurrentKey];
+        GenData = CPUIDData {
+          .Key = Data.Key,
+          .Leaf = Data.Leaf,
+          .Res = Data.Res,
+          .XCR = Data.XCR,
+          .IgnoreLeaf = Data.IgnoreLeaf,
+        };
+
+        ++CurrentKey;
+      }
+
+      return ArrayData;
+    };
+
+    constexpr static auto BaseTable = GenerateArrayInRange.operator()<0, 0x4000'0000U>();
+    constexpr static auto VMTable = GenerateArrayInRange.operator()<0x4000'0000U, 0x8000'0000U>();
+    constexpr static auto ExtendedTable = GenerateArrayInRange.operator()<0x8000'0000U, ~0U>();
+    constexpr static auto XCRTable = GenerateArrayInRange.operator()<0, ~0U, true>();
+};
+
+class CPUIDEmu final : public CPUIDBase {
 private:
   constexpr static uint32_t CPUID_VENDOR_INTEL1 = 0x756E6547; // "Genu"
   constexpr static uint32_t CPUID_VENDOR_INTEL2 = 0x49656E69; // "ineI"
@@ -36,7 +232,7 @@ public:
   // if we report anything differently then applications are likely to break
   constexpr static uint64_t CACHELINE_SIZE = 64;
 
-  FEXCore::CPUID::FunctionResults RunFunction(uint32_t Function, uint32_t Leaf) const {
+  FEXCore::CPUID::FunctionResults RunFunction(uint32_t Function, uint32_t Leaf) const override {
     if (Function < Primary.size()) {
       const auto Handler = Primary[Function];
       return (this->*Handler)(Leaf);
@@ -57,7 +253,16 @@ public:
     return Function_Reserved(Leaf);
   }
 
-  FEXCore::CPUID::FunctionResults RunFunctionName(uint32_t Function, uint32_t Leaf, uint32_t CPU) const {
+  FEXCore::CPUID::XCRResults RunXCRFunction(uint32_t Function) const override {
+    if (Function >= 1) {
+      // XCR function 1 is not yet supported.
+      return {};
+    }
+
+    return XCRFunction_0h();
+  }
+
+  FEXCore::CPUID::FunctionResults RunFunctionName(uint32_t Function, uint32_t Leaf, uint32_t CPU) const override {
     if (Function == 0x8000'0002U) {
       return Function_8000_0002h(Leaf, CPU % PerCPUData.size());
     } else if (Function == 0x8000'0003U) {
@@ -67,34 +272,12 @@ public:
     }
   }
 
-  FEXCore::CPUID::XCRResults RunXCRFunction(uint32_t Function) const {
-    if (Function >= 1) {
-      // XCR function 1 is not yet supported.
-      return {};
-    }
-
-    return XCRFunction_0h();
-  }
-
-  bool DoesXCRFunctionReportConstantData(uint32_t Function) const {
+  bool DoesXCRFunctionReportConstantData(uint32_t Function) const override {
     // Every function currently returns constant data.
     return true;
   }
 
-  enum class SupportsConstant {
-    CONSTANT,
-    NONCONSTANT,
-  };
-  enum class NeedsLeafConstant {
-    NEEDSLEAFCONSTANT,
-    NOLEAFCONSTANT,
-  };
-  struct FunctionConstant {
-    SupportsConstant SupportsConstantFunction;
-    NeedsLeafConstant NeedsLeaf;
-  };
-
-  static constexpr FunctionConstant DoesFunctionReportConstantData(uint32_t Function) {
+  FunctionConstant DoesFunctionReportConstantData(uint32_t Function) const override {
     if (Function < Primary.size()) {
       return Primary_Constant[Function];
     }

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -76,7 +76,6 @@ $end_info$
 namespace FEXCore::Context {
 ContextImpl::ContextImpl(const FEXCore::HostFeatures& Features)
   : HostFeatures {Features}
-  , CPUID {this}
   , IRCaptureCache {this} {
   if (!Config.Is64BitMode()) {
     // When operating in 32-bit mode, the virtual memory we care about is only the lower 32-bits.
@@ -99,6 +98,13 @@ ContextImpl::ContextImpl(const FEXCore::HostFeatures& Features)
 
   // Track atomic TSO emulation configuration.
   UpdateAtomicTSOEmulationConfig();
+  FEX_CONFIG_OPT(SpoofCPUID, SPOOFCPUID);
+  if (SpoofCPUID) {
+    CPUID = fextl::make_unique<SirSpoofingtonTheThird>();
+  }
+  else {
+    CPUID = fextl::make_unique<CPUIDEmu>(this);
+  }
 }
 
 struct GetFrameBlockInfoResult {

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -640,16 +640,16 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl* ctx, FEXCore::Core::In
     Common.PrintVectorValue = reinterpret_cast<uint64_t>(PrintVectorValue);
     Common.ThreadRemoveCodeEntryFromJIT = reinterpret_cast<uintptr_t>(&Context::ContextImpl::ThreadRemoveCodeEntryFromJit);
     Common.MonoBackpatcherWrite = reinterpret_cast<uint64_t>(&Context::ContextImpl::MonoBackpatcherWrite);
-    Common.CPUIDObj = reinterpret_cast<uint64_t>(&CTX->CPUID);
+    Common.CPUIDObj = reinterpret_cast<uint64_t>(CTX->CPUID.get());
 
     {
       FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::CPUIDEmu::RunFunction);
-      Common.CPUIDFunction = PMF.GetConvertedPointer();
+      Common.CPUIDFunction = PMF.GetVTableEntry(CTX->CPUID.get());
     }
 
     {
       FEXCore::Utils::MemberFunctionToPointerCast PMF(&FEXCore::CPUIDEmu::RunXCRFunction);
-      Common.XCRFunction = PMF.GetConvertedPointer();
+      Common.XCRFunction = PMF.GetVTableEntry(CTX->CPUID.get());
     }
 
     {

--- a/FEXCore/Source/Interface/IR/PassManager.cpp
+++ b/FEXCore/Source/Interface/IR/PassManager.cpp
@@ -82,7 +82,7 @@ void PassManager::AddDefaultValidationPasses() {
 }
 
 void PassManager::InsertRegisterAllocationPass(FEXCore::Context::ContextImpl* ctx) {
-  InsertPass(IR::CreateRegisterAllocationPass(&ctx->CPUID), "RA");
+  InsertPass(IR::CreateRegisterAllocationPass(ctx->CPUID.get()), "RA");
 }
 
 void PassManager::Run(IREmitter* IREmit) {

--- a/FEXCore/Source/Interface/IR/Passes.h
+++ b/FEXCore/Source/Interface/IR/Passes.h
@@ -4,7 +4,7 @@
 #include <FEXCore/fextl/memory.h>
 
 namespace FEXCore {
-class CPUIDEmu;
+class CPUIDBase;
 struct HostFeatures;
 } // namespace FEXCore
 
@@ -17,7 +17,7 @@ class Pass;
 class RegisterAllocationPass;
 
 fextl::unique_ptr<FEXCore::IR::Pass> CreateDeadFlagCalculationEliminination();
-fextl::unique_ptr<FEXCore::IR::RegisterAllocationPass> CreateRegisterAllocationPass(const FEXCore::CPUIDEmu* CPUID);
+fextl::unique_ptr<FEXCore::IR::RegisterAllocationPass> CreateRegisterAllocationPass(const FEXCore::CPUIDBase* CPUID);
 fextl::unique_ptr<FEXCore::IR::Pass> CreateX87StackOptimizationPass(const FEXCore::HostFeatures&, OpSize GPROpSize);
 
 namespace Validation {

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -53,7 +53,7 @@ namespace {
 
 class ConstrainedRAPass final : public RegisterAllocationPass {
 public:
-  explicit ConstrainedRAPass(const FEXCore::CPUIDEmu* CPUID)
+  explicit ConstrainedRAPass(const FEXCore::CPUIDBase* CPUID)
     : CPUID {CPUID} {}
   void Run(IREmitter* IREmit) override;
   void AddRegisters(IR::RegisterClassType Class, uint32_t RegisterCount) override;
@@ -64,7 +64,7 @@ private:
 
   IREmitter* IREmit;
   IRListView* IR;
-  const FEXCore::CPUIDEmu* CPUID;
+  const FEXCore::CPUIDBase* CPUID;
 
   // Map of nodes to their preferred register, to coalesce load/store reg.
   fextl::vector<PhysicalRegister> PreferredReg;
@@ -779,7 +779,7 @@ void ConstrainedRAPass::Run(IREmitter* IREmit_) {
   IR->GetHeader()->PostRA = true;
 }
 
-fextl::unique_ptr<IR::RegisterAllocationPass> CreateRegisterAllocationPass(const FEXCore::CPUIDEmu* CPUID) {
+fextl::unique_ptr<IR::RegisterAllocationPass> CreateRegisterAllocationPass(const FEXCore::CPUIDBase* CPUID) {
   return fextl::make_unique<ConstrainedRAPass>(CPUID);
 }
 } // namespace FEXCore::IR


### PR DESCRIPTION
Makes it easier to just scrape a CPUID and try it out.

Doesn't support some critical things, like filtering features FEX doesn't support. Primarily because I didn't need it for spoofing the Phenom.

Basic scraper: https://gist.github.com/Sonicadvance1/8272a8fac1e385b560262005d0076dd8

Not actually planning on merging this, just opening the PR for visibility long-term.