### PR TITLE
FEXConfig: add an option to disable L2 cache on CPU tab

### DIFF
--- a/Source/Tools/FEXConfig/main.qml
+++ b/Source/Tools/FEXConfig/main.qml
@@ -719,6 +719,11 @@ ApplicationWindow {
                 text: qsTr("Disable JIT optimization passes")
                 config: "O0"
             }
+
+            ConfigCheckBox {
+                text: qsTr("Disable L2 cache")
+                config: "DisableL2Cache"
+            }
         }
 
         // Libraries settings


### PR DESCRIPTION
The DisableL2Cache option is CPU related so show it in proper place.