### PR TITLE
IR: Remove unnecessary friend class declarations from OrderedNode

### DIFF
--- a/FEXCore/Source/Interface/IR/IR.h
+++ b/FEXCore/Source/Interface/IR/IR.h
@@ -235,8 +235,6 @@ static_assert(sizeof(OrderedNodeHeader) == sizeof(uint32_t) * 3);
  *  The second region is contiguous but they don't have any relationship with one another directly
  */
 class OrderedNode final {
-  friend class NodeWrapperIterator;
-  friend class OrderedList;
 public:
   // These three values are laid out very specifically to make it fast to access the NodeWrappers specifically
   OrderedNodeHeader Header;


### PR DESCRIPTION
These classes don't exist anymore, so we can get rid of these declarations.