### PR TITLE
[cmake] prefer end parenthesis on same line, no space after some calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,18 +30,18 @@ option(ENABLE_VIXL_SIMULATOR "Enable use of VIXL simulator for emulation (only u
 option(ENABLE_VIXL_DISASSEMBLER "Enables debug disassembler output with VIXL" FALSE)
 option(USE_LEGACY_BINFMTMISC "Uses legacy method of setting up binfmt_misc" FALSE)
 option(ENABLE_FEXCORE_PROFILER "Enables use of the FEXCore timeline profiling capabilities" FALSE)
-set (FEXCORE_PROFILER_BACKEND "gpuvis" CACHE STRING "Set which backend to use for the FEXCore profiler (gpuvis, tracy)")
+set(FEXCORE_PROFILER_BACKEND "gpuvis" CACHE STRING "Set which backend to use for the FEXCore profiler (gpuvis, tracy)")
 option(ENABLE_GLIBC_ALLOCATOR_HOOK_FAULT "Enables glibc memory allocation hooking with fault for CI testing")
 option(USE_PDB_DEBUGINFO "Builds debug info in PDB format" FALSE)
 option(BUILD_STEAM_SUPPORT "Builds FEX for integration into Steam" FALSE)
 
-set (X86_32_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/Data/CMake/toolchain_x86_32.cmake" CACHE FILEPATH "Toolchain file for the (cross-)compiler targeting i686")
-set (X86_64_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/Data/CMake/toolchain_x86_64.cmake" CACHE FILEPATH "Toolchain file for the (cross-)compiler targeting x86_64")
-set (X86_DEV_ROOTFS "/" CACHE FILEPATH "Path to the sysroot used for cross-compiling for i686 and x86_64")
-set (DATA_DIRECTORY "" CACHE PATH "Global data directory (override)")
-set (HOSTLIBS_DATA_DIRECTORY "" CACHE PATH "Global data directory (override)")
+set(X86_32_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/Data/CMake/toolchain_x86_32.cmake" CACHE FILEPATH "Toolchain file for the (cross-)compiler targeting i686")
+set(X86_64_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/Data/CMake/toolchain_x86_64.cmake" CACHE FILEPATH "Toolchain file for the (cross-)compiler targeting x86_64")
+set(X86_DEV_ROOTFS "/" CACHE FILEPATH "Path to the sysroot used for cross-compiling for i686 and x86_64")
+set(DATA_DIRECTORY "" CACHE PATH "Global data directory (override)")
+set(HOSTLIBS_DATA_DIRECTORY "" CACHE PATH "Global data directory (override)")
 if (NOT DATA_DIRECTORY)
-  set (DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/fex-emu")
+  set(DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/fex-emu")
 endif()
 
 include(GNUInstallDirs)
@@ -50,14 +50,14 @@ if (NOT HOSTLIBS_DATA_DIRECTORY)
 endif()
 
 if (MINGW)
-  message (STATUS "Building for MinGW")
-  set (ENABLE_JEMALLOC TRUE)
-  set (ENABLE_JEMALLOC_GLIBC_ALLOC FALSE)
+  message(STATUS "Building for MinGW")
+  set(ENABLE_JEMALLOC TRUE)
+  set(ENABLE_JEMALLOC_GLIBC_ALLOC FALSE)
 else ()
-  message (STATUS "Clang version ${CMAKE_CXX_COMPILER_VERSION}")
-  set (CLANG_MINIMUM_VERSION 13.0)
+  message(STATUS "Clang version ${CMAKE_CXX_COMPILER_VERSION}")
+  set(CLANG_MINIMUM_VERSION 13.0)
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${CLANG_MINIMUM_VERSION})
-    message (FATAL_ERROR "Clang version too old for FEX. Need at least ${CLANG_MINIMUM_VERSION} but has ${CMAKE_CXX_COMPILER_VERSION}")
+    message(FATAL_ERROR "Clang version too old for FEX. Need at least ${CLANG_MINIMUM_VERSION} but has ${CMAKE_CXX_COMPILER_VERSION}")
   endif()
 endif()
 
@@ -112,10 +112,10 @@ if(NOT TARGET uninstall)
 endif()
 
 # These options are meant for package management
-set (TUNE_CPU "native" CACHE STRING "Override the CPU the build is tuned for")
-set (TUNE_ARCH "generic" CACHE STRING "Override the Arch the build is tuned for")
-set (OVERRIDE_VERSION "detect" CACHE STRING "Override the FEX version")
-set (OVERRIDE_HASH "detect" CACHE STRING "Override the FEX git hash")
+set(TUNE_CPU "native" CACHE STRING "Override the CPU the build is tuned for")
+set(TUNE_ARCH "generic" CACHE STRING "Override the Arch the build is tuned for")
+set(OVERRIDE_VERSION "detect" CACHE STRING "Override the FEX version")
+set(OVERRIDE_HASH "detect" CACHE STRING "Override the FEX git hash")
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
 if (CMAKE_BUILD_TYPE MATCHES "DEBUG")
@@ -157,7 +157,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
   endif()
   set(_M_X86_64 1)
   add_definitions(-D_M_X86_64=1)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcx16")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcx16")
 endif()
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64|^arm64|^armv8\.*")
@@ -221,7 +221,7 @@ if (ENABLE_COMPILE_TIME_TRACE)
   link_libraries(-ftime-trace)
 endif()
 
-set (PTHREAD_LIB pthread)
+set(PTHREAD_LIB pthread)
 
 if (USE_LINKER)
   message(STATUS "Overriding linker to: ${USE_LINKER}")
@@ -274,7 +274,7 @@ if (ENABLE_JEMALLOC_GLIBC_ALLOC)
   # All host native libraries will use this allocator, while *most* other FEX internal allocations will use the other jemalloc allocator.
   add_subdirectory(External/jemalloc_glibc/)
 elseif (NOT MINGW)
-  message (STATUS
+  message(STATUS
     " jemalloc glibc allocator disabled!\n"
     " This is not a recommended configuration!\n"
     " This will very explicitly break thunk execution!\n"
@@ -285,7 +285,7 @@ if (ENABLE_JEMALLOC)
   # The jemalloc subproject that all FEXCore fextl objects allocate through.
   add_subdirectory(External/jemalloc/)
 elseif (NOT MINGW)
-  message (STATUS
+  message(STATUS
     " jemalloc disabled!\n"
     " This is not a recommended configuration!\n"
     " This will very explicitly break 32-bit application execution!\n"
@@ -297,11 +297,11 @@ if (USE_PDB_DEBUGINFO)
   add_link_options(-g -Wl,--pdb=)
 endif()
 
-set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fno-omit-frame-pointer")
-set (CMAKE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_LINKER_FLAGS_RELWITHDEBINFO} -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fno-omit-frame-pointer")
+set(CMAKE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_LINKER_FLAGS_RELWITHDEBINFO} -fno-omit-frame-pointer")
 
-set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer")
-set (CMAKE_LINKER_FLAGS_RELEASE "${CMAKE_LINKER_FLAGS_RELEASE} -fomit-frame-pointer")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer")
+set(CMAKE_LINKER_FLAGS_RELEASE "${CMAKE_LINKER_FLAGS_RELEASE} -fomit-frame-pointer")
 
 include_directories(External/robin-map/include/)
 
@@ -461,8 +461,7 @@ if (OVERRIDE_VERSION STREQUAL "detect")
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
       OUTPUT_VARIABLE GIT_DESCRIBE_STRING
       ERROR_QUIET
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()
 else()
   set(GIT_DESCRIBE_STRING "${OVERRIDE_VERSION}")
@@ -479,8 +478,7 @@ if (OVERRIDE_HASH STREQUAL "detect")
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
       OUTPUT_VARIABLE GIT_SHORT_HASH
       ERROR_QUIET
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()
 else()
   set(GIT_SHORT_HASH "${OVERRIDE_HASH}")
@@ -499,7 +497,7 @@ add_compile_options(-Wall)
 if (BUILD_TESTING)
   message(STATUS "Unit tests are enabled")
 
-  set (TEST_JOB_COUNT "" CACHE STRING "Override number of parallel jobs to use while running tests")
+  set(TEST_JOB_COUNT "" CACHE STRING "Override number of parallel jobs to use while running tests")
   if (TEST_JOB_COUNT)
     message(STATUS "Running tests with ${TEST_JOB_COUNT} jobs")
   elseif(CMAKE_VERSION VERSION_LESS "3.29")
@@ -540,7 +538,7 @@ if (BUILD_TESTING)
 endif()
 
 if (BUILD_THUNKS)
-  set (FEX_PROJECT_SOURCE_DIR ${PROJECT_SOURCE_DIR})
+  set(FEX_PROJECT_SOURCE_DIR ${PROJECT_SOURCE_DIR})
   add_subdirectory(ThunkLibs/Generator)
 
   # Thunk targets for both host libraries and IDE integration
@@ -567,8 +565,7 @@ if (BUILD_THUNKS)
       "-DX86_DEV_ROOTFS=${X86_DEV_ROOTFS}"
     INSTALL_COMMAND ""
     BUILD_ALWAYS ON
-    DEPENDS thunkgen
-  )
+    DEPENDS thunkgen)
 
   ExternalProject_Add(guest-libs-32
     PREFIX guest-libs-32
@@ -586,8 +583,7 @@ if (BUILD_THUNKS)
       "-DX86_DEV_ROOTFS=${X86_DEV_ROOTFS}"
     INSTALL_COMMAND ""
     BUILD_ALWAYS ON
-    DEPENDS thunkgen
-  )
+    DEPENDS thunkgen)
 
   install(
     CODE "MESSAGE(\"-- Installing: guest-libs\")"
@@ -596,8 +592,7 @@ if (BUILD_THUNKS)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest
     )"
     DEPENDS guest-libs
-    COMPONENT Runtime
-  )
+    COMPONENT Runtime)
 
   install(
     CODE "MESSAGE(\"-- Installing: guest-libs-32\")"
@@ -606,18 +601,15 @@ if (BUILD_THUNKS)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest_32
     )"
     DEPENDS guest-libs-32
-    COMPONENT Runtime
-  )
+    COMPONENT Runtime)
 
   add_custom_target(uninstall_guest-libs
     COMMAND ${CMAKE_COMMAND} "--build" "." "--target" "uninstall"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest
-  )
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest)
 
   add_custom_target(uninstall_guest-libs-32
     COMMAND ${CMAKE_COMMAND} "--build" "." "--target" "uninstall"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest_32
-  )
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Guest_32)
 
   add_dependencies(uninstall uninstall_guest-libs)
   add_dependencies(uninstall uninstall_guest-libs-32)

--- a/External/SoftFloat-3e/CMakeLists.txt
+++ b/External/SoftFloat-3e/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set (SRCS
+set(SRCS
   # F80 support
   src/extF80_add.c
   src/extF80_div.c

--- a/FEXCore/CMakeLists.txt
+++ b/FEXCore/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-set (PROJECT_NAME FEXCore)
+set(PROJECT_NAME FEXCore)
 project(${PROJECT_NAME}
   VERSION 0.01
   LANGUAGES CXX)

--- a/FEXCore/Source/CMakeLists.txt
+++ b/FEXCore/Source/CMakeLists.txt
@@ -1,20 +1,19 @@
-set (MAN_DIR share/man CACHE PATH "MAN_DIR")
+set(MAN_DIR share/man CACHE PATH "MAN_DIR")
 
-set (FEXCORE_BASE_SRCS
+set(FEXCORE_BASE_SRCS
   Interface/Config/Config.cpp
   Utils/Allocator.cpp
   Utils/FileLoading.cpp
   Utils/ForcedAssert.cpp
   Utils/LogManager.cpp
-  Utils/SpinWaitLock.cpp
-  )
+  Utils/SpinWaitLock.cpp)
 
 if (NOT MINGW)
   list(APPEND FEXCORE_BASE_SRCS
     Utils/Allocator/64BitAllocator.cpp)
 endif()
 
-set (SRCS
+set(SRCS
   Common/JitSymbols.cpp
   Interface/Context/Context.cpp
   Interface/Core/LookupCache.cpp
@@ -68,8 +67,7 @@ set (SRCS
   Utils/LongJump.cpp
   Utils/Telemetry.cpp
   Utils/Threads.cpp
-  Utils/Profiler.cpp
-  )
+  Utils/Profiler.cpp)
 
 if (_M_ARM_64)
   list(APPEND SRCS Utils/ArchHelpers/Arm64.cpp)
@@ -102,7 +100,7 @@ else()
   list(APPEND DEFINES "-DFEXCORE_PRESERVE_ALL_ATTR=;-DFEXCORE_HAS_PRESERVE_ALL_ATTR=0")
 endif()
 
-set (LIBS fmt::fmt xxHash::xxhash FEXHeaderUtils CodeEmitter cephes_128bit)
+set(LIBS fmt::fmt xxHash::xxhash FEXHeaderUtils CodeEmitter cephes_128bit)
 
 if (ENABLE_VIXL_DISASSEMBLER OR ENABLE_VIXL_SIMULATOR)
   list (APPEND LIBS vixl)
@@ -134,8 +132,8 @@ add_custom_command(
   OUTPUT "${OUTPUT_NAME}" "${OUTPUT_DISPATCHER_NAME}"
   DEPENDS "${INPUT_NAME}"
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_generator.py"
-  COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_generator.py" "${INPUT_NAME}" "${OUTPUT_NAME}" "${OUTPUT_DISPATCHER_NAME}"
-  )
+  COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_generator.py"
+    "${INPUT_NAME}" "${OUTPUT_NAME}" "${OUTPUT_DISPATCHER_NAME}")
 
 set_source_files_properties(${OUTPUT_NAME} PROPERTIES
   GENERATED TRUE)
@@ -147,8 +145,8 @@ add_custom_command(
   OUTPUT "${OUTPUT_IR_DOC}"
   DEPENDS "${INPUT_NAME}"
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_doc_generator.py"
-  COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_doc_generator.py" "${INPUT_NAME}" "${OUTPUT_IR_DOC}"
-  )
+  COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_doc_generator.py"
+    "${INPUT_NAME}" "${OUTPUT_IR_DOC}")
 
 set_source_files_properties(${OUTPUT_IR_NAME} PROPERTIES
   GENERATED TRUE)
@@ -175,14 +173,12 @@ add_custom_command(
   DEPENDS "${INPUT_CONFIG_NAME}"
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/config_generator.py"
   COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/config_generator.py" "${INPUT_CONFIG_NAME}" "${OUTPUT_CONFIG_NAME}" "${OUTPUT_MAN_NAME}"
-  "${OUTPUT_CONFIG_OPTION_NAME}"
-  )
+  "${OUTPUT_CONFIG_OPTION_NAME}")
 
 add_custom_command(
   OUTPUT "${OUTPUT_MAN_NAME_COMPRESS}"
   DEPENDS "${OUTPUT_MAN_NAME}"
-  COMMAND "gzip" "-kf9n" "${OUTPUT_MAN_NAME}"
-  )
+  COMMAND "gzip" "-kf9n" "${OUTPUT_MAN_NAME}")
 
 set_source_files_properties(${OUTPUT_CONFIG_NAME} PROPERTIES
   GENERATED TRUE)
@@ -235,8 +231,7 @@ function(AddDefaultOptionsToTarget Name)
 
     -Wno-trigraphs
     -ffunction-sections
-    -fwrapv
-  )
+    -fwrapv)
 
   if (GCC_COLOR)
     target_compile_options(${Name}
@@ -254,8 +249,7 @@ function(AddDefaultOptionsToTarget Name)
       PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
-      "LINKER:--as-needed"
-    )
+      "LINKER:--as-needed")
   endif()
 endfunction()
 

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -8,8 +8,7 @@ set(SRCS
   HostFeatures.cpp
   JSONPool.cpp
   SHMStats.cpp
-  VolatileMetadata.cpp
-  )
+  VolatileMetadata.cpp)
 
 if (NOT MINGW)
   list (APPEND SRCS
@@ -24,5 +23,4 @@ target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)
 set_target_properties(${NAME} PROPERTIES
   C_VISIBILITY_PRESET hidden
   CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN TRUE
-)
+  VISIBILITY_INLINES_HIDDEN TRUE)

--- a/Source/Tools/CodeSizeValidation/CMakeLists.txt
+++ b/Source/Tools/CodeSizeValidation/CMakeLists.txt
@@ -1,13 +1,12 @@
 list(APPEND LIBS FEXCore Common CommonTools JemallocLibs)
 
-set (SRCS Main.cpp)
+set(SRCS Main.cpp)
 add_executable(CodeSizeValidation ${SRCS})
 target_include_directories(CodeSizeValidation
   PRIVATE
-    ${CMAKE_BINARY_DIR}/generated
-)
+    ${CMAKE_BINARY_DIR}/generated)
+
 target_link_libraries(CodeSizeValidation
   PRIVATE
     ${LIBS}
-    ${PTHREAD_LIB}
-)
+    ${PTHREAD_LIB})

--- a/Source/Tools/CommonTools/CMakeLists.txt
+++ b/Source/Tools/CommonTools/CMakeLists.txt
@@ -1,12 +1,8 @@
 set(NAME CommonTools)
-set(SRCS
-  DummyHandlers.cpp
-  )
+set(SRCS DummyHandlers.cpp)
 
 if (NOT MINGW)
-  list(APPEND SRCS
-  Linux/Utils/ELFContainer.cpp
-  )
+  list(APPEND SRCS Linux/Utils/ELFContainer.cpp)
 endif()
 
 add_library(${NAME} STATIC ${SRCS})

--- a/Source/Tools/FEXBash/CMakeLists.txt
+++ b/Source/Tools/FEXBash/CMakeLists.txt
@@ -4,20 +4,17 @@ target_link_libraries(FEXBash
   PRIVATE
     FEXCore
     Common
-    JemallocLibs
-)
+    JemallocLibs)
 
 if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
   target_link_options(FEXBash
     PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
-      "LINKER:--as-needed"
-  )
+      "LINKER:--as-needed")
 endif()
 
 install(TARGETS FEXBash
   RUNTIME
     DESTINATION bin
-    COMPONENT Runtime
-)
+    COMPONENT Runtime)

--- a/Source/Tools/FEXConfig/CMakeLists.txt
+++ b/Source/Tools/FEXConfig/CMakeLists.txt
@@ -18,8 +18,7 @@ if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
     PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
-      "LINKER:--as-needed"
-  )
+      "LINKER:--as-needed")
 endif()
 
 install(TARGETS FEXConfig

--- a/Source/Tools/FEXGetConfig/CMakeLists.txt
+++ b/Source/Tools/FEXGetConfig/CMakeLists.txt
@@ -10,8 +10,7 @@ if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
     PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
-      "LINKER:--as-needed"
-  )
+      "LINKER:--as-needed")
 endif()
 
 install(TARGETS ${NAME}

--- a/Source/Tools/FEXInterpreter/CMakeLists.txt
+++ b/Source/Tools/FEXInterpreter/CMakeLists.txt
@@ -1,6 +1,6 @@
 list(APPEND LIBS FEXCore Common JemallocLibs)
 
-set (DEFINES)
+set(DEFINES)
 if (ENABLE_VIXL_SIMULATOR)
   list(APPEND DEFINES -DVIXL_SIMULATOR=1)
 endif()
@@ -16,21 +16,20 @@ set_target_properties(FEX PROPERTIES
   ENABLE_EXPORTS 1
   C_VISIBILITY_PRESET hidden
   CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN TRUE
-)
+  VISIBILITY_INLINES_HIDDEN TRUE)
 
 target_include_directories(FEX
   PRIVATE
-    ${CMAKE_BINARY_DIR}/generated
-)
+    ${CMAKE_BINARY_DIR}/generated)
+
 target_link_libraries(FEX
   PRIVATE
     ${LIBS}
     LinuxEmulation
     CommonTools
     ${PTHREAD_LIB}
-    fmt::fmt
-)
+    fmt::fmt)
+
 target_compile_options(FEX PRIVATE ${FEX_TUNE_COMPILE_FLAGS})
 
 if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
@@ -38,15 +37,13 @@ if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
     PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
-      "LINKER:--as-needed"
-  )
+      "LINKER:--as-needed")
 endif()
 
 install(TARGETS FEX
   RUNTIME
     DESTINATION bin
-    COMPONENT Runtime
-)
+    COMPONENT Runtime)
 
 # Create a copy of FEX with legacy names until phased out.
 install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FEX
@@ -59,14 +56,13 @@ if (_M_ARM_64)
     # Just restart the systemd service
     add_custom_target(binfmt_misc
       echo "Restarting systemd service now."
-      COMMAND "service" "systemd-binfmt" "restart"
-    )
+      COMMAND "service" "systemd-binfmt" "restart")
   else()
     # Check for conflicting binfmt before installing
-    set (CONFLICTING_BINFMTS_32
+    set(CONFLICTING_BINFMTS_32
       ${CMAKE_INSTALL_PREFIX}/share/binfmts/qemu-i386
       ${CMAKE_INSTALL_PREFIX}/share/binfmts/box86)
-    set (CONFLICTING_BINFMTS_64
+    set(CONFLICTING_BINFMTS_64
       ${CMAKE_INSTALL_PREFIX}/share/binfmts/qemu-x86_64
       ${CMAKE_INSTALL_PREFIX}/share/binfmts/box64)
 
@@ -79,14 +75,12 @@ if (_M_ARM_64)
         COMMAND "update-binfmts" "--importdir=${CMAKE_INSTALL_PREFIX}/share/binfmts/" "--import" "FEX-x86"
         COMMAND "update-binfmts" "--importdir=${CMAKE_INSTALL_PREFIX}/share/binfmts/" "--import" "FEX-x86_64"
         COMMAND ${CMAKE_COMMAND} -E
-        echo "FEX binfmt_misc installed"
-      )
+        echo "FEX binfmt_misc installed")
 
       if(TARGET uninstall)
         add_custom_target(uninstall_binfmt_misc
           COMMAND update-binfmts --unimport FEX-x86 || (exit 0)
-          COMMAND update-binfmts --unimport FEX-x86_64 || (exit 0)
-        )
+          COMMAND update-binfmts --unimport FEX-x86_64 || (exit 0))
 
         add_dependencies(uninstall uninstall_binfmt_misc)
       endif()
@@ -108,16 +102,14 @@ if (_M_ARM_64)
           echo
           ':FEX-x86_64:M:0:\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:${CMAKE_INSTALL_PREFIX}/bin/FEX:POCF' > /proc/sys/fs/binfmt_misc/register
         COMMAND ${CMAKE_COMMAND} -E
-          echo "binfmt_misc FEX installed"
-        )
+          echo "binfmt_misc FEX installed")
 
       if(TARGET uninstall)
         add_custom_target(uninstall_binfmt_misc
           COMMAND ${CMAKE_COMMAND} -E
             echo -1 > /proc/sys/fs/binfmt_misc/FEX-x86 || (exit 0)
           COMMAND ${CMAKE_COMMAND} -E
-            echo -1 > /proc/sys/fs/binfmt_misc/FEX-x86_64 || (exit 0)
-        )
+            echo -1 > /proc/sys/fs/binfmt_misc/FEX-x86_64 || (exit 0))
 
         add_dependencies(uninstall uninstall_binfmt_misc)
       endif()

--- a/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
+++ b/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(NAME FEXRootFSFetcher)
-set(SRCS Main.cpp
-  XXFileHash.cpp)
+set(SRCS Main.cpp XXFileHash.cpp)
 
 add_executable(${NAME} ${SRCS})
 list(APPEND LIBS FEXCore Common JemallocDummy xxHash::xxhash)
@@ -10,8 +9,7 @@ if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
     PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
-      "LINKER:--as-needed"
-  )
+      "LINKER:--as-needed")
 endif()
 
 install(TARGETS ${NAME}

--- a/Source/Tools/FEXServer/CMakeLists.txt
+++ b/Source/Tools/FEXServer/CMakeLists.txt
@@ -18,8 +18,7 @@ if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
     PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
-      "LINKER:--as-needed"
-  )
+      "LINKER:--as-needed")
 endif()
 
 install(TARGETS ${NAME}

--- a/Source/Tools/LinuxEmulation/CMakeLists.txt
+++ b/Source/Tools/LinuxEmulation/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_compile_options(-fno-operator-names)
 
-set (SRCS
+set(SRCS
   VDSO_Emulation.cpp
   Thunks.cpp
   ArchHelpers/MContext.cpp
@@ -71,37 +71,31 @@ PRIVATE
   -Werror=implicit-fallthrough
 
   -Wno-trigraphs
-  -fwrapv
-)
+  -fwrapv)
 
 set_target_properties(LinuxEmulation PROPERTIES
   C_VISIBILITY_PRESET hidden
   CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN TRUE
-)
+  VISIBILITY_INLINES_HIDDEN TRUE)
 
 target_include_directories(LinuxEmulation
 PRIVATE
   ${CMAKE_BINARY_DIR}/generated
   ${CMAKE_CURRENT_SOURCE_DIR}/
-  ${PROJECT_SOURCE_DIR}/External/drm-headers/include/
-)
+  ${PROJECT_SOURCE_DIR}/External/drm-headers/include/)
 
 target_include_directories(LinuxEmulation
   INTERFACE
-  ${CMAKE_CURRENT_SOURCE_DIR}/
-)
+  ${CMAKE_CURRENT_SOURCE_DIR}/)
 
 target_link_libraries(LinuxEmulation
   PRIVATE
   Common
-  CommonTools
-)
+  CommonTools)
 
 target_link_libraries(LinuxEmulation
   INTERFACE
-  FEXCore
-)
+  FEXCore)
 
 set(HEADERS_TO_VERIFY
   LinuxSyscalls/x32/Types.h          x86_32 # This needs to match structs to 32bit structs
@@ -119,7 +113,7 @@ set(HEADERS_TO_VERIFY
 list(LENGTH HEADERS_TO_VERIFY ARG_COUNT)
 math(EXPR ARG_COUNT "${ARG_COUNT}-1")
 
-set (ARGS
+set(ARGS
   "-x" "c++"
   "-std=c++20"
   "-fno-operator-names"

--- a/Source/Tools/pidof/CMakeLists.txt
+++ b/Source/Tools/pidof/CMakeLists.txt
@@ -5,20 +5,17 @@ target_link_libraries(FEXpidof
   cpp-optparse
   JemallocDummy
   fmt::fmt
-  range-v3::range-v3
-)
+  range-v3::range-v3)
 
 if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
   target_link_options(FEXpidof
     PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
-      "LINKER:--as-needed"
-  )
+      "LINKER:--as-needed")
 endif()
 
 install(TARGETS FEXpidof
   RUNTIME
     DESTINATION bin
-    COMPONENT Runtime
-)
+    COMPONENT Runtime)


### PR DESCRIPTION
- Some CMake LSPs have aneurysms when you put the end parenthesis on a
  different line. Annoying? Yes, but this is all we can really do about
  it for now.
- `set`, `option`, and `message` should not have spaces before their
  opening parenthesis.

Signed-off-by: crueter <crueter@eden-emu.dev>
