### PR TITLE
FEX: Disable trace profiler by default

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -338,6 +338,13 @@
           "Enables FEX's low-overhead sampling profile statistics.",
           "Requires a supported version of Mangohud to see the results"
         ]
+      },
+      "EnableGpuvisProfiling": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Enables profiling when FEX was built with the gpuvis profiler backend."
+        ]
       }
     },
     "Hacks": {

--- a/FEXCore/Source/Utils/Profiler.cpp
+++ b/FEXCore/Source/Utils/Profiler.cpp
@@ -70,6 +70,10 @@ static std::array<const char*, 2> TraceFSDirectories {
 };
 
 void Init() {
+  FEX_CONFIG_OPT(EnableGpuvisProfiling, ENABLEGPUVISPROFILING);
+  if (!EnableGpuvisProfiling()) {
+    return;
+  }
   for (auto Path : TraceFSDirectories) {
 #ifdef _WIN32
     constexpr auto flags = O_WRONLY;


### PR DESCRIPTION
Use a config option to turn it on.