### PR TITLE
Remove InterpretAsFloat from x87StackOptimizationPass

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -68,7 +68,7 @@ void OpDispatchBuilder::FLDF64(OpcodeArgs, IR::OpSize Width) {
   } else if (Width == OpSize::f80Bit) {
     ConvertedData = _F80CVT(OpSize::i64Bit, Data);
   }
-  _PushStack(ConvertedData, Data, ReadWidth, true);
+  _PushStack(ConvertedData, Data, ReadWidth);
 }
 
 void OpDispatchBuilder::FBLDF64(OpcodeArgs) {
@@ -76,7 +76,7 @@ void OpDispatchBuilder::FBLDF64(OpcodeArgs) {
   Ref Data = LoadSourceFPR_WithOpSize(Op, Op->Src[0], OpSize::f80Bit, Op->Flags);
   Ref ConvertedData = _F80BCDLoad(Data);
   ConvertedData = _F80CVT(OpSize::i64Bit, ConvertedData);
-  _PushStack(ConvertedData, Data, OpSize::i64Bit, true);
+  _PushStack(ConvertedData, Data, OpSize::i64Bit);
 }
 
 void OpDispatchBuilder::FBSTPF64(OpcodeArgs) {
@@ -88,7 +88,7 @@ void OpDispatchBuilder::FBSTPF64(OpcodeArgs) {
 
 void OpDispatchBuilder::FLDF64_Const(OpcodeArgs, uint64_t Num) {
   auto Data = _VCastFromGPR(OpSize::i64Bit, OpSize::i64Bit, Constant(Num));
-  _PushStack(Data, Data, OpSize::i64Bit, true);
+  _PushStack(Data, Data, OpSize::i64Bit);
 }
 
 void OpDispatchBuilder::FILDF64(OpcodeArgs) {
@@ -100,7 +100,7 @@ void OpDispatchBuilder::FILDF64(OpcodeArgs) {
     Data = _Sbfe(OpSize::i64Bit, IR::OpSizeAsBits(ReadWidth), 0, Data);
   }
   auto ConvertedData = _Float_FromGPR_S(OpSize::i64Bit, ReadWidth == OpSize::i32Bit ? OpSize::i32Bit : OpSize::i64Bit, Data);
-  _PushStack(ConvertedData, Data, ReadWidth, false);
+  _PushStack(ConvertedData, Invalid(), ReadWidth);
 }
 
 void OpDispatchBuilder::FISTF64(OpcodeArgs, bool Truncate) {
@@ -397,7 +397,7 @@ void OpDispatchBuilder::X87FXTRACTF64(OpcodeArgs) {
   Ref Exp = _NZCVSelectV(OpSize::i64Bit, CondClass::EQ, ExpZV, ExpNZV);
 
   _PopStackDestroy();
-  _PushStack(Exp, Exp, OpSize::i64Bit, true);
-  _PushStack(Sig, Sig, OpSize::i64Bit, true);
+  _PushStack(Exp, Invalid(), OpSize::i64Bit);
+  _PushStack(Sig, Invalid(), OpSize::i64Bit);
 }
 } // namespace FEXCore::IR

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -2818,17 +2818,13 @@
         "X87": true,
         "HasSideEffects": true
       },
-      "PushStack FPR:$X80Src, SSA:$OriginalValue, OpSize:$LoadSize, i1:$Float": {
+      "PushStack FPR:$X80Src, FPR:$OriginalValue, OpSize:$LoadSize": {
         "Desc": [
           "Pushes the provided X80Src source on to the x87 stack.",
-          "Tracks OriginalValue as the original value of X80Src.",
+          "Tracks OriginalValue as the original value of X80Src. OriginalValue can be Invalid() in which case no tracking is done.",
           "Opsize is 128bit for F80 values, 64-bit for low precision.",
           "LoadSize the original load size, i.e. of size of OriginalValue.",
-          "Float: 80-bit, 64-bit, 32-bit",
-          "Int: 64-bit, 32-bit, 16-bit"
-        ],
-        "EmitValidation": [
-          "WalkFindRegClass($OriginalValue) == RegClass::FPR || WalkFindRegClass($OriginalValue) == RegClass::GPR"
+          "Float: 80-bit, 64-bit, 32-bit"
         ],
         "HasSideEffects": true,
         "X87": true
@@ -2840,13 +2836,12 @@
         "HasSideEffects": true,
         "X87": true
       },
-      "StoreStackMem OpSize:$SourceSize, OpSize:$StoreSize, GPR:$Addr, GPR:$Offset, OpSize:$Align, MemOffsetType:$OffsetType, u8:$OffsetScale, i1:$Float": {
+      "StoreStackMem OpSize:$SourceSize, OpSize:$StoreSize, GPR:$Addr, GPR:$Offset, OpSize:$Align, MemOffsetType:$OffsetType, u8:$OffsetScale": {
         "Desc": [
           "Takes the top value off the x87 stack and stores it to memory.",
           "SourceSize is 128bit for F80 values, 64-bit for low precision.",
           "StoreSize is the store size for conversion:",
-          "Float: 80-bit, 64-bit, or 32-bit",
-          "Int: 64-bit, 32-bit, 16-bit"
+          "Float: 80-bit, 64-bit, or 32-bit"
         ],
         "HasSideEffects": true,
         "X87": true


### PR DESCRIPTION
The InterpretAsFloat was never properly made use of. There's a couple of issues that are fixed more easily with this gone, so lets remove it.

If there's a specific optimization that requires this, we can bring it back at a later time. This should not have any effect on the current code generation.