### PR TITLE
IR: Remove unnecessary forward declarations/headers

### DIFF
--- a/FEXCore/Source/Interface/IR/IR.h
+++ b/FEXCore/Source/Interface/IR/IR.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/ThreadPoolAllocator.h>
 #include <FEXCore/IR/IR.h>
 

--- a/FEXCore/include/FEXCore/IR/IR.h
+++ b/FEXCore/include/FEXCore/IR/IR.h
@@ -1,22 +1,12 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <FEXCore/Utils/CompilerDefs.h>
-#include <FEXCore/Utils/EnumUtils.h>
-#include <FEXCore/Utils/ThreadPoolAllocator.h>
-#include <FEXCore/fextl/memory.h>
-#include <FEXCore/fextl/sstream.h>
 #include <FEXCore/Utils/EnumOperators.h>
 
 #include <cstdint>
 #include <cstring>
 
-#include <fmt/format.h>
-
 namespace FEXCore::IR {
-
-class OrderedNode;
-class RegisterAllocationPass;
 
 enum class SyscallFlags : uint8_t {
   DEFAULT = 0,

--- a/Source/Tools/CommonTools/DummyHandlers.h
+++ b/Source/Tools/CommonTools/DummyHandlers.h
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 #pragma once
+
 #include <FEXCore/Core/SignalDelegator.h>
 #include <FEXCore/HLE/SyscallHandler.h>
+#include <FEXCore/Utils/AllocatorHooks.h>
+
+#include <FEXCore/fextl/memory.h>
 
 namespace FEX::DummyHandlers {
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -20,6 +20,7 @@ $end_info$
 #include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/IR/IR.h>
+#include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/Event.h>
 
 #include <FEXHeaderUtils/Syscalls.h>

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -7,6 +7,7 @@
 #include "LinuxSyscalls/Seccomp/SeccompEmulator.h"
 
 #include <FEXHeaderUtils/Syscalls.h>
+#include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/Profiler.h>
 #include <FEXCore/fextl/fmt.h>
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.cpp
@@ -3,6 +3,7 @@
 #include "LinuxSyscalls/Syscalls.h"
 
 #include <FEXCore/Core/Context.h>
+#include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/Threads.h>
 
 namespace FEX::LinuxEmulation::Threads {


### PR DESCRIPTION
Pares the base IR header down to a modest size and also reveals a few indirect reliances on the allocator facilities.