### PR TITLE
IR: Convert CondClassType over to enum class

### DIFF
--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -303,14 +303,21 @@ def parse_ops(ops):
             IROpNameMap[OpDef.Name] = 1
 
 # Print out enum values
-def print_enums():
+def print_enums(enums):
     output_file.write("#ifdef IROP_ENUM\n")
     output_file.write("enum IROps : uint16_t {\n")
-
     for op in IROps:
         output_file.write("\tOP_{},\n" .format(op.Name.upper()))
-
     output_file.write("};\n")
+
+    for name, members in enums.items():
+        output_file.write(f"enum {name} {{\n")
+        for member in members:
+            if member:
+                output_file.write(f"\t{member}\n")
+            else:
+                output_file.write("\n")
+        output_file.write("};\n\n")
 
     output_file.write("#undef IROP_ENUM\n")
     output_file.write("#endif\n\n")
@@ -865,6 +872,7 @@ json_file.close()
 json_object = json.loads(json_text)
 json_object = {k.upper(): v for k, v in json_object.items()}
 
+enums = json_object["ENUMS"]
 ops = json_object["OPS"]
 irtypes = json_object["IRTYPES"]
 defines = json_object["DEFINES"]
@@ -874,7 +882,7 @@ parse_ops(ops)
 
 output_file = open(output_filename, "w")
 
-print_enums()
+print_enums(enums)
 print_ir_structs(defines)
 print_ir_sizes()
 print_ir_reg_classes()

--- a/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
@@ -372,7 +372,7 @@ DEF_OP(CondSubNZCV) {
 DEF_OP(Neg) {
   auto Op = IROp->C<IR::IROp_Neg>();
 
-  if (Op->Cond == FEXCore::IR::COND_AL) {
+  if (Op->Cond == IR::CondClass::AL) {
     neg(ConvertSize48(IROp), GetReg(Node), GetReg(Op->Src));
   } else {
     cneg(ConvertSize48(IROp), GetReg(Node), GetReg(Op->Src), MapCC(Op->Cond));

--- a/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
@@ -235,16 +235,16 @@ DEF_OP(CondJump) {
     LOGMAN_THROW_A_FMT(IsGPR(Op->Cmp1), "CondJump: Expected GPR");
     LOGMAN_THROW_A_FMT(isConst, "CondJump: Expected constant source");
 
-    if (Op->Cond.Val == FEXCore::IR::COND_EQ) {
+    if (Op->Cond == IR::CondClass::EQ) {
       LOGMAN_THROW_A_FMT(Const == 0, "CondJump: Expected 0 source");
       cbz(Size, Reg, TrueTargetLabel);
-    } else if (Op->Cond.Val == FEXCore::IR::COND_NEQ) {
+    } else if (Op->Cond == IR::CondClass::NEQ) {
       LOGMAN_THROW_A_FMT(Const == 0, "CondJump: Expected 0 source");
       cbnz(Size, Reg, TrueTargetLabel);
-    } else if (Op->Cond.Val == FEXCore::IR::COND_TSTZ) {
+    } else if (Op->Cond == IR::CondClass::TSTZ) {
       LOGMAN_THROW_A_FMT(Const < 64, "CondJump: Expected valid bit source");
       tbz(Reg, Const, TrueTargetLabel);
-    } else if (Op->Cond.Val == FEXCore::IR::COND_TSTNZ) {
+    } else if (Op->Cond == IR::CondClass::TSTNZ) {
       LOGMAN_THROW_A_FMT(Const < 64, "CondJump: Expected valid bit source");
       tbnz(Reg, Const, TrueTargetLabel);
     } else {

--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -239,28 +239,28 @@ private:
   }
 
   [[nodiscard]]
-  static ARMEmitter::Condition MapCC(IR::CondClassType Cond) {
-    switch (Cond.Val) {
-    case IR::COND_EQ: return ARMEmitter::Condition::CC_EQ;
-    case IR::COND_NEQ: return ARMEmitter::Condition::CC_NE;
-    case IR::COND_SGE: return ARMEmitter::Condition::CC_GE;
-    case IR::COND_SLT: return ARMEmitter::Condition::CC_LT;
-    case IR::COND_SGT: return ARMEmitter::Condition::CC_GT;
-    case IR::COND_SLE: return ARMEmitter::Condition::CC_LE;
-    case IR::COND_UGE: return ARMEmitter::Condition::CC_CS;
-    case IR::COND_ULT: return ARMEmitter::Condition::CC_CC;
-    case IR::COND_UGT: return ARMEmitter::Condition::CC_HI;
-    case IR::COND_ULE: return ARMEmitter::Condition::CC_LS;
-    case IR::COND_FLU: return ARMEmitter::Condition::CC_LT;
-    case IR::COND_FGE: return ARMEmitter::Condition::CC_GE;
-    case IR::COND_FLEU: return ARMEmitter::Condition::CC_LE;
-    case IR::COND_FGT: return ARMEmitter::Condition::CC_GT;
-    case IR::COND_FU:
-    case IR::COND_VS: return ARMEmitter::Condition::CC_VS;
-    case IR::COND_FNU:
-    case IR::COND_VC: return ARMEmitter::Condition::CC_VC;
-    case IR::COND_MI: return ARMEmitter::Condition::CC_MI;
-    case IR::COND_PL: return ARMEmitter::Condition::CC_PL;
+  static ARMEmitter::Condition MapCC(IR::CondClass Cond) {
+    switch (Cond) {
+    case IR::CondClass::EQ: return ARMEmitter::Condition::CC_EQ;
+    case IR::CondClass::NEQ: return ARMEmitter::Condition::CC_NE;
+    case IR::CondClass::SGE: return ARMEmitter::Condition::CC_GE;
+    case IR::CondClass::SLT: return ARMEmitter::Condition::CC_LT;
+    case IR::CondClass::SGT: return ARMEmitter::Condition::CC_GT;
+    case IR::CondClass::SLE: return ARMEmitter::Condition::CC_LE;
+    case IR::CondClass::UGE: return ARMEmitter::Condition::CC_CS;
+    case IR::CondClass::ULT: return ARMEmitter::Condition::CC_CC;
+    case IR::CondClass::UGT: return ARMEmitter::Condition::CC_HI;
+    case IR::CondClass::ULE: return ARMEmitter::Condition::CC_LS;
+    case IR::CondClass::FLU: return ARMEmitter::Condition::CC_LT;
+    case IR::CondClass::FGE: return ARMEmitter::Condition::CC_GE;
+    case IR::CondClass::FLEU: return ARMEmitter::Condition::CC_LE;
+    case IR::CondClass::FGT: return ARMEmitter::Condition::CC_GT;
+    case IR::CondClass::FU:
+    case IR::CondClass::VS: return ARMEmitter::Condition::CC_VS;
+    case IR::CondClass::FNU:
+    case IR::CondClass::VC: return ARMEmitter::Condition::CC_VC;
+    case IR::CondClass::MI: return ARMEmitter::Condition::CC_MI;
+    case IR::CondClass::PL: return ARMEmitter::Condition::CC_PL;
     default: LOGMAN_MSG_A_FMT("Unsupported compare type"); return ARMEmitter::Condition::CC_NV;
     }
   }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -263,7 +263,7 @@ void OpDispatchBuilder::CalculateDeferredFlags() {
 Ref OpDispatchBuilder::IncrementByCarry(OpSize OpSize, Ref Src) {
   // If CF not inverted, we use .cc since the increment happens when the
   // condition is false. If CF inverted, invert to use .cs. A bit mindbendy.
-  return _NZCVSelectIncrement(OpSize, {CFInverted ? COND_UGE : COND_ULT}, Src, Src);
+  return _NZCVSelectIncrement(OpSize, CFInverted ? CondClass::UGE : CondClass::ULT, Src, Src);
 }
 
 Ref OpDispatchBuilder::CalculateFlags_ADC(IR::OpSize SrcSize, Ref Src1, Ref Src2) {
@@ -290,7 +290,7 @@ Ref OpDispatchBuilder::CalculateFlags_ADC(IR::OpSize SrcSize, Ref Src1, Ref Src2
     Res = _Bfe(OpSize, IR::OpSizeAsBits(SrcSize), 0, Res);
 
     // TODO: We can fold that second Bfe in (cmp uxth).
-    auto SelectCFInv = Select01(OpSize, CondClassType {COND_UGE}, Res, Src2PlusCF);
+    auto SelectCFInv = Select01(OpSize, CondClass::UGE, Res, Src2PlusCF);
 
     SetNZ_ZeroCV(SrcSize, Res);
     SetCFInverted(SelectCFInv);
@@ -324,7 +324,7 @@ Ref OpDispatchBuilder::CalculateFlags_SBB(IR::OpSize SrcSize, Ref Src1, Ref Src2
     Res = Sub(OpSize, Src1, Src2PlusCF);
     Res = _Bfe(OpSize, IR::OpSizeAsBits(SrcSize), 0, Res);
 
-    auto SelectCFInv = Select01(OpSize, CondClassType {COND_UGE}, Src1, Src2PlusCF);
+    auto SelectCFInv = Select01(OpSize, CondClass::UGE, Src1, Src2PlusCF);
 
     SetNZ_ZeroCV(SrcSize, Res);
     SetCFInverted(SelectCFInv);
@@ -406,7 +406,7 @@ void OpDispatchBuilder::CalculateFlags_MUL(IR::OpSize SrcSize, Ref Res, Ref High
   // If High = SignBit, then sets to nZCv. Else sets to nzcV. Since SF/ZF
   // undefined, this does what we need after inverting carry.
   auto Zero = _InlineConstant(0);
-  _CondSubNZCV(OpSize::i64Bit, Zero, Zero, CondClassType {COND_EQ}, 0x1 /* nzcV */);
+  _CondSubNZCV(OpSize::i64Bit, Zero, Zero, CondClass::EQ, 0x1 /* nzcV */);
   CFInverted = true;
 }
 
@@ -423,7 +423,7 @@ void OpDispatchBuilder::CalculateFlags_UMUL(Ref High) {
 
   // If High = 0, then sets to nZCv. Else sets to nzcV. Since SF/ZF undefined,
   // this does what we need.
-  _CondSubNZCV(Size, Zero, Zero, CondClassType {COND_EQ}, 0x1 /* nzcV */);
+  _CondSubNZCV(Size, Zero, Zero, CondClass::EQ, 0x1 /* nzcV */);
   CFInverted = true;
 }
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2125,7 +2125,7 @@ Ref OpDispatchBuilder::CVTFPR_To_GPRImpl(OpcodeArgs, Ref Src, IR::OpSize SrcElem
     Ref MaxF = LoadAndCacheNamedVectorConstant(SrcElementSize, (SrcElementSize == OpSize::i32Bit) ?
                                                                  (Dst32 ? NAMED_VECTOR_CVTMAX_F32_I32 : NAMED_VECTOR_CVTMAX_F32_I64) :
                                                                  (Dst32 ? NAMED_VECTOR_CVTMAX_F64_I32 : NAMED_VECTOR_CVTMAX_F64_I64));
-    return _Select(GPRSize, SrcElementSize, CondClassType {FEXCore::IR::COND_FGT}, MaxF, Src, Converted, MaxI);
+    return _Select(GPRSize, SrcElementSize, CondClass::FGT, MaxF, Src, Converted, MaxI);
   }
 }
 
@@ -2509,7 +2509,7 @@ void OpDispatchBuilder::XSaveOpImpl(OpcodeArgs) {
   const auto StoreIfFlagSet = [this, OpSize](uint32_t BitIndex, auto fn, uint32_t FieldSize = 1) {
     Ref Mask = LoadGPRRegister(X86State::REG_RAX);
     Ref BitFlag = _Bfe(OpSize, FieldSize, BitIndex, Mask);
-    auto CondJump_ = CondJump(BitFlag, {COND_NEQ});
+    auto CondJump_ = CondJump(BitFlag, CondClass::NEQ);
 
     auto StoreBlock = CreateNewCodeBlockAfter(GetCurrentBlock());
     SetTrueJumpTarget(CondJump_, StoreBlock);
@@ -2704,7 +2704,7 @@ void OpDispatchBuilder::XRstorOpImpl(OpcodeArgs) {
     Ref Mask = _LoadMem(GPRClass, OpSize::i64Bit, Base, Constant(512), OpSize::i64Bit, MEM_OFFSET_SXTX, 1);
 
     Ref BitFlag = _Bfe(OpSize, FieldSize, BitIndex, Mask);
-    auto CondJump_ = CondJump(BitFlag, {COND_NEQ});
+    auto CondJump_ = CondJump(BitFlag, CondClass::NEQ);
 
     auto RestoreBlock = CreateNewCodeBlockAfter(GetCurrentBlock());
     SetTrueJumpTarget(CondJump_, RestoreBlock);
@@ -4922,7 +4922,7 @@ void OpDispatchBuilder::PCMPXSTRXOpImpl(OpcodeArgs, bool IsExplicit, bool IsMask
 
     Ref IfZero = Constant(16 >> (Control & 1));
     Ref IfNotZero = UseMSBIndex ? _FindMSB(IR::OpSize::i32Bit, ResultNoFlags) : _FindLSB(IR::OpSize::i32Bit, ResultNoFlags);
-    Ref Result = _Select(IR::COND_EQ, ResultNoFlags, ZeroConst, IfZero, IfNotZero);
+    Ref Result = _Select(CondClass::EQ, ResultNoFlags, ZeroConst, IfZero, IfNotZero);
 
     // Store the result, it is already zero-extended to 64-bit implicitly.
     StoreGPRRegister(X86State::REG_RCX, Result);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -393,8 +393,8 @@ void OpDispatchBuilder::X87FXTRACTF64(OpcodeArgs) {
   SaveNZCV();
   _TestNZ(OpSize::i64Bit, Gpr, Constant(0x7fff'ffff'ffff'ffffUL));
 
-  Ref Sig = _NZCVSelectV(OpSize::i64Bit, {COND_EQ}, SigZV, SigNZV);
-  Ref Exp = _NZCVSelectV(OpSize::i64Bit, {COND_EQ}, ExpZV, ExpNZV);
+  Ref Sig = _NZCVSelectV(OpSize::i64Bit, CondClass::EQ, SigZV, SigNZV);
+  Ref Exp = _NZCVSelectV(OpSize::i64Bit, CondClass::EQ, ExpZV, ExpNZV);
 
   _PopStackDestroy();
   _PushStack(Exp, Exp, OpSize::i64Bit, true);

--- a/FEXCore/Source/Interface/IR/IR.h
+++ b/FEXCore/Source/Interface/IR/IR.h
@@ -442,15 +442,6 @@ struct FEX_PACKED RegisterClassType final {
   friend constexpr bool operator==(const RegisterClassType&, const RegisterClassType&) = default;
 };
 
-struct FEX_PACKED CondClassType final {
-  uint8_t Val;
-  [[nodiscard]] constexpr operator uint8_t() const {
-    return Val;
-  }
-  [[nodiscard]]
-  friend constexpr bool operator==(const CondClassType&, const CondClassType&) = default;
-};
-
 struct FEX_PACKED MemOffsetType final {
   uint8_t Val;
   [[nodiscard]] constexpr operator uint8_t() const {

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -52,33 +52,36 @@
     "  * These are validations that can't be automatically inferred and need to be hand-written",
     ""
   ],
+  "Enums": {
+    "class CondClass : uint8_t": [
+      "EQ    = 0,",
+      "NEQ   = 1,",
+      "UGE   = 2,",
+      "ULT   = 3,",
+      "MI    = 4,",
+      "PL    = 5,",
+      "VS    = 6,",
+      "VC    = 7,",
+      "UGT   = 8,",
+      "ULE   = 9,",
+      "SGE   = 10,",
+      "SLT   = 11,",
+      "SGT   = 12,",
+      "SLE   = 13,",
+      "TSTZ  = 14, /* bit test zero */",
+      "TSTNZ = 15, /* bit test nonzero */",
+      "",
+      "FLU   = 16, /* float less or unordered */",
+      "FGE   = 17, /* float greater or equal */",
+      "FLEU  = 18, /* float less or equal or unordered */",
+      "FGT   = 19, /* float greater */",
+      "FU    = 20, /* float unordered */",
+      "FNU   = 21, /* float not unordered */",
+      "",
+      "AL    = 32, /* always */"
+    ]
+  },
   "Defines": [
-    "constexpr uint8_t COND_EQ  = 0",
-    "constexpr uint8_t COND_NEQ = 1",
-    "constexpr uint8_t COND_UGE  = 2",
-    "constexpr uint8_t COND_ULT  = 3",
-    "constexpr uint8_t COND_MI  = 4",
-    "constexpr uint8_t COND_PL  = 5",
-    "constexpr uint8_t COND_VS  = 6",
-    "constexpr uint8_t COND_VC  = 7",
-    "constexpr uint8_t COND_UGT  = 8",
-    "constexpr uint8_t COND_ULE  = 9",
-    "constexpr uint8_t COND_SGE  = 10",
-    "constexpr uint8_t COND_SLT  = 11",
-    "constexpr uint8_t COND_SGT  = 12",
-    "constexpr uint8_t COND_SLE  = 13",
-    "constexpr uint8_t COND_TSTZ = 14 /* bit test zero */",
-    "constexpr uint8_t COND_TSTNZ = 15 /* bit test nonzero */",
-
-    "constexpr uint8_t COND_FLU  = 16 /* float less or unordred */",
-    "constexpr uint8_t COND_FGE  = 17 /* float greater or equal */",
-    "constexpr uint8_t COND_FLEU = 18 /* float less or equal or unordred */",
-    "constexpr uint8_t COND_FGT  = 19 /* float greater */",
-    "constexpr uint8_t COND_FU   = 20 /* float unordred */",
-    "constexpr uint8_t COND_FNU  = 21 /* float not unordred */",
-
-    "constexpr uint8_t COND_AL   = 32 /* always */",
-
     "constexpr FEXCore::IR::RegisterClassType InvalidClass {0}",
     "constexpr FEXCore::IR::RegisterClassType GPRClass {1}",
     "constexpr FEXCore::IR::RegisterClassType GPRFixedClass {2}",
@@ -149,7 +152,7 @@
     "FPR": "OrderedNode*",
     "FenceType": "FenceType",
     "RegisterClass": "RegisterClassType",
-    "CondClass": "CondClassType",
+    "CondClass": "CondClass",
     "SyscallFlags": "FEXCore::IR::SyscallFlags",
     "SHA256Sum": "SHA256Sum",
     "MemOffsetType": "MemOffsetType",
@@ -307,7 +310,7 @@
         "HasSideEffects": true,
         "RAOverride": "0"
       },
-      "CondJump SSA:$Cmp1, SSA:$Cmp2, SSA:$TrueBlock, SSA:$FalseBlock, CondClass:$Cond{{COND_NEQ}}, OpSize:$CompareSize{OpSize::iInvalid}, i1:$FromNZCV{false}": {
+      "CondJump SSA:$Cmp1, SSA:$Cmp2, SSA:$TrueBlock, SSA:$FalseBlock, CondClass:$Cond{CondClass::NEQ}, OpSize:$CompareSize{OpSize::iInvalid}, i1:$FromNZCV{false}": {
         "Inline": ["", "AddSub"],
         "HasSideEffects": true,
         "RAOverride": "2"
@@ -1008,7 +1011,7 @@
         "DestSize": "OpSize::i64Bit"
       },
 
-      "GPR = Neg OpSize:#Size, GPR:$Src, CondClass:$Cond{{COND_AL}}": {
+      "GPR = Neg OpSize:#Size, GPR:$Src, CondClass:$Cond{CondClass::AL}": {
         "Desc": ["Integer negation, with optional predication",
                  "Dest = Cond ? -Src : Src",
                  "Will truncate to 64 or 32bits"

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -38,8 +38,8 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, uint64_t Arg) 
   *out << fextl::fmt::format("#{:#x}", Arg);
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, CondClassType Arg) {
-  if (Arg == COND_AL) {
+static void PrintArg(fextl::stringstream* out, const IRListView*, CondClass Arg) {
+  if (Arg == CondClass::AL) {
     *out << "ALWAYS";
     return;
   }
@@ -48,7 +48,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, CondClassType 
                                                                  "UGT", "ULE", "SGE",  "SLT", "SGT", "SLE", "TSTZ", "TSTNZ",
                                                                  "FLU", "FGE", "FLEU", "FGT", "FU",  "FNU"};
 
-  *out << CondNames[Arg];
+  *out << CondNames[FEXCore::ToUnderlying(Arg)];
 }
 
 static void PrintArg(fextl::stringstream* out, const IRListView*, MemOffsetType Arg) {

--- a/FEXCore/Source/Interface/IR/IREmitter.h
+++ b/FEXCore/Source/Interface/IR/IREmitter.h
@@ -108,19 +108,19 @@ public:
   IRPair<IROp_Jump> _Jump() {
     return _Jump(InvalidNode);
   }
-  IRPair<IROp_CondJump> _CondJump(Ref ssa0, CondClassType cond = {COND_NEQ}) {
+  IRPair<IROp_CondJump> _CondJump(Ref ssa0, CondClass cond = CondClass::NEQ) {
     return _CondJump(ssa0, _Constant(0), InvalidNode, InvalidNode, cond, GetOpSize(ssa0));
   }
-  IRPair<IROp_CondJump> _CondJump(Ref ssa0, Ref ssa1, Ref ssa2, CondClassType cond = {COND_NEQ}) {
+  IRPair<IROp_CondJump> _CondJump(Ref ssa0, Ref ssa1, Ref ssa2, CondClass cond = CondClass::NEQ) {
     return _CondJump(ssa0, _Constant(0), ssa1, ssa2, cond, GetOpSize(ssa0));
   }
   // TODO: Work to remove this implicit sized Select implementation.
-  IRPair<IROp_Select> _Select(uint8_t Cond, Ref ssa0, Ref ssa1, Ref ssa2, Ref ssa3, IR::OpSize CompareSize = OpSize::iUnsized) {
+  IRPair<IROp_Select> _Select(CondClass Cond, Ref ssa0, Ref ssa1, Ref ssa2, Ref ssa3, IR::OpSize CompareSize = OpSize::iUnsized) {
     if (CompareSize == OpSize::iUnsized) {
       CompareSize = std::max(OpSize::i32Bit, std::max(GetOpSize(ssa0), GetOpSize(ssa1)));
     }
 
-    return _Select(std::max(OpSize::i32Bit, std::max(GetOpSize(ssa2), GetOpSize(ssa3))), CompareSize, CondClassType {Cond}, ssa0, ssa1, ssa2, ssa3);
+    return _Select(std::max(OpSize::i32Bit, std::max(GetOpSize(ssa2), GetOpSize(ssa3))), CompareSize, Cond, ssa0, ssa1, ssa2, ssa3);
   }
   IRPair<IROp_LoadMem> _LoadMem(FEXCore::IR::RegisterClassType Class, IR::OpSize Size, Ref ssa0, IR::OpSize Align = OpSize::i8Bit) {
     return _LoadMem(Class, Size, ssa0, Invalid(), Align, MEM_OFFSET_SXTX, 1);
@@ -129,15 +129,15 @@ public:
     return _StoreMem(Class, Size, Value, Addr, Invalid(), Align, MEM_OFFSET_SXTX, 1);
   }
 
-  IRPair<IROp_Select> Select01(FEXCore::IR::OpSize CompareSize, CondClassType Cond, OrderedNode* Cmp1, OrderedNode* Cmp2) {
+  IRPair<IROp_Select> Select01(FEXCore::IR::OpSize CompareSize, CondClass Cond, OrderedNode* Cmp1, OrderedNode* Cmp2) {
     return _Select(OpSize::i64Bit, CompareSize, Cond, Cmp1, Cmp2, _InlineConstant(1), _InlineConstant(0));
   }
 
   IRPair<IROp_Select> To01(FEXCore::IR::OpSize CompareSize, OrderedNode* Cmp1) {
-    return Select01(CompareSize, CondClassType {COND_NEQ}, Cmp1, Constant(0));
+    return Select01(CompareSize, CondClass::NEQ, Cmp1, Constant(0));
   }
 
-  IRPair<IROp_NZCVSelect> _NZCVSelect01(CondClassType Cond) {
+  IRPair<IROp_NZCVSelect> _NZCVSelect01(CondClass Cond) {
     return _NZCVSelect(OpSize::i64Bit, Cond, _InlineConstant(1), _InlineConstant(0));
   }
 

--- a/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
@@ -506,7 +506,7 @@ inline Ref X87StackOptimization::SilenceNaN(Ref Value) {
   IREmit->_FCmp(OpSize::i64Bit, Value, Value); // Comparison with itself should set VS if nan
   Ref QuietNaNGPR = IREmit->_Or(OpSize::i64Bit, GPRValue, IREmit->_Constant(0x0008000000000000ULL));
   Ref SilencedValue = IREmit->_VCastFromGPR(OpSize::i64Bit, OpSize::i64Bit, QuietNaNGPR);
-  return IREmit->_NZCVSelectV(OpSize::i64Bit, CondClassType {COND_VS}, SilencedValue, Value);
+  return IREmit->_NZCVSelectV(OpSize::i64Bit, CondClass::VS, SilencedValue, Value);
 }
 
 inline std::optional<X87StackOptimization::StackMemberInfo> X87StackOptimization::MigrateToSlowPath_IfInvalid(uint8_t Offset) {


### PR DESCRIPTION
Instead of having this sort of odd indirection through a struct type, we can add support for defining custom enums in the IR description. This lets us both get strong typing (and allow for weak typing, should any enum in the future need it), without needing a struct for a basic value type.

Even then, if we do need a struct for anything in the future, then we still allow strong typing for values themselves while allowing them to be used in various ways.