### PR TITLE
Core/Thunks: Remove unused IR header/forward declarations

### DIFF
--- a/FEXCore/include/FEXCore/Core/Thunks.h
+++ b/FEXCore/include/FEXCore/Core/Thunks.h
@@ -7,18 +7,6 @@ $end_info$
 
 #pragma once
 
-#include <FEXCore/fextl/memory.h>
-#include <FEXCore/fextl/vector.h>
-#include <FEXCore/IR/IR.h>
-
-namespace FEXCore::Context {
-class Context;
-}
-
-namespace FEXCore::Core {
-struct InternalThreadState;
-}
-
 namespace FEXCore::IR {
 struct SHA256Sum;
 }
@@ -28,7 +16,7 @@ typedef void ThunkedFunction(void* ArgsRv);
 
 class ThunkHandler {
 public:
+  virtual ~ThunkHandler() = default;
   virtual ThunkedFunction* LookupThunk(const IR::SHA256Sum& sha256) = 0;
-  virtual ~ThunkHandler() {}
 };
-}; // namespace FEXCore
+} // namespace FEXCore

--- a/Source/Tools/LinuxEmulation/Thunks.h
+++ b/Source/Tools/LinuxEmulation/Thunks.h
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
+#pragma once
+
 #include <FEXCore/Core/Thunks.h>
 #include <FEXCore/fextl/memory.h>
+#include <FEXCore/IR/IR.h>
 
 #include <span>
 


### PR DESCRIPTION
Moves the IR include into one of the more specific headers, which avoids dumping the IR header into any core bits that use the interface.

Also uncovered a missing header guard.