### PR TITLE
[cmake] FEXCore: further reduce library redundancy

### DIFF
--- a/FEXCore/Source/CMakeLists.txt
+++ b/FEXCore/Source/CMakeLists.txt
@@ -259,7 +259,7 @@ function(AddDefaultOptionsToTarget Name)
   endif()
 endfunction()
 
-# Build FEXCore_Config static library
+# Build FEXCore_Base static library
 add_library(FEXCore_Base STATIC ${FEXCORE_BASE_SRCS})
 target_link_libraries(FEXCore_Base ${LIBS})
 AddDefaultOptionsToTarget(FEXCore_Base)
@@ -268,26 +268,27 @@ if (ENABLE_FEXCORE_PROFILER AND FEXCORE_PROFILER_BACKEND STREQUAL "TRACY")
   target_link_libraries(FEXCore_Base TracyClient)
 endif()
 
-function(AddObject Name Type)
-  add_library(${Name} ${Type} ${SRCS})
+function(AddObject Name)
+  add_library(${Name} OBJECT ${SRCS})
 
-  target_link_libraries(${Name} FEXCore_Base)
+  target_link_libraries(${Name} PRIVATE FEXCore_Base)
   target_compile_options(${Name} PRIVATE ${FEX_TUNE_COMPILE_FLAGS})
   AddDefaultOptionsToTarget(${Name})
-
-  set_target_properties(${Name} PROPERTIES OUTPUT_NAME FEXCore)
 endfunction()
 
 function(AddLibrary Name Type)
   add_library(${Name} ${Type} $<TARGET_OBJECTS:${PROJECT_NAME}_object>)
-  target_link_libraries(${Name} FEXCore_Base)
-  target_compile_options(${Name} PRIVATE ${FEX_TUNE_COMPILE_FLAGS})
   set_target_properties(${Name} PROPERTIES OUTPUT_NAME FEXCore)
 
+  # During generation of the import library (dll.a), MinGW needs some extra symbols from libraries
+  # such as fmt, which are propagated by FEXCore_Base. Wonderful.
+  if (MINGW)
+    target_link_libraries(${Name} FEXCore_Base)
+  endif()
   AddDefaultOptionsToTarget(${Name})
 endfunction()
 
-AddObject(${PROJECT_NAME}_object OBJECT)
+AddObject(${PROJECT_NAME}_object)
 AddLibrary(${PROJECT_NAME} STATIC)
 AddLibrary(${PROJECT_NAME}_shared SHARED)
 


### PR DESCRIPTION
- `AddObject` doesn't need an additional Type parameter since it's
  already assumed to be an object library
- The static and shared libraries don't need any explicit compile
  options, as the object already handled this.
- ~~They also don't need to be linked to FEXCore_Base. Object libraries
  already handle that for us since the symbols already get pulled in
  anyways.~~ Windows sucks. It apparently needs the symbols for the shared import library.
- The object library doesn't need an output name. Only the user-facing
  libraries do

Signed-off-by: crueter <crueter@eden-emu.dev>
