### PR TITLE
Config: Prevent duplicate lookup in EnvLoader::Load() 

### DIFF
--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -571,7 +571,7 @@ fextl::string GetConfigDirectory(bool Global, const PortableInformation& Portabl
     return fextl::fmt::format("{}/fex-emu/", PortableInfo.InterpreterPath);
   } else if (PortableInfo.IsPortable && ConfigOverride && !Global) {
     fextl::string AppConfigStr = ConfigOverride;
-    if (PortableInfo.IsPortable && FHU::Filesystem::IsRelative(AppConfigStr)) {
+    if (FHU::Filesystem::IsRelative(AppConfigStr)) {
       AppConfigStr = PortableInfo.InterpreterPath + AppConfigStr;
     }
 


### PR DESCRIPTION
Avoids redundantly doing map retrievals when initializing the environment layer (plus 2 other minor cleanups noticed in the area)