### PR TITLE
Config: Remove unused Context.h include

### DIFF
--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <FEXCore/Core/Context.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/EnumOperators.h>
 #include <FEXCore/Utils/EnumUtils.h>
@@ -12,9 +11,12 @@
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/unordered_map.h>
 
+#include <algorithm>
+#include <array>
 #include <charconv>
+#include <cstdint>
 #include <optional>
-#include <stdint.h>
+#include <type_traits>
 #include <variant>
 
 namespace FEXCore::Config {

--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -6,6 +6,9 @@
 #include <Common/FileFormatCheck.h>
 #include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/map.h>
+#include <FEXCore/fextl/string.h>
+#include <FEXCore/fextl/unordered_map.h>
+#include <FEXCore/fextl/vector.h>
 #include <FEXCore/Config/Config.h>
 #include <FEXHeaderUtils/Filesystem.h>
 
@@ -16,6 +19,13 @@
 
 #include <sys/inotify.h>
 #include <poll.h>
+
+#include <charconv>
+#include <cstdlib>
+#include <filesystem>
+#include <stdexcept>
+#include <thread>
+#include <utility>
 
 namespace fextl {
 // Helper to convert a std::filesystem::path to a fextl::string.

--- a/Source/Tools/FEXGetConfig/Main.cpp
+++ b/Source/Tools/FEXGetConfig/Main.cpp
@@ -9,7 +9,8 @@
 #include <FEXCore/fextl/string.h>
 #include <FEXHeaderUtils/Filesystem.h>
 
-#include <stdio.h>
+#include <cstdio>
+#include <filesystem>
 #include <string>
 #include <sys/prctl.h>
 

--- a/Source/Tools/FEXRootFSFetcher/Main.cpp
+++ b/Source/Tools/FEXRootFSFetcher/Main.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <FEXCore/fextl/fmt.h>
 #include <FEXCore/fextl/string.h>
+#include <FEXCore/fextl/vector.h>
 
 #include "Common/cpp-optparse/OptionParser.h"
 #include "Common/JSONPool.h"
@@ -9,11 +10,14 @@
 #include "Common/ArgumentLoader.h"
 #include "Common/Config.h"
 
+#include <array>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <unistd.h>
 #include <optional>
+#include <span>
 #include <sstream>
 #include <sys/mman.h>
 #include <sys/syscall.h>

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -12,11 +12,13 @@
 #include <fmt/color.h>
 
 #include <chrono>
+#include <ctime>
 #include <dirent.h>
 #include <fcntl.h>
 #include <filesystem>
 #include <iterator>
 #include <mutex>
+#include <optional>
 #include <poll.h>
 #include <sys/prctl.h>
 #include <sys/signal.h>


### PR DESCRIPTION
Removes quite a heavy unused include from the config system and specifies any indirect inclusion that were relied on because of it.