### PR TITLE
FEXCore: Adds some more per-thread stats.

### DIFF
--- a/FEXCore/include/FEXCore/Utils/SHMStats.h
+++ b/FEXCore/include/FEXCore/Utils/SHMStats.h
@@ -63,6 +63,12 @@ struct ThreadStats {
   uint64_t AccumulatedSIGBUSCount;
   uint64_t AccumulatedSMCCount;
   uint64_t AccumulatedFloatFallbackCount;
+
+  uint64_t AccumulatedCacheMissCount;
+  uint64_t AccumulatedCacheReadLockTime;
+  uint64_t AccumulatedCacheWriteLockTime;
+
+  uint64_t AccumulatedJITCount;
 };
 
 // Ensure 16-byte alignment to take advantage of ARM single-copy atomicity.


### PR DESCRIPTION
- Cache miss counts
  - Useful for determining if L2 cache or dynamic cache could help
- Cache read/write lock contention times
  - Useful to see if threads are blocking each other on contention
  - Read lock is the case where a read-lock is beneficial, even if we
    currently use a write lock.
- JIT count
  - Useful to see if any new JIT blocks are generating

eg:
Middle of compiling
```
       JIT Time: 277.647490 ms/second (2.31 percent)
    Signal Time: 0.139980 ms/second (0.00 percent)
     SIGBUS Cnt: 294 (295.820556 per second)
        SMC Cnt: 0
  Softfloat Cnt: 27160
  CacheMiss Cnt: 21633 (21766.959497 per second)
    $RDLck Time: 0.934010 ms/second (0.01 percent)
    $WRLck Time: 2.319050 ms/second (0.02 percent)
        JIT Cnt: 5697 (5732.277920 percent)
```

Idle:
```
       JIT Time: 1.396660 ms/second (0.01 percent)
    Signal Time: 0.000000 ms/second (0.00 percent)
     SIGBUS Cnt: 0 (0.000000 per second)
        SMC Cnt: 0
  Softfloat Cnt: 170648
  CacheMiss Cnt: 34 (34.171477 per second)
    $RDLck Time: 0.004350 ms/second (0.00 percent)
    $WRLck Time: 0.002880 ms/second (0.00 percent)
        JIT Cnt: 8 (8.040348 percent)
```

Necrodancer bad case:
```
Total (1000 millisecond sample period):
       JIT Time: 672.021240 ms/second (5.60 percent)
    Signal Time: 1.884800 ms/second (0.02 percent)
     SIGBUS Cnt: 4 (4.005191 per second)
        SMC Cnt: 3
  Softfloat Cnt: 0
  CacheMiss Cnt: 15219 (15238.751873 per second)
    $RDLck Time: 0.983350 ms/second (0.01 percent)
    $WRLck Time: 0.680150 ms/second (0.01 percent)
        JIT Cnt: 5334 (5340.922695 percent)
```