### PR TITLE
Common Utils: Remove unused/unnecessary inclusions from headers

### DIFF
--- a/FEXCore/Source/Common/JitSymbols.h
+++ b/FEXCore/Source/Common/JitSymbols.h
@@ -2,12 +2,10 @@
 #pragma once
 
 #include <FEXCore/fextl/memory.h>
-#include <FEXCore/Debug/InternalThreadState.h>
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
-#include <cstdio>
-#include <memory>
 #include <string_view>
 
 namespace FEXCore {

--- a/FEXCore/include/FEXCore/Utils/LogManager.h
+++ b/FEXCore/include/FEXCore/Utils/LogManager.h
@@ -9,7 +9,7 @@
 #include <fmt/color.h>
 
 namespace LogMan {
-enum DebugLevels {
+enum DebugLevels : uint32_t {
   NONE = 0,   ///< Expect zero messages
   ASSERT = 1, ///< Assert throwing
   ERROR = 2,  ///< Only Errors printed

--- a/Source/Common/CPUInfo.h
+++ b/Source/Common/CPUInfo.h
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 #pragma once
-#include <FEXCore/Utils/CompilerDefs.h>
 
 #include <cstdint>
 

--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -12,10 +12,12 @@
 #include <FEXHeaderUtils/SymlinkChecks.h>
 
 #include <cstring>
+#include <functional>
 #ifndef _WIN32
 #include <linux/limits.h>
 #include <pwd.h>
 #endif
+#include <optional>
 #include <utility>
 #include <tiny-json.h>
 

--- a/Source/Common/Config.h
+++ b/Source/Common/Config.h
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 #pragma once
+
 #include <FEXCore/Config/Config.h>
+#include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/string.h>
+#include <FEXCore/fextl/unordered_map.h>
+#include <FEXCore/fextl/vector.h>
+
+#include <string_view>
 
 namespace FEX::ArgLoader {
 class ArgLoader;

--- a/Source/Common/FDUtils.h
+++ b/Source/Common/FDUtils.h
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <FEXCore/Utils/Allocator.h>
-#include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/fextl/fmt.h>
-#include <FEXCore/fextl/string.h>
 
 #include <fcntl.h>
-#include <filesystem>
 #include <linux/limits.h>
-#include <optional>
 #include <unistd.h>
 
 namespace FEX {

--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -10,6 +10,7 @@
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/vector.h>
 #include <FEXHeaderUtils/Filesystem.h>
+#include <FEXHeaderUtils/Syscalls.h>
 
 #include <cstdlib>
 #include <fcntl.h>
@@ -27,6 +28,17 @@
 #include <cstring>
 
 namespace FEXServerClient {
+Logging::PacketHeader Logging::FillHeader(PacketTypes Type) {
+  Logging::PacketHeader Msg {
+    .PacketType = Type,
+    .PID = ::getpid(),
+    .TID = FHU::Syscalls::gettid(),
+  };
+  clock_gettime(CLOCK_MONOTONIC, &Msg.Timestamp);
+
+  return Msg;
+}
+
 int RequestPIDFDPacket(int ServerSocket, PacketType Type) {
   fasio::tcp_socket Socket {ServerSocket};
   FEXServerRequestPacket Req {

--- a/Source/Common/FEXServerClient.h
+++ b/Source/Common/FEXServerClient.h
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/fextl/string.h>
-#include <FEXHeaderUtils/Syscalls.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <string_view>
+
+namespace LogMan {
+enum DebugLevels : uint32_t;
+}
 
 namespace FEXServerClient {
 enum class PacketType {
@@ -134,18 +141,7 @@ namespace Logging {
 
   static_assert(sizeof(PacketHeader) == 32, "Wrong size");
 
-  [[maybe_unused]]
-  static PacketHeader FillHeader(Logging::PacketTypes Type) {
-
-    Logging::PacketHeader Msg {
-      .PacketType = Type,
-      .PID = ::getpid(),
-      .TID = FHU::Syscalls::gettid(),
-    };
-    clock_gettime(CLOCK_MONOTONIC, &Msg.Timestamp);
-
-    return Msg;
-  }
+  PacketHeader FillHeader(PacketTypes Type);
 } // namespace Logging
 
 void MsgHandler(int FD, LogMan::DebugLevels Level, const char* Message);

--- a/Source/Common/JSONPool.h
+++ b/Source/Common/JSONPool.h
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-#include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/list.h>
 
 #include <tiny-json.h>

--- a/Source/Common/JSONPool.h
+++ b/Source/Common/JSONPool.h
@@ -2,6 +2,7 @@
 
 #include <FEXCore/fextl/list.h>
 
+#include <iterator>
 #include <tiny-json.h>
 
 namespace FEX::JSON {
@@ -13,10 +14,10 @@ struct JsonAllocator : jsonPool_t {
 
 template<typename T>
 const json_t* CreateJSON(T& Container, JsonAllocator& Allocator) {
-  if (Container.empty()) {
+  if (std::empty(Container)) {
     return nullptr;
   }
 
-  return json_createWithPool(&Container.at(0), &Allocator);
+  return json_createWithPool(std::data(Container), &Allocator);
 }
 } // namespace FEX::JSON

--- a/Source/Common/StringUtil.cpp
+++ b/Source/Common/StringUtil.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include "Common/StringUtil.h"
 
+#include <algorithm>
+
 namespace FEX::StringUtil {
 void ltrim(fextl::string& s) {
   s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));

--- a/Source/Common/StringUtil.h
+++ b/Source/Common/StringUtil.h
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
-#include <FEXCore/fextl/string.h>
 
-#include <algorithm>
+#include <FEXCore/fextl/string.h>
 
 namespace FEX::StringUtil {
 void ltrim(fextl::string& s);

--- a/Source/Common/VolatileMetadata.cpp
+++ b/Source/Common/VolatileMetadata.cpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 #include "Common/VolatileMetadata.h"
 
+#include <FEXCore/Utils/LogManager.h>
+
+#include <cstdlib>
+
 #include <range/v3/view/split.hpp>
 #include <range/v3/view/transform.hpp>
 

--- a/Source/Common/VolatileMetadata.h
+++ b/Source/Common/VolatileMetadata.h
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 #pragma once
+
 #include <FEXCore/Utils/IntervalList.h>
 #include <FEXCore/fextl/unordered_map.h>
 #include <FEXCore/fextl/set.h>
 #include <FEXCore/fextl/string.h>
+
+#include <string_view>
 
 namespace FEX::VolatileMetadata {
 struct ExtendedVolatileMetadata {

--- a/Source/Tools/FEXServer/SquashFS.cpp
+++ b/Source/Tools/FEXServer/SquashFS.cpp
@@ -5,10 +5,12 @@
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/fextl/string.h>
+#include <FEXHeaderUtils/Syscalls.h>
 
 #include <fcntl.h>
 #include <filesystem>
 #include <sys/poll.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <thread>
 


### PR DESCRIPTION
Just culls a few unused dependencies from the Common utilities (and explicitly specifies some indirect includes)