### PR TITLE
JIT: Check for suspend interrupts at back-edges 

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -406,7 +406,9 @@ private:
                            std::optional<ARMEmitter::VRegister> VectorIndexHigh, ARMEmitter::VRegister MaskReg, IR::OpSize VectorIndexSize,
                            size_t DataElementOffsetStart, size_t IndexElementOffsetStart, uint8_t OffsetScale);
 
-  void EmitInterruptChecks(bool CheckTF);
+  void EmitTFCheck();
+
+  void EmitSuspendInterruptCheck();
 
   void EmitEntryPoint(ARMEmitter::BackwardLabel& HeaderLabel, bool CheckTF);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -209,10 +209,17 @@ public:
   }
 
   static bool CanHaveSideEffects(const FEXCore::X86Tables::X86InstInfo* TableInfo, FEXCore::X86Tables::DecodedOp Op) {
-    if (TableInfo && TableInfo->Flags & X86Tables::InstFlags::FLAGS_DEBUG_MEM_ACCESS) {
-      // If it is marked as having memory access then always say it has a side-effect.
-      // Not always true but better to be safe.
-      return true;
+    if (TableInfo) {
+      if (TableInfo->Flags & X86Tables::InstFlags::FLAGS_DEBUG_MEM_ACCESS) {
+        // If it is marked as having memory access then always say it has a side-effect.
+        // Not always true but better to be safe.
+        return true;
+      }
+
+      if (TableInfo->Flags & (X86Tables::InstFlags::FLAGS_SETS_RIP | X86Tables::InstFlags::FLAGS_BLOCK_END)) {
+        // Cooperative suspend interrupts can be triggered at any back-edge, the RIP must be reconstructed correctly in such cases
+        return true;
+      }
     }
 
     auto CanHaveSideEffects = false;


### PR DESCRIPTION
Avoids most cases where an infinite loop could lead to suspend interrupts never getting checked. Conditional jumps and indirect jumps are currently not treated as suspend points due to context reconstruction issues, but this is enough to get ubisoft games launching (they do a jmp +0 infloop, which uplay intercepts).