### PR TITLE
Windows: Avoid redeclaring strtoll as unimplemented

### DIFF
--- a/Source/Windows/Common/CRT/String.cpp
+++ b/Source/Windows/Common/CRT/String.cpp
@@ -56,10 +56,6 @@ long long atoll(const char*) {
   UNIMPLEMENTED();
 }
 
-long long strtoll(const char* __restrict__, char** __restrict, int) {
-  UNIMPLEMENTED();
-}
-
 long double strtold(const char* __restrict__, char** __restrict__) {
   UNIMPLEMENTED();
 }


### PR DESCRIPTION
Included as part of the musl code we pull in. Fixes ARM64EC/WOW64 FEX.