### PR TITLE
Syscalls: Fix DEBUG_STRACE printing

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -394,19 +394,19 @@ struct ArgToFmtString;
   };
 
 // Base types
-ARG_TO_STR(int, "%d")
-ARG_TO_STR(unsigned int, "%u")
-ARG_TO_STR(long, "%ld")
-ARG_TO_STR(unsigned long, "%lu")
+ARG_TO_STR(int, "{}")
+ARG_TO_STR(unsigned int, "{}")
+ARG_TO_STR(long, "{}")
+ARG_TO_STR(unsigned long, "{}")
 
 // string types
-ARG_TO_STR(char*, "%s")
-ARG_TO_STR(const char*, "%s")
+ARG_TO_STR(char*, "{}")
+ARG_TO_STR(const char*, "{}")
 
 // Pointers
 template<typename T>
 struct ArgToFmtString<T*> {
-  inline static const char* const Format = "%p";
+  inline static const char* const Format = "{:x}";
 };
 
 // Use ArgToFmtString and variadic template to create a format string from an args list

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
@@ -87,7 +87,7 @@ fextl::unique_ptr<FEX::HLE::SyscallHandler> CreateHandler(FEXCore::Context::Cont
 template<typename R, typename... Args>
 void RegisterSyscall(SyscallHandler* Handler, int SyscallNumber, const char* Name, R (*fn)(FEXCore::Core::CpuStateFrame* Frame, Args...)) {
 #ifdef DEBUG_STRACE
-  auto TraceFormatString = fextl::string(Name) + "(" + CollectArgsFmtString<Args...>() + ") = %ld";
+  auto TraceFormatString = fextl::string(Name) + "(" + CollectArgsFmtString<Args...>() + ") = {}";
 #endif
   Handler->RegisterSyscall_32(SyscallNumber,
 #ifdef DEBUG_STRACE

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
@@ -78,7 +78,7 @@ CreateHandler(FEXCore::Context::Context* ctx, FEX::HLE::SignalDelegator* _Signal
 template<typename R, typename... Args>
 void RegisterSyscall(SyscallHandler* Handler, int SyscallNumber, const char* Name, R (*fn)(FEXCore::Core::CpuStateFrame* Frame, Args...)) {
 #ifdef DEBUG_STRACE
-  auto TraceFormatString = fextl::string(Name) + "(" + CollectArgsFmtString<Args...>() + ") = %ld";
+  auto TraceFormatString = fextl::string(Name) + "(" + CollectArgsFmtString<Args...>() + ") = {}";
 #endif
   Handler->RegisterSyscall_64(SyscallNumber,
 #ifdef DEBUG_STRACE


### PR DESCRIPTION
Replaces the % strings with {} in syscall TraceFormatString / Def.StraceFmt

Looks something like this on main:
```
D write(%ld, %ld, %ld) = %ld
D write(%ld, %ld, %ld) = %ld
D write(%ld, %ld, %ld) = %ld
```

Looks like this now:
```
D write(9, 140737488343440, 128) = 128
D write(9, 140737488343440, 34) = 34
D write(9, 94078319113395, 1) = 1
D openat(4294967196, 94078319267264, 524288, 0) = 10
D read(10, 140737488340936, 832) = 832
D fstat(10, 7fffffffc660) = 0
```

