### PR TITLE
FEXInterpreter: Fixes crash with code maps

### DIFF
--- a/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
+++ b/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
@@ -428,6 +428,10 @@ int main(int argc, char** argv, char** const envp) {
       char* RealPath = realpath(Program.ProgramPath.c_str(), ExistsTempPath);
       if (RealPath) {
         FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_FILENAME, fextl::string(RealPath));
+      } else {
+        // Can happen when jumping in to pressure-vessel.
+        // `/usr/lib/pressure-vessel/from-host/libexec/steam-runtime-tools-0/pv-adverb` can't get resolved.
+        FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_FILENAME, Program.ProgramPath);
       }
     }
     FEXCore::Config::Set(FEXCore::Config::CONFIG_APP_CONFIG_NAME, Program.ProgramName);


### PR DESCRIPTION
When the realpath of a program path can't be resolved, we weren't setting the config option. This was cascading to be a crashing in codemaps where it was unconditionally using the optional value (with assert checks), and causing things to crash.

Pass in the path that can't be resolved to work around a crash in PV that can happen.