### PR TITLE
FEXCore/Common: Adds the ability to override HostFeatures registers by config.

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -94,6 +94,13 @@
         "Desc": [
           "Scales the cycle counter on systems that have low frequencies."
         ]
+      },
+      "CPUFeatureRegisters": {
+        "Type": "str",
+        "Default": "",
+        "Desc": [
+          "Allows overriding cpu feature flags for manual testing"
+        ]
       }
     },
     "Emulation": {


### PR DESCRIPTION
This is going to be necessary for the offline compiler work. Also allow FEXGetConfig to print the same registers in the correct format for easy fetching.