### PR TITLE
Arm64Emitter: Cull unnecessary includes

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 #include "Interface/Core/ArchHelpers/Arm64Emitter.h"
-#include "FEXCore/Core/X86Enums.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"
 #include "Interface/Context/Context.h"
 
 #include <FEXCore/Core/CoreState.h>
+#include <FEXCore/Core/X86Enums.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/MathUtils.h>
 

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -1,29 +1,30 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "FEXCore/Utils/EnumUtils.h"
-#include "Interface/Core/JIT/Relocations.h"
-
 #ifdef VIXL_DISASSEMBLER
 #include <aarch64/disasm-aarch64.h>
+#include <FEXCore/Config/Config.h>
+#include <FEXCore/fextl/memory.h>
+#include <FEXCore/fextl/vector.h>
 #endif
 #ifdef VIXL_SIMULATOR
 #include <aarch64/simulator-aarch64.h>
 #include <aarch64/simulator-constants-aarch64.h>
 #endif
 
-#include <FEXCore/Core/X86Enums.h>
-#include <FEXCore/Config/Config.h>
-#include <FEXCore/fextl/vector.h>
 #include <CodeEmitter/Emitter.h>
 #include <CodeEmitter/Registers.h>
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <span>
 
 namespace FEXCore::Context {
 class ContextImpl;
+}
+namespace FEXCore::X86State {
+enum X86Reg : uint32_t;
 }
 
 namespace FEXCore::CPU {

--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -10,13 +10,17 @@ $end_info$
 #include "Interface/Core/ArchHelpers/Arm64Emitter.h"
 #include "Interface/Core/CPUBackend.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"
+#include "Interface/Core/JIT/Relocations.h"
 #include "Interface/IR/IR.h"
 #include "Interface/IR/IntrusiveIRList.h"
 #include "Interface/IR/RegisterAllocationData.h"
 
+#include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/IR/IR.h>
+#include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/fextl/map.h>
+#include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/vector.h>
 
@@ -25,6 +29,7 @@ $end_info$
 #include <array>
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <utility>
 #include <variant>
 


### PR DESCRIPTION
Also fixes an indirect include and makes the disassembler dependencies a little more explicit.