### PR TITLE
FEXServer: Add support for a `wait_fd`

### DIFF
--- a/Source/Tools/FEXServer/ArgumentLoader.cpp
+++ b/Source/Tools/FEXServer/ArgumentLoader.cpp
@@ -2,6 +2,7 @@
 #include "ArgumentLoader.h"
 #include "Common/cpp-optparse/OptionParser.h"
 #include "PipeScanner.h"
+#include "ProcessPipe.h"
 
 #include "git_version.h"
 
@@ -22,6 +23,7 @@ FEXServerOptions Load(int argc, char** argv) {
 
   Parser.add_option("-w", "--wait").action("store_true").set_default(false).help("Wait for the FEXServer to shutdown");
   Parser.add_option("--wait_pipe").action("store").type("int").set_default(-1).set_optional_value(true);
+  Parser.add_option("--watch_fd").action("store").type("int").set_default(-1).set_optional_value(true).help("Adds FD to watch list of active processes");
 
   Parser.add_option("-v").action("version").help("Version string");
 
@@ -39,6 +41,7 @@ FEXServerOptions Load(int argc, char** argv) {
   if (WaitPipe != -1) {
     PipeScanner::SetWaitPipe(WaitPipe);
   }
+  ProcessPipe::SetWatchFD(Options.get("watch_fd"));
   return FEXOptions;
 }
 } // namespace FEXServer::Config

--- a/Source/Tools/FEXServer/ProcessPipe.h
+++ b/Source/Tools/FEXServer/ProcessPipe.h
@@ -8,4 +8,5 @@ bool InitializeServerSocket(bool abstract);
 void WaitForRequests();
 void SetConfiguration(bool Foreground, uint32_t PersistentTimeout);
 void Shutdown();
+void SetWatchFD(int FD);
 } // namespace ProcessPipe


### PR DESCRIPTION
This was a requested feature. To make sure that FEXServer is running and managed by a parent process, we need to have a way to tell FEXServer to keep alive without any FEX clients. The best way to do this is to pass FEXServer a Pipe (like FEX does when a client starts it), but instead of FEXServer signaling to FEXInterpreter that it's ready. FEXServer listens to the pipe to see if the management process is still alive.

The expectation here is that the management process passes FEXServer the read end of a pipe, and when the management software is done (or gets killed by the kernel!) then the write end of the pipe is closed, and FEXServer naturally closes (As long as there's no FEX processes remaining).