### PR TITLE
ARM64Emitter: Force NOP padding to be enabled

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -418,6 +418,11 @@ FEXCore::X86State::X86Reg Arm64Emitter::GetX86RegRelationToARMReg(ARMEmitter::Re
 }
 
 void Arm64Emitter::LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, uint64_t Constant, bool NOPPad) {
+  if (EnableCodeCaching) {
+    // Force NOP padding to ensure relocated constants always have enough encoding space available
+    NOPPad = true;
+  }
+
   bool Is64Bit = s == ARMEmitter::Size::i64Bit;
   int Segments = Is64Bit ? 4 : 2;
 

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <FEXCore/Config/Config.h>
+
 #ifdef VIXL_DISASSEMBLER
 #include <aarch64/disasm-aarch64.h>
-#include <FEXCore/Config/Config.h>
 #include <FEXCore/fextl/memory.h>
 #include <FEXCore/fextl/vector.h>
 #endif
@@ -272,6 +273,8 @@ protected:
 
   FEX_CONFIG_OPT(Disassemble, DISASSEMBLE);
 #endif
+
+  FEX_CONFIG_OPT(EnableCodeCaching, ENABLECODECACHINGWIP);
 };
 
 } // namespace FEXCore::CPU


### PR DESCRIPTION
When loading code caches, these constants get patched up for the new guest address. The new value may be larger than the original, so the padding bytes ensure the maximum of 16 bytes of encoding space is always available.