### PR TITLE
FEXServer: Remove usage of ArgLoader

### DIFF
--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -135,8 +135,7 @@ int main(int argc, char** argv, char** const envp) {
     DeparentSelf();
   }
 
-  auto ArgsLoader = fextl::make_unique<FEX::ArgLoader::ArgLoader>(FEX::ArgLoader::ArgLoader::LoadType::WITHOUT_FEXLOADER_PARSER, argc, argv);
-  FEX::Config::LoadConfig(std::move(ArgsLoader), {}, envp, FEX::ReadPortabilityInformation());
+  FEX::Config::LoadConfig({}, {}, envp, FEX::ReadPortabilityInformation());
 
   // Reload the meta layer
   FEXCore::Config::ReloadMetaLayer();


### PR DESCRIPTION
This is entirely unused as FEXServer only ever reads the environment and other configs.

There was /technically/ a weird conflict with FEXServer arguments but that was an accident if it ever happened.