### PR TITLE
WOW64: Fix CsSeg initialization

### DIFF
--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -595,16 +595,17 @@ void BTCpuProcessInit() {
 void BTCpuProcessTerm(HANDLE Handle, BOOL After, ULONG Status) {}
 
 void BTCpuThreadInit() {
+  static constexpr size_t DefaultWow64CS {4};
   std::scoped_lock Lock(ThreadCreationMutex);
   FEX::Windows::InitCRTThread();
   auto* Thread = CTX->CreateThread(0, 0);
 
   // Default segment setup.
   auto Frame = Thread->CurrentFrame;
-  auto NewSegments = new FEXCore::Core::CPUState::gdt_segment[32];
+  auto NewSegments = new FEXCore::Core::CPUState::gdt_segment[32]();
 
   // Setup initial code-segment GDT
-  auto& GDT = NewSegments[FEXCore::Core::CPUState::DEFAULT_USER_CS];
+  auto& GDT = NewSegments[DefaultWow64CS];
   FEXCore::Core::CPUState::SetGDTBase(&GDT, 0);
   FEXCore::Core::CPUState::SetGDTLimit(&GDT, 0xF'FFFFU);
   GDT.L = 0; // L = Long Mode = 32-bit
@@ -614,7 +615,7 @@ void BTCpuThreadInit() {
   // TODO: LDTs are currently unsupported, mirror them to GDT.
   Frame->State.segment_arrays[FEXCore::Core::CPUState::SEGMENT_ARRAY_INDEX_LDT] = &NewSegments[0];
 
-  Frame->State.cs_idx = FEXCore::Core::CPUState::DEFAULT_USER_CS << 3;
+  Frame->State.cs_idx = DefaultWow64CS << 3;
   Frame->State.cs_cached = FEXCore::Core::CPUState::CalculateGDTBase(GDT);
 
   FEX::Windows::CallRetStack::InitializeThread(Thread);


### PR DESCRIPTION
DEFAULT_USER_CS isn't the default CS segment actually used on wow64