### PR TITLE
LinuxSyscalls: Fix incorrectly inferred base address observed in glxtest

### DIFF
--- a/Source/Common/FileMappingBaseAddress.h
+++ b/Source/Common/FileMappingBaseAddress.h
@@ -2,9 +2,9 @@
 #pragma once
 
 #include <FEXCore/Utils/TypeDefines.h>
+#include <FEXCore/fextl/vector.h>
 
 #include <cstdint>
-#include <optional>
 #include <span>
 
 #include <elf.h>
@@ -15,12 +15,16 @@ namespace FEXCore {
  * Infers the base virtual address from a file mapping (as described by parameters to a single
  * call to mmap()).
  *
+ * Usually the base address can uniquely be inferred, but in edge cases multiple possible
+ * candidates are returned.
+ *
  * The file offset of any given mapping need not match its virtual address offset from the base
  * mapping (file offset = 0). Instead, this function searches the corresponding ELF program headers
  * for an entry that generated the given file mapping.
  */
-inline std::optional<uint64_t>
+inline fextl::vector<uint64_t>
 InferMappingBaseAddress(std::span<const Elf64_Phdr> ProgramHeaders, uint64_t Addr, uint64_t Size, uint64_t FileOffset, int AccessFlags) {
+  fextl::vector<uint64_t> Ret;
   for (auto& phdr : ProgramHeaders) {
     if (phdr.p_type != PT_LOAD) {
       // Skip headers that don't trigger memory mappings
@@ -36,11 +40,11 @@ InferMappingBaseAddress(std::span<const Elf64_Phdr> ProgramHeaders, uint64_t Add
     if (FileOffset >= SegmentStartOffset && FileOffset < SegmentStartOffset + phdr.p_filesz &&
         (FileOffset & Utils::FEX_PAGE_MASK) == (phdr.p_offset & Utils::FEX_PAGE_MASK)) {
       // Compute VA offset relative to the base mapping
-      return Addr - (phdr.p_vaddr - (phdr.p_offset & 0xfff)) + (ProgramHeaders[0].p_vaddr - (ProgramHeaders[0].p_offset & 0xfff)) -
-             (FileOffset - SegmentStartOffset);
+      Ret.push_back(Addr - (phdr.p_vaddr - (phdr.p_offset & 0xfff)) + (ProgramHeaders[0].p_vaddr - (ProgramHeaders[0].p_offset & 0xfff)) -
+                    (FileOffset - SegmentStartOffset));
     }
   }
 
-  return std::nullopt;
+  return Ret;
 }
 } // namespace FEXCore

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -442,10 +442,10 @@ std::optional<SyscallHandler::LateApplyExtendedVolatileMetadata> SyscallHandler:
 
         ResourceIt = std::find_if(ResourceIt, ResourceEnd, [&](const VMATracking::MappedResource::ContainerType::value_type& ResourcePair) {
           auto& Resource = ResourcePair.second;
-          auto ExpectedBase = FEXCore::InferMappingBaseAddress(
+          auto ExpectedBases = FEXCore::InferMappingBaseAddress(
             Resource.ProgramHeaders, addr, Size, offset,
             (ProtMapping.Executable ? PF_X : 0) | (ProtMapping.Writable ? PF_W : 0) | (ProtMapping.Readable ? PF_R : 0));
-          return ExpectedBase == Resource.FirstVMA->Base;
+          return std::ranges::find(ExpectedBases, Resource.FirstVMA->Base) != ExpectedBases.end();
         });
         LOGMAN_THROW_A_FMT(ResourceIt != ResourceEnd, "ERROR: Could not find base for file mapping at {:#x} (offset {:#x})", addr, offset);
         Resource = &ResourceIt->second;


### PR DESCRIPTION
At runtime, glxtest is mapped as follows:
```
0x000055fd9a030000 0x000055fd9a034000 0x4000  0x0     r--p  glxtest
0x000055fd9a034000 0x000055fd9a038000 0x4000  0x3000  r-xp  glxtest
0x000055fd9a038000 0x000055fd9a039000 0x1000  0x6000  rw-p  glxtest
0x000055fd9a039000 0x000055fd9a03a000 0x1000  0x6000  rw-p  glxtest
```

The problem here is that the last two sections can't be distinguished solely by their mmap parameters. This would cause the wrong base address to be inferred for the last mapping. To fix this, we can be more permissive by allowing multiple candidates to be returned.

In practice, this only affects non-code sections, so it's not a big issue either way.