### PR TITLE
TestHarnessRunner: Removes ArgumentLoader

### DIFF
--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -17,7 +17,6 @@ $end_info$
 #include "LinuxSyscalls/SignalDelegator.h"
 #endif
 
-#include "Common/ArgumentLoader.h"
 #include "Common/HostFeatures.h"
 #include "HarnessHelpers.h"
 #include "TestHarnessRunner/HostRunner.h"
@@ -198,20 +197,16 @@ int main(int argc, char** argv, char** const envp) {
 
   FEX::Config::InitializeConfigs(FEX::Config::PortableInformation {});
   FEXCore::Config::Initialize();
-  auto ArgsLoader = fextl::make_unique<FEX::ArgLoader::ArgLoader>(FEX::ArgLoader::ArgLoader::LoadType::WITH_FEXLOADER_PARSER, argc, argv);
-  auto Args = ArgsLoader->Get();
-  FEXCore::Config::AddLayer(std::move(ArgsLoader));
   FEXCore::Config::AddLayer(FEX::Config::CreateEnvironmentLayer(envp));
   FEXCore::Config::Load();
 
-
-  if (Args.size() < 2) {
+  if (argc < 3) {
     LogMan::Msg::EFmt("Not enough arguments");
     return -1;
   }
 
-  auto Filename = Args[0];
-  auto ConfigFile = Args[1];
+  auto Filename = argv[1];
+  auto ConfigFile = argv[2];
 
   if (!FHU::Filesystem::Exists(Filename)) {
     LogMan::Msg::EFmt("File {} does not exist", Filename);

--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -51,9 +51,9 @@ foreach(ASM_SRC ${ASM_SOURCES})
   set(TEST_ARGS)
   if (_M_ARM_64 OR ENABLE_VIXL_SIMULATOR)
     list(APPEND TEST_ARGS
-      "--no-silentlog -g -n 1   --no-multiblock --no-tsoenabled"   "jit_1"     "jit"
-      "--no-silentlog -g -n 500 --no-multiblock --no-tsoenabled"   "jit_500"   "jit"
-      "--no-silentlog -g -n 500 --multiblock    --no-tsoenabled"      "jit_500_m" "jit"
+      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=1 FEX_MULTIBLOCK=0 FEX_TSOENABLED=0"   "jit_1"     "jit"
+      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=500 FEX_MULTIBLOCK=0 FEX_TSOENABLED=0" "jit_500"   "jit"
+      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=500 FEX_MULTIBLOCK=1 FEX_TSOENABLED=0" "jit_500_m" "jit"
       )
   endif()
 
@@ -61,7 +61,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
     set(CPU_CLASS Simulator)
   elseif (_M_X86_64)
     list(APPEND TEST_ARGS
-      "--no-silentlog -g"       "host"      "host"
+      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1" "host" "host"
       )
   endif()
 
@@ -77,12 +77,12 @@ foreach(ASM_SRC ${ASM_SOURCES})
     math(EXPR TEST_NAME_INDEX "${Index}+1")
     math(EXPR TEST_TYPE_INDEX "${Index}+2")
 
-    list(GET TEST_ARGS ${Index} ARGS)
+    list(GET TEST_ARGS ${Index} FEX_ARGS)
     list(GET TEST_ARGS ${TEST_NAME_INDEX} TEST_DESC)
     list(GET TEST_ARGS ${TEST_TYPE_INDEX} TEST_TYPE)
 
     set(TEST_NAME "${TEST_DESC}/Test_32Bit_${REL_TEST_ASM}")
-    string(REPLACE " " ";" ARGS_LIST ${ARGS})
+    string(REPLACE " " ";" FEX_ARGS_LIST ${FEX_ARGS})
     add_test(NAME ${TEST_NAME}
       COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/testharness_runner.py"
       "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Known_Failures"
@@ -92,8 +92,6 @@ foreach(ASM_SRC ${ASM_SOURCES})
       "${CMAKE_SOURCE_DIR}/unittests/32Bit_ASM/Disabled_Tests_${CPU_CLASS}"
       "Test_32Bit_${REL_TEST_ASM}"
       ${LAUNCH_PROGRAM}
-      ${ARGS_LIST}
-      "--"
       "${OUTPUT_NAME}" "${OUTPUT_CONFIG_NAME}")
     # This will cause the ASM tests to fail if it can't find the TestHarness or ASMN files
     # Prety crap way to work around the fact that tests can't have a build dependency in a different directory
@@ -102,9 +100,10 @@ foreach(ASM_SRC ${ASM_SOURCES})
     set_property(TEST ${TEST_NAME} APPEND PROPERTY DEPENDS "${OUTPUT_NAME}")
     set_property(TEST ${TEST_NAME} APPEND PROPERTY DEPENDS "${OUTPUT_CONFIG_NAME}")
     set_property(TEST ${TEST_NAME} APPEND PROPERTY SKIP_RETURN_CODE 125)
+    set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT ${FEX_ARGS_LIST})
     if (MINGW_BUILD)
       # Ensure the DOS region can be allocated.
-      set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "WINEPRELOADRESERVE=10000-110000")
+      set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT "WINEPRELOADRESERVE=10000-110000")
     endif()
   endforeach()
 

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -53,9 +53,9 @@ foreach(ASM_SRC ${ASM_SOURCES})
   set(TEST_ARGS)
   if (_M_ARM_64 OR ENABLE_VIXL_SIMULATOR)
     list(APPEND TEST_ARGS
-      "--no-silentlog -g -n 1   --no-multiblock --no-tsoenabled"   "jit_1"     "jit"
-      "--no-silentlog -g -n 500 --no-multiblock --no-tsoenabled"   "jit_500"   "jit"
-      "--no-silentlog -g -n 500 --multiblock    --no-tsoenabled"      "jit_500_m" "jit"
+      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=1 FEX_MULTIBLOCK=0 FEX_TSOENABLED=0"   "jit_1"     "jit"
+      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=500 FEX_MULTIBLOCK=0 FEX_TSOENABLED=0" "jit_500"   "jit"
+      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=500 FEX_MULTIBLOCK=1 FEX_TSOENABLED=0" "jit_500_m" "jit"
       )
   endif()
 
@@ -63,7 +63,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
     set(CPU_CLASS Simulator)
   elseif (_M_X86_64)
     list(APPEND TEST_ARGS
-      "--no-silentlog -g"       "host"      "host"
+      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1" "host" "host"
       )
   endif()
 
@@ -79,15 +79,15 @@ foreach(ASM_SRC ${ASM_SOURCES})
     math(EXPR TEST_NAME_INDEX "${Index}+1")
     math(EXPR TEST_TYPE_INDEX "${Index}+2")
 
-    list(GET TEST_ARGS ${Index} ARGS)
+    list(GET TEST_ARGS ${Index} FEX_ARGS)
     list(GET TEST_ARGS ${TEST_NAME_INDEX} TEST_DESC)
     list(GET TEST_ARGS ${TEST_TYPE_INDEX} TEST_TYPE)
 
     set(TEST_NAME "${TEST_DESC}/Test_64Bit_${REL_TEST_ASM}")
-    string(REPLACE " " ";" ARGS_LIST ${ARGS})
+    string(REPLACE " " ";" FEX_ARGS_LIST ${FEX_ARGS})
 
     if (TEST_NAME MATCHES "SelfModifyingCode")
-      list(APPEND ARGS_LIST "--smcchecks=full")
+      list(APPEND FEX_ARGS_LIST "FEX_SMCCHECKS=full")
     endif()
 
     add_test(NAME ${TEST_NAME}
@@ -99,8 +99,6 @@ foreach(ASM_SRC ${ASM_SOURCES})
       "${CMAKE_SOURCE_DIR}/unittests/ASM/Disabled_Tests_${CPU_CLASS}"
       "Test_${REL_TEST_ASM}"
       ${LAUNCH_PROGRAM}
-      ${ARGS_LIST}
-      "--"
       "${OUTPUT_NAME}" "${OUTPUT_CONFIG_NAME}")
     # This will cause the ASM tests to fail if it can't find the TestHarness or ASMN files
     # Prety crap way to work around the fact that tests can't have a build dependency in a different directory
@@ -109,9 +107,10 @@ foreach(ASM_SRC ${ASM_SOURCES})
     set_property(TEST ${TEST_NAME} APPEND PROPERTY DEPENDS "${OUTPUT_NAME}")
     set_property(TEST ${TEST_NAME} APPEND PROPERTY DEPENDS "${OUTPUT_CONFIG_NAME}")
     set_property(TEST ${TEST_NAME} APPEND PROPERTY SKIP_RETURN_CODE 125)
+    set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT ${FEX_ARGS_LIST})
     if (MINGW_BUILD)
       # Ensure the DOS region can be allocated.
-      set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "WINEPRELOADRESERVE=10000-110000")
+      set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT "WINEPRELOADRESERVE=10000-110000")
     endif()
   endforeach()
 


### PR DESCRIPTION
Only use environment variables for setting arguments here.