### PR TITLE
FEXCore/Config: Support fetching config options as a single shot

### DIFF
--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -123,6 +123,12 @@ namespace DefaultValues {
     FEXCore::Config::DefaultValues::enum                                    \
   }
 
+// Get a configuration option as a single-shot.
+#define FEX_CONFIG_OPT_SINGLE(enum)                                    \
+  FEXCore::Config::Value<FEXCore::Config::DefaultValues::Type::enum> { \
+    FEXCore::Config::CONFIG_##enum,                                    \
+    FEXCore::Config::DefaultValues::enum                               \
+  }()
 #undef P
 } // namespace DefaultValues
 


### PR DESCRIPTION
There's quite a few locations where we fetch a config value once, but the current define always defines a variable so it can't be used inline in if-statements. This usually leaves us with a long-lived variable that exists far beyond what is necessary, or makes a single if-statement turn in to a two liner.

Define a new define that creates an anonymous variable that can be checked directly inside of if-statements or passed as arguments or whatever is necessary. It still does a map lookup for each variable fetch as usual, so regular caution still needs to be used.

eg:
`if (FEX_CONFIG_OPT_SINGLE(MULTIBLOCK)) {`
`LogMan::Msg::DFmt("Inst: {}", FEX_CONFIG_OPT_SINGLE(MAXINST));`

eg to not do: (Does a map lookup for each iteration)
```
for (size_t i = 0; i < FEX_CONFIG_OPT_SINGLE(MAXINST); ++i) {
```

Instead do something like this in this case?
```
for (size_t i = 0, max = FEX_CONFIG_OPT_SINGLE(MAXINST); i < max; ++i) {
```