### PR TITLE
Removes anonymous lambda usage from common syscalls

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/EPoll.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/EPoll.cpp
@@ -16,12 +16,12 @@ $end_info$
 #include <sys/epoll.h>
 
 namespace FEX::HLE {
+auto epoll_create(FEXCore::Core::CpuStateFrame* Frame, int size) -> uint64_t {
+  uint64_t Result = ::epoll_create(size);
+  SYSCALL_ERRNO();
+}
 void RegisterEpoll(FEX::HLE::SyscallHandler* Handler) {
   using namespace FEXCore::IR;
-
-  REGISTER_SYSCALL_IMPL(epoll_create, [](FEXCore::Core::CpuStateFrame* Frame, int size) -> uint64_t {
-    uint64_t Result = epoll_create(size);
-    SYSCALL_ERRNO();
-  });
+  REGISTER_SYSCALL_IMPL(epoll_create, epoll_create);
 }
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/FD.cpp
@@ -29,112 +29,129 @@ $end_info$
 #include <sys/syscall.h>
 
 namespace FEX::HLE {
+auto poll(FEXCore::Core::CpuStateFrame* Frame, struct pollfd* fds, nfds_t nfds, int timeout) -> uint64_t {
+  if (nfds) {
+    // fds is allowed to be garbage if nfds is zero.
+    FaultSafeUserMemAccess::VerifyIsWritable(fds, sizeof(struct pollfd) * nfds);
+  }
+  uint64_t Result = ::poll(fds, nfds, timeout);
+  SYSCALL_ERRNO();
+}
+
+auto open(FEXCore::Core::CpuStateFrame* Frame, const char* pathname, int flags, uint32_t mode) -> uint64_t {
+  flags = FEX::HLE::RemapFromX86Flags(flags);
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Open(pathname, flags, mode);
+  SYSCALL_ERRNO();
+}
+
+auto close(FEXCore::Core::CpuStateFrame* Frame, int fd) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Close(fd);
+  SYSCALL_ERRNO();
+}
+
+auto chown(FEXCore::Core::CpuStateFrame* Frame, const char* pathname, uid_t owner, gid_t group) -> uint64_t {
+  uint64_t Result = ::chown(pathname, owner, group);
+  SYSCALL_ERRNO();
+}
+
+auto lchown(FEXCore::Core::CpuStateFrame* Frame, const char* pathname, uid_t owner, gid_t group) -> uint64_t {
+  uint64_t Result = ::lchown(pathname, owner, group);
+  SYSCALL_ERRNO();
+}
+
+auto access(FEXCore::Core::CpuStateFrame* Frame, const char* pathname, int mode) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Access(pathname, mode);
+  SYSCALL_ERRNO();
+}
+
+auto pipe(FEXCore::Core::CpuStateFrame* Frame, int pipefd[2]) -> uint64_t {
+  uint64_t Result = ::pipe(pipefd);
+  SYSCALL_ERRNO();
+}
+
+auto dup3(FEXCore::Core::CpuStateFrame* Frame, int oldfd, int newfd, int flags) -> uint64_t {
+  flags = FEX::HLE::RemapFromX86Flags(flags);
+  uint64_t Result = ::dup3(oldfd, newfd, flags);
+  SYSCALL_ERRNO();
+}
+
+auto inotify_init(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
+  uint64_t Result = ::inotify_init();
+  SYSCALL_ERRNO();
+}
+
+auto openat(FEXCore::Core::CpuStateFrame* Frame, int dirfs, const char* pathname, int flags, uint32_t mode) -> uint64_t {
+  flags = FEX::HLE::RemapFromX86Flags(flags);
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Openat(dirfs, pathname, flags, mode);
+  SYSCALL_ERRNO();
+}
+
+auto readlinkat(FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, char* buf, size_t bufsiz) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Readlinkat(dirfd, pathname, buf, bufsiz);
+  SYSCALL_ERRNO();
+}
+
+auto faccessat(FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, int mode) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.FAccessat(dirfd, pathname, mode);
+  SYSCALL_ERRNO();
+}
+
+auto faccessat2(FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, int mode, int flags) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.FAccessat2(dirfd, pathname, mode, flags);
+  SYSCALL_ERRNO();
+}
+
+auto openat2(FEXCore::Core::CpuStateFrame* Frame, int dirfs, const char* pathname, struct open_how* how, size_t usize) -> uint64_t {
+  open_how HostHow {};
+  size_t HostSize = std::min(sizeof(open_how), usize);
+  memcpy(&HostHow, how, HostSize);
+
+  HostHow.flags = FEX::HLE::RemapFromX86Flags(HostHow.flags);
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Openat2(dirfs, pathname, &HostHow, HostSize);
+  SYSCALL_ERRNO();
+}
+
+auto eventfd(FEXCore::Core::CpuStateFrame* Frame, uint32_t count) -> uint64_t {
+  uint64_t Result = ::syscall(SYSCALL_DEF(eventfd2), count, 0);
+  SYSCALL_ERRNO();
+}
+
+auto pipe2(FEXCore::Core::CpuStateFrame* Frame, int pipefd[2], int flags) -> uint64_t {
+  flags = FEX::HLE::RemapFromX86Flags(flags);
+  uint64_t Result = ::pipe2(pipefd, flags);
+  SYSCALL_ERRNO();
+}
+
+auto statx(FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, int flags, uint32_t mask, struct statx* statxbuf) -> uint64_t {
+  // Flags don't need remapped
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statx(dirfd, pathname, flags, mask, statxbuf);
+  SYSCALL_ERRNO();
+}
+
+auto close_range(FEXCore::Core::CpuStateFrame* Frame, unsigned int first, unsigned int last, unsigned int flags) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.CloseRange(first, last, flags);
+  SYSCALL_ERRNO();
+}
+
 void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
   using namespace FEXCore::IR;
-  REGISTER_SYSCALL_IMPL(poll, [](FEXCore::Core::CpuStateFrame* Frame, struct pollfd* fds, nfds_t nfds, int timeout) -> uint64_t {
-    if (nfds) {
-      // fds is allowed to be garbage if nfds is zero.
-      FaultSafeUserMemAccess::VerifyIsWritable(fds, sizeof(struct pollfd) * nfds);
-    }
-    uint64_t Result = ::poll(fds, nfds, timeout);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(open, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname, int flags, uint32_t mode) -> uint64_t {
-    flags = FEX::HLE::RemapFromX86Flags(flags);
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.Open(pathname, flags, mode);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(close, [](FEXCore::Core::CpuStateFrame* Frame, int fd) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.Close(fd);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(chown, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname, uid_t owner, gid_t group) -> uint64_t {
-    uint64_t Result = ::chown(pathname, owner, group);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(lchown, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname, uid_t owner, gid_t group) -> uint64_t {
-    uint64_t Result = ::lchown(pathname, owner, group);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(access, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname, int mode) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.Access(pathname, mode);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(pipe, [](FEXCore::Core::CpuStateFrame* Frame, int pipefd[2]) -> uint64_t {
-    uint64_t Result = ::pipe(pipefd);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(dup3, [](FEXCore::Core::CpuStateFrame* Frame, int oldfd, int newfd, int flags) -> uint64_t {
-    flags = FEX::HLE::RemapFromX86Flags(flags);
-    uint64_t Result = ::dup3(oldfd, newfd, flags);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(inotify_init, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
-    uint64_t Result = ::inotify_init();
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(openat, [](FEXCore::Core::CpuStateFrame* Frame, int dirfs, const char* pathname, int flags, uint32_t mode) -> uint64_t {
-    flags = FEX::HLE::RemapFromX86Flags(flags);
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.Openat(dirfs, pathname, flags, mode);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(readlinkat, [](FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, char* buf, size_t bufsiz) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.Readlinkat(dirfd, pathname, buf, bufsiz);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(faccessat, [](FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, int mode) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.FAccessat(dirfd, pathname, mode);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(faccessat2, [](FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, int mode, int flags) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.FAccessat2(dirfd, pathname, mode, flags);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(
-    openat2, [](FEXCore::Core::CpuStateFrame* Frame, int dirfs, const char* pathname, struct open_how* how, size_t usize) -> uint64_t {
-      open_how HostHow {};
-      size_t HostSize = std::min(sizeof(open_how), usize);
-      memcpy(&HostHow, how, HostSize);
-
-      HostHow.flags = FEX::HLE::RemapFromX86Flags(HostHow.flags);
-      uint64_t Result = FEX::HLE::_SyscallHandler->FM.Openat2(dirfs, pathname, &HostHow, HostSize);
-      SYSCALL_ERRNO();
-    });
-
-  REGISTER_SYSCALL_IMPL(eventfd, [](FEXCore::Core::CpuStateFrame* Frame, uint32_t count) -> uint64_t {
-    uint64_t Result = ::syscall(SYSCALL_DEF(eventfd2), count, 0);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(pipe2, [](FEXCore::Core::CpuStateFrame* Frame, int pipefd[2], int flags) -> uint64_t {
-    flags = FEX::HLE::RemapFromX86Flags(flags);
-    uint64_t Result = ::pipe2(pipefd, flags);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(
-    statx, [](FEXCore::Core::CpuStateFrame* Frame, int dirfd, const char* pathname, int flags, uint32_t mask, struct statx* statxbuf) -> uint64_t {
-      // Flags don't need remapped
-      uint64_t Result = FEX::HLE::_SyscallHandler->FM.Statx(dirfd, pathname, flags, mask, statxbuf);
-      SYSCALL_ERRNO();
-    });
-
-  REGISTER_SYSCALL_IMPL(close_range, [](FEXCore::Core::CpuStateFrame* Frame, unsigned int first, unsigned int last, unsigned int flags) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.CloseRange(first, last, flags);
-    SYSCALL_ERRNO();
-  });
+  REGISTER_SYSCALL_IMPL(poll, poll);
+  REGISTER_SYSCALL_IMPL(open, open);
+  REGISTER_SYSCALL_IMPL(close, close);
+  REGISTER_SYSCALL_IMPL(chown, chown);
+  REGISTER_SYSCALL_IMPL(lchown, lchown);
+  REGISTER_SYSCALL_IMPL(access, access);
+  REGISTER_SYSCALL_IMPL(pipe, pipe);
+  REGISTER_SYSCALL_IMPL(dup3, dup3);
+  REGISTER_SYSCALL_IMPL(inotify_init, inotify_init);
+  REGISTER_SYSCALL_IMPL(openat, openat);
+  REGISTER_SYSCALL_IMPL(readlinkat, readlinkat);
+  REGISTER_SYSCALL_IMPL(faccessat, faccessat);
+  REGISTER_SYSCALL_IMPL(faccessat2, faccessat2);
+  REGISTER_SYSCALL_IMPL(openat2, openat2);
+  REGISTER_SYSCALL_IMPL(eventfd, eventfd);
+  REGISTER_SYSCALL_IMPL(pipe2, pipe2);
+  REGISTER_SYSCALL_IMPL(statx, statx);
+  REGISTER_SYSCALL_IMPL(close_range, close_range);
 }
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/FS.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/FS.cpp
@@ -22,129 +22,155 @@ $end_info$
 #include <sys/xattr.h>
 
 namespace FEX::HLE {
+using namespace FEXCore::IR;
+
+auto rename(FEXCore::Core::CpuStateFrame* Frame, const char* oldpath, const char* newpath) -> uint64_t {
+  uint64_t Result = ::rename(oldpath, newpath);
+  SYSCALL_ERRNO();
+}
+
+auto mkdir(FEXCore::Core::CpuStateFrame* Frame, const char* pathname, mode_t mode) -> uint64_t {
+  uint64_t Result = ::mkdir(pathname, mode);
+  SYSCALL_ERRNO();
+}
+
+auto rmdir(FEXCore::Core::CpuStateFrame* Frame, const char* pathname) -> uint64_t {
+  uint64_t Result = ::rmdir(pathname);
+  SYSCALL_ERRNO();
+}
+
+auto link(FEXCore::Core::CpuStateFrame* Frame, const char* oldpath, const char* newpath) -> uint64_t {
+  uint64_t Result = ::link(oldpath, newpath);
+  SYSCALL_ERRNO();
+}
+
+auto unlink(FEXCore::Core::CpuStateFrame* Frame, const char* pathname) -> uint64_t {
+  uint64_t Result = ::unlink(pathname);
+  SYSCALL_ERRNO();
+}
+
+auto symlink(FEXCore::Core::CpuStateFrame* Frame, const char* target, const char* linkpath) -> uint64_t {
+  uint64_t Result = ::symlink(target, linkpath);
+  SYSCALL_ERRNO();
+}
+
+auto readlink(FEXCore::Core::CpuStateFrame* Frame, const char* pathname, char* buf, size_t bufsiz) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Readlink(pathname, buf, bufsiz);
+  SYSCALL_ERRNO();
+}
+
+auto chmod(FEXCore::Core::CpuStateFrame* Frame, const char* pathname, mode_t mode) -> uint64_t {
+  uint64_t Result = ::chmod(pathname, mode);
+  SYSCALL_ERRNO();
+}
+
+auto mknod(FEXCore::Core::CpuStateFrame* Frame, const char* pathname, mode_t mode, dev_t dev) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Mknod(pathname, mode, dev);
+  SYSCALL_ERRNO();
+}
+
+auto creat(FEXCore::Core::CpuStateFrame* Frame, const char* pathname, mode_t mode) -> uint64_t {
+  uint64_t Result = ::creat(pathname, mode);
+  SYSCALL_ERRNO();
+}
+
+auto setxattr(FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name, const void* value, size_t size, int flags) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Setxattr(path, name, value, size, flags);
+  SYSCALL_ERRNO();
+}
+
+auto lsetxattr(FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name, const void* value, size_t size, int flags) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.LSetxattr(path, name, value, size, flags);
+  SYSCALL_ERRNO();
+}
+
+auto getxattr(FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name, void* value, size_t size) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Getxattr(path, name, value, size);
+  SYSCALL_ERRNO();
+}
+
+auto lgetxattr(FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name, void* value, size_t size) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.LGetxattr(path, name, value, size);
+  SYSCALL_ERRNO();
+}
+
+auto listxattr(FEXCore::Core::CpuStateFrame* Frame, const char* path, char* list, size_t size) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Listxattr(path, list, size);
+  SYSCALL_ERRNO();
+}
+
+auto llistxattr(FEXCore::Core::CpuStateFrame* Frame, const char* path, char* list, size_t size) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.LListxattr(path, list, size);
+  SYSCALL_ERRNO();
+}
+
+auto removexattr(FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.Removexattr(path, name);
+  SYSCALL_ERRNO();
+}
+
+auto lremovexattr(FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.LRemovexattr(path, name);
+  SYSCALL_ERRNO();
+}
+auto setxattrat(FEXCore::Core::CpuStateFrame* Frame, int dfd, const char* pathname, uint32_t at_flags, const char* name,
+                const FileManager::xattr_args* uargs, size_t usize) -> uint64_t {
+  if (!FEX::HLE::_SyscallHandler->IsHostKernelVersionAtLeast(6, 13, 0)) {
+    return -ENOSYS;
+  }
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.SetxattrAt(dfd, pathname, at_flags, name, uargs, usize);
+  SYSCALL_ERRNO();
+}
+auto getxattrat(FEXCore::Core::CpuStateFrame* Frame, int dfd, const char* pathname, uint32_t at_flags, const char* name,
+                const FileManager::xattr_args* uargs, size_t usize) -> uint64_t {
+
+  if (!FEX::HLE::_SyscallHandler->IsHostKernelVersionAtLeast(6, 13, 0)) {
+    return -ENOSYS;
+  }
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.GetxattrAt(dfd, pathname, at_flags, name, uargs, usize);
+  SYSCALL_ERRNO();
+}
+
+auto listxattrat(FEXCore::Core::CpuStateFrame* Frame, int dfd, const char* pathname, uint32_t at_flags, char* list, size_t size) -> uint64_t {
+
+  if (!FEX::HLE::_SyscallHandler->IsHostKernelVersionAtLeast(6, 13, 0)) {
+    return -ENOSYS;
+  }
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.ListxattrAt(dfd, pathname, at_flags, list, size);
+  SYSCALL_ERRNO();
+}
+auto removexattrat(FEXCore::Core::CpuStateFrame* Frame, int dfd, const char* pathname, uint32_t at_flags, const char* name) -> uint64_t {
+
+  if (!FEX::HLE::_SyscallHandler->IsHostKernelVersionAtLeast(6, 13, 0)) {
+    return -ENOSYS;
+  }
+  uint64_t Result = FEX::HLE::_SyscallHandler->FM.RemovexattrAt(dfd, pathname, at_flags, name);
+  SYSCALL_ERRNO();
+}
 void RegisterFS(FEX::HLE::SyscallHandler* Handler) {
   using namespace FEXCore::IR;
 
-  REGISTER_SYSCALL_IMPL(rename, [](FEXCore::Core::CpuStateFrame* Frame, const char* oldpath, const char* newpath) -> uint64_t {
-    uint64_t Result = ::rename(oldpath, newpath);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(mkdir, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname, mode_t mode) -> uint64_t {
-    uint64_t Result = ::mkdir(pathname, mode);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(rmdir, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname) -> uint64_t {
-    uint64_t Result = ::rmdir(pathname);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(link, [](FEXCore::Core::CpuStateFrame* Frame, const char* oldpath, const char* newpath) -> uint64_t {
-    uint64_t Result = ::link(oldpath, newpath);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(unlink, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname) -> uint64_t {
-    uint64_t Result = ::unlink(pathname);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(symlink, [](FEXCore::Core::CpuStateFrame* Frame, const char* target, const char* linkpath) -> uint64_t {
-    uint64_t Result = ::symlink(target, linkpath);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(readlink, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname, char* buf, size_t bufsiz) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.Readlink(pathname, buf, bufsiz);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(chmod, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname, mode_t mode) -> uint64_t {
-    uint64_t Result = ::chmod(pathname, mode);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(mknod, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname, mode_t mode, dev_t dev) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.Mknod(pathname, mode, dev);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(creat, [](FEXCore::Core::CpuStateFrame* Frame, const char* pathname, mode_t mode) -> uint64_t {
-    uint64_t Result = ::creat(pathname, mode);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(
-    setxattr, [](FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name, const void* value, size_t size, int flags) -> uint64_t {
-      uint64_t Result = FEX::HLE::_SyscallHandler->FM.Setxattr(path, name, value, size, flags);
-      SYSCALL_ERRNO();
-    });
-
-  REGISTER_SYSCALL_IMPL(
-    lsetxattr, [](FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name, const void* value, size_t size, int flags) -> uint64_t {
-      uint64_t Result = FEX::HLE::_SyscallHandler->FM.LSetxattr(path, name, value, size, flags);
-      SYSCALL_ERRNO();
-    });
-
-  REGISTER_SYSCALL_IMPL(getxattr, [](FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name, void* value, size_t size) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.Getxattr(path, name, value, size);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(lgetxattr, [](FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name, void* value, size_t size) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.LGetxattr(path, name, value, size);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(listxattr, [](FEXCore::Core::CpuStateFrame* Frame, const char* path, char* list, size_t size) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.Listxattr(path, list, size);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(llistxattr, [](FEXCore::Core::CpuStateFrame* Frame, const char* path, char* list, size_t size) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.LListxattr(path, list, size);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(removexattr, [](FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.Removexattr(path, name);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(lremovexattr, [](FEXCore::Core::CpuStateFrame* Frame, const char* path, const char* name) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->FM.LRemovexattr(path, name);
-    SYSCALL_ERRNO();
-  });
-  if (Handler->IsHostKernelVersionAtLeast(6, 13, 0)) {
-    REGISTER_SYSCALL_IMPL(setxattrat,
-                          [](FEXCore::Core::CpuStateFrame* Frame, int dfd, const char* pathname, uint32_t at_flags, const char* name,
-                             const FileManager::xattr_args* uargs, size_t usize) -> uint64_t {
-                            uint64_t Result = FEX::HLE::_SyscallHandler->FM.SetxattrAt(dfd, pathname, at_flags, name, uargs, usize);
-                            SYSCALL_ERRNO();
-                          });
-    REGISTER_SYSCALL_IMPL(getxattrat,
-                          [](FEXCore::Core::CpuStateFrame* Frame, int dfd, const char* pathname, uint32_t at_flags, const char* name,
-                             const FileManager::xattr_args* uargs, size_t usize) -> uint64_t {
-                            uint64_t Result = FEX::HLE::_SyscallHandler->FM.GetxattrAt(dfd, pathname, at_flags, name, uargs, usize);
-                            SYSCALL_ERRNO();
-                          });
-
-    REGISTER_SYSCALL_IMPL(
-      listxattrat, [](FEXCore::Core::CpuStateFrame* Frame, int dfd, const char* pathname, uint32_t at_flags, char* list, size_t size) -> uint64_t {
-        uint64_t Result = FEX::HLE::_SyscallHandler->FM.ListxattrAt(dfd, pathname, at_flags, list, size);
-        SYSCALL_ERRNO();
-      });
-    REGISTER_SYSCALL_IMPL(
-      removexattrat, [](FEXCore::Core::CpuStateFrame* Frame, int dfd, const char* pathname, uint32_t at_flags, const char* name) -> uint64_t {
-        uint64_t Result = FEX::HLE::_SyscallHandler->FM.RemovexattrAt(dfd, pathname, at_flags, name);
-        SYSCALL_ERRNO();
-      });
-  } else {
-    REGISTER_SYSCALL_IMPL(setxattrat, UnimplementedSyscallSafe);
-    REGISTER_SYSCALL_IMPL(getxattrat, UnimplementedSyscallSafe);
-    REGISTER_SYSCALL_IMPL(listxattrat, UnimplementedSyscallSafe);
-    REGISTER_SYSCALL_IMPL(removexattrat, UnimplementedSyscallSafe);
-  }
+  REGISTER_SYSCALL_IMPL(rename, rename);
+  REGISTER_SYSCALL_IMPL(mkdir, mkdir);
+  REGISTER_SYSCALL_IMPL(rmdir, rmdir);
+  REGISTER_SYSCALL_IMPL(link, link);
+  REGISTER_SYSCALL_IMPL(unlink, unlink);
+  REGISTER_SYSCALL_IMPL(symlink, symlink);
+  REGISTER_SYSCALL_IMPL(readlink, readlink);
+  REGISTER_SYSCALL_IMPL(chmod, chmod);
+  REGISTER_SYSCALL_IMPL(mknod, mknod);
+  REGISTER_SYSCALL_IMPL(creat, creat);
+  REGISTER_SYSCALL_IMPL(setxattr, setxattr);
+  REGISTER_SYSCALL_IMPL(lsetxattr, lsetxattr);
+  REGISTER_SYSCALL_IMPL(getxattr, getxattr);
+  REGISTER_SYSCALL_IMPL(lgetxattr, lgetxattr);
+  REGISTER_SYSCALL_IMPL(listxattr, listxattr);
+  REGISTER_SYSCALL_IMPL(llistxattr, llistxattr);
+  REGISTER_SYSCALL_IMPL(removexattr, removexattr);
+  REGISTER_SYSCALL_IMPL(lremovexattr, lremovexattr);
+  REGISTER_SYSCALL_IMPL(setxattrat, setxattrat);
+  REGISTER_SYSCALL_IMPL(getxattrat, getxattrat);
+  REGISTER_SYSCALL_IMPL(listxattrat, listxattrat);
+  REGISTER_SYSCALL_IMPL(removexattrat, removexattrat);
 }
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/IO.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/IO.cpp
@@ -16,17 +16,16 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE {
+auto noperm(FEXCore::Core::CpuStateFrame* Frame, int level) -> uint64_t {
+  // Just claim we don't have permission
+  return -EPERM;
+};
+
+
 void RegisterIO(FEX::HLE::SyscallHandler* Handler) {
   using namespace FEXCore::IR;
 
-  REGISTER_SYSCALL_IMPL(iopl, [](FEXCore::Core::CpuStateFrame* Frame, int level) -> uint64_t {
-    // Just claim we don't have permission
-    return -EPERM;
-  });
-
-  REGISTER_SYSCALL_IMPL(ioperm, [](FEXCore::Core::CpuStateFrame* Frame, unsigned long from, unsigned long num, int turn_on) -> uint64_t {
-    // ioperm not available on our architecture
-    return -EPERM;
-  });
+  REGISTER_SYSCALL_IMPL(iopl, noperm);
+  REGISTER_SYSCALL_IMPL(ioperm, noperm);
 }
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Info.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Info.cpp
@@ -34,86 +34,90 @@ namespace FEX::HLE {
 using cap_user_header_t = void*;
 using cap_user_data_t = void*;
 
+auto uname(FEXCore::Core::CpuStateFrame* Frame, struct utsname* buf) -> uint64_t {
+  auto Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
+
+  struct utsname Local {};
+  if (::uname(&Local) == 0) {
+    memcpy(buf->nodename, Local.nodename, sizeof(Local.nodename));
+    static_assert(sizeof(Local.nodename) <= sizeof(buf->nodename));
+    memcpy(buf->domainname, Local.domainname, sizeof(Local.domainname));
+    static_assert(sizeof(Local.domainname) <= sizeof(buf->domainname));
+  } else {
+    strcpy(buf->nodename, "FEXCore");
+    LogMan::Msg::EFmt("Couldn't determine host nodename. Defaulting to '{}'", buf->nodename);
+  }
+  strcpy(buf->sysname, "Linux");
+  uint32_t GuestVersion = FEX::HLE::_SyscallHandler->GetGuestKernelVersion();
+  if (Thread->persona & UNAME26) {
+    // Kernel version converts from 6.x.y to 2.6.60+x.
+    GuestVersion = FEX::HLE::SyscallHandler::KernelVersion(2, 6, 60 + FEX::HLE::SyscallHandler::KernelMinor(GuestVersion));
+  }
+  snprintf(buf->release, sizeof(buf->release), "%d.%d.%d", FEX::HLE::SyscallHandler::KernelMajor(GuestVersion),
+           FEX::HLE::SyscallHandler::KernelMinor(GuestVersion), FEX::HLE::SyscallHandler::KernelPatch(GuestVersion));
+
+  const char version[] = "#" GIT_DESCRIBE_STRING " SMP " __DATE__ " " __TIME__;
+  strcpy(buf->version, version);
+  static_assert(sizeof(version) <= sizeof(buf->version), "uname version define became too large!");
+  if (Thread->persona & PER_LINUX32) {
+    // Tell the guest that we are a 32bit kernel
+    strcpy(buf->machine, "i686");
+  } else {
+    // Tell the guest that we are a 64bit kernel
+    strcpy(buf->machine, "x86_64");
+  }
+  return 0;
+}
+
+auto personality(FEXCore::Core::CpuStateFrame* Frame, uint32_t persona) -> uint64_t {
+  auto Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
+
+  if (persona == ~0U) {
+    // Special case, only queries the persona.
+    return Thread->persona;
+  }
+
+  // Mask off `PER_LINUX32` because AArch64 doesn't support it.
+  uint32_t NewPersona = persona & ~PER_LINUX32;
+
+  // This syscall can not physically fail with PER_LINUX32 masked off.
+  // It also can not fail on a real x86 kernel.
+  (void)::syscall(SYSCALL_DEF(personality), NewPersona);
+
+  // Return the old persona while setting the new one.
+  auto OldPersona = Thread->persona;
+  Thread->persona = persona;
+  return OldPersona;
+}
+
+auto seccomp(FEXCore::Core::CpuStateFrame* Frame, unsigned int operation, unsigned int flags, void* args) -> uint64_t {
+  return FEX::HLE::_SyscallHandler->SeccompEmulator.Handle(Frame, operation, flags, args);
+};
+auto ptrace(FEXCore::Core::CpuStateFrame* Frame, int /*enum __ptrace_request*/ request, pid_t pid, void* addr, void* data) -> uint64_t {
+  uint64_t Result {};
+
+  switch (request) {
+  case PTRACE_PEEKTEXT:
+  case PTRACE_PEEKDATA:
+  case PTRACE_POKETEXT:
+  case PTRACE_POKEDATA:
+  case PTRACE_ATTACH:
+  case PTRACE_DETACH:
+    // Passthrough these requests. Allows Wine to run the Ubisoft launcher.
+    Result = ::syscall(SYSCALL_DEF(ptrace), request, pid, addr, data);
+    SYSCALL_ERRNO();
+  default: break;
+  }
+  // We don't support this
+  return -EPERM;
+}
+
 void RegisterInfo(FEX::HLE::SyscallHandler* Handler) {
   using namespace FEXCore::IR;
 
-  REGISTER_SYSCALL_IMPL(uname, [](FEXCore::Core::CpuStateFrame* Frame, struct utsname* buf) -> uint64_t {
-    auto Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
-
-    struct utsname Local {};
-    if (::uname(&Local) == 0) {
-      memcpy(buf->nodename, Local.nodename, sizeof(Local.nodename));
-      static_assert(sizeof(Local.nodename) <= sizeof(buf->nodename));
-      memcpy(buf->domainname, Local.domainname, sizeof(Local.domainname));
-      static_assert(sizeof(Local.domainname) <= sizeof(buf->domainname));
-    } else {
-      strcpy(buf->nodename, "FEXCore");
-      LogMan::Msg::EFmt("Couldn't determine host nodename. Defaulting to '{}'", buf->nodename);
-    }
-    strcpy(buf->sysname, "Linux");
-    uint32_t GuestVersion = FEX::HLE::_SyscallHandler->GetGuestKernelVersion();
-    if (Thread->persona & UNAME26) {
-      // Kernel version converts from 6.x.y to 2.6.60+x.
-      GuestVersion = FEX::HLE::SyscallHandler::KernelVersion(2, 6, 60 + FEX::HLE::SyscallHandler::KernelMinor(GuestVersion));
-    }
-    snprintf(buf->release, sizeof(buf->release), "%d.%d.%d", FEX::HLE::SyscallHandler::KernelMajor(GuestVersion),
-             FEX::HLE::SyscallHandler::KernelMinor(GuestVersion), FEX::HLE::SyscallHandler::KernelPatch(GuestVersion));
-
-    const char version[] = "#" GIT_DESCRIBE_STRING " SMP " __DATE__ " " __TIME__;
-    strcpy(buf->version, version);
-    static_assert(sizeof(version) <= sizeof(buf->version), "uname version define became too large!");
-    if (Thread->persona & PER_LINUX32) {
-      // Tell the guest that we are a 32bit kernel
-      strcpy(buf->machine, "i686");
-    } else {
-      // Tell the guest that we are a 64bit kernel
-      strcpy(buf->machine, "x86_64");
-    }
-    return 0;
-  });
-
-  REGISTER_SYSCALL_IMPL(personality, [](FEXCore::Core::CpuStateFrame* Frame, uint32_t persona) -> uint64_t {
-    auto Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
-
-    if (persona == ~0U) {
-      // Special case, only queries the persona.
-      return Thread->persona;
-    }
-
-    // Mask off `PER_LINUX32` because AArch64 doesn't support it.
-    uint32_t NewPersona = persona & ~PER_LINUX32;
-
-    // This syscall can not physically fail with PER_LINUX32 masked off.
-    // It also can not fail on a real x86 kernel.
-    (void)::syscall(SYSCALL_DEF(personality), NewPersona);
-
-    // Return the old persona while setting the new one.
-    auto OldPersona = Thread->persona;
-    Thread->persona = persona;
-    return OldPersona;
-  });
-
-  REGISTER_SYSCALL_IMPL(seccomp, [](FEXCore::Core::CpuStateFrame* Frame, unsigned int operation, unsigned int flags, void* args) -> uint64_t {
-    return FEX::HLE::_SyscallHandler->SeccompEmulator.Handle(Frame, operation, flags, args);
-  });
-  REGISTER_SYSCALL_IMPL(
-    ptrace, [](FEXCore::Core::CpuStateFrame* Frame, int /*enum __ptrace_request*/ request, pid_t pid, void* addr, void* data) -> uint64_t {
-      uint64_t Result {};
-
-      switch (request) {
-      case PTRACE_PEEKTEXT:
-      case PTRACE_PEEKDATA:
-      case PTRACE_POKETEXT:
-      case PTRACE_POKEDATA:
-      case PTRACE_ATTACH:
-      case PTRACE_DETACH:
-        // Passthrough these requests. Allows Wine to run the Ubisoft launcher.
-        Result = ::syscall(SYSCALL_DEF(ptrace), request, pid, addr, data);
-        SYSCALL_ERRNO();
-      default: break;
-      }
-      // We don't support this
-      return -EPERM;
-    });
+  REGISTER_SYSCALL_IMPL(uname, uname);
+  REGISTER_SYSCALL_IMPL(personality, personality);
+  REGISTER_SYSCALL_IMPL(seccomp, seccomp);
+  REGISTER_SYSCALL_IMPL(ptrace, ptrace);
 }
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Memory.cpp
@@ -19,21 +19,23 @@ $end_info$
 #include <unistd.h>
 
 namespace FEX::HLE {
+auto brk(FEXCore::Core::CpuStateFrame* Frame, void* addr) -> uint64_t {
+  uint64_t Result = FEX::HLE::_SyscallHandler->HandleBRK(Frame, addr);
+  SYSCALL_ERRNO();
+}
+
+auto madvise(FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length, int32_t advice) -> uint64_t {
+  uint64_t Result = ::madvise(addr, length, advice);
+
+  if (Result != -1) {
+    FEX::HLE::_SyscallHandler->TrackMadvise(Frame->Thread, (uintptr_t)addr, length, advice);
+  }
+  SYSCALL_ERRNO();
+}
+
 void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
   using namespace FEXCore::IR;
-
-  REGISTER_SYSCALL_IMPL(brk, [](FEXCore::Core::CpuStateFrame* Frame, void* addr) -> uint64_t {
-    uint64_t Result = FEX::HLE::_SyscallHandler->HandleBRK(Frame, addr);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(madvise, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length, int32_t advice) -> uint64_t {
-    uint64_t Result = ::madvise(addr, length, advice);
-
-    if (Result != -1) {
-      FEX::HLE::_SyscallHandler->TrackMadvise(Frame->Thread, (uintptr_t)addr, length, advice);
-    }
-    SYSCALL_ERRNO();
-  });
+  REGISTER_SYSCALL_IMPL(brk, brk);
+  REGISTER_SYSCALL_IMPL(madvise, madvise);
 }
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/NotImplemented.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/NotImplemented.cpp
@@ -13,45 +13,75 @@ $end_info$
 #include <stdint.h>
 #include <sys/epoll.h>
 
-#define REGISTER_SYSCALL_NOT_IMPL(name)                                             \
-  REGISTER_SYSCALL_IMPL(name, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { \
-    LogMan::Msg::DFmt("Using deprecated/removed syscall: " #name);                  \
-    return -ENOSYS;                                                                 \
-  });
+#define SYSCALL_NOT_IMPL(name)                                     \
+  auto name(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {     \
+    LogMan::Msg::DFmt("Using deprecated/removed syscall: " #name); \
+    return -ENOSYS;                                                \
+  }
 
-#define REGISTER_SYSCALL_NO_PERM(name) REGISTER_SYSCALL_IMPL(name, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { return -EPERM; });
+#define SYSCALL_NO_PERM(name)                                  \
+  auto name(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { \
+    return -EPERM;                                             \
+  }
 
-#define REGISTER_SYSCALL_NO_ACCESS(name) \
-  REGISTER_SYSCALL_IMPL(name, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { return -EACCES; });
+#define SYSCALL_NO_ACCESS(name)                                \
+  auto name(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { \
+    return -EACCES;                                            \
+  }
 
 namespace FEX::HLE {
 // these are removed/not implemented in the linux kernel we present
+SYSCALL_NOT_IMPL(ustat);
+SYSCALL_NOT_IMPL(sysfs);
+SYSCALL_NOT_IMPL(uselib);
+SYSCALL_NOT_IMPL(create_module);
+SYSCALL_NOT_IMPL(get_kernel_syms);
+SYSCALL_NOT_IMPL(query_module);
+SYSCALL_NOT_IMPL(nfsservctl); // Was removed in Linux 3.1
+SYSCALL_NOT_IMPL(getpmsg);
+SYSCALL_NOT_IMPL(putpmsg);
+SYSCALL_NOT_IMPL(afs_syscall);
+SYSCALL_NOT_IMPL(vserver);
+SYSCALL_NOT_IMPL(_sysctl); // Was removed in Linux 5.5
+
+SYSCALL_NO_PERM(vhangup);
+SYSCALL_NO_PERM(reboot)
+SYSCALL_NO_PERM(sethostname);
+SYSCALL_NO_PERM(setdomainname);
+SYSCALL_NO_PERM(kexec_load);
+SYSCALL_NO_PERM(finit_module);
+SYSCALL_NO_PERM(bpf);
+SYSCALL_NO_PERM(lookup_dcookie);
+SYSCALL_NO_PERM(init_module)
+SYSCALL_NO_PERM(delete_module);
+SYSCALL_NO_PERM(quotactl);
+SYSCALL_NO_ACCESS(perf_event_open);
 
 void RegisterNotImplemented(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_NOT_IMPL(ustat);
-  REGISTER_SYSCALL_NOT_IMPL(sysfs);
-  REGISTER_SYSCALL_NOT_IMPL(uselib);
-  REGISTER_SYSCALL_NOT_IMPL(create_module);
-  REGISTER_SYSCALL_NOT_IMPL(get_kernel_syms);
-  REGISTER_SYSCALL_NOT_IMPL(query_module);
-  REGISTER_SYSCALL_NOT_IMPL(nfsservctl); // Was removed in Linux 3.1
-  REGISTER_SYSCALL_NOT_IMPL(getpmsg);
-  REGISTER_SYSCALL_NOT_IMPL(putpmsg);
-  REGISTER_SYSCALL_NOT_IMPL(afs_syscall);
-  REGISTER_SYSCALL_NOT_IMPL(vserver);
-  REGISTER_SYSCALL_NOT_IMPL(_sysctl); // Was removed in Linux 5.5
+  REGISTER_SYSCALL_IMPL(ustat, ustat);
+  REGISTER_SYSCALL_IMPL(sysfs, sysfs);
+  REGISTER_SYSCALL_IMPL(uselib, uselib);
+  REGISTER_SYSCALL_IMPL(create_module, create_module);
+  REGISTER_SYSCALL_IMPL(get_kernel_syms, get_kernel_syms);
+  REGISTER_SYSCALL_IMPL(query_module, query_module);
+  REGISTER_SYSCALL_IMPL(nfsservctl, nfsservctl); // Was removed in Linux 3.1
+  REGISTER_SYSCALL_IMPL(getpmsg, getpmsg);
+  REGISTER_SYSCALL_IMPL(putpmsg, putpmsg);
+  REGISTER_SYSCALL_IMPL(afs_syscall, afs_syscall);
+  REGISTER_SYSCALL_IMPL(vserver, vserver);
+  REGISTER_SYSCALL_IMPL(_sysctl, _sysctl); // Was removed in Linux 5.5
 
-  REGISTER_SYSCALL_NO_PERM(vhangup);
-  REGISTER_SYSCALL_NO_PERM(reboot)
-  REGISTER_SYSCALL_NO_PERM(sethostname);
-  REGISTER_SYSCALL_NO_PERM(setdomainname);
-  REGISTER_SYSCALL_NO_PERM(kexec_load);
-  REGISTER_SYSCALL_NO_PERM(finit_module);
-  REGISTER_SYSCALL_NO_PERM(bpf);
-  REGISTER_SYSCALL_NO_PERM(lookup_dcookie);
-  REGISTER_SYSCALL_NO_PERM(init_module)
-  REGISTER_SYSCALL_NO_PERM(delete_module);
-  REGISTER_SYSCALL_NO_PERM(quotactl);
-  REGISTER_SYSCALL_NO_ACCESS(perf_event_open);
+  REGISTER_SYSCALL_IMPL(vhangup, vhangup);
+  REGISTER_SYSCALL_IMPL(reboot, reboot);
+  REGISTER_SYSCALL_IMPL(sethostname, sethostname);
+  REGISTER_SYSCALL_IMPL(setdomainname, setdomainname);
+  REGISTER_SYSCALL_IMPL(kexec_load, kexec_load);
+  REGISTER_SYSCALL_IMPL(finit_module, finit_module);
+  REGISTER_SYSCALL_IMPL(bpf, bpf);
+  REGISTER_SYSCALL_IMPL(lookup_dcookie, lookup_dcookie);
+  REGISTER_SYSCALL_IMPL(init_module, init_module);
+  REGISTER_SYSCALL_IMPL(delete_module, delete_module);
+  REGISTER_SYSCALL_IMPL(quotactl, quotactl);
+  REGISTER_SYSCALL_IMPL(perf_event_open, perf_event_open);
 }
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Stubs.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Stubs.cpp
@@ -15,23 +15,21 @@ $end_info$
 #include <stdint.h>
 #include <sys/types.h>
 
-#define SYSCALL_STUB(name)                         \
-  do {                                             \
-    ERROR_AND_DIE_FMT("Syscall: " #name " stub!"); \
-    return -ENOSYS;                                \
-  } while (0)
-
 namespace FEXCore::Core {
 struct CpuStateFrame;
 }
 
 namespace FEX::HLE {
-void RegisterStubs(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_IMPL(restart_syscall, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t { SYSCALL_STUB(restart_syscall); });
+auto stub_fault(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
+  ERROR_AND_DIE_FMT("Syscall: stub!");
+  return -ENOSYS;
+}
+auto stub(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
+  return -ENOSYS;
+}
 
-  REGISTER_SYSCALL_IMPL(rseq, [](FEXCore::Core::CpuStateFrame* Frame, struct rseq* rseq, uint32_t rseq_len, int flags, uint32_t sig) -> uint64_t {
-    // We don't support this
-    return -ENOSYS;
-  });
+void RegisterStubs(FEX::HLE::SyscallHandler* Handler) {
+  REGISTER_SYSCALL_IMPL(restart_syscall, stub_fault);
+  REGISTER_SYSCALL_IMPL(rseq, stub);
 }
 } // namespace FEX::HLE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Timer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Timer.cpp
@@ -6,7 +6,6 @@ $end_info$
 */
 
 #include "LinuxSyscalls/Syscalls.h"
-#include "LinuxSyscalls/Types.h"
 #include "LinuxSyscalls/x64/Syscalls.h"
 #include "LinuxSyscalls/x32/Syscalls.h"
 
@@ -14,24 +13,24 @@ $end_info$
 
 #include <stddef.h>
 #include <stdint.h>
-#include <signal.h>
 #include <sys/time.h>
-#include <time.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
 namespace FEX::HLE {
+auto alarm(FEXCore::Core::CpuStateFrame* Frame, unsigned int seconds) -> uint64_t {
+  uint64_t Result = ::alarm(seconds);
+  SYSCALL_ERRNO();
+}
+
+auto pause(FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
+  uint64_t Result = ::pause();
+  SYSCALL_ERRNO();
+}
+
 void RegisterTimer(FEX::HLE::SyscallHandler* Handler) {
   using namespace FEXCore::IR;
-
-  REGISTER_SYSCALL_IMPL(alarm, [](FEXCore::Core::CpuStateFrame* Frame, unsigned int seconds) -> uint64_t {
-    uint64_t Result = ::alarm(seconds);
-    SYSCALL_ERRNO();
-  });
-
-  REGISTER_SYSCALL_IMPL(pause, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
-    uint64_t Result = ::pause();
-    SYSCALL_ERRNO();
-  });
+  REGISTER_SYSCALL_IMPL(alarm, alarm);
+  REGISTER_SYSCALL_IMPL(pause, pause);
 }
 } // namespace FEX::HLE


### PR DESCRIPTION
It be like #4899 and #4900 but this time for the common syscalls.

Passthrough is untouched  because that needs some more jiggery-pokery with how the constexpr tables get laid out.

NFC.