### PR TITLE
HostFeatures: Disable SupportsTSOImm9 for some CPUs

### DIFF
--- a/Source/Common/HostFeatures.h
+++ b/Source/Common/HostFeatures.h
@@ -662,7 +662,8 @@ protected:
 
 void FillMIDRInformationViaLinux(FEXCore::HostFeatures* Features);
 
-FEXCore::HostFeatures FetchHostFeatures(FEX::CPUFeatures& Features, bool SupportsCacheMaintenanceOps, uint64_t CTR, uint64_t MIDR);
+void FetchHostFeatures(FEX::CPUFeatures& Features, FEXCore::HostFeatures& HostFeatures, bool SupportsCacheMaintenanceOps, uint64_t CTR,
+                       uint64_t MIDR);
 FEXCore::HostFeatures FetchHostFeatures();
 FEX::CPUFeatures GetCPUFeaturesFromIDRegisters();
 } // namespace FEX

--- a/Source/Windows/Common/CPUFeatures.cpp
+++ b/Source/Windows/Common/CPUFeatures.cpp
@@ -58,18 +58,19 @@ FEXCore::HostFeatures CPUFeatures::FetchHostFeatures(bool IsWine) {
   uint64_t CTR = ReadRegU64(Key, "CP 5801");
   uint64_t MIDR = ReadRegU64(Key, "CP 4000");
 
-
-  auto HostFeatures = FEX::FetchHostFeatures(Features, !IsWine, CTR, MIDR);
-
-  // Force-disable SVE until wine/windows gain support for SVE context save/restore
-  HostFeatures.SupportsSVE128 = false;
-  HostFeatures.SupportsSVE256 = false;
+  FEXCore::HostFeatures HostFeatures = {};
 
   for (uint32_t Idx = 0; Key; Key = OpenProcessorKey(++Idx)) {
     // Truncate to 32-bits, top 32-bits are all reserved in MIDR
     HostFeatures.CPUMIDRs.push_back(static_cast<uint32_t>(ReadRegU64(Key, "CP 4000")));
     RegCloseKey(Key);
   }
+
+  FEX::FetchHostFeatures(Features, HostFeatures, !IsWine, CTR, MIDR);
+
+  // Force-disable SVE until wine/windows gain support for SVE context save/restore
+  HostFeatures.SupportsSVE128 = false;
+  HostFeatures.SupportsSVE256 = false;
 
   HostFeatures.SupportsCPUIndexInTPIDRRO = !IsWine;
   return HostFeatures;


### PR DESCRIPTION
This change avoids using the LDAPUR instruction with CPUs that are know to be impacted by an ARM CPU errata that results in poor performance.