### PR TITLE
FEXCore/Config: Expose GetConv members

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.cpp
+++ b/FEXCore/Source/Interface/Config/Config.cpp
@@ -436,6 +436,12 @@ std::optional<T> GetConv(ConfigOption Option) {
   return Meta->GetConv<T>(Option);
 }
 
+template std::optional<bool> GetConv(ConfigOption Option);
+template std::optional<uint8_t> GetConv(ConfigOption Option);
+template std::optional<int32_t> GetConv(ConfigOption Option);
+template std::optional<uint32_t> GetConv(ConfigOption Option);
+template std::optional<uint64_t> GetConv(ConfigOption Option);
+
 void Set(ConfigOption Option, std::string_view Data) {
   Meta->Set(Option, Data);
 }

--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -233,6 +233,8 @@ FEX_DEFAULT_VISIBILITY void AddLayer(fextl::unique_ptr<FEXCore::Config::Layer> _
 
 FEX_DEFAULT_VISIBILITY bool Exists(ConfigOption Option);
 FEX_DEFAULT_VISIBILITY std::optional<StringArrayType*> All(ConfigOption Option);
+template<typename T>
+FEX_DEFAULT_VISIBILITY std::optional<T> GetConv(ConfigOption Option);
 FEX_DEFAULT_VISIBILITY std::optional<fextl::string*> Get(ConfigOption Option);
 FEX_DEFAULT_VISIBILITY void Set(ConfigOption Option, std::string_view Data);
 FEX_DEFAULT_VISIBILITY void Erase(ConfigOption Option);


### PR DESCRIPTION
From working branch commit 8244ca1666796267ce25741cdf1103eef4f7539d `Make cache generation aware of FEX configuration`