### PR TITLE
Docs: fix typo

### DIFF
--- a/docs/SourceOutline.md
+++ b/docs/SourceOutline.md
@@ -5,7 +5,7 @@ See [FEXCore/Readme.md](../FEXCore/Readme.md) for more details
 
 ### Glossary
 
-- Splatter: a code generator backend that concaternates configurable macros instead of doing isel
+- Splatter: a code generator backend that concatenates configurable macros instead of doing isel
 - IR: Intermediate Representation, our high-level opcode representation, loosely modeling arm64
 - SSA: Single Static Assignment, a form of representing IR in memory
 - Basic Block: A block of instructions with no control flow, terminated by control flow


### PR DESCRIPTION
Sorry for the low effort PR, I've just spent 2 minutes searching for `concaternates` because I was not sure if this is something I just don't know or if this might be a typo.
So if this is really just a typo, I'd like to propose fixing it :3

_Thank you for your great work btw ❤️_