### PR TITLE
Fix mapping for VS and VC condition codes

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -244,10 +244,10 @@ private:
     case FEXCore::IR::COND_FGE: return ARMEmitter::Condition::CC_GE;
     case FEXCore::IR::COND_FLEU: return ARMEmitter::Condition::CC_LE;
     case FEXCore::IR::COND_FGT: return ARMEmitter::Condition::CC_GT;
-    case FEXCore::IR::COND_FU: return ARMEmitter::Condition::CC_VS;
-    case FEXCore::IR::COND_FNU: return ARMEmitter::Condition::CC_VC;
-    case FEXCore::IR::COND_VS:
-    case FEXCore::IR::COND_VC:
+    case FEXCore::IR::COND_FU:
+    case FEXCore::IR::COND_VS: return ARMEmitter::Condition::CC_VS;
+    case FEXCore::IR::COND_FNU:
+    case FEXCore::IR::COND_VC: return ARMEmitter::Condition::CC_VC;
     case FEXCore::IR::COND_MI: return ARMEmitter::Condition::CC_MI;
     case FEXCore::IR::COND_PL: return ARMEmitter::Condition::CC_PL;
     default: LOGMAN_MSG_A_FMT("Unsupported compare type"); return ARMEmitter::Condition::CC_NV;


### PR DESCRIPTION
This doesn't seem to be generated in-code therefore it's not fixing any existing bug, but fixes the mapping for future uses of the condition code.