### PR TITLE
EnumUtils: Further simplify enum passthrough formatting

### DIFF
--- a/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
+++ b/FEXCore/Source/Interface/Core/X86Tables/X86Tables.h
@@ -590,6 +590,6 @@ constexpr static inline void GenerateX87Table(X86InstInfo *FinalTable, X86Tables
   }
 };
 
-}
-
 FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::X86Tables::DecodedOperand::OpType);
+
+} // namespace FEXCore::X86Tables

--- a/FEXCore/Source/Interface/IR/IR.h
+++ b/FEXCore/Source/Interface/IR/IR.h
@@ -693,6 +693,15 @@ inline NodeID NodeWrapperBase<Type>::ID() const {
 bool IsBlockExit(FEXCore::IR::IROps Op);
 
 void Dump(fextl::stringstream* out, const IRListView* IR);
+
+constexpr auto format_as(FEXCore::IR::NodeID ID) {
+  return ID.Value;
+}
+
+FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::FenceType)
+FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::MemOffsetType)
+FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::OpSize)
+FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::RegClass)
 } // namespace FEXCore::IR
 
 template<>
@@ -701,20 +710,3 @@ struct std::hash<FEXCore::IR::NodeID> {
     return std::hash<FEXCore::IR::NodeID::value_type> {}(ID.Value);
   }
 };
-
-template<>
-struct fmt::formatter<FEXCore::IR::NodeID> : fmt::formatter<FEXCore::IR::NodeID::value_type> {
-  using Base = fmt::formatter<FEXCore::IR::NodeID::value_type>;
-
-  // Pass-through the underlying value, so IDs can
-  // be formatted like any integral value.
-  template<typename FormatContext>
-  auto format(const FEXCore::IR::NodeID& ID, FormatContext& ctx) const {
-    return Base::format(ID.Value, ctx);
-  }
-};
-
-FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::FenceType);
-FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::MemOffsetType);
-FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::OpSize);
-FEX_DEFINE_ENUM_FMT_PASSTHROUGH(FEXCore::IR::RegClass);

--- a/FEXCore/include/FEXCore/Utils/EnumUtils.h
+++ b/FEXCore/include/FEXCore/Utils/EnumUtils.h
@@ -57,15 +57,9 @@ namespace FEXCore {
 
 // Macro that defines a fmt formatter for a reasonable case where an enum
 // is formatted as a purely integral type based on its underlying type.
-#define FEX_DEFINE_ENUM_FMT_PASSTHROUGH(type)                                  \
-  template<>                                                                   \
-  struct fmt::formatter<type> : fmt::formatter<std::underlying_type_t<type>> { \
-    using Base = fmt::formatter<std::underlying_type_t<type>>;                 \
-                                                                               \
-    template<typename FormatContext>                                           \
-    auto format(const type& Value, FormatContext& ctx) const {                 \
-      return Base::format(FEXCore::ToUnderlying(Value), ctx);                  \
-    }                                                                          \
+#define FEX_DEFINE_ENUM_FMT_PASSTHROUGH(type) \
+  constexpr auto format_as(type t) {          \
+    return FEXCore::ToUnderlying(t);          \
   }
 
 // Equivalent to C++23's std::to_underlying.


### PR DESCRIPTION
Turns out a simpler way was added to the docs at some point and I never noticed.

Before:
```
   text     data      bss      dec      hex  filename
4159895  1471360  4336824  9968079   9819cf  Bin/FEX
```

After:
```
   text     data      bss      dec      hex  filename
4157159  1471360  4336824  9965343   980f1f  Bin/FEX
```