### PR TITLE
EnumUtils: Add define for default passthrough formatting

### DIFF
--- a/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -7,6 +7,7 @@ $end_info$
 
 #pragma once
 
+#include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <array>
@@ -606,10 +607,4 @@ constexpr static inline void GenerateX87Table(X86InstInfo *FinalTable, X86Tables
 
 }
 
-template <>
-struct fmt::formatter<FEXCore::X86Tables::DecodedOperand::OpType> : formatter<uint32_t> {
-  template <typename FormatContext>
-  auto format(FEXCore::X86Tables::DecodedOperand::OpType type, FormatContext& ctx) const {
-    return fmt::formatter<uint32_t>::format(static_cast<uint32_t>(type), ctx);
-  }
-};
+FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::X86Tables::DecodedOperand::OpType);

--- a/FEXCore/Source/Interface/IR/IR.h
+++ b/FEXCore/Source/Interface/IR/IR.h
@@ -715,42 +715,7 @@ struct fmt::formatter<FEXCore::IR::NodeID> : fmt::formatter<FEXCore::IR::NodeID:
   }
 };
 
-template<>
-struct fmt::formatter<FEXCore::IR::RegClass> : fmt::formatter<std::underlying_type_t<FEXCore::IR::RegClass>> {
-  using Base = fmt::formatter<std::underlying_type_t<FEXCore::IR::RegClass>>;
-
-  template<typename FormatContext>
-  auto format(const FEXCore::IR::RegClass& Class, FormatContext& ctx) const {
-    return Base::format(FEXCore::ToUnderlying(Class), ctx);
-  }
-};
-
-template<>
-struct fmt::formatter<FEXCore::IR::FenceType> : fmt::formatter<std::underlying_type_t<FEXCore::IR::FenceType>> {
-  using Base = fmt::formatter<std::underlying_type_t<FEXCore::IR::FenceType>>;
-
-  template<typename FormatContext>
-  auto format(const FEXCore::IR::FenceType& Fence, FormatContext& ctx) const {
-    return Base::format(FEXCore::ToUnderlying(Fence), ctx);
-  }
-};
-
-template<>
-struct fmt::formatter<FEXCore::IR::MemOffsetType> : fmt::formatter<std::underlying_type_t<FEXCore::IR::MemOffsetType>> {
-  using Base = fmt::formatter<std::underlying_type_t<FEXCore::IR::MemOffsetType>>;
-
-  template<typename FormatContext>
-  auto format(const FEXCore::IR::MemOffsetType& Type, FormatContext& ctx) const {
-    return Base::format(FEXCore::ToUnderlying(Type), ctx);
-  }
-};
-
-template<>
-struct fmt::formatter<FEXCore::IR::OpSize> : fmt::formatter<std::underlying_type_t<FEXCore::IR::OpSize>> {
-  using Base = fmt::formatter<std::underlying_type_t<FEXCore::IR::OpSize>>;
-
-  template<typename FormatContext>
-  auto format(const FEXCore::IR::OpSize& OpSize, FormatContext& ctx) const {
-    return Base::format(FEXCore::ToUnderlying(OpSize), ctx);
-  }
-};
+FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::FenceType);
+FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::MemOffsetType);
+FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::OpSize);
+FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::RegClass);

--- a/FEXCore/include/FEXCore/Utils/EnumUtils.h
+++ b/FEXCore/include/FEXCore/Utils/EnumUtils.h
@@ -3,6 +3,7 @@
 
 // Header for various utilities related to operating with enums
 
+#include <FEXCore/fextl/fmt.h>
 #include <type_traits>
 
 namespace FEXCore {
@@ -52,6 +53,19 @@ namespace FEXCore {
   constexpr bool False(type key) noexcept {                          \
     using T = std::underlying_type_t<type>;                          \
     return static_cast<T>(key) == 0;                                 \
+  }
+
+// Macro that defines a fmt formatter for a reasonable case where an enum
+// is formatted as a purely integral type based on its underlying type.
+#define FEX_DEFINE_ENUM_FMT_PASSTHROUGH(type)                                  \
+  template<>                                                                   \
+  struct fmt::formatter<type> : fmt::formatter<std::underlying_type_t<type>> { \
+    using Base = fmt::formatter<std::underlying_type_t<type>>;                 \
+                                                                               \
+    template<typename FormatContext>                                           \
+    auto format(const type& Value, FormatContext& ctx) const {                 \
+      return Base::format(FEXCore::ToUnderlying(Value), ctx);                  \
+    }                                                                          \
   }
 
 // Equivalent to C++23's std::to_underlying.


### PR DESCRIPTION
Handles a normal case where printing an enum type as an integral value is still desirable.

Mainly just a way to reduce boilerplate.