### PR TITLE
FEXConfig: Fix string list handling

### DIFF
--- a/Source/Tools/FEXConfig/Main.cpp
+++ b/Source/Tools/FEXConfig/Main.cpp
@@ -78,6 +78,10 @@ void ConfigModel::Reload() {
     if (!LoadedConfig->OptionExists(Option.first)) {
       continue;
     }
+    if (std::holds_alternative<fextl::list<fextl::string>>(Option.second)) {
+      // Omit string lists from the model since they require special handling
+      continue;
+    }
 
     auto& [Name, TypeId] = ConfigToNameLookup.find(Option.first)->second;
     auto Item = new QStandardItem(QString::fromStdString(Name));
@@ -122,7 +126,7 @@ void ConfigModel::setStringList(const QString& Name, const QStringList& Values) 
   const auto& Option = NameToConfigLookup.at(Name.toStdString());
   LoadedConfig->Erase(Option);
   for (auto& Value : Values) {
-    LoadedConfig->Set(Option, Value.toStdString().c_str());
+    LoadedConfig->AppendStrArrayValue(Option, Value.toStdString().c_str());
   }
   Reload();
 }


### PR DESCRIPTION
Fixes FEXConfig crashes when trying to add environment variables or when loading/saving a Config.json with such entries.

Not sure if something about the Config interfaces changed here recently, since this certainly must have been working at some point.