### PR TITLE
CodeCache: Trigger delayed cache loading for the main executables and its interpreter

### DIFF
--- a/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
+++ b/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
@@ -561,9 +561,10 @@ int main(int argc, char** argv, char** const envp) {
 
   SyscallHandler->DeserializeSeccompFD(ParentThread, FEXSeccompFD);
 
-  // Request code cache generation
+  // Request code cache generation and load caches for all binaries loaded previously
   if (FEXCore::Config::Get_ENABLECODECACHINGWIP()) {
     FEXServerClient::PopulateCodeCache(FEXServerClient::GetServerFD(), ProgramFD, FEXCore::Config::Get_MULTIBLOCK());
+    SyscallHandler->TriggerPostStartupCodeCacheLoad(*ParentThread->Thread);
   }
   close(ProgramFD);
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -292,6 +292,7 @@ public:
   std::optional<FEXCore::ExecutableFileSectionInfo>
   LookupExecutableFileSection(FEXCore::Core::InternalThreadState& Thread, uint64_t GuestAddr) final override;
 
+  void TriggerPostStartupCodeCacheLoad(FEXCore::Core::InternalThreadState&);
   int OpenCodeMapFile() override;
 
   FEXCore::HLE::ExecutableRangeInfo QueryGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Address) override;
@@ -323,6 +324,8 @@ public:
   constexpr static size_t LDT_ENTRY_SIZE = sizeof(FEXCore::Core::CPUState::gdt_segment);
 
   VMATracking::VMATracking VMATracking;
+  // Collects file mappings added during FEX startup.
+  fextl::vector<FEXCore::ExecutableFileSectionInfo> StartupBinaryLoads;
 
   const uint64_t CodeCacheConfigId = 0; // TODO: Make unique to active configuration
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -350,6 +350,18 @@ uint64_t SyscallHandler::GuestMremap(bool Is64Bit, FEXCore::Core::InternalThread
   return Result;
 }
 
+void SyscallHandler::TriggerPostStartupCodeCacheLoad(FEXCore::Core::InternalThreadState& Thread) {
+  if (!EnableCodeCaching) {
+    return;
+  }
+
+  FEX_CONFIG_OPT(Multiblock, MULTIBLOCK);
+  for (auto& FileSection : StartupBinaryLoads) {
+    LoadCodeCache(Thread, FileSection, CodeCacheConfigId);
+  }
+  StartupBinaryLoads.clear();
+}
+
 int SyscallHandler::OpenCodeMapFile() {
   // Query from FEXServer whether this is the first instance of this executable; if it is, also enable code dumping!
   FEX_CONFIG_OPT(RootFSPath, ROOTFS);
@@ -563,7 +575,8 @@ SyscallHandler::TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t a
     if (Thread) {
       CachedSection.emplace(BuildSectionInfo(*Resource, addr, Size));
     } else {
-      // Cache can't be loaded without a thread; skip this for now
+      // Delay loading this entry until FEX is fully initialized
+      StartupBinaryLoads.push_back(BuildSectionInfo(*Resource, addr, Size));
     }
   }
 


### PR DESCRIPTION
FEX isn't fully initialized by the time these are mapped into memory, so their caches must be loaded later.