### PR TITLE
CPUID: Fixes regression from #5033

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -277,7 +277,7 @@ private:
     // 0: Highest function parameter and ID
     {SupportsConstant::CONSTANT, NeedsLeafConstant::NOLEAFCONSTANT},
     // 1: Processor info
-    {SupportsConstant::CONSTANT, NeedsLeafConstant::NOLEAFCONSTANT},
+    {SupportsConstant::NONCONSTANT, NeedsLeafConstant::NOLEAFCONSTANT},
     // 2: Cache and TLB info
     {SupportsConstant::CONSTANT, NeedsLeafConstant::NOLEAFCONSTANT},
     // 3: Serial Number(previously), now reserved


### PR DESCRIPTION
This leaf changed to being non-constant on that PR since CPUID function 1h returns APICID now.