### PR TITLE
Tools/pidof: Fixes FEXpidof after #5097

### DIFF
--- a/Source/Tools/pidof/pidof.cpp
+++ b/Source/Tools/pidof/pidof.cpp
@@ -328,6 +328,12 @@ int main(int argc, char** argv) {
       continue;
     }
 
+    // If matching all "FEX" instances then add arm64ec/wow64 FEX to the matched list.
+    if (ProgramArg != -1 && Config::AllFEX) {
+      MatchedPIDs.emplace(pid.pid);
+      continue;
+    }
+
     ProgramPair Arg = FindEmulatedWineArgument(ProgramArg, Args, IsWine);
     bool Matched = false;
     for (const auto& CompareProgram : Config::Programs) {


### PR DESCRIPTION
FEX argument will no longer exist in `/proc/<pid>/cmdline` after this PR. Ensure this tool still works.

After #5097 is merged, one can use regular `pidof` for Linux applications, but this is still useful as it finds Wine applications running with FEX as well.