### PR TITLE
LookupCache: Fix use of invalidated iterators

### DIFF
--- a/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/FEXCore/Source/Interface/Core/LookupCache.h
@@ -341,8 +341,9 @@ public:
         InvalidateCache(Entry, lk);
       }
     }
+    bool ret = upper != lower;
     CachedCodePages.erase(lower, upper);
-    return upper != lower;
+    return ret;
   }
 
   void AddBlockLink(uint64_t GuestDestination, FEXCore::Context::ExitFunctionLinkData* HostLink,


### PR DESCRIPTION
`erase` invalidates these iterators, so the return value must be computed before erasing elements. Fixes assertions when building with `_GLIBCXX_DEBUG`.