### PR TITLE
unittests: Remove FEXLoader usage from unittests

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -34,7 +34,6 @@ jobs:
         echo "FEX_ROOTFS_MOUNT=/mnt/AutoNFS/rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS_PATH=$HOME/Rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
-        echo "ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -41,7 +41,6 @@ jobs:
         echo "FEX_ROOTFS_MOUNT=/mnt/AutoNFS/rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS_PATH=$HOME/Rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
-        echo "ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/hostrunner.yml
+++ b/.github/workflows/hostrunner.yml
@@ -34,7 +34,6 @@ jobs:
         echo "FEX_ROOTFS_MOUNT=/mnt/AutoNFS/rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS_PATH=$HOME/Rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
-        echo "ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -33,7 +33,6 @@ jobs:
         echo "FEX_ROOTFS_MOUNT=/mnt/AutoNFS/rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS_PATH=$HOME/Rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
-        echo "ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/mingw_build.yml
+++ b/.github/workflows/mingw_build.yml
@@ -48,7 +48,6 @@ jobs:
         echo "FEX_ROOTFS_MOUNT=/mnt/AutoNFS/rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS_PATH=$HOME/Rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
-        echo "ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -35,7 +35,6 @@ jobs:
         echo "FEX_ROOTFS_MOUNT=/mnt/AutoNFS/rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS_PATH=$HOME/Rootfs/" >> $GITHUB_ENV
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
-        echo "ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
       # Use a bash shell so we can use the same syntax for environment variable

--- a/Scripts/guest_test_runner.py
+++ b/Scripts/guest_test_runner.py
@@ -10,11 +10,6 @@ def DoesFEXSupportAVX(mode):
 
     args = list()
     args.append(fex_interpreter_path)
-    if (mode == "guest"):
-        ROOTFS_ENV = os.getenv("ROOTFS")
-        if ROOTFS_ENV != None:
-            args.append("-R")
-            args.append(ROOTFS_ENV)
     args.append('/bin/cat')
     args.append('/proc/cpuinfo')
 
@@ -109,12 +104,6 @@ flake_tests = LoadTestsFile(flake_tests_file)
 RunnerArgs = []
 
 RunnerArgs.append(fexecutable)
-
-if (mode == "guest"):
-    ROOTFS_ENV = os.getenv("ROOTFS")
-    if ROOTFS_ENV != None:
-        RunnerArgs.append("-R")
-        RunnerArgs.append(ROOTFS_ENV)
 
 # Add the rest of the arguments
 for i in range(len(sys.argv) - StartingFEXArgsOffset):

--- a/unittests/APITests/StringUtils.cpp
+++ b/unittests/APITests/StringUtils.cpp
@@ -5,78 +5,78 @@ using namespace FEXCore::StringUtils;
 
 TEST_CASE("ltrim") {
   CHECK(LeftTrim("") == "");
-  CHECK(LeftTrim("FEXLoader") == "FEXLoader");
+  CHECK(LeftTrim("FEXInterpreter") == "FEXInterpreter");
 
-  CHECK(LeftTrim("FEXLoader\n") == "FEXLoader\n");
-  CHECK(LeftTrim("FEXLoader\r") == "FEXLoader\r");
-  CHECK(LeftTrim("FEXLoader\f") == "FEXLoader\f");
-  CHECK(LeftTrim("FEXLoader\t") == "FEXLoader\t");
-  CHECK(LeftTrim("FEXLoader\v") == "FEXLoader\v");
-  CHECK(LeftTrim("FEXLoader ") == "FEXLoader ");
+  CHECK(LeftTrim("FEXInterpreter\n") == "FEXInterpreter\n");
+  CHECK(LeftTrim("FEXInterpreter\r") == "FEXInterpreter\r");
+  CHECK(LeftTrim("FEXInterpreter\f") == "FEXInterpreter\f");
+  CHECK(LeftTrim("FEXInterpreter\t") == "FEXInterpreter\t");
+  CHECK(LeftTrim("FEXInterpreter\v") == "FEXInterpreter\v");
+  CHECK(LeftTrim("FEXInterpreter ") == "FEXInterpreter ");
 
-  CHECK(LeftTrim("\nFEXLoader") == "FEXLoader");
-  CHECK(LeftTrim("\rFEXLoader") == "FEXLoader");
-  CHECK(LeftTrim("\fFEXLoader") == "FEXLoader");
-  CHECK(LeftTrim("\tFEXLoader") == "FEXLoader");
-  CHECK(LeftTrim("\vFEXLoader") == "FEXLoader");
-  CHECK(LeftTrim(" FEXLoader") == "FEXLoader");
+  CHECK(LeftTrim("\nFEXInterpreter") == "FEXInterpreter");
+  CHECK(LeftTrim("\rFEXInterpreter") == "FEXInterpreter");
+  CHECK(LeftTrim("\fFEXInterpreter") == "FEXInterpreter");
+  CHECK(LeftTrim("\tFEXInterpreter") == "FEXInterpreter");
+  CHECK(LeftTrim("\vFEXInterpreter") == "FEXInterpreter");
+  CHECK(LeftTrim(" FEXInterpreter") == "FEXInterpreter");
 
-  CHECK(LeftTrim("\nFEXLoader\n") == "FEXLoader\n");
-  CHECK(LeftTrim("\rFEXLoader\r") == "FEXLoader\r");
-  CHECK(LeftTrim("\fFEXLoader\f") == "FEXLoader\f");
-  CHECK(LeftTrim("\tFEXLoader\t") == "FEXLoader\t");
-  CHECK(LeftTrim("\vFEXLoader\v") == "FEXLoader\v");
-  CHECK(LeftTrim(" FEXLoader ") == "FEXLoader ");
+  CHECK(LeftTrim("\nFEXInterpreter\n") == "FEXInterpreter\n");
+  CHECK(LeftTrim("\rFEXInterpreter\r") == "FEXInterpreter\r");
+  CHECK(LeftTrim("\fFEXInterpreter\f") == "FEXInterpreter\f");
+  CHECK(LeftTrim("\tFEXInterpreter\t") == "FEXInterpreter\t");
+  CHECK(LeftTrim("\vFEXInterpreter\v") == "FEXInterpreter\v");
+  CHECK(LeftTrim(" FEXInterpreter ") == "FEXInterpreter ");
 }
 
 TEST_CASE("rtrim") {
   CHECK(RightTrim("") == "");
-  CHECK(RightTrim("FEXLoader") == "FEXLoader");
+  CHECK(RightTrim("FEXInterpreter") == "FEXInterpreter");
 
-  CHECK(RightTrim("FEXLoader\n") == "FEXLoader");
-  CHECK(RightTrim("FEXLoader\r") == "FEXLoader");
-  CHECK(RightTrim("FEXLoader\f") == "FEXLoader");
-  CHECK(RightTrim("FEXLoader\t") == "FEXLoader");
-  CHECK(RightTrim("FEXLoader\v") == "FEXLoader");
-  CHECK(RightTrim("FEXLoader ") == "FEXLoader");
+  CHECK(RightTrim("FEXInterpreter\n") == "FEXInterpreter");
+  CHECK(RightTrim("FEXInterpreter\r") == "FEXInterpreter");
+  CHECK(RightTrim("FEXInterpreter\f") == "FEXInterpreter");
+  CHECK(RightTrim("FEXInterpreter\t") == "FEXInterpreter");
+  CHECK(RightTrim("FEXInterpreter\v") == "FEXInterpreter");
+  CHECK(RightTrim("FEXInterpreter ") == "FEXInterpreter");
 
-  CHECK(RightTrim("\nFEXLoader") == "\nFEXLoader");
-  CHECK(RightTrim("\rFEXLoader") == "\rFEXLoader");
-  CHECK(RightTrim("\fFEXLoader") == "\fFEXLoader");
-  CHECK(RightTrim("\tFEXLoader") == "\tFEXLoader");
-  CHECK(RightTrim("\vFEXLoader") == "\vFEXLoader");
-  CHECK(RightTrim(" FEXLoader") == " FEXLoader");
+  CHECK(RightTrim("\nFEXInterpreter") == "\nFEXInterpreter");
+  CHECK(RightTrim("\rFEXInterpreter") == "\rFEXInterpreter");
+  CHECK(RightTrim("\fFEXInterpreter") == "\fFEXInterpreter");
+  CHECK(RightTrim("\tFEXInterpreter") == "\tFEXInterpreter");
+  CHECK(RightTrim("\vFEXInterpreter") == "\vFEXInterpreter");
+  CHECK(RightTrim(" FEXInterpreter") == " FEXInterpreter");
 
-  CHECK(RightTrim("\nFEXLoader\n") == "\nFEXLoader");
-  CHECK(RightTrim("\rFEXLoader\r") == "\rFEXLoader");
-  CHECK(RightTrim("\fFEXLoader\f") == "\fFEXLoader");
-  CHECK(RightTrim("\tFEXLoader\t") == "\tFEXLoader");
-  CHECK(RightTrim("\vFEXLoader\v") == "\vFEXLoader");
-  CHECK(RightTrim(" FEXLoader ") == " FEXLoader");
+  CHECK(RightTrim("\nFEXInterpreter\n") == "\nFEXInterpreter");
+  CHECK(RightTrim("\rFEXInterpreter\r") == "\rFEXInterpreter");
+  CHECK(RightTrim("\fFEXInterpreter\f") == "\fFEXInterpreter");
+  CHECK(RightTrim("\tFEXInterpreter\t") == "\tFEXInterpreter");
+  CHECK(RightTrim("\vFEXInterpreter\v") == "\vFEXInterpreter");
+  CHECK(RightTrim(" FEXInterpreter ") == " FEXInterpreter");
 }
 
 TEST_CASE("trim") {
   CHECK(Trim("") == "");
-  CHECK(Trim("FEXLoader") == "FEXLoader");
+  CHECK(Trim("FEXInterpreter") == "FEXInterpreter");
 
-  CHECK(Trim("FEXLoader\n") == "FEXLoader");
-  CHECK(Trim("FEXLoader\r") == "FEXLoader");
-  CHECK(Trim("FEXLoader\f") == "FEXLoader");
-  CHECK(Trim("FEXLoader\t") == "FEXLoader");
-  CHECK(Trim("FEXLoader\v") == "FEXLoader");
-  CHECK(Trim("FEXLoader ") == "FEXLoader");
+  CHECK(Trim("FEXInterpreter\n") == "FEXInterpreter");
+  CHECK(Trim("FEXInterpreter\r") == "FEXInterpreter");
+  CHECK(Trim("FEXInterpreter\f") == "FEXInterpreter");
+  CHECK(Trim("FEXInterpreter\t") == "FEXInterpreter");
+  CHECK(Trim("FEXInterpreter\v") == "FEXInterpreter");
+  CHECK(Trim("FEXInterpreter ") == "FEXInterpreter");
 
-  CHECK(Trim("\nFEXLoader") == "FEXLoader");
-  CHECK(Trim("\rFEXLoader") == "FEXLoader");
-  CHECK(Trim("\fFEXLoader") == "FEXLoader");
-  CHECK(Trim("\tFEXLoader") == "FEXLoader");
-  CHECK(Trim("\vFEXLoader") == "FEXLoader");
-  CHECK(Trim(" FEXLoader") == "FEXLoader");
+  CHECK(Trim("\nFEXInterpreter") == "FEXInterpreter");
+  CHECK(Trim("\rFEXInterpreter") == "FEXInterpreter");
+  CHECK(Trim("\fFEXInterpreter") == "FEXInterpreter");
+  CHECK(Trim("\tFEXInterpreter") == "FEXInterpreter");
+  CHECK(Trim("\vFEXInterpreter") == "FEXInterpreter");
+  CHECK(Trim(" FEXInterpreter") == "FEXInterpreter");
 
-  CHECK(Trim("\nFEXLoader\n") == "FEXLoader");
-  CHECK(Trim("\rFEXLoader\r") == "FEXLoader");
-  CHECK(Trim("\fFEXLoader\f") == "FEXLoader");
-  CHECK(Trim("\tFEXLoader\t") == "FEXLoader");
-  CHECK(Trim("\vFEXLoader\v") == "FEXLoader");
-  CHECK(Trim(" FEXLoader ") == "FEXLoader");
+  CHECK(Trim("\nFEXInterpreter\n") == "FEXInterpreter");
+  CHECK(Trim("\rFEXInterpreter\r") == "FEXInterpreter");
+  CHECK(Trim("\fFEXInterpreter\f") == "FEXInterpreter");
+  CHECK(Trim("\tFEXInterpreter\t") == "FEXInterpreter");
+  CHECK(Trim("\vFEXInterpreter\v") == "FEXInterpreter");
+  CHECK(Trim(" FEXInterpreter ") == "FEXInterpreter");
 }

--- a/unittests/FEXLinuxTests/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/CMakeLists.txt
@@ -38,14 +38,11 @@ function(AddTests Tests BinDirectory Bitness)
     set(BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${BinDirectory}/${TEST_NAME}.${Bitness}")
     set(TEST_CASE "${TEST_NAME}.${Bitness}")
 
-    set(THUNK_ARGS "")
     if(TEST_NAME STREQUAL "thunk_testlib")
       # Test thunking only if thunks are enabled and supported
       if(NOT BUILD_THUNKS OR ENABLE_GLIBC_ALLOCATOR_HOOK_FAULT)
         continue()
       endif()
-
-      set(THUNK_ARGS "-k" "${CMAKE_SOURCE_DIR}/Data/CI/FEXLinuxTestsThunks.json")
     endif()
 
     # Add jit test case
@@ -57,10 +54,14 @@ function(AddTests Tests BinDirectory Bitness)
       "${CMAKE_CURRENT_SOURCE_DIR}/Flake_Tests"
       "${TEST_CASE}"
       "guest"
-      "$<TARGET_FILE:FEXLoader>"
-      ${THUNK_ARGS}
-      "-o" "stderr" "--no-silentlog" "-n" "500" "--"
+      "$<TARGET_FILE:FEXInterpreter>"
       "${BIN_PATH}")
+
+    set_property(TEST "${TEST_CASE}.jit.flt" APPEND PROPERTY ENVIRONMENT "FEX_OUTPUTLOG=stderr;FEX_SILENTLOG=0;FEX_MAXINST=500")
+
+    if(TEST_NAME STREQUAL "thunk_testlib")
+      set_property(TEST "${TEST_CASE}.jit.flt" APPEND PROPERTY ENVIRONMENT "FEX_THUNKCONFIG=${CMAKE_SOURCE_DIR}/Data/CI/FEXLinuxTestsThunks.json")
+    endif()
 
     if (_M_X86_64 AND NOT TEST_NAME STREQUAL "thunk_testlib")
       # Add host test case
@@ -89,8 +90,8 @@ AddTests("${TESTS_32_ONLY}" "FEXLinuxTests_32" 32)
 
 if(TEST thunk_testlib.64.jit.flt)
   # Ensure libfex_thunk_test is found even when using an uncommon install prefix
-  set_property(TEST "thunk_testlib.32.jit.flt" PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib")
-  set_property(TEST "thunk_testlib.64.jit.flt" PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib")
+  set_property(TEST "thunk_testlib.32.jit.flt" APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib")
+  set_property(TEST "thunk_testlib.64.jit.flt" APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
 # Only emulated
@@ -99,7 +100,7 @@ add_custom_target(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "30" ${TEST_JOB_FLAG} "-R" "\.*\.jit\.flt$$"
-  DEPENDS FEXLinuxTests FEXLinuxTests_32 FEXLoader
+  DEPENDS FEXLinuxTests FEXLinuxTests_32 FEXInterpreter
   )
 
 # Only host
@@ -117,5 +118,5 @@ add_custom_target(
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "30" ${TEST_JOB_FLAG} "-R" "\.*\.flt$$"
-  DEPENDS FEXLinuxTests FEXLinuxTests_32 FEXLoader
+  DEPENDS FEXLinuxTests FEXLinuxTests_32 FEXInterpreter
   )

--- a/unittests/POSIX/CMakeLists.txt
+++ b/unittests/POSIX/CMakeLists.txt
@@ -17,10 +17,10 @@ foreach(POSIX_TEST ${POSIX_TESTS})
     "${CMAKE_CURRENT_SOURCE_DIR}/Flake_Tests"
     "${TEST_NAME}"
     "guest"
-    "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "-o" "stderr" "--no-silentlog" "-n" "500" "--"
+    "${CMAKE_BINARY_DIR}/Bin/FEXInterpreter"
     "${POSIX_TEST}")
   set_property(TEST "${TEST_NAME}.jit.posix" APPEND PROPERTY SKIP_RETURN_CODE 125)
+  set_property(TEST "${TEST_NAME}.jit.posix" APPEND PROPERTY ENVIRONMENT "FEX_OUTPUTLOG=stderr;FEX_SILENTLOG=0;FEX_MAXINST=500")
 endforeach()
 
 add_custom_target(

--- a/unittests/Readme.md
+++ b/unittests/Readme.md
@@ -7,10 +7,10 @@ We also regularly run and pass qemu's and valgrind's tests for validation, but t
 ## x86/64 testing
 - A lot of handwritten assembly unit tests in [32Bit_ASM](32Bit_ASM) and [ASM](ASM) folders, run via our TestHarnessHelper
 - A few handwritten IR tests in [IR](IR), run via our IRLoader
-- gcc-target-tests-32 and gcc-target-tests-64, run via FEXLoader. The tests binaries are in [External/fex-gcc-target-tests-bins](../External/fex-gcc-target-tests-bins)
+- gcc-target-tests-32 and gcc-target-tests-64, run via FEXInterpreter. The tests binaries are in [External/fex-gcc-target-tests-bins](../External/fex-gcc-target-tests-bins)
 
 
 ## Syscall testing
-- 64-bit posixtest from http://posixtest.sourceforge.net/, run via FEXLoader. The tests binaries are in [External/fex-posixtest-bins](../External/fex-posixtest-bins)
-- 64-bit gvisor tests from https://github.com/google/gvisor, run via FEXLoader. The tests binaries are in [External/fex-gvisor-tests-bins](../External/fex-gvisor-tests-bins)
+- 64-bit posixtest from http://posixtest.sourceforge.net/, run via FEXInterpreter. The tests binaries are in [External/fex-posixtest-bins](../External/fex-posixtest-bins)
+- 64-bit gvisor tests from https://github.com/google/gvisor, run via FEXInterpreter. The tests binaries are in [External/fex-gvisor-tests-bins](../External/fex-gvisor-tests-bins)
 

--- a/unittests/ThunkFunctionalTests/CMakeLists.txt
+++ b/unittests/ThunkFunctionalTests/CMakeLists.txt
@@ -1,26 +1,22 @@
 set(FUNCTIONAL_DEPENDS "")
 
 function(AddThunksTest Bin ThunksFile)
-  set (ARGS
-    "-t" "${HOSTLIBS_DATA_DIRECTORY}/HostThunks"
-    "-j" "${CMAKE_INSTALL_PREFIX}/share/fex-emu/GuestThunks"
-    "-o" "stderr" "--no-silentlog" "-n" "500"
-    )
   if (NOT ThunksFile)
     set (TEST_NAME ThunkFunctionalTest-NoThunks-${Bin})
   else()
     set (TEST_NAME ThunkFunctionalTest-Thunks-${Bin})
-    list (APPEND ARGS
-      "-k" "${CMAKE_SOURCE_DIR}/Data/CI/${ThunksFile}")
   endif()
 
   add_test(NAME ${TEST_NAME}
-    COMMAND "$<TARGET_FILE:FEXLoader>"
-    ${ARGS}
-    "--"
+    COMMAND "$<TARGET_FILE:FEXInterpreter>"
     ${Bin})
     set_property(TEST ${TEST_NAME} APPEND PROPERTY DEPENDS "${Bin}")
+    set_property(TEST "${TEST_NAME}" APPEND PROPERTY ENVIRONMENT
+      "FEX_OUTPUTLOG=stderr;FEX_SILENTLOG=0;FEX_MAXINST=500;FEX_THUNKHOSTLIBS=${HOSTLIBS_DATA_DIRECTORY}/HostThunks;FEX_THUNKGUESTLIBS=${CMAKE_INSTALL_PREFIX}/share/fex-emu/GuestThunks")
 
+    if (ThunksFile)
+      set_property(TEST "${TEST_NAME}" APPEND PROPERTY ENVIRONMENT "FEX_THUNKCONFIG=${CMAKE_SOURCE_DIR}/Data/CI/${ThunksFile}")
+    endif()
   list(APPEND FUNCTIONAL_DEPENDS "${TEST_NAME}")
 endfunction()
 

--- a/unittests/gcc-target-tests-32/CMakeLists.txt
+++ b/unittests/gcc-target-tests-32/CMakeLists.txt
@@ -7,13 +7,13 @@ foreach(TEST ${TESTS})
   # Extract test file name
   string(REPLACE "/fex-gcc-target-tests-bins/32/" ";" TEST_NAME_LIST ${TEST})
   list(GET TEST_NAME_LIST 1 TEST_FILE_NAME)
-  
+
   # Loop over block sizes
   foreach(BLOCK_SIZE 500 1)
     # Create TEST_NAME from TEST_FILE_NAME
     string(REPLACE "/" "-" TEST_NAME ${TEST_FILE_NAME})
     string(APPEND TEST_NAME ".n${BLOCK_SIZE}.gcc-target-32")
-    
+
     add_test(NAME "${TEST_NAME}"
       COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/guest_test_runner.py"
       "${CMAKE_CURRENT_SOURCE_DIR}/Known_Failures"
@@ -22,10 +22,10 @@ foreach(TEST ${TESTS})
       "${CMAKE_CURRENT_SOURCE_DIR}/Flake_Tests"
       "${TEST_NAME}"
       "guest"
-      "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-      "-o" "stderr" "--no-silentlog" "-n" "${BLOCK_SIZE}" "--"
+      "${CMAKE_BINARY_DIR}/Bin/FEXInterpreter"
       "${TEST}")
     set_property(TEST "${TEST_NAME}" APPEND PROPERTY SKIP_RETURN_CODE 125)
+    set_property(TEST "${TEST_NAME}" APPEND PROPERTY ENVIRONMENT "FEX_OUTPUTLOG=stderr;FEX_SILENTLOG=0;FEX_MAXINST=${BLOCK_SIZE}")
   endforeach()
 endforeach()
 

--- a/unittests/gcc-target-tests-64/CMakeLists.txt
+++ b/unittests/gcc-target-tests-64/CMakeLists.txt
@@ -22,10 +22,10 @@ foreach(TEST ${TESTS})
       "${CMAKE_CURRENT_SOURCE_DIR}/Flake_Tests"
       "${TEST_NAME}"
       "guest"
-      "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-      "-o" "stderr" "--no-silentlog" "-n" "${BLOCK_SIZE}" "--"
+      "${CMAKE_BINARY_DIR}/Bin/FEXInterpreter"
       "${TEST}")
     set_property(TEST "${TEST_NAME}" APPEND PROPERTY SKIP_RETURN_CODE 125)
+    set_property(TEST "${TEST_NAME}" APPEND PROPERTY ENVIRONMENT "FEX_OUTPUTLOG=stderr;FEX_SILENTLOG=0;FEX_MAXINST=${BLOCK_SIZE}")
   endforeach()
 endforeach()
 

--- a/unittests/gvisor-tests/CMakeLists.txt
+++ b/unittests/gvisor-tests/CMakeLists.txt
@@ -17,13 +17,13 @@ foreach(TEST ${TESTS})
     "${CMAKE_CURRENT_SOURCE_DIR}/Flake_Tests"
     "${TEST_NAME}"
     "guest"
-    "${CMAKE_BINARY_DIR}/Bin/FEXLoader"
-    "-o" "stderr" "--no-silentlog" "-n" "500" "--"
+    "${CMAKE_BINARY_DIR}/Bin/FEXInterpreter"
     "${TEST}")
   set_property(TEST "${TEST_NAME}.jit.gvisor" APPEND PROPERTY SKIP_RETURN_CODE 125)
+  set_property(TEST "${TEST_NAME}.jit.gvisor" APPEND PROPERTY ENVIRONMENT "FEX_OUTPUTLOG=stderr;FEX_SILENTLOG=0;FEX_MAXINST=500")
 endforeach()
 
-set(RM_DIR_COMMAND "rm $ENV{ROOTFS}/tmp 2> /dev/null || true")
+set(RM_DIR_COMMAND "rm $ENV{FEX_ROOTFS}/tmp 2> /dev/null || true")
 
 add_custom_target(
   gvisor_tests


### PR DESCRIPTION
Use FEXInterpreter directly and pass FEX options through environment variables.