### PR TITLE
General: Migrate to std::bit_cast

### DIFF
--- a/CodeEmitter/CodeEmitter/SVEOps.inl
+++ b/CodeEmitter/CodeEmitter/SVEOps.inl
@@ -5125,7 +5125,7 @@ private:
   requires (std::is_same_v<T, float> || std::is_same_v<T, double>)
   [[nodiscard]]
   static bool IsValidFPValueForImm8(T value) {
-    const uint64_t bits = FEXCore::BitCast<FloatToEquivalentUInt<T>>(value);
+    const uint64_t bits = std::bit_cast<FloatToEquivalentUInt<T>>(value);
     const uint64_t datasize_idx = FEXCore::ilog2(sizeof(T)) - 1;
 
     static constexpr std::array mantissa_masks {
@@ -5171,7 +5171,7 @@ protected:
     LOGMAN_THROW_A_FMT(IsValidFPValueForImm8(value), "Value ({}) cannot be encoded into an 8-bit immediate", value);
 #endif
 
-    const auto bits = FEXCore::BitCast<uint32_t>(value);
+    const auto bits = std::bit_cast<uint32_t>(value);
     const auto sign = (bits & 0x80000000) >> 24;
     const auto expb2 = (bits & 0x20000000) >> 23;
     const auto b5_to_0 = (bits >> 19) & 0x3F;
@@ -5184,7 +5184,7 @@ protected:
     LOGMAN_THROW_A_FMT(IsValidFPValueForImm8(value), "Value ({}) cannot be encoded into an 8-bit immediate", value);
 #endif
 
-    const auto bits = FEXCore::BitCast<uint64_t>(value);
+    const auto bits = std::bit_cast<uint64_t>(value);
     const auto sign = (bits & 0x80000000'00000000) >> 56;
     const auto expb2 = (bits & 0x20000000'00000000) >> 55;
     const auto b5_to_0 = (bits >> 48) & 0x3F;

--- a/FEXCore/Source/Common/SoftFloat.h
+++ b/FEXCore/Source/Common/SoftFloat.h
@@ -4,9 +4,9 @@
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/fextl/sstream.h>
 #include <FEXCore/fextl/string.h>
-#include <FEXHeaderUtils/BitUtils.h>
 #include "cephes_128bit.h"
 
+#include <bit>
 #include <cmath>
 #include <cstring>
 #include <stdint.h>
@@ -501,7 +501,7 @@ struct FEX_PACKED X80SoftFloat {
 
   float ToF32(softfloat_state* state) const {
     const float32_t Result = extF80_to_f32(state, *this);
-    return FEXCore::BitCast<float>(Result);
+    return std::bit_cast<float>(Result);
   }
 
   bool IsSignalingNaN() const {
@@ -533,21 +533,21 @@ struct FEX_PACKED X80SoftFloat {
       ieee_frac &= ~0x0008000000000000ULL;
 
       uint64_t result_bits = sign_bit | exp_bits | ieee_frac;
-      return FEXCore::BitCast<double>(result_bits);
+      return std::bit_cast<double>(result_bits);
     } else if (IsQuietNaN()) {
       const float64_t Result = extF80_to_f64(state, *this);
-      uint64_t result_bits = FEXCore::BitCast<uint64_t>(Result);
+      uint64_t result_bits = std::bit_cast<uint64_t>(Result);
       result_bits |= 0x0008000000000000ULL;
-      return FEXCore::BitCast<double>(result_bits);
+      return std::bit_cast<double>(result_bits);
     } else {
       const float64_t Result = extF80_to_f64(state, *this);
-      return FEXCore::BitCast<double>(Result);
+      return std::bit_cast<double>(Result);
     }
   }
 
   double ToF64(softfloat_state* state) const {
     const float64_t Result = extF80_to_f64(state, *this);
-    return FEXCore::BitCast<double>(Result);
+    return std::bit_cast<double>(Result);
   }
 
   FEXCore::VectorRegType ToVector() const {
@@ -559,7 +559,7 @@ struct FEX_PACKED X80SoftFloat {
   BIGFLOAT ToFMax(softfloat_state* state) const {
 #if BIGFLOATSIZE == 16
     const float128_t Result = extF80_to_f128(state, *this);
-    return FEXCore::BitCast<BIGFLOAT>(Result);
+    return std::bit_cast<BIGFLOAT>(Result);
 #else
     BIGFLOAT result {};
     memcpy(&result, this, sizeof(result));
@@ -618,16 +618,16 @@ struct FEX_PACKED X80SoftFloat {
   }
 
   X80SoftFloat(softfloat_state* state, const float rhs) {
-    *this = f32_to_extF80(state, FEXCore::BitCast<float32_t>(rhs));
+    *this = f32_to_extF80(state, std::bit_cast<float32_t>(rhs));
   }
 
   X80SoftFloat(softfloat_state* state, const double rhs) {
-    *this = f64_to_extF80(state, FEXCore::BitCast<float64_t>(rhs));
+    *this = f64_to_extF80(state, std::bit_cast<float64_t>(rhs));
   }
 
   // Create X80SoftFloat from double while preserving NaN signaling properties
   static X80SoftFloat FromF64_PreserveNaN(softfloat_state* state, double value) {
-    uint64_t bits = FEXCore::BitCast<uint64_t>(value);
+    uint64_t bits = std::bit_cast<uint64_t>(value);
 
     // Check if it's a nan
     if ((bits & 0x7FF0000000000000ULL) == 0x7FF0000000000000ULL && (bits & 0x000FFFFFFFFFFFFFULL) != 0) {
@@ -660,9 +660,9 @@ struct FEX_PACKED X80SoftFloat {
 
   X80SoftFloat(softfloat_state* state, BIGFLOAT rhs) {
 #if BIGFLOATSIZE == 16
-    *this = f128_to_extF80(state, FEXCore::BitCast<float128_t>(rhs));
+    *this = f128_to_extF80(state, std::bit_cast<float128_t>(rhs));
 #else
-    *this = FEXCore::BitCast<long double>(rhs);
+    *this = std::bit_cast<long double>(rhs);
 #endif
   }
 

--- a/FEXHeaderUtils/FEXHeaderUtils/BitUtils.h
+++ b/FEXHeaderUtils/FEXHeaderUtils/BitUtils.h
@@ -7,7 +7,6 @@
 #include <climits>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <type_traits>
 
 namespace FEXCore {
@@ -64,19 +63,6 @@ constexpr int FindFirstSetBit(T value) noexcept {
 
   const int trailing_zeroes = std::countr_zero(value);
   return trailing_zeroes + 1;
-}
-
-// Stand-in for std::bit_cast until libc++ implements it.
-template<typename To, typename From>
-[[nodiscard]]
-inline To BitCast(const From& source) noexcept {
-  static_assert(sizeof(From) == sizeof(To), "BitCast source and destination types must be equal in size.");
-  static_assert(std::is_trivially_copyable_v<From>, "BitCast source type must be trivially copyable.");
-  static_assert(std::is_trivially_copyable_v<To>, "BitCast destination type must be trivially copyable.");
-
-  std::aligned_storage_t<sizeof(To), alignof(To)> storage;
-  std::memcpy(&storage, &source, sizeof(storage));
-  return reinterpret_cast<To&>(storage);
 }
 
 } // namespace FEXCore


### PR DESCRIPTION
We already have a few cases where we already use bit_cast in the emitter, so we may as well move all of our temporary helper instances over as well.