### PR TITLE
FileLoading: Add missing self-header

### DIFF
--- a/FEXCore/Source/Utils/FileLoading.cpp
+++ b/FEXCore/Source/Utils/FileLoading.cpp
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+#include <FEXCore/Utils/FileLoading.h>
+
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/vector.h>
 


### PR DESCRIPTION
Ensures that the exposed interface is visible to the implementation (i.e. gets rid of some -Wmissing-declaration warnings).