### PR TITLE
[cmake] propagate `-ISource` to all Tools

### DIFF
--- a/Source/Tools/CodeSizeValidation/CMakeLists.txt
+++ b/Source/Tools/CodeSizeValidation/CMakeLists.txt
@@ -4,7 +4,6 @@ set (SRCS Main.cpp)
 add_executable(CodeSizeValidation ${SRCS})
 target_include_directories(CodeSizeValidation
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/Source/
     ${CMAKE_BINARY_DIR}/generated
 )
 target_link_libraries(CodeSizeValidation

--- a/Source/Tools/FEXBash/CMakeLists.txt
+++ b/Source/Tools/FEXBash/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_executable(FEXBash FEXBash.cpp)
-target_include_directories(FEXBash PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 
 target_link_libraries(FEXBash
   PRIVATE

--- a/Source/Tools/FEXConfig/CMakeLists.txt
+++ b/Source/Tools/FEXConfig/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_AUTOMOC ON)
 
 add_executable(FEXConfig)
 target_sources(FEXConfig PRIVATE Main.cpp Main.h)
-target_include_directories(FEXConfig PRIVATE ${CMAKE_SOURCE_DIR}/Source/)
+
 target_link_libraries(FEXConfig PRIVATE Common JemallocDummy)
 if (Qt6_FOUND)
   qt_add_resources(QT_RESOURCES qml6.qrc)

--- a/Source/Tools/FEXGDBReader/CMakeLists.txt
+++ b/Source/Tools/FEXGDBReader/CMakeLists.txt
@@ -8,7 +8,6 @@ install(TARGETS ${NAME}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/gdb
   COMPONENT Development)
 
-target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
 # We don't actually link, but this is a nice way to get the include dirs

--- a/Source/Tools/FEXGetConfig/CMakeLists.txt
+++ b/Source/Tools/FEXGetConfig/CMakeLists.txt
@@ -21,5 +21,4 @@ install(TARGETS ${NAME}
 
 target_link_libraries(${NAME} PRIVATE ${LIBS})
 
-target_include_directories(${NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Source/)
 target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)

--- a/Source/Tools/FEXInterpreter/CMakeLists.txt
+++ b/Source/Tools/FEXInterpreter/CMakeLists.txt
@@ -21,7 +21,6 @@ set_target_properties(FEX PROPERTIES
 
 target_include_directories(FEX
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/
     ${CMAKE_BINARY_DIR}/generated
 )
 target_link_libraries(FEX

--- a/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
+++ b/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
@@ -5,8 +5,6 @@ set(SRCS Main.cpp
 add_executable(${NAME} ${SRCS})
 list(APPEND LIBS FEXCore Common JemallocDummy xxHash::xxhash)
 
-target_include_directories(${NAME} PRIVATE ${CMAKE_SOURCE_DIR}/Source/)
-
 if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
   target_link_options(${NAME}
     PRIVATE

--- a/Source/Tools/FEXServer/CMakeLists.txt
+++ b/Source/Tools/FEXServer/CMakeLists.txt
@@ -9,8 +9,7 @@ set(SRCS Main.cpp
 add_executable(${NAME} ${SRCS})
 
 target_include_directories(${NAME} PRIVATE
-  ${CMAKE_BINARY_DIR}/generated
-  ${CMAKE_SOURCE_DIR}/Source/)
+  ${CMAKE_BINARY_DIR}/generated)
 
 target_link_libraries(${NAME} PRIVATE FEXCore Common CommonTools JemallocDummy ${PTHREAD_LIB})
 

--- a/Source/Tools/LinuxEmulation/CMakeLists.txt
+++ b/Source/Tools/LinuxEmulation/CMakeLists.txt
@@ -123,8 +123,7 @@ set (ARGS
   "-x" "c++"
   "-std=c++20"
   "-fno-operator-names"
-  "-I${PROJECT_SOURCE_DIR}/External/drm-headers/include/"
-  "-I${CMAKE_CURRENT_SOURCE_DIR}/../")
+  "-I${PROJECT_SOURCE_DIR}/External/drm-headers/include/")
 # Global include directories
 get_directory_property (INC_DIRS INCLUDE_DIRECTORIES)
 list(TRANSFORM INC_DIRS PREPEND "-I")

--- a/Source/Tools/TestHarnessRunner/CMakeLists.txt
+++ b/Source/Tools/TestHarnessRunner/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 
 target_include_directories(TestHarnessRunner
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/Source/
     ${CMAKE_BINARY_DIR}/generated
 )
 target_link_libraries(TestHarnessRunner


### PR DESCRIPTION
Rather than individually adding `${CMAKE_SOURCE_DIR}/Source` as
an include directory to each target, just use `include_directories` once
in the Tools directory and each subsequent target will have this
propagated down.

Also removed a seemingly unnecessary `-I` in LinuxEmulation--maybe
needed? But I can't test compilation right now as I don't have an ARM
development environment on hand for the next day or two.

Signed-off-by: crueter <crueter@eden-emu.dev>
