### PR TITLE
CodeCache: Implement runtime cache validation

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -23,6 +23,13 @@
           "Enable the code caching subsystem"
         ]
       },
+      "EnableCodeCacheValidation": {
+        "Type": "bool",
+        "Default": "false",
+        "Desc": [
+          "Enable expensive validation when loading code caches"
+        ]
+      },
       "HostFeatures": {
         "Type": "strenum",
         "Default": "FEXCore::Config::HostFeatures::OFF",


### PR DESCRIPTION
## Overview

This PR adds a validation pass for loaded code caches: All cached code is recompiled on-the-fly using the normal JIT code paths to ensure the offline-compiled cache perfectly matches runtime behavior. This has proven tremendously useful for debugging while bringing up the initial code caching implementation and when debugging regressions afterwards, so we'll want to keep maintaining this feature going forward.

The new validation pass is enabled using a new `EnableCodeCacheValidation` setting that will be off default since this extra validation is so expensive. Upon detecting any differences, a fatal error is raised (and an assertion message with diagnostic information is sent to the logs).

Here is some example output printed on failure. The mismatching host code address is automatically mapped back to the guest-side block address base, allowing IR to be printed along the way:
```
I 34745|34745 935.827 Cache load:   229 blocks; base=0x7ffff7ec2000; off=   0x1000-0x002c000; dbd3d54d31294247 ROOTFS/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
E 34745|34745 935.883 recorded rip 0: 0x7ffff7ec3000 (offset 0x1000)
E 34745|34745 935.883 recorded rip 1: 0x7ffff7ec3000 (offset 0x1000)
E 34745|34745 935.883 IR:
        (%0) IRHeader %2, #0x7ffff7ec3000, #1, #2
        (%2) CodeBlock %3, %4
                (%3 i0) BeginBlock %2
                (%7 i64) InlineConstant #0x0
                %8(R16) i64 = SubWithFlags R7, %7
                (%9 i0) InvalidateFlags #0x10
                (%10 i64) InlineEntrypointOffset #0x7
                (%11 i64) StorePF R16
                (%12 i64) ExitFunction %10, None, %Invalid, %Invalid
                (%4 i0) EndBlock %2

A 34745|34745 935.883 Cache validation failed at offset 0x4: e0ffff10 <-> 00ffff10 (at 0xaaab6c6cc000 <-> 0xaaadfeb32000, guest block 0x1000)
```

## Implementation

All code is compiled in a separate ContextImpl instance. This ensures normal operation is not affected, and it allows constructing a fake Thread object (which is needed for WoA, where a valid Thread object may not be available otherwise).
