### PR TITLE
LinuxSyscalls: Fix null pointer dereference in LookupExecutableFileSection

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -175,7 +175,7 @@ SyscallHandler::LookupExecutableFileSection(FEXCore::Core::InternalThreadState& 
   auto lk = FEXCore::GuardSignalDeferringSection<std::shared_lock>(VMATracking.Mutex, &Thread);
 
   auto EntryIt = VMATracking.FindVMAEntry(GuestAddr);
-  if (EntryIt == VMATracking.VMAs.end() || !EntryIt->second.Resource) {
+  if (EntryIt == VMATracking.VMAs.end() || !EntryIt->second.Resource || !EntryIt->second.Resource->MappedFile) {
     return std::nullopt;
   }
 


### PR DESCRIPTION
Pulled from the working branch.