### PR TITLE
OpcodeDispatcher: Don't assert on invalid ALU op encoding

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -273,8 +273,9 @@ void OpDispatchBuilder::SecondaryALUOp(OpcodeArgs) {
   default:
     IROp = FEXCore::IR::IROps::OP_LAST;
     AtomicIROp = FEXCore::IR::IROps::OP_LAST;
-    LOGMAN_MSG_A_FMT("Unknown ALU Op: 0x{:x}", Op->OP);
-    break;
+    LogMan::Msg::EFmt("Unknown ALU Op: 0x{:x}", Op->OP);
+    DecodeFailure = true;
+    return;
   };
 #undef OPD
 


### PR DESCRIPTION
This can be hit in multiblock