### PR TITLE
Allocator: Name FEX's VMA regions for allocation

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include "FEXCore/IR/IR.h"
 #include "FEXCore/Utils/AllocatorHooks.h"
+#include "Utils/PrctlUtils.h"
 #include "Interface/Context/Context.h"
 #include "Interface/Core/CPUBackend.h"
 #include "Interface/Core/Dispatcher/Dispatcher.h"
@@ -9,6 +10,7 @@
 #include "LookupCache.h"
 
 #ifndef _WIN32
+#include <linux/prctl.h>
 #include <sys/prctl.h>
 #endif
 
@@ -356,6 +358,10 @@ namespace CPU {
                                             FEXCore::Allocator::ProtectOptions::None)) {
       LogMan::Msg::EFmt("Failed to mprotect last page of code buffer.");
     }
+
+#ifndef _WIN32
+    prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, Ptr, Size, "FEXMemJIT");
+#endif
 
     LookupCache = fextl::make_unique<GuestToHostMap>();
   }

--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include "Utils/Allocator/HostAllocator.h"
+#include "Utils/PrctlUtils.h"
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/LogManager.h>
@@ -49,6 +50,10 @@ void* FEX_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t off
   if (Result >= (void*)-4096) {
     errno = -(uint64_t)Result;
     return (void*)-1;
+  }
+
+  if (flags & MAP_ANONYMOUS) {
+    prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, Result, length, "FEXMem");
   }
   return Result;
 }

--- a/FEXCore/Source/Utils/PrctlUtils.h
+++ b/FEXCore/Source/Utils/PrctlUtils.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#ifndef _WIN32
+#include <linux/prctl.h>
+#include <sys/mman.h>
+#include <sys/user.h>
+#include <sys/prctl.h>
+
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#endif
+
+#ifndef PR_SET_VMA_ANON_NAME
+#define PR_SET_VMA_ANON_NAME 0
+#endif
+#endif


### PR DESCRIPTION
Will allow external tools to track how much memory FEX allocates. Necessary since we can't use traditional memory usage tools to track FEX memory allocation independently of guest allocations. Plus most tools like heaptrack hook allocation symbols, which break under jemalloc.

Using this information I can see with Steam loaded with my library that FEX consumes ~825MB. Total process resident memory is 1204M, accounting for around 379MB being used by steam itself. This is /relatively/ close to my desktop running steam at around 261MB. There's a bit of variance due to what Steam chooses to do at startup.

This tracking will be the first step towards seeing where our memory usage is going.