### PR TITLE
EnumUtils: Remove fmt include

### DIFF
--- a/FEXCore/include/FEXCore/Utils/EnumUtils.h
+++ b/FEXCore/include/FEXCore/Utils/EnumUtils.h
@@ -3,7 +3,6 @@
 
 // Header for various utilities related to operating with enums
 
-#include <FEXCore/fextl/fmt.h>
 #include <type_traits>
 
 namespace FEXCore {


### PR DESCRIPTION
Forgot to remove this in the previous PR. This is no longer necessary with the simplified interface