### PR TITLE
fextl/string: Correct <filesystem> include to <functional>

### DIFF
--- a/FEXCore/include/FEXCore/fextl/string.h
+++ b/FEXCore/include/FEXCore/fextl/string.h
@@ -2,7 +2,7 @@
 #pragma once
 #include <FEXCore/fextl/allocator.h>
 
-#include <filesystem>
+#include <functional>
 #include <string>
 
 namespace fextl {


### PR DESCRIPTION
This was unintentionally putting all the filesystem utilities into headers implicitly.