### PR TITLE
General: std::alignment_of -> alignof

### DIFF
--- a/FEXCore/Source/Utils/Allocator/IntrusiveArenaAllocator.h
+++ b/FEXCore/Source/Utils/Allocator/IntrusiveArenaAllocator.h
@@ -28,13 +28,13 @@ public:
 
   template<class U, class... Args>
   U* new_construct(Args&&... args) {
-    void* Ptr = do_allocate(sizeof(U), std::alignment_of<U>::value);
+    void* Ptr = do_allocate(sizeof(U), alignof(U));
     return new (Ptr) U(args...);
   }
 
   template<class U, class... Args>
   U* new_construct(U* Class, Args&&... args) {
-    void* Ptr = do_allocate(sizeof(U), std::alignment_of<U>::value);
+    void* Ptr = do_allocate(sizeof(U), alignof(U));
     return new (Ptr) U(args...);
   }
 
@@ -91,13 +91,13 @@ public:
 
   template<class U, class... Args>
   U* new_construct(Args&&... args) {
-    void* Ptr = do_allocate(sizeof(U), std::alignment_of<U>::value);
+    void* Ptr = do_allocate(sizeof(U), alignof(U));
     return new (Ptr) U(args...);
   }
 
   template<class U, class... Args>
   U* new_construct(U* Class, Args&&... args) {
-    void* Ptr = do_allocate(sizeof(U), std::alignment_of<U>::value);
+    void* Ptr = do_allocate(sizeof(U), alignof(U));
     return new (Ptr) U(args...);
   }
 

--- a/FEXCore/include/FEXCore/Core/CoreState.h
+++ b/FEXCore/include/FEXCore/Core/CoreState.h
@@ -437,6 +437,6 @@ static_assert(offsetof(CpuStateFrame, Pointers) + sizeof(CpuStateFrame::Pointers
 
 static_assert(std::is_standard_layout<CpuStateFrame>::value, "This needs to be standard layout");
 static_assert(sizeof(CpuStateFrame::SynchronousFaultData) == 8, "This needs to be 8 bytes");
-static_assert(std::alignment_of_v<CpuStateFrame::SynchronousFaultDataStruct> == 8, "This needs to be 8 bytes");
+static_assert(alignof(CpuStateFrame::SynchronousFaultDataStruct) == 8, "This needs to be 8 bytes");
 static_assert(offsetof(CpuStateFrame, SynchronousFaultData) % 8 == 0, "This needs to be aligned");
 } // namespace FEXCore::Core

--- a/FEXCore/include/FEXCore/fextl/allocator.h
+++ b/FEXCore/include/FEXCore/fextl/allocator.h
@@ -19,7 +19,7 @@ public:
   FEXAlloc(const FEXAlloc<U>&) noexcept {}
 
   inline value_type* allocate(std::size_t n) {
-    return reinterpret_cast<value_type*>(::FEXCore::Allocator::aligned_alloc(std::alignment_of_v<value_type>, n * sizeof(value_type)));
+    return reinterpret_cast<value_type*>(::FEXCore::Allocator::aligned_alloc(alignof(value_type), n * sizeof(value_type)));
   }
 
   inline void deallocate(value_type* p, size_t) noexcept {

--- a/FEXCore/include/FEXCore/fextl/functional.h
+++ b/FEXCore/include/FEXCore/fextl/functional.h
@@ -42,7 +42,7 @@ public:
 
       // First, relocate argument to a location returned from FEX's allocators
       using Fnoref = std::remove_reference_t<F>;
-      storage = Alloc(std::alignment_of_v<Fnoref>, sizeof(Fnoref));
+      storage = Alloc(alignof(Fnoref), sizeof(Fnoref));
       auto moved_lambda = new (storage) Fnoref {std::move(f)};
 
       // Second, wrap the relocated argument in a single-capture lambda

--- a/FEXCore/include/FEXCore/fextl/memory.h
+++ b/FEXCore/include/FEXCore/fextl/memory.h
@@ -31,7 +31,7 @@ using shared_ptr = std::shared_ptr<T>;
 template<class T, class... Args>
 requires (!std::is_array_v<T>)
 fextl::unique_ptr<T> make_unique(Args&&... args) {
-  auto ptr = FEXCore::Allocator::aligned_alloc(std::alignment_of_v<T>, sizeof(T));
+  auto ptr = FEXCore::Allocator::aligned_alloc(alignof(T), sizeof(T));
   auto Result = ::new (ptr) T(std::forward<Args>(args)...);
   return fextl::unique_ptr<T>(Result);
 }


### PR DESCRIPTION
We can just use the compiler built-in in these cases. std::alignment_of mainly has utility in metaprogramming.