### PR TITLE
Removes anonymous lambda usage from 32-bit syscalls

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FS.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FS.cpp
@@ -15,33 +15,37 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE::x32 {
+
+auto umount(FEXCore::Core::CpuStateFrame* Frame, const char* target) -> uint64_t {
+  uint64_t Result = ::umount(target);
+  SYSCALL_ERRNO();
+}
+
+auto truncate64(FEXCore::Core::CpuStateFrame* Frame, const char* path, uint32_t offset_low, uint32_t offset_high) -> uint64_t {
+  uint64_t Offset = offset_high;
+  Offset <<= 32;
+  Offset |= offset_low;
+  uint64_t Result = ::truncate(path, Offset);
+  SYSCALL_ERRNO();
+}
+
+auto ftruncate64(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t offset_low, uint32_t offset_high) -> uint64_t {
+  uint64_t Offset = offset_high;
+  Offset <<= 32;
+  Offset |= offset_low;
+  uint64_t Result = ::ftruncate(fd, Offset);
+  SYSCALL_ERRNO();
+}
+
+auto sigprocmask(FEXCore::Core::CpuStateFrame* Frame, int how, const uint64_t* set, uint64_t* oldset, size_t sigsetsize) -> uint64_t {
+  return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigProcMask(FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame), how,
+                                                                           set, oldset);
+}
+
 void RegisterFS(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_IMPL_X32(umount, [](FEXCore::Core::CpuStateFrame* Frame, const char* target) -> uint64_t {
-    uint64_t Result = ::umount(target);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(
-    truncate64, [](FEXCore::Core::CpuStateFrame* Frame, const char* path, uint32_t offset_low, uint32_t offset_high) -> uint64_t {
-      uint64_t Offset = offset_high;
-      Offset <<= 32;
-      Offset |= offset_low;
-      uint64_t Result = ::truncate(path, Offset);
-      SYSCALL_ERRNO();
-    });
-
-  REGISTER_SYSCALL_IMPL_X32(ftruncate64, [](FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t offset_low, uint32_t offset_high) -> uint64_t {
-    uint64_t Offset = offset_high;
-    Offset <<= 32;
-    Offset |= offset_low;
-    uint64_t Result = ::ftruncate(fd, Offset);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(
-    sigprocmask, [](FEXCore::Core::CpuStateFrame* Frame, int how, const uint64_t* set, uint64_t* oldset, size_t sigsetsize) -> uint64_t {
-      return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigProcMask(FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame),
-                                                                               how, set, oldset);
-    });
+  REGISTER_SYSCALL_IMPL_X32(umount, umount);
+  REGISTER_SYSCALL_IMPL_X32(truncate64, truncate64);
+  REGISTER_SYSCALL_IMPL_X32(ftruncate64, ftruncate64);
+  REGISTER_SYSCALL_IMPL_X32(sigprocmask, sigprocmask);
 }
 } // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/IO.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/IO.cpp
@@ -16,35 +16,35 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE::x32 {
+auto io_getevents(FEXCore::Core::CpuStateFrame* Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event* events,
+                  struct timespec32* timeout) -> uint64_t {
+  struct timespec* timeout_ptr {};
+  struct timespec tp64 {};
+  if (timeout) {
+    FaultSafeUserMemAccess::VerifyIsReadable(timeout, sizeof(*timeout));
+    tp64 = *timeout;
+    timeout_ptr = &tp64;
+  }
+
+  uint64_t Result = ::syscall(SYSCALL_DEF(io_getevents), ctx_id, min_nr, nr, events, timeout_ptr);
+  SYSCALL_ERRNO();
+}
+
+auto io_pgetevents(FEXCore::Core::CpuStateFrame* Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event* events,
+                   struct timespec32* timeout, const struct io_sigset* usig) -> uint64_t {
+  struct timespec* timeout_ptr {};
+  struct timespec tp64 {};
+  if (timeout) {
+    FaultSafeUserMemAccess::VerifyIsReadable(timeout, sizeof(*timeout));
+    tp64 = *timeout;
+    timeout_ptr = &tp64;
+  }
+
+  uint64_t Result = ::syscall(SYSCALL_DEF(io_pgetevents), ctx_id, min_nr, nr, events, timeout_ptr, usig);
+  SYSCALL_ERRNO();
+}
 void RegisterIO(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_IMPL_X32(io_getevents,
-                            [](FEXCore::Core::CpuStateFrame* Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event* events,
-                               struct timespec32* timeout) -> uint64_t {
-                              struct timespec* timeout_ptr {};
-                              struct timespec tp64 {};
-                              if (timeout) {
-                                FaultSafeUserMemAccess::VerifyIsReadable(timeout, sizeof(*timeout));
-                                tp64 = *timeout;
-                                timeout_ptr = &tp64;
-                              }
-
-                              uint64_t Result = ::syscall(SYSCALL_DEF(io_getevents), ctx_id, min_nr, nr, events, timeout_ptr);
-                              SYSCALL_ERRNO();
-                            });
-
-  REGISTER_SYSCALL_IMPL_X32(io_pgetevents,
-                            [](FEXCore::Core::CpuStateFrame* Frame, aio_context_t ctx_id, long min_nr, long nr, struct io_event* events,
-                               struct timespec32* timeout, const struct io_sigset* usig) -> uint64_t {
-                              struct timespec* timeout_ptr {};
-                              struct timespec tp64 {};
-                              if (timeout) {
-                                FaultSafeUserMemAccess::VerifyIsReadable(timeout, sizeof(*timeout));
-                                tp64 = *timeout;
-                                timeout_ptr = &tp64;
-                              }
-
-                              uint64_t Result = ::syscall(SYSCALL_DEF(io_pgetevents), ctx_id, min_nr, nr, events, timeout_ptr, usig);
-                              SYSCALL_ERRNO();
-                            });
+  REGISTER_SYSCALL_IMPL_X32(io_getevents, io_getevents);
+  REGISTER_SYSCALL_IMPL_X32(io_pgetevents, io_pgetevents);
 }
 } // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Memory.cpp
@@ -18,61 +18,68 @@ $end_info$
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/shm.h>
-#include <system_error>
-#include <filesystem>
 
 namespace FEX::HLE::x32 {
 
+struct old_mmap_struct {
+  uint32_t addr;
+  uint32_t len;
+  uint32_t prot;
+  uint32_t flags;
+  uint32_t fd;
+  uint32_t offset;
+};
+
+auto mmap(FEXCore::Core::CpuStateFrame* Frame, const old_mmap_struct* arg) -> uint64_t {
+  return reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->GuestMmap(false, Frame->Thread, reinterpret_cast<void*>(arg->addr), arg->len,
+                                                                         arg->prot, arg->flags, arg->fd, arg->offset));
+}
+
+auto mmap2(FEXCore::Core::CpuStateFrame* Frame, uint32_t addr, uint32_t length, int prot, int flags, int fd, uint32_t pgoffset) -> uint64_t {
+  return reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->GuestMmap(false, Frame->Thread, reinterpret_cast<void*>(addr), length, prot,
+                                                                         flags, fd, (uint64_t)pgoffset * 0x1000));
+}
+
+auto munmap(FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length) -> uint64_t {
+  return FEX::HLE::_SyscallHandler->GuestMunmap(Frame->Thread, addr, length);
+}
+
+auto mprotect(FEXCore::Core::CpuStateFrame* Frame, void* addr, uint32_t len, int prot) -> uint64_t {
+  return FEX::HLE::_SyscallHandler->GuestMprotect(Frame->Thread, addr, len, prot);
+}
+
+auto mremap(FEXCore::Core::CpuStateFrame* Frame, void* old_address, size_t old_size, size_t new_size, int flags, void* new_address) -> uint64_t {
+  return FEX::HLE::_SyscallHandler->GuestMremap(false, Frame->Thread, old_address, old_size, new_size, flags, new_address);
+}
+
+auto mlockall(FEXCore::Core::CpuStateFrame* Frame, int flags) -> uint64_t {
+  uint64_t Result = ::syscall(SYSCALL_DEF(mlock2), reinterpret_cast<void*>(0x1'0000), 0x1'0000'0000ULL - 0x1'0000, flags);
+  SYSCALL_ERRNO();
+}
+
+auto munlockall(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
+  uint64_t Result = ::munlock(reinterpret_cast<void*>(0x1'0000), 0x1'0000'0000ULL - 0x1'0000);
+  SYSCALL_ERRNO();
+}
+
+auto shmat(FEXCore::Core::CpuStateFrame* Frame, int shmid, const void* shmaddr, int shmflg) -> uint64_t {
+  return FEX::HLE::_SyscallHandler->GuestShmat(false, Frame->Thread, shmid, shmaddr, shmflg);
+}
+
+auto shmdt(FEXCore::Core::CpuStateFrame* Frame, const void* shmaddr) -> uint64_t {
+  return FEX::HLE::_SyscallHandler->GuestShmdt(false, Frame->Thread, shmaddr);
+}
+
 void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
-  struct old_mmap_struct {
-    uint32_t addr;
-    uint32_t len;
-    uint32_t prot;
-    uint32_t flags;
-    uint32_t fd;
-    uint32_t offset;
-  };
-  REGISTER_SYSCALL_IMPL_X32(mmap, [](FEXCore::Core::CpuStateFrame* Frame, const old_mmap_struct* arg) -> uint64_t {
-    return reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->GuestMmap(false, Frame->Thread, reinterpret_cast<void*>(arg->addr),
-                                                                           arg->len, arg->prot, arg->flags, arg->fd, arg->offset));
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(
-    mmap2, [](FEXCore::Core::CpuStateFrame* Frame, uint32_t addr, uint32_t length, int prot, int flags, int fd, uint32_t pgoffset) -> uint64_t {
-      return reinterpret_cast<uint64_t>(FEX::HLE::_SyscallHandler->GuestMmap(false, Frame->Thread, reinterpret_cast<void*>(addr), length,
-                                                                             prot, flags, fd, (uint64_t)pgoffset * 0x1000));
-    });
-
-  REGISTER_SYSCALL_IMPL_X32(munmap, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length) -> uint64_t {
-    return FEX::HLE::_SyscallHandler->GuestMunmap(Frame->Thread, addr, length);
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(mprotect, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, uint32_t len, int prot) -> uint64_t {
-    return FEX::HLE::_SyscallHandler->GuestMprotect(Frame->Thread, addr, len, prot);
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(
-    mremap, [](FEXCore::Core::CpuStateFrame* Frame, void* old_address, size_t old_size, size_t new_size, int flags, void* new_address) -> uint64_t {
-      return FEX::HLE::_SyscallHandler->GuestMremap(false, Frame->Thread, old_address, old_size, new_size, flags, new_address);
-    });
-
-  REGISTER_SYSCALL_IMPL_X32(mlockall, [](FEXCore::Core::CpuStateFrame* Frame, int flags) -> uint64_t {
-    uint64_t Result = ::syscall(SYSCALL_DEF(mlock2), reinterpret_cast<void*>(0x1'0000), 0x1'0000'0000ULL - 0x1'0000, flags);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(munlockall, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
-    uint64_t Result = ::munlock(reinterpret_cast<void*>(0x1'0000), 0x1'0000'0000ULL - 0x1'0000);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(shmat, [](FEXCore::Core::CpuStateFrame* Frame, int shmid, const void* shmaddr, int shmflg) -> uint64_t {
-    return FEX::HLE::_SyscallHandler->GuestShmat(false, Frame->Thread, shmid, shmaddr, shmflg);
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(shmdt, [](FEXCore::Core::CpuStateFrame* Frame, const void* shmaddr) -> uint64_t {
-    return FEX::HLE::_SyscallHandler->GuestShmdt(false, Frame->Thread, shmaddr);
-  });
+  REGISTER_SYSCALL_IMPL_X32(mmap, mmap);
+  REGISTER_SYSCALL_IMPL_X32(mmap2, mmap2);
+  REGISTER_SYSCALL_IMPL_X32(munmap, munmap);
+  REGISTER_SYSCALL_IMPL_X32(mprotect, mprotect);
+  REGISTER_SYSCALL_IMPL_X32(mremap, mremap);
+  REGISTER_SYSCALL_IMPL_X32(mlockall, mlockall);
+  REGISTER_SYSCALL_IMPL_X32(munlockall, munlockall);
+  REGISTER_SYSCALL_IMPL_X32(shmat, shmat);
+  REGISTER_SYSCALL_IMPL_X32(shmdt, shmdt);
 }
 
 } // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/NotImplemented.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/NotImplemented.cpp
@@ -24,20 +24,43 @@ namespace FEX::HLE::x32 {
 #define REGISTER_SYSCALL_NO_PERM_X32(name) \
   REGISTER_SYSCALL_IMPL_X32(name, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { return -EPERM; });
 
+#define SYSCALL_NOT_IMPL_X32(name)                                 \
+  auto name(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {     \
+    LogMan::Msg::DFmt("Using deprecated/removed syscall: " #name); \
+    return -ENOSYS;                                                \
+  };
+#define SYSCALL_NO_PERM_X32(name)                              \
+  auto name(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { \
+    return -EPERM;                                             \
+  };
+
+SYSCALL_NOT_IMPL_X32(_break);
+SYSCALL_NOT_IMPL_X32(stty);
+SYSCALL_NOT_IMPL_X32(gtty);
+SYSCALL_NOT_IMPL_X32(prof);
+SYSCALL_NOT_IMPL_X32(ftime);
+SYSCALL_NOT_IMPL_X32(mpx);
+SYSCALL_NOT_IMPL_X32(lock);
+SYSCALL_NOT_IMPL_X32(ulimit);
+SYSCALL_NOT_IMPL_X32(profil);
+SYSCALL_NOT_IMPL_X32(idle);
+
+SYSCALL_NO_PERM_X32(stime);
+SYSCALL_NO_PERM_X32(bdflush);
 // these are removed/not implemented in the linux kernel we present
 void RegisterNotImplemented(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_NOT_IMPL_X32(break);
-  REGISTER_SYSCALL_NOT_IMPL_X32(stty);
-  REGISTER_SYSCALL_NOT_IMPL_X32(gtty);
-  REGISTER_SYSCALL_NOT_IMPL_X32(prof);
-  REGISTER_SYSCALL_NOT_IMPL_X32(ftime);
-  REGISTER_SYSCALL_NOT_IMPL_X32(mpx);
-  REGISTER_SYSCALL_NOT_IMPL_X32(lock);
-  REGISTER_SYSCALL_NOT_IMPL_X32(ulimit);
-  REGISTER_SYSCALL_NOT_IMPL_X32(profil);
-  REGISTER_SYSCALL_NOT_IMPL_X32(idle);
+  REGISTER_SYSCALL_IMPL_X32(break, _break);
+  REGISTER_SYSCALL_IMPL_X32(stty, stty);
+  REGISTER_SYSCALL_IMPL_X32(gtty, gtty);
+  REGISTER_SYSCALL_IMPL_X32(prof, prof);
+  REGISTER_SYSCALL_IMPL_X32(ftime, ftime);
+  REGISTER_SYSCALL_IMPL_X32(mpx, mpx);
+  REGISTER_SYSCALL_IMPL_X32(lock, lock);
+  REGISTER_SYSCALL_IMPL_X32(ulimit, ulimit);
+  REGISTER_SYSCALL_IMPL_X32(profil, profil);
+  REGISTER_SYSCALL_IMPL_X32(idle, idle);
 
-  REGISTER_SYSCALL_NO_PERM_X32(stime);
-  REGISTER_SYSCALL_NO_PERM_X32(bdflush);
+  REGISTER_SYSCALL_IMPL_X32(stime, stime);
+  REGISTER_SYSCALL_IMPL_X32(bdflush, bdflush);
 }
 } // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Sched.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Sched.cpp
@@ -20,15 +20,17 @@ struct CpuStateFrame;
 }
 
 namespace FEX::HLE::x32 {
+auto sched_rr_get_interval(FEXCore::Core::CpuStateFrame* Frame, pid_t pid, struct timespec32* tp) -> uint64_t {
+  struct timespec tp64 {};
+  uint64_t Result = ::sched_rr_get_interval(pid, tp ? &tp64 : nullptr);
+  if (tp) {
+    FaultSafeUserMemAccess::VerifyIsWritable(tp, sizeof(*tp));
+    *tp = tp64;
+  }
+  SYSCALL_ERRNO();
+}
+
 void RegisterSched(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_IMPL_X32(sched_rr_get_interval, [](FEXCore::Core::CpuStateFrame* Frame, pid_t pid, struct timespec32* tp) -> uint64_t {
-    struct timespec tp64 {};
-    uint64_t Result = ::sched_rr_get_interval(pid, tp ? &tp64 : nullptr);
-    if (tp) {
-      FaultSafeUserMemAccess::VerifyIsWritable(tp, sizeof(*tp));
-      *tp = tp64;
-    }
-    SYSCALL_ERRNO();
-  });
+  REGISTER_SYSCALL_IMPL_X32(sched_rr_get_interval, sched_rr_get_interval);
 }
 } // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Stubs.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Stubs.cpp
@@ -25,13 +25,26 @@ struct CpuStateFrame;
 }
 
 namespace FEX::HLE::x32 {
+auto modify_ldt(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
+  SYSCALL_STUB(readdir);
+}
+
+auto readdir(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
+  SYSCALL_STUB(readdir);
+}
+
+auto vm86old(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
+  return -ENOSYS;
+}
+
+auto vm86(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
+  return -ENOSYS;
+}
+
 void RegisterStubs(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_IMPL_X32(modify_ldt, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { SYSCALL_STUB(readdir); });
-
-  REGISTER_SYSCALL_IMPL_X32(readdir, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { SYSCALL_STUB(readdir); });
-
-  REGISTER_SYSCALL_IMPL_X32(vm86old, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { return -ENOSYS; });
-
-  REGISTER_SYSCALL_IMPL_X32(vm86, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { return -ENOSYS; });
+  REGISTER_SYSCALL_IMPL_X32(modify_ldt, modify_ldt);
+  REGISTER_SYSCALL_IMPL_X32(readdir, readdir);
+  REGISTER_SYSCALL_IMPL_X32(vm86old, vm86old);
+  REGISTER_SYSCALL_IMPL_X32(vm86, vm86);
 }
 } // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Time.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Time.cpp
@@ -29,218 +29,230 @@ struct CpuStateFrame;
 }
 
 namespace FEX::HLE::x32 {
+auto time(FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::x32::old_time32_t* tloc) -> uint64_t {
+  time_t Host {};
+  uint64_t Result = ::time(&Host);
+
+  if (tloc) {
+    FaultSafeUserMemAccess::VerifyIsWritable(tloc, sizeof(*tloc));
+    // On 32-bit this truncates
+    *tloc = (FEX::HLE::x32::old_time32_t)Host;
+  }
+
+  SYSCALL_ERRNO();
+}
+
+auto times(FEXCore::Core::CpuStateFrame* Frame, struct FEX::HLE::x32::compat_tms* buf) -> uint64_t {
+  struct tms Host {};
+  uint64_t Result = ::times(&Host);
+  if (buf) {
+    FaultSafeUserMemAccess::VerifyIsWritable(buf, sizeof(*buf));
+    *buf = Host;
+  }
+  SYSCALL_ERRNO();
+}
+
+auto utime(FEXCore::Core::CpuStateFrame* Frame, char* filename, const FEX::HLE::x32::old_utimbuf32* times) -> uint64_t {
+  struct utimbuf Host {};
+  struct utimbuf* Host_p {};
+  if (times) {
+    FaultSafeUserMemAccess::VerifyIsReadable(times, sizeof(*times));
+    Host = *times;
+    Host_p = &Host;
+  }
+  uint64_t Result = ::utime(filename, Host_p);
+  SYSCALL_ERRNO();
+}
+
+auto gettimeofday(FEXCore::Core::CpuStateFrame* Frame, timeval32* tv, struct timezone* tz) -> uint64_t {
+  struct timeval tv64 {};
+  struct timeval* tv_ptr {};
+  if (tv) {
+    tv_ptr = &tv64;
+  }
+
+  uint64_t Result = ::gettimeofday(tv_ptr, tz);
+
+  if (tv) {
+    FaultSafeUserMemAccess::VerifyIsWritable(tv, sizeof(*tv));
+    *tv = tv64;
+  }
+  SYSCALL_ERRNO();
+}
+
+auto settimeofday(FEXCore::Core::CpuStateFrame* Frame, const timeval32* tv, const struct timezone* tz) -> uint64_t {
+  struct timeval tv64 {};
+  struct timeval* tv_ptr {};
+  if (tv) {
+    FaultSafeUserMemAccess::VerifyIsReadable(tv, sizeof(*tv));
+    tv64 = *tv;
+    tv_ptr = &tv64;
+  }
+
+  const uint64_t Result = ::settimeofday(tv_ptr, tz);
+  SYSCALL_ERRNO();
+}
+
+auto nanosleep(FEXCore::Core::CpuStateFrame* Frame, const timespec32* req, timespec32* rem) -> uint64_t {
+  struct timespec rem64 {};
+  struct timespec* rem64_ptr {};
+
+  if (rem) {
+    FaultSafeUserMemAccess::VerifyIsReadable(rem, sizeof(*rem));
+    rem64 = *rem;
+    rem64_ptr = &rem64;
+  }
+
+  uint64_t Result = 0;
+  if (req) {
+    FaultSafeUserMemAccess::VerifyIsReadable(req, sizeof(*req));
+    const struct timespec req64 = *req;
+    Result = ::nanosleep(&req64, rem64_ptr);
+  } else {
+    Result = ::nanosleep(nullptr, rem64_ptr);
+  }
+
+  if (rem) {
+    FaultSafeUserMemAccess::VerifyIsWritable(rem, sizeof(*rem));
+    *rem = rem64;
+  }
+  SYSCALL_ERRNO();
+}
+
+auto clock_gettime(FEXCore::Core::CpuStateFrame* Frame, clockid_t clk_id, timespec32* tp) -> uint64_t {
+  struct timespec tp64 {};
+  uint64_t Result = ::clock_gettime(clk_id, &tp64);
+  if (tp) {
+    FaultSafeUserMemAccess::VerifyIsWritable(tp, sizeof(*tp));
+    *tp = tp64;
+  }
+  SYSCALL_ERRNO();
+}
+
+auto clock_getres(FEXCore::Core::CpuStateFrame* Frame, clockid_t clk_id, timespec32* tp) -> uint64_t {
+  struct timespec tp64 {};
+  uint64_t Result = ::clock_getres(clk_id, &tp64);
+  if (tp) {
+    FaultSafeUserMemAccess::VerifyIsWritable(tp, sizeof(*tp));
+    *tp = tp64;
+  }
+  SYSCALL_ERRNO();
+}
+
+auto clock_nanosleep(FEXCore::Core::CpuStateFrame* Frame, clockid_t clockid, int flags, const timespec32* request, timespec32* remain) -> uint64_t {
+  struct timespec req64 {};
+  struct timespec* req64_ptr {};
+
+  struct timespec rem64 {};
+  struct timespec* rem64_ptr {};
+
+  if (request) {
+    FaultSafeUserMemAccess::VerifyIsReadable(request, sizeof(*request));
+    req64 = *request;
+    req64_ptr = &req64;
+  }
+
+  if (remain) {
+    FaultSafeUserMemAccess::VerifyIsReadable(remain, sizeof(*remain));
+    rem64 = *remain;
+    rem64_ptr = &rem64;
+  }
+
+  // Can't use glibc helper here since it does additional validation and data munging that breaks games.
+  uint64_t Result = ::syscall(SYSCALL_DEF(clock_nanosleep), clockid, flags, req64_ptr, rem64_ptr);
+
+  if (remain && (flags & TIMER_ABSTIME) == 0) {
+    FaultSafeUserMemAccess::VerifyIsWritable(remain, sizeof(*remain));
+    // Remain is completely ignored if TIMER_ABSTIME is set.
+    *remain = rem64;
+  }
+  SYSCALL_ERRNO();
+}
+
+auto clock_settime(FEXCore::Core::CpuStateFrame* Frame, clockid_t clockid, const timespec32* tp) -> uint64_t {
+  if (!tp) {
+    // clock_settime is required to pass a timespec.
+    return -EFAULT;
+  }
+
+  uint64_t Result = 0;
+  FaultSafeUserMemAccess::VerifyIsReadable(tp, sizeof(*tp));
+  const struct timespec tp64 = *tp;
+  Result = ::clock_settime(clockid, &tp64);
+  SYSCALL_ERRNO();
+}
+
+auto futimesat(FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, const timeval32 times[2]) -> uint64_t {
+  return FEX::HLE::futimesat_compat<timeval32>(dirfd, pathname, times);
+}
+
+auto utimensat(FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, const compat_ptr<timespec32> times, int flags) -> uint64_t {
+  uint64_t Result = 0;
+  if (times) {
+    FaultSafeUserMemAccess::VerifyIsReadable(times, sizeof(timeval32) * 2);
+    timespec times64[2] {};
+    times64[0] = times[0];
+    times64[1] = times[1];
+    Result = ::syscall(SYSCALL_DEF(utimensat), dirfd, pathname, times64, flags);
+  } else {
+    Result = ::syscall(SYSCALL_DEF(utimensat), dirfd, pathname, nullptr, flags);
+  }
+  SYSCALL_ERRNO();
+}
+
+auto utimes(FEXCore::Core::CpuStateFrame* Frame, const char* filename, const timeval32 times[2]) -> uint64_t {
+  uint64_t Result = 0;
+  if (times) {
+    FaultSafeUserMemAccess::VerifyIsReadable(times, sizeof(timeval32) * 2);
+    struct timeval times64[2] {};
+    times64[0] = times[0];
+    times64[1] = times[1];
+    Result = ::utimes(filename, times64);
+  } else {
+    Result = ::utimes(filename, nullptr);
+  }
+  SYSCALL_ERRNO();
+}
+
+auto adjtimex(FEXCore::Core::CpuStateFrame* Frame, compat_ptr<FEX::HLE::x32::timex32> buf) -> uint64_t {
+  FaultSafeUserMemAccess::VerifyIsReadable(buf, sizeof(*buf));
+  struct timex Host {};
+  Host = *buf;
+  uint64_t Result = ::adjtimex(&Host);
+  if (Result != -1) {
+    FaultSafeUserMemAccess::VerifyIsWritable(buf, sizeof(*buf));
+    *buf = Host;
+  }
+  SYSCALL_ERRNO();
+}
+
+auto clock_adjtime(FEXCore::Core::CpuStateFrame* Frame, clockid_t clk_id, compat_ptr<FEX::HLE::x32::timex32> buf) -> uint64_t {
+  FaultSafeUserMemAccess::VerifyIsReadable(buf, sizeof(*buf));
+  struct timex Host {};
+  Host = *buf;
+  uint64_t Result = ::clock_adjtime(clk_id, &Host);
+  if (Result != -1) {
+    FaultSafeUserMemAccess::VerifyIsWritable(buf, sizeof(*buf));
+    *buf = Host;
+  }
+  SYSCALL_ERRNO();
+}
+
 void RegisterTime(FEX::HLE::SyscallHandler* Handler) {
-
-  REGISTER_SYSCALL_IMPL_X32(time, [](FEXCore::Core::CpuStateFrame* Frame, FEX::HLE::x32::old_time32_t* tloc) -> uint64_t {
-    time_t Host {};
-    uint64_t Result = ::time(&Host);
-
-    if (tloc) {
-      FaultSafeUserMemAccess::VerifyIsWritable(tloc, sizeof(*tloc));
-      // On 32-bit this truncates
-      *tloc = (FEX::HLE::x32::old_time32_t)Host;
-    }
-
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(times, [](FEXCore::Core::CpuStateFrame* Frame, struct FEX::HLE::x32::compat_tms* buf) -> uint64_t {
-    struct tms Host {};
-    uint64_t Result = ::times(&Host);
-    if (buf) {
-      FaultSafeUserMemAccess::VerifyIsWritable(buf, sizeof(*buf));
-      *buf = Host;
-    }
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(utime, [](FEXCore::Core::CpuStateFrame* Frame, char* filename, const FEX::HLE::x32::old_utimbuf32* times) -> uint64_t {
-    struct utimbuf Host {};
-    struct utimbuf* Host_p {};
-    if (times) {
-      FaultSafeUserMemAccess::VerifyIsReadable(times, sizeof(*times));
-      Host = *times;
-      Host_p = &Host;
-    }
-    uint64_t Result = ::utime(filename, Host_p);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(gettimeofday, [](FEXCore::Core::CpuStateFrame* Frame, timeval32* tv, struct timezone* tz) -> uint64_t {
-    struct timeval tv64 {};
-    struct timeval* tv_ptr {};
-    if (tv) {
-      tv_ptr = &tv64;
-    }
-
-    uint64_t Result = ::gettimeofday(tv_ptr, tz);
-
-    if (tv) {
-      FaultSafeUserMemAccess::VerifyIsWritable(tv, sizeof(*tv));
-      *tv = tv64;
-    }
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(settimeofday, [](FEXCore::Core::CpuStateFrame* Frame, const timeval32* tv, const struct timezone* tz) -> uint64_t {
-    struct timeval tv64 {};
-    struct timeval* tv_ptr {};
-    if (tv) {
-      FaultSafeUserMemAccess::VerifyIsReadable(tv, sizeof(*tv));
-      tv64 = *tv;
-      tv_ptr = &tv64;
-    }
-
-    const uint64_t Result = ::settimeofday(tv_ptr, tz);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(nanosleep, [](FEXCore::Core::CpuStateFrame* Frame, const timespec32* req, timespec32* rem) -> uint64_t {
-    struct timespec rem64 {};
-    struct timespec* rem64_ptr {};
-
-    if (rem) {
-      FaultSafeUserMemAccess::VerifyIsReadable(rem, sizeof(*rem));
-      rem64 = *rem;
-      rem64_ptr = &rem64;
-    }
-
-    uint64_t Result = 0;
-    if (req) {
-      FaultSafeUserMemAccess::VerifyIsReadable(req, sizeof(*req));
-      const struct timespec req64 = *req;
-      Result = ::nanosleep(&req64, rem64_ptr);
-    } else {
-      Result = ::nanosleep(nullptr, rem64_ptr);
-    }
-
-    if (rem) {
-      FaultSafeUserMemAccess::VerifyIsWritable(rem, sizeof(*rem));
-      *rem = rem64;
-    }
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(clock_gettime, [](FEXCore::Core::CpuStateFrame* Frame, clockid_t clk_id, timespec32* tp) -> uint64_t {
-    struct timespec tp64 {};
-    uint64_t Result = ::clock_gettime(clk_id, &tp64);
-    if (tp) {
-      FaultSafeUserMemAccess::VerifyIsWritable(tp, sizeof(*tp));
-      *tp = tp64;
-    }
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(clock_getres, [](FEXCore::Core::CpuStateFrame* Frame, clockid_t clk_id, timespec32* tp) -> uint64_t {
-    struct timespec tp64 {};
-    uint64_t Result = ::clock_getres(clk_id, &tp64);
-    if (tp) {
-      FaultSafeUserMemAccess::VerifyIsWritable(tp, sizeof(*tp));
-      *tp = tp64;
-    }
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(
-    clock_nanosleep, [](FEXCore::Core::CpuStateFrame* Frame, clockid_t clockid, int flags, const timespec32* request, timespec32* remain) -> uint64_t {
-      struct timespec req64 {};
-      struct timespec* req64_ptr {};
-
-      struct timespec rem64 {};
-      struct timespec* rem64_ptr {};
-
-      if (request) {
-        FaultSafeUserMemAccess::VerifyIsReadable(request, sizeof(*request));
-        req64 = *request;
-        req64_ptr = &req64;
-      }
-
-      if (remain) {
-        FaultSafeUserMemAccess::VerifyIsReadable(remain, sizeof(*remain));
-        rem64 = *remain;
-        rem64_ptr = &rem64;
-      }
-
-      // Can't use glibc helper here since it does additional validation and data munging that breaks games.
-      uint64_t Result = ::syscall(SYSCALL_DEF(clock_nanosleep), clockid, flags, req64_ptr, rem64_ptr);
-
-      if (remain && (flags & TIMER_ABSTIME) == 0) {
-        FaultSafeUserMemAccess::VerifyIsWritable(remain, sizeof(*remain));
-        // Remain is completely ignored if TIMER_ABSTIME is set.
-        *remain = rem64;
-      }
-      SYSCALL_ERRNO();
-    });
-
-  REGISTER_SYSCALL_IMPL_X32(clock_settime, [](FEXCore::Core::CpuStateFrame* Frame, clockid_t clockid, const timespec32* tp) -> uint64_t {
-    if (!tp) {
-      // clock_settime is required to pass a timespec.
-      return -EFAULT;
-    }
-
-    uint64_t Result = 0;
-    FaultSafeUserMemAccess::VerifyIsReadable(tp, sizeof(*tp));
-    const struct timespec tp64 = *tp;
-    Result = ::clock_settime(clockid, &tp64);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(futimesat, [](FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, const timeval32 times[2]) -> uint64_t {
-    return FEX::HLE::futimesat_compat<timeval32>(dirfd, pathname, times);
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(
-    utimensat, [](FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, const compat_ptr<timespec32> times, int flags) -> uint64_t {
-      uint64_t Result = 0;
-      if (times) {
-        FaultSafeUserMemAccess::VerifyIsReadable(times, sizeof(timeval32) * 2);
-        timespec times64[2] {};
-        times64[0] = times[0];
-        times64[1] = times[1];
-        Result = ::syscall(SYSCALL_DEF(utimensat), dirfd, pathname, times64, flags);
-      } else {
-        Result = ::syscall(SYSCALL_DEF(utimensat), dirfd, pathname, nullptr, flags);
-      }
-      SYSCALL_ERRNO();
-    });
-
-  REGISTER_SYSCALL_IMPL_X32(utimes, [](FEXCore::Core::CpuStateFrame* Frame, const char* filename, const timeval32 times[2]) -> uint64_t {
-    uint64_t Result = 0;
-    if (times) {
-      FaultSafeUserMemAccess::VerifyIsReadable(times, sizeof(timeval32) * 2);
-      struct timeval times64[2] {};
-      times64[0] = times[0];
-      times64[1] = times[1];
-      Result = ::utimes(filename, times64);
-    } else {
-      Result = ::utimes(filename, nullptr);
-    }
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(adjtimex, [](FEXCore::Core::CpuStateFrame* Frame, compat_ptr<FEX::HLE::x32::timex32> buf) -> uint64_t {
-    FaultSafeUserMemAccess::VerifyIsReadable(buf, sizeof(*buf));
-    struct timex Host {};
-    Host = *buf;
-    uint64_t Result = ::adjtimex(&Host);
-    if (Result != -1) {
-      FaultSafeUserMemAccess::VerifyIsWritable(buf, sizeof(*buf));
-      *buf = Host;
-    }
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(clock_adjtime,
-                            [](FEXCore::Core::CpuStateFrame* Frame, clockid_t clk_id, compat_ptr<FEX::HLE::x32::timex32> buf) -> uint64_t {
-                              FaultSafeUserMemAccess::VerifyIsReadable(buf, sizeof(*buf));
-                              struct timex Host {};
-                              Host = *buf;
-                              uint64_t Result = ::clock_adjtime(clk_id, &Host);
-                              if (Result != -1) {
-                                FaultSafeUserMemAccess::VerifyIsWritable(buf, sizeof(*buf));
-                                *buf = Host;
-                              }
-                              SYSCALL_ERRNO();
-                            });
+  REGISTER_SYSCALL_IMPL_X32(time, time);
+  REGISTER_SYSCALL_IMPL_X32(times, times);
+  REGISTER_SYSCALL_IMPL_X32(utime, utime);
+  REGISTER_SYSCALL_IMPL_X32(gettimeofday, gettimeofday);
+  REGISTER_SYSCALL_IMPL_X32(settimeofday, settimeofday);
+  REGISTER_SYSCALL_IMPL_X32(nanosleep, nanosleep);
+  REGISTER_SYSCALL_IMPL_X32(clock_gettime, clock_gettime);
+  REGISTER_SYSCALL_IMPL_X32(clock_getres, clock_getres);
+  REGISTER_SYSCALL_IMPL_X32(clock_nanosleep, clock_nanosleep);
+  REGISTER_SYSCALL_IMPL_X32(clock_settime, clock_settime);
+  REGISTER_SYSCALL_IMPL_X32(futimesat, futimesat);
+  REGISTER_SYSCALL_IMPL_X32(utimensat, utimensat);
+  REGISTER_SYSCALL_IMPL_X32(utimes, utimes);
+  REGISTER_SYSCALL_IMPL_X32(adjtimex, adjtimex);
+  REGISTER_SYSCALL_IMPL_X32(clock_adjtime, clock_adjtime);
 }
 } // namespace FEX::HLE::x32

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Timer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Timer.cpp
@@ -24,84 +24,86 @@ struct CpuStateFrame;
 ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEX::HLE::x32::sigevent32>, "%lx")
 
 namespace FEX::HLE::x32 {
+auto timer_settime(FEXCore::Core::CpuStateFrame* Frame, kernel_timer_t timerid, int flags, const FEX::HLE::x32::old_itimerspec32* new_value,
+                   FEX::HLE::x32::old_itimerspec32* old_value) -> uint64_t {
+  itimerspec new_value_host {};
+  itimerspec old_value_host {};
+  itimerspec* old_value_host_p {};
+
+  FaultSafeUserMemAccess::VerifyIsReadable(new_value, sizeof(*new_value));
+  new_value_host = *new_value;
+  if (old_value) {
+    old_value_host_p = &old_value_host;
+  }
+  uint64_t Result = ::syscall(SYSCALL_DEF(timer_settime), timerid, flags, &new_value_host, old_value_host_p);
+  if (Result != -1 && old_value) {
+    FaultSafeUserMemAccess::VerifyIsWritable(old_value, sizeof(*old_value));
+    *old_value = old_value_host;
+  }
+  SYSCALL_ERRNO();
+}
+
+auto timer_gettime(FEXCore::Core::CpuStateFrame* Frame, kernel_timer_t timerid, FEX::HLE::x32::old_itimerspec32* curr_value) -> uint64_t {
+  itimerspec curr_value_host {};
+  uint64_t Result = ::syscall(SYSCALL_DEF(timer_gettime), timerid, curr_value_host);
+  FaultSafeUserMemAccess::VerifyIsWritable(curr_value, sizeof(*curr_value));
+  *curr_value = curr_value_host;
+  SYSCALL_ERRNO();
+}
+
+auto getitimer(FEXCore::Core::CpuStateFrame* Frame, int which, FEX::HLE::x32::itimerval32* curr_value) -> uint64_t {
+  itimerval val {};
+  itimerval* val_p {};
+  if (curr_value) {
+    val_p = &val;
+  }
+  uint64_t Result = ::getitimer(which, val_p);
+  if (curr_value) {
+    FaultSafeUserMemAccess::VerifyIsWritable(curr_value, sizeof(*curr_value));
+    *curr_value = val;
+  }
+  SYSCALL_ERRNO();
+}
+
+auto setitimer(FEXCore::Core::CpuStateFrame* Frame, int which, const FEX::HLE::x32::itimerval32* new_value,
+               FEX::HLE::x32::itimerval32* old_value) -> uint64_t {
+  itimerval val {};
+  itimerval old {};
+  itimerval* val_p {};
+  itimerval* old_p {};
+
+  if (new_value) {
+    FaultSafeUserMemAccess::VerifyIsReadable(new_value, sizeof(*new_value));
+    val = *new_value;
+    val_p = &val;
+  }
+
+  if (old_value) {
+    old_p = &old;
+  }
+
+  uint64_t Result = ::setitimer(which, val_p, old_p);
+
+  if (old_value) {
+    FaultSafeUserMemAccess::VerifyIsWritable(old_value, sizeof(*old_value));
+    *old_value = old;
+  }
+  SYSCALL_ERRNO();
+}
+
+auto timer_create(FEXCore::Core::CpuStateFrame* Frame, clockid_t clockid, compat_ptr<FEX::HLE::x32::sigevent32> sevp, kernel_timer_t* timerid)
+  -> uint64_t {
+  FaultSafeUserMemAccess::VerifyIsReadable(sevp, sizeof(*sevp));
+  sigevent Host = *sevp;
+  uint64_t Result = ::syscall(SYSCALL_DEF(timer_create), clockid, &Host, timerid);
+  SYSCALL_ERRNO();
+}
+
 void RegisterTimer(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_IMPL_X32(timer_settime,
-                            [](FEXCore::Core::CpuStateFrame* Frame, kernel_timer_t timerid, int flags,
-                               const FEX::HLE::x32::old_itimerspec32* new_value, FEX::HLE::x32::old_itimerspec32* old_value) -> uint64_t {
-                              itimerspec new_value_host {};
-                              itimerspec old_value_host {};
-                              itimerspec* old_value_host_p {};
-
-                              FaultSafeUserMemAccess::VerifyIsReadable(new_value, sizeof(*new_value));
-                              new_value_host = *new_value;
-                              if (old_value) {
-                                old_value_host_p = &old_value_host;
-                              }
-                              uint64_t Result = ::syscall(SYSCALL_DEF(timer_settime), timerid, flags, &new_value_host, old_value_host_p);
-                              if (Result != -1 && old_value) {
-                                FaultSafeUserMemAccess::VerifyIsWritable(old_value, sizeof(*old_value));
-                                *old_value = old_value_host;
-                              }
-                              SYSCALL_ERRNO();
-                            });
-
-  REGISTER_SYSCALL_IMPL_X32(
-    timer_gettime, [](FEXCore::Core::CpuStateFrame* Frame, kernel_timer_t timerid, FEX::HLE::x32::old_itimerspec32* curr_value) -> uint64_t {
-      itimerspec curr_value_host {};
-      uint64_t Result = ::syscall(SYSCALL_DEF(timer_gettime), timerid, curr_value_host);
-      FaultSafeUserMemAccess::VerifyIsWritable(curr_value, sizeof(*curr_value));
-      *curr_value = curr_value_host;
-      SYSCALL_ERRNO();
-    });
-
-  REGISTER_SYSCALL_IMPL_X32(getitimer, [](FEXCore::Core::CpuStateFrame* Frame, int which, FEX::HLE::x32::itimerval32* curr_value) -> uint64_t {
-    itimerval val {};
-    itimerval* val_p {};
-    if (curr_value) {
-      val_p = &val;
-    }
-    uint64_t Result = ::getitimer(which, val_p);
-    if (curr_value) {
-      FaultSafeUserMemAccess::VerifyIsWritable(curr_value, sizeof(*curr_value));
-      *curr_value = val;
-    }
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL_X32(setitimer,
-                            [](FEXCore::Core::CpuStateFrame* Frame, int which, const FEX::HLE::x32::itimerval32* new_value,
-                               FEX::HLE::x32::itimerval32* old_value) -> uint64_t {
-                              itimerval val {};
-                              itimerval old {};
-                              itimerval* val_p {};
-                              itimerval* old_p {};
-
-                              if (new_value) {
-                                FaultSafeUserMemAccess::VerifyIsReadable(new_value, sizeof(*new_value));
-                                val = *new_value;
-                                val_p = &val;
-                              }
-
-                              if (old_value) {
-                                old_p = &old;
-                              }
-
-                              uint64_t Result = ::setitimer(which, val_p, old_p);
-
-                              if (old_value) {
-                                FaultSafeUserMemAccess::VerifyIsWritable(old_value, sizeof(*old_value));
-                                *old_value = old;
-                              }
-                              SYSCALL_ERRNO();
-                            });
-
-  REGISTER_SYSCALL_IMPL_X32(
-    timer_create,
-    [](FEXCore::Core::CpuStateFrame* Frame, clockid_t clockid, compat_ptr<FEX::HLE::x32::sigevent32> sevp, kernel_timer_t* timerid) -> uint64_t {
-      FaultSafeUserMemAccess::VerifyIsReadable(sevp, sizeof(*sevp));
-      sigevent Host = *sevp;
-      uint64_t Result = ::syscall(SYSCALL_DEF(timer_create), clockid, &Host, timerid);
-      SYSCALL_ERRNO();
-    });
+  REGISTER_SYSCALL_IMPL_X32(timer_settime, timer_settime);
+  REGISTER_SYSCALL_IMPL_X32(timer_gettime, timer_gettime);
+  REGISTER_SYSCALL_IMPL_X32(getitimer, getitimer);
+  REGISTER_SYSCALL_IMPL_X32(setitimer, setitimer);
+  REGISTER_SYSCALL_IMPL_X32(timer_create, timer_create);
 }
 } // namespace FEX::HLE::x32


### PR DESCRIPTION
These need to not be anonymous, so just remove the lambdas entirely.
This is the first step towards syscall dispatcher tables being constexpr and supporting both 32-bit and 64-bit tables being executable inside the same process.

NFC.