### PR TITLE
Add F_ADD_SEALS and F_GET_SEALS support to 32-bit fcntl

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
@@ -117,7 +117,9 @@ auto fcntlHandler = [](FEXCore::Core::CpuStateFrame* Frame, int fd, int cmd, uin
   case F_DUPFD_CLOEXEC:
   case F_GETFD:
   case F_SETFD:
-  case F_GETFL: break;
+  case F_GETFL:
+  case F_ADD_SEALS:
+  case F_GET_SEALS: break;
 
   default: LOGMAN_MSG_A_FMT("Unhandled fcntl64: 0x{:x}", cmd); break;
   }


### PR DESCRIPTION
Fixes crash with "Unhandled fcntl64: 0x409"
Seen with steam running Bayonetta with Proton Experimental.