### PR TITLE
CodeEmitter: Removes a few spurious asserts

### DIFF
--- a/CodeEmitter/CodeEmitter/ALUOps.inl
+++ b/CodeEmitter/CodeEmitter/ALUOps.inl
@@ -38,8 +38,6 @@ public:
 
   [[nodiscard]] BranchEncodeSucceeded adr(ARMEmitter::Register rd, const BackwardLabel* Label) {
     int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
-    LOGMAN_THROW_A_FMT(IsADRRange(Imm), "Unscaled offset too large");
-
     if (IsADRRange(Imm)) {
       constexpr uint32_t Op = 0b0001'0000 << 24;
       DataProcessing_PCRel_Imm(Op, rd, Imm);
@@ -73,7 +71,6 @@ public:
 
   [[nodiscard]] BranchEncodeSucceeded adrp(ARMEmitter::Register rd, const BackwardLabel* Label) {
     int64_t Imm = reinterpret_cast<int64_t>(Label->Location) - (GetCursorAddress<int64_t>() & ~0xFFFLL);
-    LOGMAN_THROW_A_FMT(IsADRPRange(Imm) && IsADRPAligned(Imm), "Unscaled offset too large");
 
     if (IsADRPRange(Imm) && IsADRPAligned(Imm)) {
       constexpr uint32_t Op = 0b1001'0000 << 24;

--- a/CodeEmitter/CodeEmitter/BranchOps.inl
+++ b/CodeEmitter/CodeEmitter/BranchOps.inl
@@ -301,7 +301,6 @@ public:
   }
   [[nodiscard]] BranchEncodeSucceeded tbnz(ARMEmitter::Register rt, uint32_t Bit, const BackwardLabel* Label) {
     int32_t Imm = static_cast<int32_t>(Label->Location - GetCursorAddress<uint8_t*>());
-    LOGMAN_THROW_A_FMT(Imm >= -32768 && Imm <= 32764 && ((Imm & 0b11) == 0), "Unscaled offset too large");
 
     if (Imm >= -32768 && Imm <= 32764 && ((Imm & 0b11) == 0)) {
       constexpr uint32_t Op = 0b0011'0111 << 24;


### PR DESCRIPTION
These are handled with restart.