### PR TITLE
IRDumper: Add missing enum entries

### DIFF
--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -750,6 +750,7 @@
                  "FenceType::Load: Ensures load memory operations are serialized",
                  "FenceType::Store: Ensures store memory operations are serialized",
                  "FenceType::LoadStore: Ensures loads and store memory operations are serialized",
+                 "FenceType::Inst: Instruction barrier. Ensures all instructions after this point will be explicitly fetched",
                  "Ensures the memory operations are globally visible"
                 ],
         "HasSideEffects": true

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -147,15 +147,18 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, RoundMode Arg)
   }
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::SyscallFlags Arg) {
-  switch (Arg) {
-  case FEXCore::IR::SyscallFlags::DEFAULT: *out << "Default"; break;
-  case FEXCore::IR::SyscallFlags::OPTIMIZETHROUGH: *out << "Optimize Through"; break;
-  case FEXCore::IR::SyscallFlags::NOSYNCSTATEONENTRY: *out << "No Sync State on Entry"; break;
-  case FEXCore::IR::SyscallFlags::NORETURN: *out << "No Return"; break;
-  case FEXCore::IR::SyscallFlags::NOSIDEEFFECTS: *out << "No Side Effects"; break;
-  default: *out << "<Unknown Syscall Flags>"; break;
-  }
+static void PrintArg(fextl::stringstream* out, const IRListView*, SyscallFlags Arg) {
+  *out << [Arg] {
+    switch (Arg) {
+    case SyscallFlags::DEFAULT: return "Default";
+    case SyscallFlags::OPTIMIZETHROUGH: return "Optimize Through";
+    case SyscallFlags::NOSYNCSTATEONENTRY: return "No Sync State on Entry";
+    case SyscallFlags::NORETURN: return "No Return";
+    case SyscallFlags::NOSIDEEFFECTS: return "No Side Effects";
+    case SyscallFlags::NORETURNEDRESULT: return "No Returned Result";
+    }
+    return "<Unknown Syscall Flags>";
+  }();
 }
 
 static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::NamedVectorConstant Arg) {

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -294,12 +294,15 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::S
 }
 
 static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::BranchHint Arg) {
-  switch (Arg) {
-  case BranchHint::None: *out << "None"; break;
-  case BranchHint::Call: *out << "Call"; break;
-  case BranchHint::Return: *out << "Return"; break;
-  default: *out << "<Unknown Branch Hint>"; break;
-  }
+  *out << [Arg] {
+    switch (Arg) {
+    case BranchHint::None: return "None";
+    case BranchHint::Call: return "Call";
+    case BranchHint::Return: return "Return";
+    case BranchHint::CheckTF: return "CheckTF";
+    }
+    return "<Unknown Branch Hint>";
+  }();
 }
 
 static void PrintArg(fextl::stringstream* out, const IRListView*, const std::array<uint8_t, 0x10>& Arg) {

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -137,14 +137,16 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, FenceType Arg)
 }
 
 static void PrintArg(fextl::stringstream* out, const IRListView*, RoundMode Arg) {
-  switch (Arg) {
-  case RoundMode::Nearest: *out << "Nearest"; break;
-  case RoundMode::NegInfinity: *out << "-Inf"; break;
-  case RoundMode::PosInfinity: *out << "+Inf"; break;
-  case RoundMode::TowardsZero: *out << "Towards Zero"; break;
-  case RoundMode::Host: *out << "Host"; break;
-  default: *out << "<Unknown Round Type>"; break;
-  }
+  *out << [Arg] {
+    switch (Arg) {
+    case RoundMode::Nearest: return "Nearest";
+    case RoundMode::NegInfinity: return "-Inf";
+    case RoundMode::PosInfinity: return "+Inf";
+    case RoundMode::TowardsZero: return "Towards Zero";
+    case RoundMode::Host: return "Host";
+    }
+    return "<Unknown Round Type>";
+  }();
 }
 
 static void PrintArg(fextl::stringstream* out, const IRListView*, SyscallFlags Arg) {
@@ -161,7 +163,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, SyscallFlags A
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::NamedVectorConstant Arg) {
+static void PrintArg(fextl::stringstream* out, const IRListView*, NamedVectorConstant Arg) {
   *out << [Arg] {
     // clang-format off
     switch (Arg) {
@@ -219,9 +221,8 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::N
         return "cvtmax_i32";
       case NamedVectorConstant::NAMED_VECTOR_CVTMAX_I64:
         return "cvtmax_i64";
-      default:
-        return "<Unknown Named Vector Constant>";
     }
+    return "<Unknown Named Vector Constant>";
     // clang-format on
   }();
 }
@@ -244,36 +245,41 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, IndexNamedVect
       return "dppd_mask";
     case IndexNamedVectorConstant::INDEXED_NAMED_VECTOR_PBLENDW:
       return "pblendw";
-    default:
-      return "<Unknown Indexed Named Vector Constant>";
     }
+    return "<Unknown Indexed Named Vector Constant>";
     // clang-format on
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::OpSize Arg) {
-  switch (Arg) {
-  case OpSize::i8Bit: *out << "i8"; break;
-  case OpSize::i16Bit: *out << "i16"; break;
-  case OpSize::i32Bit: *out << "i32"; break;
-  case OpSize::i64Bit: *out << "i64"; break;
-  case OpSize::i128Bit: *out << "i128"; break;
-  case OpSize::i256Bit: *out << "i256"; break;
-  case OpSize::f80Bit: *out << "f80"; break;
-  default: *out << "<Unknown OpSize Type>"; break;
-  }
+static void PrintArg(fextl::stringstream* out, const IRListView*, OpSize Arg) {
+  *out << [Arg] {
+    switch (Arg) {
+    case OpSize::iUnsized: return "Unsized";
+    case OpSize::i8Bit: return "i8";
+    case OpSize::i16Bit: return "i16";
+    case OpSize::i32Bit: return "i32";
+    case OpSize::i64Bit: return "i64";
+    case OpSize::f80Bit: return "f80";
+    case OpSize::i128Bit: return "i128";
+    case OpSize::i256Bit: return "i256";
+    case OpSize::iInvalid: return "Invalid";
+    }
+    return "<Unknown OpSize Type>";
+  }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::FloatCompareOp Arg) {
-  switch (Arg) {
-  case FloatCompareOp::EQ: *out << "FEQ"; break;
-  case FloatCompareOp::LT: *out << "FLT"; break;
-  case FloatCompareOp::LE: *out << "FLE"; break;
-  case FloatCompareOp::UNO: *out << "UNO"; break;
-  case FloatCompareOp::NEQ: *out << "NEQ"; break;
-  case FloatCompareOp::ORD: *out << "ORD"; break;
-  default: *out << "<Unknown FloatCompareOp Type>"; break;
-  }
+static void PrintArg(fextl::stringstream* out, const IRListView*, FloatCompareOp Arg) {
+  *out << [Arg] {
+    switch (Arg) {
+    case FloatCompareOp::EQ: return "FEQ";
+    case FloatCompareOp::LT: return "FLT";
+    case FloatCompareOp::LE: return "FLE";
+    case FloatCompareOp::UNO: return "UNO";
+    case FloatCompareOp::NEQ: return "NEQ";
+    case FloatCompareOp::ORD: return "ORD";
+    }
+    return "<Unknown FloatCompareOp Type>";
+  }();
 }
 
 static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::BreakDefinition Arg) {
@@ -283,17 +289,19 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::B
   *out << static_cast<uint32_t>(Arg.si_code) << "}";
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::ShiftType Arg) {
-  switch (Arg) {
-  case ShiftType::LSL: *out << "LSL"; break;
-  case ShiftType::LSR: *out << "LSR"; break;
-  case ShiftType::ASR: *out << "ASR"; break;
-  case ShiftType::ROR: *out << "ROR"; break;
-  default: *out << "<Unknown Shift Type>"; break;
-  }
+static void PrintArg(fextl::stringstream* out, const IRListView*, ShiftType Arg) {
+  *out << [Arg] {
+    switch (Arg) {
+    case ShiftType::LSL: return "LSL";
+    case ShiftType::LSR: return "LSR";
+    case ShiftType::ASR: return "ASR";
+    case ShiftType::ROR: return "ROR";
+    }
+    return "<Unknown Shift Type>";
+  }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::BranchHint Arg) {
+static void PrintArg(fextl::stringstream* out, const IRListView*, BranchHint Arg) {
   *out << [Arg] {
     switch (Arg) {
     case BranchHint::None: return "None";

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -272,7 +272,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::F
   case FloatCompareOp::UNO: *out << "UNO"; break;
   case FloatCompareOp::NEQ: *out << "NEQ"; break;
   case FloatCompareOp::ORD: *out << "ORD"; break;
-  default: *out << "<Unknown OpSize Type>"; break;
+  default: *out << "<Unknown FloatCompareOp Type>"; break;
   }
 }
 

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -125,15 +125,15 @@ static void PrintArg(fextl::stringstream* out, const IRListView* IR, OrderedNode
 }
 
 static void PrintArg(fextl::stringstream* out, const IRListView*, FenceType Arg) {
-  if (Arg == FenceType::Load) {
-    *out << "Loads";
-  } else if (Arg == FenceType::Store) {
-    *out << "Stores";
-  } else if (Arg == FenceType::LoadStore) {
-    *out << "LoadStores";
-  } else {
-    *out << "<Unknown Fence Type>";
-  }
+  *out << [Arg] {
+    switch (Arg) {
+    case FenceType::Load: return "Loads";
+    case FenceType::Store: return "Stores";
+    case FenceType::LoadStore: return "LoadStores";
+    case FenceType::Inst: return "Instruction";
+    }
+    return "<Unknown Fence Type>";
+  }();
 }
 
 static void PrintArg(fextl::stringstream* out, const IRListView*, RoundMode Arg) {

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -191,6 +191,22 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, NamedVectorCon
         return "movmskps_shift";
       case NamedVectorConstant::NAMED_VECTOR_AESKEYGENASSIST_SWIZZLE:
         return "aeskeygenassist_swizzle";
+      case NamedVectorConstant::NAMED_VECTOR_BLENDPS_0110B:
+        return "blendps_0110b";
+      case NamedVectorConstant::NAMED_VECTOR_BLENDPS_0111B:
+        return "blendps_0111b";
+      case NamedVectorConstant::NAMED_VECTOR_BLENDPS_1001B:
+        return "blendps_1001b";
+      case NamedVectorConstant::NAMED_VECTOR_BLENDPS_1011B:
+        return "blendps_1011b";
+      case NamedVectorConstant::NAMED_VECTOR_BLENDPS_1101B:
+        return "blendps_1101b";
+      case NamedVectorConstant::NAMED_VECTOR_BLENDPS_1110B:
+        return "blendps_1110b";
+      case NamedVectorConstant::NAMED_VECTOR_MOVMASKB:
+        return "movmaskb";
+      case NamedVectorConstant::NAMED_VECTOR_MOVMASKB_UPPER:
+        return "movmaskb_upper";
       case NamedVectorConstant::NAMED_VECTOR_ZERO:
         return "vectorzero";
       case NamedVectorConstant::NAMED_VECTOR_X87_ONE:
@@ -221,6 +237,18 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, NamedVectorCon
         return "cvtmax_i32";
       case NamedVectorConstant::NAMED_VECTOR_CVTMAX_I64:
         return "cvtmax_i64";
+      case NamedVectorConstant::NAMED_VECTOR_F80_SIGN_MASK:
+        return "f80_sign_mask";
+      case NamedVectorConstant::NAMED_VECTOR_SHA1RNDS_K0:
+        return "sha1rnds_k0";
+      case NamedVectorConstant::NAMED_VECTOR_SHA1RNDS_K1:
+        return "sha1rnds_k1";
+      case NamedVectorConstant::NAMED_VECTOR_SHA1RNDS_K2:
+        return "sha1rnds_k2";
+      case NamedVectorConstant::NAMED_VECTOR_SHA1RNDS_K3:
+        return "sha1rnds_k3";
+      case NamedVectorConstant::NAMED_VECTOR_MAX:
+        return "<Programming Error: Printing MAX value>";
     }
     return "<Unknown Named Vector Constant>";
     // clang-format on
@@ -245,6 +273,8 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, IndexNamedVect
       return "dppd_mask";
     case IndexNamedVectorConstant::INDEXED_NAMED_VECTOR_PBLENDW:
       return "pblendw";
+    case INDEXED_NAMED_VECTOR_MAX:
+      return "<Programming Error: Printing MAX value>";
     }
     return "<Unknown Indexed Named Vector Constant>";
     // clang-format on


### PR DESCRIPTION
There were a few printers that were missing a few enum values. We can just fills these in so dumped IR is a little more informative