### PR TITLE
Windows: Split out CRT/WinAPI reimplementation

### DIFF
--- a/Source/Windows/ARM64EC/CMakeLists.txt
+++ b/Source/Windows/ARM64EC/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(arm64ecfex
   Common
   CommonTools
   CommonWindows
+  CommonWindowsRuntime
   ntdll_ex
 )
 

--- a/Source/Windows/Common/CMakeLists.txt
+++ b/Source/Windows/Common/CMakeLists.txt
@@ -1,8 +1,16 @@
-add_library(CommonWindows STATIC CPUFeatures.cpp SHMStats.cpp InvalidationTracker.cpp Logging.cpp LoadConfig.S)
+add_library(CommonWindowsRuntime STATIC LoadConfig.S)
 add_subdirectory(CRT)
 add_subdirectory(WinAPI)
-target_link_libraries(CommonWindows FEXCore_Base JemallocLibs)
-target_compile_options(CommonWindows PRIVATE -Wno-inconsistent-dllimport)
+
+target_link_libraries(CommonWindowsRuntime FEXCore_Base JemallocLibs)
+target_compile_options(CommonWindowsRuntime PRIVATE -Wno-inconsistent-dllimport)
+target_include_directories(CommonWindowsRuntime PRIVATE
+  "${CMAKE_SOURCE_DIR}/Source/Windows/include/"
+)
+
+add_library(CommonWindows STATIC CPUFeatures.cpp SHMStats.cpp InvalidationTracker.cpp Logging.cpp)
+
+target_link_libraries(CommonWindows FEXCore_Base)
 target_include_directories(CommonWindows PRIVATE
   "${CMAKE_SOURCE_DIR}/Source/Windows/include/"
 )

--- a/Source/Windows/Common/CRT/CMakeLists.txt
+++ b/Source/Windows/Common/CRT/CMakeLists.txt
@@ -1,2 +1,2 @@
-target_sources(CommonWindows PRIVATE Alloc.cpp IO.cpp Math.cpp String.cpp Misc.cpp CRT.cpp)
+target_sources(CommonWindowsRuntime PRIVATE Alloc.cpp IO.cpp Math.cpp String.cpp Misc.cpp CRT.cpp)
 add_subdirectory(Musl)

--- a/Source/Windows/Common/CRT/Musl/CMakeLists.txt
+++ b/Source/Windows/Common/CRT/Musl/CMakeLists.txt
@@ -1,1 +1,1 @@
-target_sources(CommonWindows PRIVATE exp2.c log2_data.c remainder.c strtoimax.c strtoull.c exp_data.c fmod.c log2.c isnan.c remquo.c strtoll.c strtoumax.c __math_uflow.c __math_oflow.c __math_xflow.c __math_invalid.c __math_divzero.c)
+target_sources(CommonWindowsRuntime PRIVATE exp2.c log2_data.c remainder.c strtoimax.c strtoull.c exp_data.c fmod.c log2.c isnan.c remquo.c strtoll.c strtoumax.c __math_uflow.c __math_oflow.c __math_xflow.c __math_invalid.c __math_divzero.c)

--- a/Source/Windows/Common/WinAPI/CMakeLists.txt
+++ b/Source/Windows/Common/WinAPI/CMakeLists.txt
@@ -1,1 +1,1 @@
-target_sources(CommonWindows PRIVATE Alloc.cpp Sync.cpp IO.cpp Misc.cpp)
+target_sources(CommonWindowsRuntime PRIVATE Alloc.cpp Sync.cpp IO.cpp Misc.cpp)

--- a/Source/Windows/WOW64/CMakeLists.txt
+++ b/Source/Windows/WOW64/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(wow64fex
   Common
   CommonTools
   CommonWindows
+  CommonWindowsRuntime
   wow64_ex
   ntdll_ex
 )


### PR DESCRIPTION
We can use the system CRT for the offline compiler, but still want to pull in e.g. InvalidationTracker and other helpers.