### PR TITLE
SyscallsVMATracking: Make list management internally linked

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsVMATracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsVMATracking.cpp
@@ -35,7 +35,7 @@ auto VMAFlags::fromFlags(int Flags) -> VMAFlags {
 }
 
 /// List Operations ///
-inline void VMATracking::ListCheckVMALinks(VMAEntry* VMA) {
+static inline void ListCheckVMALinks(const VMAEntry* VMA) {
   if (VMA) {
     LOGMAN_THROW_A_FMT(VMA->ResourceNextVMA != VMA, "VMA tracking error");
     LOGMAN_THROW_A_FMT(VMA->ResourcePrevVMA != VMA, "VMA tracking error");
@@ -44,7 +44,7 @@ inline void VMATracking::ListCheckVMALinks(VMAEntry* VMA) {
 
 // Removes a VMA from corresponding MappedResource list
 // Returns true if list is empty
-bool VMATracking::ListRemove(VMAEntry* VMA) {
+static bool ListRemove(VMAEntry* VMA) {
   LOGMAN_THROW_A_FMT(VMA->Resource != nullptr, "VMA tracking error");
 
   // if it has prev, make prev to next
@@ -78,7 +78,7 @@ bool VMATracking::ListRemove(VMAEntry* VMA) {
 
 // Replaces a VMA in corresponding MappedResource list
 // Requires NewVMA->Resource, NewVMA->ResourcePrevVMA and NewVMA->ResourceNextVMA to be already setup
-void VMATracking::ListReplace(VMAEntry* VMA, VMAEntry* NewVMA) {
+static void ListReplace(VMAEntry* VMA, VMAEntry* NewVMA) {
   LOGMAN_THROW_A_FMT(VMA->Resource != nullptr, "VMA tracking error");
 
   LOGMAN_THROW_A_FMT(VMA->Resource == NewVMA->Resource, "VMA tracking error");
@@ -107,7 +107,7 @@ void VMATracking::ListReplace(VMAEntry* VMA, VMAEntry* NewVMA) {
 
 // Inserts a VMA in corresponding MappedResource list
 // Requires NewVMA->Resource, NewVMA->ResourcePrevVMA and NewVMA->ResourceNextVMA to be already setup
-void VMATracking::ListInsertAfter(VMAEntry* AfterVMA, VMAEntry* NewVMA) {
+static void ListInsertAfter(VMAEntry* AfterVMA, VMAEntry* NewVMA) {
   LOGMAN_THROW_A_FMT(NewVMA->Resource != nullptr, "VMA tracking error");
 
   LOGMAN_THROW_A_FMT(AfterVMA->Resource == NewVMA->Resource, "VMA tracking error");
@@ -128,7 +128,7 @@ void VMATracking::ListInsertAfter(VMAEntry* AfterVMA, VMAEntry* NewVMA) {
 
 // Prepends a VMA
 // Requires NewVMA->Resource, NewVMA->ResourcePrevVMA and NewVMA->ResourceNextVMA to be already setup
-void VMATracking::ListPrepend(MappedResource* Resource, VMAEntry* NewVMA) {
+static void ListPrepend(MappedResource* Resource, VMAEntry* NewVMA) {
   LOGMAN_THROW_A_FMT(Resource != nullptr, "VMA tracking error");
 
   LOGMAN_THROW_A_FMT(NewVMA->Resource == Resource, "VMA tracking error");

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsVMATracking.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsVMATracking.h
@@ -115,13 +115,8 @@ struct VMATracking {
   inline auto InsertMappedResource(const MRID& mrid, MappedResource Resource) {
     return MappedResources.emplace(mrid, std::move(Resource));
   }
-private:
-  bool ListRemove(VMAEntry* Mapping);
-  void ListReplace(VMAEntry* Mapping, VMAEntry* NewMapping);
-  void ListInsertAfter(VMAEntry* Mapping, VMAEntry* NewMapping);
-  void ListPrepend(MappedResource* Resource, VMAEntry* NewVMA);
-  static void ListCheckVMALinks(VMAEntry* VMA);
 
+private:
   MappedResource::ContainerType MappedResources;
 };
 


### PR DESCRIPTION
These don't require being bound to class state directly, and so the list management can be completely opaque to the outside (also means less rebuilding if these change)