### PR TITLE
FEXCore/Allocator: Remove unused headers

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -24,6 +24,7 @@ $end_info$
 
 #include <array>
 #include <cstdint>
+#include <functional>
 #include <utility>
 #include <variant>
 

--- a/FEXCore/Source/Interface/IR/IR.h
+++ b/FEXCore/Source/Interface/IR/IR.h
@@ -7,6 +7,8 @@
 #include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/sstream.h>
 
+#include <array>
+
 namespace FEXCore::IR {
 
 class OrderedNode;

--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -3,26 +3,26 @@
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/MathUtils.h>
 #include <FEXCore/Utils/TypeDefines.h>
 #include <FEXCore/fextl/fmt.h>
+#include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/memory_resource.h>
 #include <FEXHeaderUtils/Syscalls.h>
 
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cerrno>
 #include <charconv>
+#include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <fcntl.h>
 #ifndef _WIN32
 #include <sys/mman.h>
 #include <sys/user.h>
 #endif
-
-#include <errno.h>
-#include <memory>
-#include <stddef.h>
-#include <stdint.h>
 
 namespace fextl::pmr {
 static fextl::pmr::default_resource FEXDefaultResource;

--- a/FEXCore/Source/Utils/Allocator/HostAllocator.h
+++ b/FEXCore/Source/Utils/Allocator/HostAllocator.h
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: MIT
 #pragma once
-#include <FEXCore/fextl/allocator.h>
+
 #include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/vector.h>
-#include <FEXCore/Utils/Allocator.h>
 
 #include <cstddef>
 #include <sys/types.h>
 
+namespace FEXCore::Allocator {
+struct MemoryRegion;
+}
 namespace FEXCore::Core {
 struct InternalThreadState;
 }

--- a/FEXCore/include/FEXCore/Utils/Allocator.h
+++ b/FEXCore/include/FEXCore/Utils/Allocator.h
@@ -5,8 +5,6 @@
 #include <FEXCore/fextl/vector.h>
 
 #include <cstdint>
-#include <functional>
-#include <optional>
 #include <sys/types.h>
 
 namespace FEXCore::Core {

--- a/FEXCore/include/FEXCore/Utils/ThreadPoolAllocator.h
+++ b/FEXCore/include/FEXCore/Utils/ThreadPoolAllocator.h
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <atomic>
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/fextl/list.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <mutex>
+#include <optional>
+#include <type_traits>
 
 namespace FEXCore::Utils {
 /**


### PR DESCRIPTION
Reveals some more indirect inclusions.

This just about covers most of the exposed core API