### PR TITLE
unittests/ASM: Enables some previously disabled tests

### DIFF
--- a/unittests/ASM/Disabled_Tests_host
+++ b/unittests/ASM/Disabled_Tests_host
@@ -5,14 +5,6 @@ Test_TwoByte/0F_3F.asm
 Test_Primary/Primary_8C.asm
 Test_Primary/Primary_8C_2.asm
 
-# Intel CI doesn't have a new enough kernel to support this
-Test_Secondary/15_F3_00.asm
-Test_Secondary/15_F3_01.asm
-Test_Secondary/15_F3_02.asm
-Test_Secondary/15_F3_03.asm
-Test_Secondary/15_F3_02_2.asm
-Test_Secondary/15_F3_03_2.asm
-
 # Zen+ CI doesn't support UMIP so it returns "real" values
 Test_Secondary/07_XX_00.asm
 

--- a/unittests/ASM/Secondary/15_F3_00.asm
+++ b/unittests/ASM/Secondary/15_F3_00.asm
@@ -8,6 +8,10 @@
 }
 %endif
 
+; Save FS
+rdfsbase rax
+mov [rel .data_backup], rax
+
 mov rax, 0x0000434445464748
 mov rbx, -1
 mov rcx, -1
@@ -16,4 +20,11 @@ wrfsbase rax
 rdfsbase ebx ; 32bit
 rdfsbase rcx ; 64bit
 
+; Restore FS
+mov rdx, [rel .data_backup]
+wrfsbase rdx
+
 hlt
+
+.data_backup:
+dq 0

--- a/unittests/ASM/Secondary/15_F3_02.asm
+++ b/unittests/ASM/Secondary/15_F3_02.asm
@@ -6,6 +6,10 @@
 }
 %endif
 
+; Save FS
+rdfsbase rax
+mov [rel .data_backup], rax
+
 mov rdx, 0xe0000000
 wrfsbase rdx
 
@@ -15,4 +19,11 @@ mov [rdx + 8 * 0], rax
 mov rax, -1
 mov rax, qword [fs:0]
 
+; Restore FS
+mov rbx, [rel .data_backup]
+wrfsbase rbx
+
 hlt
+
+.data_backup:
+dq 0

--- a/unittests/ASM/Secondary/15_F3_02_2.asm
+++ b/unittests/ASM/Secondary/15_F3_02_2.asm
@@ -7,6 +7,10 @@
 }
 %endif
 
+; Save FS
+rdfsbase rax
+mov [rel .data_backup], rax
+
 mov rax, 0x0000434445464748
 mov rbx, -1
 
@@ -15,4 +19,11 @@ wrfsbase rax
 wrfsbase ebx
 rdfsbase rbx ; 64bit
 
+; Restore FS
+mov rcx, [rel .data_backup]
+wrfsbase rcx
+
 hlt
+
+.data_backup:
+dq 0


### PR DESCRIPTION
The new Zen system in CI has a new enough kernel for these tests.

Just need to modify the tests to be safe for our signal handler.