### PR TITLE
FEX: Name remaining allocations as "Misc"

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -360,9 +360,7 @@ namespace CPU {
       LogMan::Msg::EFmt("Failed to mprotect last page of code buffer.");
     }
 
-#ifndef _WIN32
-    prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, Ptr, Size, "FEXMemJIT");
-#endif
+    FEXCore::Allocator::VirtualName("FEXMemJIT", reinterpret_cast<void*>(Ptr), Size);
 
     LookupCache = fextl::make_unique<GuestToHostMap>();
   }

--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -44,6 +44,8 @@ Dispatcher::Dispatcher(FEXCore::Context::ContextImpl* ctx)
   : Arm64Emitter(ctx, FEXCore::Allocator::VirtualAlloc(MAX_DISPATCHER_CODE_SIZE, true), MAX_DISPATCHER_CODE_SIZE)
   , CTX {ctx} {
   EmitDispatcher();
+
+  FEXCore::Allocator::VirtualName("FEXMem_Misc", reinterpret_cast<void*>(GetBufferBase()), MAX_DISPATCHER_CODE_SIZE);
 }
 
 Dispatcher::~Dispatcher() {

--- a/FEXCore/Source/Interface/Core/X86HelperGen.cpp
+++ b/FEXCore/Source/Interface/Core/X86HelperGen.cpp
@@ -51,7 +51,9 @@ void* X86GeneratedCode::AllocateGuestCodeSpace(size_t Size) {
 
   if (Is64BitMode()) {
     // 64bit mode can have its sigret handler anywhere
-    return FEXCore::Allocator::VirtualAlloc(Size);
+    auto Result = FEXCore::Allocator::VirtualAlloc(Size);
+    FEXCore::Allocator::VirtualName("FEXMem_Misc", reinterpret_cast<void*>(Result), Size);
+    return Result;
   }
 
   // First 64bit page

--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -53,7 +53,7 @@ void* FEX_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t off
   }
 
   if (flags & MAP_ANONYMOUS) {
-    prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, Result, length, "FEXMem");
+    VirtualName("FEXMem", Result, length);
   }
   return Result;
 }
@@ -93,7 +93,7 @@ void* DisableSBRKAllocations() {
   // calls won't allocate any memory through that.
   void* AlignedBRK = reinterpret_cast<void*>(FEXCore::AlignUp(reinterpret_cast<uintptr_t>(StartingSBRK), FEXCore::Utils::FEX_PAGE_SIZE));
   void* AfterBRK =
-    mmap(AlignedBRK, FEXCore::Utils::FEX_PAGE_SIZE, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE | MAP_NORESERVE, -1, 0);
+    ::mmap(AlignedBRK, FEXCore::Utils::FEX_PAGE_SIZE, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE | MAP_NORESERVE, -1, 0);
   if (AfterBRK == INVALID_PTR) {
     // Couldn't allocate the page after the aligned brk? This should never happen.
     // FEXCore::LogMan isn't configured yet so we just need to print the message.
@@ -294,7 +294,7 @@ fextl::vector<MemoryRegion> StealMemoryRegion(uintptr_t Begin, uintptr_t End) {
       --StackRegionIt;
 
       auto Alloc =
-        mmap(StackRegionIt->Ptr, StackRegionIt->Size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED, -1, 0);
+        ::mmap(StackRegionIt->Ptr, StackRegionIt->Size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED, -1, 0);
 
       LogMan::Throw::AFmt(Alloc != MAP_FAILED, "mmap({},{:x}) failed", fmt::ptr(StackRegionIt->Ptr), StackRegionIt->Size);
       LogMan::Throw::AFmt(Alloc == StackRegionIt->Ptr, "mmap returned {} instead of {}", Alloc, fmt::ptr(StackRegionIt->Ptr));
@@ -305,7 +305,7 @@ fextl::vector<MemoryRegion> StealMemoryRegion(uintptr_t Begin, uintptr_t End) {
 
   // Block remaining memory gaps
   for (auto RegionIt = Regions.begin(); RegionIt != Regions.end(); ++RegionIt) {
-    auto Alloc = mmap(RegionIt->Ptr, RegionIt->Size, PROT_NONE, MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED_NOREPLACE, -1, 0);
+    auto Alloc = ::mmap(RegionIt->Ptr, RegionIt->Size, PROT_NONE, MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED_NOREPLACE, -1, 0);
 
     LogMan::Throw::AFmt(Alloc != MAP_FAILED, "mmap({},{:x}) failed", fmt::ptr(RegionIt->Ptr), RegionIt->Size);
     LogMan::Throw::AFmt(Alloc == RegionIt->Ptr, "mmap returned {} instead of {}", Alloc, fmt::ptr(RegionIt->Ptr));

--- a/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -168,6 +168,7 @@ private:
     LOGMAN_THROW_A_FMT(Res != -1, "Couldn't mprotect region: {} '{}' Likely occurs when running out of memory or Maximum VMAs", errno,
                        strerror(errno));
 
+    FEXCore::Allocator::VirtualName("FEXMem_Misc", reinterpret_cast<void*>(ReservedRegion->Base), SizePlusManagedData);
     LiveVMARegion* LiveRange = new (reinterpret_cast<void*>(ReservedRegion->Base)) LiveVMARegion();
 
     // Copy over the reserved data
@@ -505,6 +506,8 @@ void OSAllocator_64Bit::AllocateMemoryRegions(fextl::vector<FEXCore::Allocator::
     // This enables the kernel to use transparent large pages in the allocator which can reduce memory pressure
     ::madvise(it.Ptr, ObjectAllocSize, MADV_HUGEPAGE);
 
+    FEXCore::Allocator::VirtualName("FEXMem_Misc", reinterpret_cast<void*>(it.Ptr), ObjectAllocSize);
+
     ObjectAlloc = new (it.Ptr) Alloc::ForwardOnlyIntrusiveArenaAllocator(it.Ptr, ObjectAllocSize);
     ReservedRegions = ObjectAlloc->new_construct(ReservedRegions, ObjectAlloc);
     LiveRegions = ObjectAlloc->new_construct(LiveRegions, ObjectAlloc);
@@ -601,6 +604,8 @@ fextl::unique_ptr<T> make_alloc_unique(FEXCore::Allocator::MemoryRegion& Base, A
   if (ptr == MAP_FAILED) {
     ERROR_AND_DIE_FMT("Couldn't allocate memory region");
   }
+
+  FEXCore::Allocator::VirtualName("FEXMem_Misc", reinterpret_cast<void*>(ptr), MinPage);
 
   // Remove the page from the base region.
   // Could be zero after this.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Seccomp/BPFEmitter.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Seccomp/BPFEmitter.cpp
@@ -384,6 +384,8 @@ uint64_t BPFEmitter::JITFilter(uint32_t flags, const sock_fprog* prog) {
 
   SetBuffer((uint8_t*)FEXCore::Allocator::mmap(nullptr, FuncSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0), FuncSize);
 
+  FEXCore::Allocator::VirtualName("FEXMem_Misc", reinterpret_cast<void*>(GetBufferBase()), FuncSize);
+
   const auto CodeBegin = GetCursorAddress<uint8_t*>();
 
   uint64_t Result = HandleEmission<false, EmissionErrorCheck>(flags, prog);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Seccomp/SeccompEmulator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Seccomp/SeccompEmulator.cpp
@@ -300,6 +300,8 @@ void SeccompEmulator::DeserializeFilters(FEXCore::Core::CpuStateFrame* Frame, in
 
     ::mprotect(Ptr, SFilter.CodeSize, PROT_READ | PROT_EXEC);
 
+    FEXCore::Allocator::VirtualName("FEXMem_Misc", reinterpret_cast<void*>(Ptr), SFilter.CodeSize);
+
     auto& it =
       Filters.emplace_back(SeccompFilterInfo {(SeccompFilterFunc)Ptr, 1, SFilter.CodeSize, SFilter.FilterInstructions, SFilter.ShouldLog});
     TotalFilterInstructions += SFilter.FilterInstructions;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -995,6 +995,7 @@ void SignalDelegator::RegisterTLSState(FEX::HLE::ThreadStateObject* Thread) {
   // Set up our signal alternative stack
   // This is per thread rather than per signal
   Thread->SignalInfo.AltStackPtr = FEXCore::Allocator::mmap(nullptr, SIGSTKSZ * 16, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  FEXCore::Allocator::VirtualName("FEXMem_Misc", reinterpret_cast<void*>(Thread->SignalInfo.AltStackPtr), SIGSTKSZ * 16);
   stack_t altstack {};
   altstack.ss_sp = reinterpret_cast<void*>(reinterpret_cast<uint64_t>(Thread->SignalInfo.AltStackPtr) + 8);
   altstack.ss_size = SIGSTKSZ * 16 - 8;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.cpp
@@ -32,6 +32,7 @@ void* StackTracker::AllocateStackObject() {
 
   if (Ptr == nullptr) {
     Ptr = FEXCore::Allocator::mmap(nullptr, FEX::LinuxEmulation::Threads::STACK_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    FEXCore::Allocator::VirtualName("FEXMem_Misc", reinterpret_cast<void*>(Ptr), FEX::LinuxEmulation::Threads::STACK_SIZE);
   }
 
   return Ptr;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Thread.cpp
@@ -190,6 +190,8 @@ uint64_t SyscallHandler::write_ldt(FEXCore::Core::CpuStateFrame* Frame, void* pt
   const auto new_ldt_entries = reinterpret_cast<FEXCore::Core::CPUState::gdt_segment*>(
     FEXCore::Allocator::mmap(nullptr, new_ldt_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
 
+  FEXCore::Allocator::VirtualName("FEXMem_Misc", reinterpret_cast<void*>(new_ldt_entries), new_ldt_size);
+
   if (old_ldt) {
     // Copy old entries if they existed.
     memcpy(new_ldt_entries, old_ldt, old_ldt_entries * LDT_ENTRY_SIZE);


### PR DESCRIPTION
This captures the remaining FEX allocations that /aren't/ coming from JEMalloc, allowing us to separate our mapped regions versus just jemalloc allocations.

With some additional naming in jemalloc (which I'm not adding here) this gets us interesting results:
```
        Misc resident:        54 MiB
    JEMalloc resident:        208 MiB
```

So 208MB of active jemalloc allocations in this particular case. These will be able to be tracked in heaptrack-like applications if careful. This should let us target down whatever live allocations we're keeping large amounts of data around if possible.