### PR TITLE
OpcodeDispatcher: Only flush MMX registers on MMX -> x87 transitions

### DIFF
--- a/unittests/ASM/FEX_bugs/X87MMXNZCV.asm
+++ b/unittests/ASM/FEX_bugs/X87MMXNZCV.asm
@@ -1,0 +1,13 @@
+%ifdef CONFIG
+{
+  "RegData": {},
+  "Env": { "FEX_X87REDUCEDPRECISION" : "1" }
+}
+%endif
+
+; FEX had a bug where a mmx->x87 switch would flush the saved NZCV value used for ftst, causing a crash in RA
+
+movq mm0, mm1 ; enters mmx state
+ftst ; enters x87 state
+
+hlt


### PR DESCRIPTION
This is not necessary, and breaks any ConvertNZCVToX87 use which relies previously saved NZCV values, as the flag-setting NZCV op after the save could trigger a flush of the saved NZCV.

Fixes a crash in the UPlay installer