### PR TITLE
Interface/Context: Remove unnecessary headers/forward declarations

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.cpp
+++ b/FEXCore/Source/Interface/Context/Context.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include "Interface/Context/Context.h"
 #include "Interface/Core/OpcodeDispatcher.h"
+#include "Interface/Core/Dispatcher/Dispatcher.h"
 #include "Interface/Core/X86Tables/X86Tables.h"
 
 #include <FEXCore/Core/CoreState.h>

--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -5,52 +5,45 @@
 #include "Interface/Core/CPUBackend.h"
 #include "Interface/Core/CPUID.h"
 #include "Interface/Core/X86HelperGen.h"
-#include "Interface/Core/Dispatcher/Dispatcher.h"
-#include <Interface/Core/JIT/DebugData.h>
 #include <Interface/IR/IntrusiveIRList.h>
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Core/HostFeatures.h>
-#include <FEXCore/Core/SignalDelegator.h>
-#include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/IR/IR.h>
 #include <FEXCore/Utils/CompilerDefs.h>
-#include <FEXCore/Utils/Event.h>
 #include <FEXCore/Utils/SignalScopeGuards.h>
 #include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/set.h>
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/unordered_map.h>
 #include <FEXCore/fextl/vector.h>
-#include <FEXHeaderUtils/Syscalls.h>
-#include <stdint.h>
 
 #include <atomic>
+#include <cstddef>
+#include <cstdint>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 
 namespace FEXCore {
-class CodeLoader;
+class SignalDelegator;
 class ThunkHandler;
 
+namespace Core {
+  struct DebugData;
+  struct InternalThreadState;
+} // namespace Core
+
 namespace CPU {
-  class Arm64JITCore;
   class Dispatcher;
 } // namespace CPU
+
 namespace HLE {
-  struct SyscallArguments;
-  class SyscallHandler;
   class SourcecodeResolver;
-  struct SourcecodeMap;
+  class SyscallHandler;
 } // namespace HLE
 } // namespace FEXCore
-
-namespace FEXCore::IR {
-namespace Validation {
-  class IRValidation;
-}
-} // namespace FEXCore::IR
 
 namespace FEXCore::Context {
 struct FEX_PACKED ExitFunctionLinkData {
@@ -190,13 +183,6 @@ public:
   void MarkMonoBackpatcherBlock(uint64_t BlockEntry) override;
 
 public:
-  friend class FEXCore::HLE::SyscallHandler;
-#ifdef JIT_ARM64
-  friend class FEXCore::CPU::Arm64JITCore;
-#endif
-
-  friend class FEXCore::IR::Validation::IRValidation;
-
   struct {
     uint64_t VirtualMemSize {1ULL << 36};
     uint64_t TSCScale = 0;

--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -17,6 +17,7 @@
 #include <FEXCore/Utils/Event.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/MathUtils.h>
+#include <FEXHeaderUtils/Syscalls.h>
 
 #include <CodeEmitter/Emitter.h>
 

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -12,14 +12,13 @@ $end_info$
 */
 
 #include "Common/SoftFloat.h"
-#include "FEXCore/Utils/Telemetry.h"
-#include "FEXCore/Utils/TypeDefines.h"
+
 #include "Interface/Context/Context.h"
 #include "Interface/Core/LookupCache.h"
-
 #include "Interface/Core/Dispatcher/Dispatcher.h"
+#include "Interface/Core/Interpreter/InterpreterOps.h"
+#include "Interface/Core/JIT/DebugData.h"
 #include "Interface/Core/JIT/JITClass.h"
-
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
 
 #include "Utils/MemberFunctionToPointer.h"
@@ -30,15 +29,16 @@ $end_info$
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/EnumUtils.h>
+#include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/Profiler.h>
+#include <FEXCore/Utils/Telemetry.h>
+#include <FEXCore/Utils/TypeDefines.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 
-#include "Interface/Core/Interpreter/InterpreterOps.h"
-
-#include <stdio.h>
-#include <unistd.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <limits>
+#include <unistd.h>
 
 namespace {
 struct DivRem {

--- a/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
@@ -10,10 +10,11 @@ $end_info$
 #endif
 
 #include "Interface/Context/Context.h"
+#include "Interface/Core/JIT/DebugData.h"
 #include "Interface/Core/JIT/JITClass.h"
-#include "FEXCore/Debug/InternalThreadState.h"
 
 #include <FEXCore/Core/SignalDelegator.h>
+#include <FEXCore/Debug/InternalThreadState.h>
 
 namespace FEXCore::CPU {
 


### PR DESCRIPTION
Does a minor sweep of the last main interface header