### PR TITLE
SHMStats: Add a 16-byte alignment guarantee

### DIFF
--- a/FEXCore/include/FEXCore/Utils/SHMStats.h
+++ b/FEXCore/include/FEXCore/Utils/SHMStats.h
@@ -44,7 +44,7 @@ enum class AppType : uint8_t {
 struct ThreadStatsHeader {
   uint8_t Version;
   AppType app_type;
-  uint8_t _pad[2];
+  uint16_t ThreadStatsSize;
   char fex_version[48];
   std::atomic<uint32_t> Head;
   std::atomic<uint32_t> Size;

--- a/Source/Common/SHMStats.cpp
+++ b/Source/Common/SHMStats.cpp
@@ -13,10 +13,11 @@ void StatAllocBase::SaveHeader(FEXCore::SHMStats::AppType AppType) {
   Head = reinterpret_cast<FEXCore::SHMStats::ThreadStatsHeader*>(Base);
   Head->Size.store(CurrentSize, std::memory_order_relaxed);
   Head->Version = FEXCore::SHMStats::STATS_VERSION;
+  Head->app_type = AppType;
+  Head->ThreadStatsSize = sizeof(FEXCore::SHMStats::ThreadStats);
 
   std::string_view GitString = GIT_DESCRIBE_STRING;
   strncpy(Head->fex_version, GitString.data(), std::min(GitString.size(), sizeof(Head->fex_version)));
-  Head->app_type = AppType;
 
   Stats = reinterpret_cast<FEXCore::SHMStats::ThreadStats*>(reinterpret_cast<uint64_t>(Base) + sizeof(FEXCore::SHMStats::ThreadStatsHeader));
 


### PR DESCRIPTION
We want to take advantage of 16-byte single-copy atomicity. Which I am relying on, but didn't codify it the first time.

Additionally add comments to explain that new members should be added to the end to allow tools time to gain support gradually. This will allow me to add new members without fully breaking mangohud, they'll just not display the new information until support is added.

We're not guaranteeing backwards compatibility, just an attempt not to constantly churn the format unless necessary. This way if we do break compatibility, the tool will have an upper bound on supported versions before needing to rewrite code.

Also adds the ThreadStatsSize to the header so that can be used. Using the pad area so the version doesn't need to change. We guaranteed the padding to be zero before.