### PR TITLE
Async: Adapt precondition checks when receiving FDs

### DIFF
--- a/Source/Common/Async.h
+++ b/Source/Common/Async.h
@@ -18,6 +18,7 @@
 #include <FEXCore/fextl/functional.h>
 #include <FEXCore/fextl/map.h>
 #include <FEXCore/fextl/vector.h>
+#include <FEXCore/Utils/LogManager.h>
 
 namespace fasio {
 
@@ -368,6 +369,7 @@ std::size_t read(AsyncReadStream& Stream, mutable_buffer Buffers, error& ec) {
     auto BytesRead = Stream.read_some(Buffers, ec);
     TotalBytesRead += BytesRead;
     if (Buffers.FD) {
+      LOGMAN_THROW_A_FMT(**Buffers.FD != -1, "Receiver requested a file descriptor but none was sent");
       (void)Buffers.consume_fd();
     }
     Buffers += BytesRead;

--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -59,8 +59,8 @@ int RequestPIDFDPacket(int ServerSocket, PacketType Type) {
   fasio::mutable_buffer ResBuffer {std::as_writable_bytes(std::span {&Res, 1})};
   int NewFD = -1;
   ResBuffer.FD = &NewFD;
-  read(Socket, ResBuffer, ec);
-  if (ec != fasio::error::success || Res.Header.Type != PacketType::TYPE_SUCCESS) {
+  auto BytesRead = Socket.read_some(ResBuffer, ec);
+  if (ec != fasio::error::success || BytesRead != sizeof(Res) || Res.Header.Type != PacketType::TYPE_SUCCESS) {
     return -1;
   }
 


### PR DESCRIPTION
Allows `read_some` to succeed when the sender provides data but no FD despite the latter being requested. Conversely, `read` checks are strengthened from silent failure to assert since at the moment this should happen nowhere.

#5059 tried cherry-picking an incomplete version of this patch under a wrong commit message, so it's reverted before applying the patches. This fixes an assertion failure that would crash FEX on startup in some configurations.
