### PR TITLE
unittests/ASM: Fixes xlat test so it can be run

### DIFF
--- a/unittests/ASM/Disabled_Tests
+++ b/unittests/ASM/Disabled_Tests
@@ -1,6 +1,3 @@
-# Not supported in userspace in all cases
-Test_Primary/Primary_D7.asm
-
 # Can't test this in a real environment
 Test_Primary/Primary_E8.asm
 Test_Primary/Primary_E9.asm

--- a/unittests/ASM/Primary/Primary_D7.asm
+++ b/unittests/ASM/Primary/Primary_D7.asm
@@ -8,6 +8,12 @@
 }
 %endif
 
+; Save FS/GS
+rdfsbase rax
+mov [rel .data_backup], rax
+rdgsbase rax
+mov [rel .data_backup + 8], rax
+
 mov rbx, 0xe0000000
 lea r9, [rbx + 8 * 1]
 wrfsbase r9
@@ -38,4 +44,14 @@ mov rbx, 0
 gs xlat
 mov r13, rax
 
+; Restore FS/GS
+mov rax, [rel .data_backup]
+wrfsbase rax
+mov rax, [rel .data_backup + 8]
+wrgsbase rax
+
 hlt
+
+.data_backup:
+dq 0
+dq 0


### PR DESCRIPTION
Just need to make sure to save and restore gs/fs in the test, otherwise our signal handler gets /very/ upset.