### PR TITLE
InternalThreadState: Make bool operator explicit

### DIFF
--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -71,7 +71,7 @@ struct NonMovableUniquePtr {
     return Ptr;
   }
 
-  operator bool() const noexcept {
+  explicit operator bool() const noexcept {
     return Ptr != nullptr;
   }
 


### PR DESCRIPTION
We definitely don't want the boolean null test to be able to be implicitly converted (e.g. to an int or whatever else).

For example a non-explicit bool operator allows for silly things like:

```cpp
NonMovableUniquePtr<...> ptr;
// ...
auto k = 5 + ptr;
```

to build without issue, which we should really force the user to be explicit about if it's a desired behavior.