### PR TITLE
FEXCore: Remove the last recursive_mutex

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -29,6 +29,7 @@
 namespace FEXCore {
 class SignalDelegator;
 class ThunkHandler;
+struct LookupCacheWriteLockToken;
 
 namespace Core {
   struct DebugData;
@@ -233,7 +234,7 @@ public:
 
   ContextImpl(const FEXCore::HostFeatures& Features);
 
-  static bool ThreadRemoveCodeEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP);
+  static bool ThreadRemoveCodeEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestRIP, const FEXCore::LookupCacheWriteLockToken& lk);
 
   static void ThreadRemoveCodeEntryFromJit(FEXCore::Core::CpuStateFrame* Frame, uint64_t GuestRIP);
 

--- a/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -67,31 +67,26 @@ LookupCache::~LookupCache() {
   // These will get freed when their memory allocators are deallocated.
 }
 
-void LookupCache::ClearL2Cache() {
-  auto lk = Shared->AcquireLock();
+void LookupCache::ClearL2Cache(const FEXCore::LookupCacheWriteLockToken& lk) {
   // Clear out the page memory
   // PagePointer and PageMemory are sequential with each other. Clear both at once.
   FEXCore::Allocator::VirtualDontNeed(reinterpret_cast<void*>(PagePointer), ctx->Config.VirtualMemSize / 4096 * 8 + CODE_SIZE, false);
   AllocateOffset = 0;
 }
 
-void LookupCache::ClearThreadLocalCaches() {
-  auto lk = Shared->AcquireLock();
-
+void LookupCache::ClearThreadLocalCaches(const LookupCacheWriteLockToken&) {
   // Clear L1 and L2 by clearing the full cache.
   FEXCore::Allocator::VirtualDontNeed(reinterpret_cast<void*>(PagePointer), TotalCacheSize, false);
 }
 
-void LookupCache::ClearCache() {
-  auto lk = Shared->AcquireLock();
-
+void LookupCache::ClearCache(const LookupCacheWriteLockToken& lk) {
   // Clear L1 and L2 by clearing the full cache.
   FEXCore::Allocator::VirtualDontNeed(reinterpret_cast<void*>(PagePointer), TotalCacheSize, false);
 
   Shared->ClearCache(lk);
 }
 
-void GuestToHostMap::ClearCache(const LockToken&) {
+void GuestToHostMap::ClearCache(const LookupCacheWriteLockToken&) {
   // Allocate a new pointer from the BlockLinks pma again.
   BlockLinks = BlockLinks_pma->new_object<BlockLinksMapType>();
   // All code is gone, clear the block list


### PR DESCRIPTION
Every time I see this recursive mutex I glare at it. Remove the last one so that we no longer need to deal with it.

The only reason why this recursive mutex still existed today was because it is fairly intertwined with the ContextImpl and tracing it all was a pain.

Peel back the layers and follow the idiom to have ContextImpl pull the write mutex when requiredand pass it through by reference to ensure it stays alive. This allows us to entirely give rid of the recursive nature of the mutex, which means that `FindBlock` can eventually be switched over to a read-lock to improve multiple threads reading the caches at the same time.

I didn't do that exercise since that can be followed up in a subsequent PR.