### PR TITLE
FEXLinuxTests: Adds a small sleep for consistency

### DIFF
--- a/unittests/FEXLinuxTests/tests/syscalls/futimesat.cpp
+++ b/unittests/FEXLinuxTests/tests/syscalls/futimesat.cpp
@@ -61,6 +61,7 @@ TEST_CASE("futimesat - valid - null") {
 
   // Remove the nanoseconds to ensure consistent time setting.
   time.tv_nsec = 0;
+  sleep(1);
 
   // Sets the time to "Now".
   REQUIRE(compat_futimesat(fd, nullptr, nullptr) == 0);


### PR DESCRIPTION
Sleep a second to make this test more consistent. Sometimes the filesystem times are slightly different than wallclock times.