### PR TITLE
Frontend/OpcodeDispatcher: Remove unused headers

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -8,6 +8,8 @@
 #include <FEXCore/Core/CPUID.h>
 #include <FEXCore/Core/HostFeatures.h>
 #include <FEXCore/Core/SignalDelegator.h>
+#include <FEXCore/HLE/SyscallHandler.h>
+
 #include <FEXCore/Core/Thunks.h>
 #include "FEXCore/Debug/InternalThreadState.h"
 

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -4,17 +4,20 @@
 #include "Interface/Core/X86Tables/X86Tables.h"
 #include "Interface/IR/IR.h"
 
-#include <FEXCore/HLE/SyscallHandler.h>
-#include <FEXCore/Utils/Telemetry.h>
+#include <FEXCore/Utils/ThreadPoolAllocator.h>
 #include <FEXCore/fextl/set.h>
 #include <FEXCore/fextl/vector.h>
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
-#include <stddef.h>
+#include <optional>
 
 namespace FEXCore::Context {
 class ContextImpl;
+}
+namespace FEXCore::HLE {
+enum class SyscallOSABI;
 }
 
 namespace FEXCore::Frontend {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -27,8 +27,6 @@
 #include <xxhash.h>
 
 namespace FEXCore::IR {
-class Pass;
-class PassManager;
 
 enum class MemoryAccessType {
   // Choose TSO or Non-TSO depending on access type
@@ -87,9 +85,6 @@ struct DispatchTableEntry {
 };
 
 class OpDispatchBuilder final : public IREmitter {
-  friend class FEXCore::IR::Pass;
-  friend class FEXCore::IR::PassManager;
-
 public:
   Ref GetNewJumpBlock(uint64_t RIP) {
     auto it = JumpTargets.find(RIP);

--- a/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -6,18 +6,20 @@ $end_info$
 */
 
 #pragma once
-#include <FEXCore/Core/Context.h>
 
 #include <FEXCore/Utils/LogManager.h>
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
 namespace FEXCore::IR {
-///< Forward declaration of OpDispatchBuilder
 class OpDispatchBuilder;
 }
 
 namespace FEXCore::X86Tables {
-
-///< Forward declaration of X86InstInfo
 struct X86InstInfo;
 
 namespace DecodeFlags {


### PR DESCRIPTION
Removes assorted unused headers and forward declarations. Forgot to cross this area off.