### PR TITLE
Fix movzx instruction syntax

### DIFF
--- a/unittests/ASM/Includes/x87cw.mac
+++ b/unittests/ASM/Includes/x87cw.mac
@@ -7,7 +7,7 @@
 %macro set_cw_precision_rounding 2
   sub rsp, 2
   fnstcw [rsp]
-  movzx ax, [rsp]
+  movzx eax, word [rsp]
 
   ; Precision
   and eax, ~(3 << 8)


### PR DESCRIPTION
nasm 2.16 was happy with it but it generates a bunch of errors in nasm3. The generated binaries remain the same.