### PR TITLE
SyscallHandler: Shrink definition struct from 24 to 16 bytes

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -128,8 +128,6 @@ public:
   using SyscallPtrArg6 = uint64_t (*)(FEXCore::Core::CpuStateFrame* Frame, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
 
   struct SyscallFunctionDefinition {
-    uint8_t NumArgs;
-    FEXCore::IR::SyscallFlags Flags;
     union {
       void* Ptr;
       SyscallPtrArg0 Ptr0;
@@ -141,6 +139,8 @@ public:
       SyscallPtrArg6 Ptr6;
     };
     int32_t HostSyscallNumber;
+    uint8_t NumArgs;
+    FEXCore::IR::SyscallFlags Flags;
 #ifdef DEBUG_STRACE
     fextl::string StraceFmt;
 #endif
@@ -335,8 +335,8 @@ protected:
 
   fextl::vector<SyscallFunctionDefinition> Definitions {std::max<std::size_t>(FEX::HLE::x64::SYSCALL_x64_MAX, FEX::HLE::x32::SYSCALL_x86_MAX),
                                                         {
-                                                          .NumArgs = 255,
                                                           .Ptr = reinterpret_cast<void*>(&UnimplementedSyscall),
+                                                          .NumArgs = 255,
                                                         }};
   std::mutex MMapMutex;
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.cpp
@@ -63,10 +63,10 @@ void x64SyscallHandler::RegisterSyscallHandlers() {
   constexpr int SYSCALL_GAP_END = 424;
 
   const SyscallFunctionDefinition InvalidSyscall {
-    .NumArgs = 0,
-    .Flags = FEXCore::IR::SyscallFlags::DEFAULT,
     .Ptr = reinterpret_cast<void*>(&UnimplementedSyscall),
     .HostSyscallNumber = SYSCALL_DEF(MAX),
+    .NumArgs = 0,
+    .Flags = FEXCore::IR::SyscallFlags::DEFAULT,
 #ifdef DEBUG_STRACE
     .StraceFmt = "Invalid",
 #endif


### PR DESCRIPTION
Just a minor space saving, given how many syscall definitions we'll have (512)