### PR TITLE
Core: Drop support for TSO auto migration

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -395,14 +395,6 @@
           "This is required to ensure a split-lock doesn't tear inside the process"
         ]
       },
-      "TSOAutoMigration": {
-        "Type": "bool",
-        "Default": "true",
-        "Desc": [
-          "Automatically enables TSO when shared memory is used.",
-          "Should work without issues in most cases."
-        ]
-      },
       "VolatileMetadata": {
         "Type": "bool",
         "Default": "true",

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -893,23 +893,6 @@ void ContextImpl::InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* T
   InvalidateGuestThreadCodeRange(Thread, Accumulator, Start, Length);
 }
 
-void ContextImpl::MarkMemoryShared(FEXCore::Core::InternalThreadState* Thread) {
-  if (!Thread) {
-    return;
-  }
-
-  if (!IsMemoryShared) {
-    IsMemoryShared = true;
-    UpdateAtomicTSOEmulationConfig();
-
-    if (Config.TSOAutoMigration) {
-      // Only the lookup cache is cleared here, so that old code can keep running until next compilation.
-      // This will leak previously compiled blocks until the CodeBuffer is cleared for some other reason.
-      Thread->LookupCache->ClearCache();
-    }
-  }
-}
-
 bool ContextImpl::ThreadRemoveCodeEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP) {
   LogMan::Throw::AFmt(static_cast<ContextImpl*>(Thread->CTX)->CodeInvalidationMutex.try_lock() == false, "CodeInvalidationMutex needs to "
                                                                                                          "be unique_locked here");

--- a/FEXCore/include/FEXCore/Core/Context.h
+++ b/FEXCore/include/FEXCore/Core/Context.h
@@ -158,8 +158,6 @@ public:
     FEXCore::Core::InternalThreadState* Thread, InvalidatedEntryAccumulator& Accumulator, uint64_t Start, uint64_t Length) = 0;
   FEX_DEFAULT_VISIBILITY virtual FEXCore::ForkableSharedMutex& GetCodeInvalidationMutex() = 0;
 
-  FEX_DEFAULT_VISIBILITY virtual void MarkMemoryShared(FEXCore::Core::InternalThreadState* Thread) = 0;
-
   FEX_DEFAULT_VISIBILITY virtual void
   ConfigureAOTGen(FEXCore::Core::InternalThreadState* Thread, fextl::set<uint64_t>* ExternalBranches, uint64_t SectionMaxAddress) = 0;
 

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -509,6 +509,8 @@ int main(int argc, char** argv, char** const envp) {
   // Disable vixl simulator indirect calls as it can affect instruction counts.
   FEXCore::Config::Set(FEXCore::Config::CONFIG_DISABLE_VIXL_INDIRECT_RUNTIME_CALLS, "1");
 
+  FEXCore::Config::Set(FEXCore::Config::CONFIG_TSOENABLED, "0");
+
   // Host feature override. Only supports overriding SVE width.
   enum HostFeatures {
     FEATURE_SVE128 = (1U << 0),
@@ -580,11 +582,12 @@ int main(int argc, char** argv, char** const envp) {
   }
 
   if (TestHeaderData->EnabledHostFeatures & FEATURE_TSO) {
-    // Always disable auto migration.
-    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
     FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED, "1");
     FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_VECTORTSOENABLED, "1");
     FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_MEMCPYSETTSOENABLED, "1");
+  } else {
+    // Override the TSO default setting, since TSO is not relevant for most tests
+    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED, "0");
   }
 
   // Always enable ARMv8.1 LSE atomics.
@@ -634,8 +637,6 @@ int main(int argc, char** argv, char** const envp) {
   }
 
   if (TestHeaderData->DisabledHostFeatures & FEATURE_TSO) {
-    // Always disable auto migration.
-    FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
     FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOENABLED, "0");
     FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_VECTORTSOENABLED, "0");
     FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_MEMCPYSETTSOENABLED, "0");

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.cpp
@@ -620,10 +620,6 @@ uint64_t CloneHandler(FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::clone3_args
     return false;
   };
 
-  if (flags & CLONE_VM) {
-    Frame->Thread->CTX->MarkMemoryShared(Frame->Thread);
-  }
-
   // If there are flags that can't be handled regularly then we need to hand off to the true clone handler
   if (HasUnhandledFlags(args)) {
     if (!AnyFlagsSet(flags, CLONE_THREAD)) {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -201,10 +201,6 @@ void* SyscallHandler::GuestMmap(bool Is64Bit, FEXCore::Core::InternalThreadState
   uint64_t Result {};
   size_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);
 
-  if (flags & MAP_SHARED) {
-    CTX->MarkMemoryShared(Thread);
-  }
-
   {
     // NOTE: Frontend calls this with a nullptr Thread during initialization, but
     //       providing this code with a valid Thread object earlier would allow
@@ -307,10 +303,8 @@ uint64_t SyscallHandler::GuestMprotect(FEXCore::Core::InternalThreadState* Threa
 }
 
 uint64_t SyscallHandler::GuestShmat(bool Is64Bit, FEXCore::Core::InternalThreadState* Thread, int shmid, const void* shmaddr, int shmflg) {
-  auto CTX = Thread->CTX;
   uint64_t Result {};
   uint64_t Length {};
-  CTX->MarkMemoryShared(Thread);
 
   {
     auto lk = FEXCore::GuardSignalDeferringSection(FEX::HLE::_SyscallHandler->VMATracking.Mutex, Thread);

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -641,9 +641,6 @@ NTSTATUS ProcessInit() {
 
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, "1");
 
-  // Not applicable to Windows
-  FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
-
   FEXCore::Profiler::Init("", "");
 
   FEX_CONFIG_OPT(ExtendedVolatileMetadataConfig, EXTENDEDVOLATILEMETADATA);

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -518,9 +518,6 @@ void BTCpuProcessInit() {
   FEXCore::Config::Set(FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, "0");
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, "0");
 
-  // Not applicable to Windows
-  FEXCore::Config::Set(FEXCore::Config::ConfigOption::CONFIG_TSOAUTOMIGRATION, "0");
-
   FEXCore::Profiler::Init("", "");
 
   FEX_CONFIG_OPT(ExtendedVolatileMetadataConfig, EXTENDEDVOLATILEMETADATA);

--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -51,9 +51,9 @@ foreach(ASM_SRC ${ASM_SOURCES})
   set(TEST_ARGS)
   if (_M_ARM_64 OR ENABLE_VIXL_SIMULATOR)
     list(APPEND TEST_ARGS
-      "--no-silentlog -g -n 1   --no-multiblock"   "jit_1"     "jit"
-      "--no-silentlog -g -n 500 --no-multiblock"   "jit_500"   "jit"
-      "--no-silentlog -g -n 500 --multiblock"      "jit_500_m" "jit"
+      "--no-silentlog -g -n 1   --no-multiblock --no-tsoenabled"   "jit_1"     "jit"
+      "--no-silentlog -g -n 500 --no-multiblock --no-tsoenabled"   "jit_500"   "jit"
+      "--no-silentlog -g -n 500 --multiblock    --no-tsoenabled"      "jit_500_m" "jit"
       )
   endif()
 

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -53,9 +53,9 @@ foreach(ASM_SRC ${ASM_SOURCES})
   set(TEST_ARGS)
   if (_M_ARM_64 OR ENABLE_VIXL_SIMULATOR)
     list(APPEND TEST_ARGS
-      "--no-silentlog -g -n 1   --no-multiblock"   "jit_1"     "jit"
-      "--no-silentlog -g -n 500 --no-multiblock"   "jit_500"   "jit"
-      "--no-silentlog -g -n 500 --multiblock"      "jit_500_m" "jit"
+      "--no-silentlog -g -n 1   --no-multiblock --no-tsoenabled"   "jit_1"     "jit"
+      "--no-silentlog -g -n 500 --no-multiblock --no-tsoenabled"   "jit_500"   "jit"
+      "--no-silentlog -g -n 500 --multiblock    --no-tsoenabled"      "jit_500_m" "jit"
       )
   endif()
 


### PR DESCRIPTION
Originally added in https://github.com/FEX-Emu/FEX/pull/1752, TSO auto migration is a heuristic to disable TSO emulation until the application creates a second thread. This heuristic doesn't mesh well with code caching (see below), so I'm proposing we remove it entirely.

There are some other reasons why dropping support isn't too bad:
* The general impact of TSO emulation has been greatly reduced since 2022 (see e.g. https://github.com/FEX-Emu/FEX/pull/2760 and https://github.com/FEX-Emu/FEX/pull/3511)
* For specific applications, AppConfigs and TSO heuristics can be a good alternative (#4728, #4825)
* WoA deployments never used TSO auto migration and instead can use volatile metadata (#4378)
* Ever since #4479 was merged, we've been soft-leaking any CodeBuffer memory allocated before TSO auto migration

Specifically the interaction with #4479 also causes TSO auto migration to re-compile any code executed by the first application thread, which can have a minor loading time impact on the vast majority of applications that use multiple threads.

## Conflicts with code caching

The TSO heuristic carries design overhead when considering its interaction with code caching. The suggested resolution in the [TSO auto-migration PR](https://github.com/FEX-Emu/FEX/pull/1752) itself was to disable TSO automigration when code caching is enabled. Since there's no reason *not* to enable code caching unconditionally, this would have the same ultimate effect as removing the heuristic entirely.

Here are some specific problems that would need consideration if we keep the heuristic:

### Should FEX generate a non-TSO cache "just in case"?

Any benefit of TSO auto-migration would be defeated by loading a code cache compiled with TSO emulation enabled. So should FEX always generate two version of the same cache (one with TSO, one without)? It's dubious whether code caching brings any tangible benefit to the type of application that would benefit from TSO auto-migration anyway, so compiling two caches seems wasteful.

We could record whether an application uses multiple threads in a code map, but again this doesn't seem worth the increase in design complexity. Notably this also wouldn't work for script interpreters (e.g. python), where the effectiveness of TSO migration depends on the script being executed.

### Runtime interaction of TSO auto-migration with code cache loading

What should FEX do if a cache is present but TSO hasn't been auto-enabled yet? If we don't load the cache, we won't be able to retroactively do so after TSO auto-migration; if we do load the cache, the LookupCache clear triggered during auto-migration will throw it away.
