### PR TITLE
VDSO_Emulator: Cull unnecessary includes

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -55,6 +55,8 @@ $end_info$
 #include <utility>
 
 #include "LinuxSyscalls/GdbServer.h"
+#include "LinuxSyscalls/Syscalls.h"
+#include "LinuxSyscalls/ThreadManager.h"
 
 namespace FEX {
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -14,25 +14,30 @@ $end_info$
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/fextl/memory.h>
+#include <FEXCore/fextl/string.h>
+#include <FEXCore/fextl/vector.h>
 
 #include <array>
 #include <atomic>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <mutex>
 
 #include <FEXCore/Core/SignalDelegator.h>
 #include <FEXCore/Utils/ArchHelpers/Arm64.h>
 #include <FEXCore/Utils/Telemetry.h>
 
-namespace FEXCore {
-namespace Context {
-  class Context;
+namespace FEXCore::Context {
+class Context;
 }
-namespace Core {
-  struct InternalThreadState;
+namespace FEXCore::Core {
+struct InternalThreadState;
 }
-} // namespace FEXCore
+namespace FEX::HLE {
+enum class SignalEvent : uint32_t;
+struct ThreadStateObject;
+} // namespace FEX::HLE
 
 namespace FEX::HLE {
 using HostSignalDelegatorFunction = std::function<bool(FEXCore::Core::InternalThreadState* Thread, int Signal, void* info, void* ucontext)>;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator/GuestFramesManagement.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator/GuestFramesManagement.cpp
@@ -8,10 +8,18 @@ $end_info$
 
 #include "LinuxSyscalls/SignalDelegator.h"
 
+#include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/SignalDelegator.h>
+#include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/Utils/ArchHelpers/Arm64.h>
-#include <FEXCore/Utils/MathUtils.h>
 #include <FEXCore/Utils/FPState.h>
+#include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/MathUtils.h>
+
+#include <csignal>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 
 namespace FEX::HLE {
 // Total number of layouts that siginfo supports.

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: MIT
 #include "VDSO_Emulation.h"
-#include "FEXCore/IR/IR.h"
+
+#include "LinuxSyscalls/Syscalls.h"
 #include "LinuxSyscalls/x32/Types.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/Context.h>
-#include <FEXCore/Utils/MathUtils.h>
+#include <FEXCore/IR/IR.h>
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/MathUtils.h>
+#include <FEXCore/Utils/SignalScopeGuards.h>
+#include <FEXCore/Utils/TypeDefines.h>
 #include <FEXCore/fextl/fmt.h>
+#include <FEXCore/fextl/map.h>
 #include <FEXHeaderUtils/Syscalls.h>
 
 #include <array>

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.h
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.h
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MIT
 #pragma once
-#include <FEXCore/IR/IR.h>
-#include <FEXCore/fextl/vector.h>
 
-#include "LinuxSyscalls/Syscalls.h"
+#include <FEXCore/IR/IR.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+namespace FEX::HLE {
+class SyscallHandler;
+}
 
 namespace FEX::VDSO {
-using MapperFn = std::function<void*(void* addr, size_t length, int prot, int flags, int fd, off_t offset)>;
 struct VDSOMapping {
   void* VDSOBase {};
   size_t VDSOSize {};


### PR DESCRIPTION
Reveals a bunch of indirect includes inside the SignalDelegator.