### PR TITLE
IR: Move RegisterAllocationPass forward decl to JITClass

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/JITClass.h
+++ b/FEXCore/Source/Interface/Core/JIT/JITClass.h
@@ -36,9 +36,11 @@ $end_info$
 namespace FEXCore::Core {
 struct InternalThreadState;
 }
-
 namespace FEXCore::Context {
 struct ExitFunctionLinkData;
+}
+namespace FEXCore::IR {
+class RegisterAllocationPass;
 }
 
 namespace FEXCore::CPU {

--- a/FEXCore/Source/Interface/IR/IR.h
+++ b/FEXCore/Source/Interface/IR/IR.h
@@ -20,7 +20,6 @@
 namespace FEXCore::IR {
 
 class OrderedNode;
-class RegisterAllocationPass;
 
 /**
  * @brief The IROp_Header is an dynamically sized array


### PR DESCRIPTION
This isn't actually used anywhere in the IR header, so we can move it to where it's actually used.

Now the IR interface header doesn't have anything related to the independent passes in it.