### PR TITLE
Utils/WritePriorityMutex: Support being forkable

### DIFF
--- a/FEXCore/Source/Utils/WritePriorityMutex.h
+++ b/FEXCore/Source/Utils/WritePriorityMutex.h
@@ -124,7 +124,6 @@ public:
     uint32_t Desired {};
 
     while (true) {
-
       bool Sleep = false;
       do {
         if ((Expected & WRITE_OWNED_BIT) == 0 && (Expected & WRITE_WAITER_COUNT_MASK) == 0) {
@@ -230,6 +229,14 @@ public:
     // Uncontended mutex check
     return AtomicFutex.compare_exchange_strong(Expected, Desired, std::memory_order_acq_rel, std::memory_order_acquire);
   }
+
+#if !defined(_WIN32)
+  // Initialize the internal mutex object to its default initializer state.
+  // Should only ever be used in the child process when a Linux fork() has occured.
+  void StealAndDropActiveLocks() {
+    Futex = 0;
+  }
+#endif
 
 private:
 


### PR DESCRIPTION
This will be useful to fix the mutex locking mess that occurs currently when forks occur. Instead of needing to be /very/ meticulous with many futexes, we can instead have working threads shared_lock this one, then when a fork occurs just only have the forker themselves unique_lock and let the readers drain out. Since it's write-priority it'll happen quite quickly, letting the fork get in and out relatively easily.

This is going to take some massaging to get the frontend and FEXCore to a place that this works but we can get this simple change in early.