### PR TITLE
[cmake] reduce usage of trivial variables

### DIFF
--- a/External/SoftFloat-3e/CMakeLists.txt
+++ b/External/SoftFloat-3e/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCS
+add_library(softfloat_3e STATIC
   # F80 support
   src/extF80_add.c
   src/extF80_div.c
@@ -92,7 +92,6 @@ endif()
 
 list(APPEND DEFINES "-DSOFTFLOAT_BUILTIN_CLZ=1;-DINLINE=static inline;-DINLINE_LEVEL=4;-DSOFTFLOAT_FAST_INT64=1;-DSOFTFLOAT_FAST_DIV32TO16=1;-DSOFTFLOAT_FAST_DIV64TO32=1")
 
-add_library(softfloat_3e STATIC ${SRCS})
 target_include_directories(softfloat_3e PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 target_include_directories(softfloat_3e PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/SoftFloat-3e/)
 target_compile_definitions(softfloat_3e PUBLIC ${DEFINES})

--- a/External/cephes/CMakeLists.txt
+++ b/External/cephes/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SRCS_128BIT
+add_library(cephes_128bit STATIC
   src/128bit/Impl.cpp
   src/128bit/atanll.c
   src/128bit/constll.c
@@ -11,7 +11,6 @@ set(SRCS_128BIT
   src/128bit/tanll.c)
 
 # 128-bit library
-add_library(cephes_128bit STATIC ${SRCS_128BIT})
 target_link_libraries(cephes_128bit softfloat_3e)
 target_include_directories(cephes_128bit PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 target_compile_options(cephes_128bit PRIVATE -fno-builtin)

--- a/Source/Tools/CodeSizeValidation/CMakeLists.txt
+++ b/Source/Tools/CodeSizeValidation/CMakeLists.txt
@@ -1,7 +1,6 @@
 list(APPEND LIBS FEXCore Common CommonTools JemallocLibs)
 
-set(SRCS Main.cpp)
-add_executable(CodeSizeValidation ${SRCS})
+add_executable(CodeSizeValidation Main.cpp)
 target_include_directories(CodeSizeValidation
   PRIVATE
     ${CMAKE_BINARY_DIR}/generated)

--- a/Source/Tools/CommonTools/CMakeLists.txt
+++ b/Source/Tools/CommonTools/CMakeLists.txt
@@ -1,10 +1,9 @@
-set(NAME CommonTools)
 set(SRCS DummyHandlers.cpp)
 
 if (NOT MINGW)
   list(APPEND SRCS Linux/Utils/ELFContainer.cpp)
 endif()
 
-add_library(${NAME} STATIC ${SRCS})
-target_link_libraries(${NAME} FEXCore_Base FEXHeaderUtils)
-target_include_directories(${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(CommonTools STATIC ${SRCS})
+target_link_libraries(CommonTools FEXCore_Base FEXHeaderUtils)
+target_include_directories(CommonTools PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Source/Tools/FEXGDBReader/CMakeLists.txt
+++ b/Source/Tools/FEXGDBReader/CMakeLists.txt
@@ -1,14 +1,11 @@
-set(NAME FEXGDBReader)
-set(SRCS FEXGDBReader.cpp)
+add_library(FEXGDBReader SHARED FEXGDBReader.cpp)
 
-add_library(${NAME} SHARED ${SRCS})
-
-install(TARGETS ${NAME}
+install(TARGETS FEXGDBReader
   RUNTIME
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/gdb
   COMPONENT Development)
 
-target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)
+target_include_directories(FEXGDBReader PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
 # We don't actually link, but this is a nice way to get the include dirs
-target_link_libraries(${NAME} PRIVATE Common)
+target_link_libraries(FEXGDBReader PRIVATE Common)

--- a/Source/Tools/FEXGetConfig/CMakeLists.txt
+++ b/Source/Tools/FEXGetConfig/CMakeLists.txt
@@ -1,23 +1,20 @@
-set(NAME FEXGetConfig)
-set(SRCS Main.cpp)
-
-add_executable(${NAME} ${SRCS})
+add_executable(FEXGetConfig Main.cpp)
 
 list(APPEND LIBS Common JemallocDummy)
 
 if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(${NAME}
+  target_link_options(FEXGetConfig
     PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
       "LINKER:--as-needed")
 endif()
 
-install(TARGETS ${NAME}
+install(TARGETS FEXGetConfig
   RUNTIME
   DESTINATION bin
   COMPONENT Runtime)
 
-target_link_libraries(${NAME} PRIVATE ${LIBS})
+target_link_libraries(FEXGetConfig PRIVATE ${LIBS})
 
-target_include_directories(${NAME} PRIVATE ${CMAKE_BINARY_DIR}/generated)
+target_include_directories(FEXGetConfig PRIVATE ${CMAKE_BINARY_DIR}/generated)

--- a/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
+++ b/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
@@ -1,20 +1,17 @@
-set(NAME FEXRootFSFetcher)
-set(SRCS Main.cpp XXFileHash.cpp)
-
-add_executable(${NAME} ${SRCS})
+add_executable(FEXRootFSFetcher Main.cpp XXFileHash.cpp)
 list(APPEND LIBS FEXCore Common JemallocDummy xxHash::xxhash)
 
 if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(${NAME}
+  target_link_options(FEXRootFSFetcher
     PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
       "LINKER:--as-needed")
 endif()
 
-install(TARGETS ${NAME}
+install(TARGETS FEXRootFSFetcher
   RUNTIME
   DESTINATION bin
   COMPONENT Runtime)
 
-target_link_libraries(${NAME} PRIVATE ${LIBS} ${PTHREAD_LIB})
+target_link_libraries(FEXRootFSFetcher PRIVATE ${LIBS} ${PTHREAD_LIB})

--- a/Source/Tools/FEXServer/CMakeLists.txt
+++ b/Source/Tools/FEXServer/CMakeLists.txt
@@ -1,27 +1,25 @@
-set(NAME FEXServer)
-set(SRCS Main.cpp
+add_executable(FEXServer
+  Main.cpp
   ArgumentLoader.cpp
   Logger.cpp
   PipeScanner.cpp
   ProcessPipe.cpp
   SquashFS.cpp)
 
-add_executable(${NAME} ${SRCS})
-
-target_include_directories(${NAME} PRIVATE
+target_include_directories(FEXServer PRIVATE
   ${CMAKE_BINARY_DIR}/generated)
 
-target_link_libraries(${NAME} PRIVATE FEXCore Common CommonTools JemallocDummy ${PTHREAD_LIB})
+target_link_libraries(FEXServer PRIVATE FEXCore Common CommonTools JemallocDummy ${PTHREAD_LIB})
 
 if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(${NAME}
+  target_link_options(FEXServer
     PRIVATE
       "LINKER:--gc-sections"
       "LINKER:--strip-all"
       "LINKER:--as-needed")
 endif()
 
-install(TARGETS ${NAME}
+install(TARGETS FEXServer
   RUNTIME
   DESTINATION bin
   COMPONENT Runtime)

--- a/Source/Tools/LinuxEmulation/CMakeLists.txt
+++ b/Source/Tools/LinuxEmulation/CMakeLists.txt
@@ -1,6 +1,7 @@
+# TODO: why is this add_compile_options instead of target?
 add_compile_options(-fno-operator-names)
 
-set(SRCS
+add_library(LinuxEmulation STATIC
   VDSO_Emulation.cpp
   Thunks.cpp
   ArchHelpers/MContext.cpp
@@ -61,8 +62,6 @@ set(SRCS
   LinuxSyscalls/Syscalls/NotImplemented.cpp
   LinuxSyscalls/Syscalls/Stubs.cpp)
 
-add_library(LinuxEmulation STATIC ${SRCS})
-
 target_compile_options(LinuxEmulation
 PRIVATE
   -Wall
@@ -96,19 +95,20 @@ target_link_libraries(LinuxEmulation
 target_link_libraries(LinuxEmulation
   INTERFACE
   FEXCore)
-
 set(HEADERS_TO_VERIFY
-  LinuxSyscalls/x32/Types.h          x86_32 # This needs to match structs to 32bit structs
-  LinuxSyscalls/x32/Ioctl/asound.h   x86_32 # This needs to match structs to 32bit structs
-  LinuxSyscalls/x32/Ioctl/drm.h      x86_32 # This needs to match structs to 32bit structs
-  LinuxSyscalls/x32/Ioctl/streams.h  x86_32 # This needs to match structs to 32bit structs
-  LinuxSyscalls/x32/Ioctl/usbdev.h   x86_32 # This needs to match structs to 32bit structs
-  LinuxSyscalls/x32/Ioctl/input.h    x86_32 # This needs to match structs to 32bit structs
-  LinuxSyscalls/x32/Ioctl/sockios.h  x86_32 # This needs to match structs to 32bit structs
-  LinuxSyscalls/x32/Ioctl/joystick.h x86_32 # This needs to match structs to 32bit structs
-  LinuxSyscalls/x32/Ioctl/v4l2.h     x86_32 # This needs to match structs to 32bit structs
-  LinuxSyscalls/x64/Types.h          x86_64 # This needs to match structs to 64bit structs
-)
+  # These need to match structs to 32bit structs
+  LinuxSyscalls/x32/Types.h          x86_32
+  LinuxSyscalls/x32/Ioctl/asound.h   x86_32
+  LinuxSyscalls/x32/Ioctl/drm.h      x86_32
+  LinuxSyscalls/x32/Ioctl/streams.h  x86_32
+  LinuxSyscalls/x32/Ioctl/usbdev.h   x86_32
+  LinuxSyscalls/x32/Ioctl/input.h    x86_32
+  LinuxSyscalls/x32/Ioctl/sockios.h  x86_32
+  LinuxSyscalls/x32/Ioctl/joystick.h x86_32
+  LinuxSyscalls/x32/Ioctl/v4l2.h     x86_32
+
+  # This needs to match structs to 64bit structs
+  LinuxSyscalls/x64/Types.h          x86_64)
 
 list(LENGTH HEADERS_TO_VERIFY ARG_COUNT)
 math(EXPR ARG_COUNT "${ARG_COUNT}-1")
@@ -118,6 +118,7 @@ set(ARGS
   "-std=c++20"
   "-fno-operator-names"
   "-I${PROJECT_SOURCE_DIR}/External/drm-headers/include/")
+
 # Global include directories
 get_directory_property (INC_DIRS INCLUDE_DIRECTORIES)
 list(TRANSFORM INC_DIRS PREPEND "-I")

--- a/Source/Tools/TestHarnessRunner/CMakeLists.txt
+++ b/Source/Tools/TestHarnessRunner/CMakeLists.txt
@@ -14,10 +14,9 @@ endif()
 
 target_include_directories(TestHarnessRunner
   PRIVATE
-    ${CMAKE_BINARY_DIR}/generated
-)
+    ${CMAKE_BINARY_DIR}/generated)
+
 target_link_libraries(TestHarnessRunner
   PRIVATE
     ${LIBS}
-    ${PTHREAD_LIB}
-)
+    ${PTHREAD_LIB})


### PR DESCRIPTION
Trivial variables like SRCS, NAME, etc. actually do more harm than good.
They *will* make your IDE mad, and are also less readable. Remember:
verbosity is not a bad thing! Usually

Also: did a few tiny cleanups that I missed from my `endpara` PR.

Signed-off-by: crueter <crueter@eden-emu.dev>
