### PR TITLE
FEXCore: Adds option to disable L2 cache lookups

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -161,6 +161,14 @@
         "Desc": [
           "Allows the user to pass additional arguments to the application"
         ]
+      },
+      "DisableL2Cache": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Disables FEXCore's JIT L2 cache lookup. Saving memory.",
+          "Can potentially introduce more stutters."
+        ]
       }
     },
     "Debug": {

--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.h
@@ -4,6 +4,7 @@
 #include "Interface/Core/ArchHelpers/Arm64Emitter.h"
 #include "Interface/Core/Interpreter/InterpreterOps.h"
 
+#include <FEXCore/Config/Config.h>
 #include <FEXCore/fextl/memory.h>
 
 #include <array>
@@ -92,6 +93,8 @@ private:
 
   void EmitDispatcher();
   uint64_t GenerateABICall(FallbackABI ABI);
+
+  FEX_CONFIG_OPT(DisableL2Cache, DISABLEL2CACHE);
 };
 
 } // namespace FEXCore::CPU


### PR DESCRIPTION
This saves a whole bunch of memory. Cutting `Just Cause 2`'s title
screen from 1132MB anonymous FEX memory down to 438MB. 629MB in L2
alone.

L2 is primarily a means to reduce overhead in map queries, so it's all
about performance. But because it consumes a lot of people it's kind of
hard.

One idea is that the L2 lookups can be moved to shared data structures,
since we already pull the shared lock when doing an L2 lookup this is
already halfway there.

Side note, we're using unique locks even with read-only code paths
which we can't use the shared lock because this terrible recursive
mutex!

Instead of outright changing L2 behaviour and potentially wrecking
havoc, add a config option for now so testing can happen over time.

before:
```
Total FEX Anon memory resident: 1132 mB
    JIT resident:             60 mB
    OpDispatcher resident:    97 mB
    Frontend resident:        37 mB
    CPUBackend resident:      500 kB
    Lookup cache resident:    629 mB
    Lookup L1 cache resident: 108 mB
    ThreadStates resident:    436 kB
```

after:
```
Total FEX Anon memory resident: 438 mB
    JIT resident:             62 mB
    OpDispatcher resident:    56 mB
    Frontend resident:        22 mB
    CPUBackend resident:      496 kB
    Lookup cache resident:    0 (null)
    Lookup L1 cache resident: 109 mB
    ThreadStates resident:    436 kB
```