### PR TITLE
FEXConfig: Fix crash caused by no longer recognized option

### DIFF
--- a/Source/Tools/FEXConfig/main.qml
+++ b/Source/Tools/FEXConfig/main.qml
@@ -711,11 +711,6 @@ ApplicationWindow {
             }
 
             ConfigCheckBox {
-                text: qsTr("Unsafe local flags optimization")
-                config: "ABILocalFlags"
-            }
-
-            ConfigCheckBox {
                 text: qsTr("Disable JIT optimization passes")
                 config: "O0"
             }


### PR DESCRIPTION
This option was removed in #4997 but the corresponding GUI code wasn't updated accordingly.