### PR TITLE
Change required Python version from 3.10 to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,7 +319,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 find_package(PkgConfig REQUIRED)
-find_package(Python 3.10 REQUIRED COMPONENTS Interpreter)
+find_package(Python 3.9 REQUIRED COMPONENTS Interpreter)
 
 set(BUILD_SHARED_LIBS OFF)
 


### PR DESCRIPTION
Debian bullseye is a supported build environment which only provides 3.9