### PR TITLE
[cmake] more parenthesis cleanups, linker gc module, more same-line stuff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ if (HAS_CLANG_PRESERVE_ALL)
   else()
     message(STATUS "Has clang::preserve_all")
   endif()
-endif ()
+endif()
 
 if (ARCHITECTURE_arm64 AND HAS_CLANG_PRESERVE_ALL)
   add_definitions("-DFEX_PRESERVE_ALL_ATTR=__attribute__((preserve_all))" "-DFEX_HAS_PRESERVE_ALL_ATTR=1")
@@ -319,6 +319,9 @@ set(CMAKE_LINKER_FLAGS_RELEASE "${CMAKE_LINKER_FLAGS_RELEASE} -fomit-frame-point
 ## Modules ##
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMakeModules/)
 
+include(LinkerGC)
+
+## Externals ##
 include_directories(External/robin-map/include/)
 
 include(CTest)

--- a/CMakeModules/LinkerGC.cmake
+++ b/CMakeModules/LinkerGC.cmake
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+
+# This applies some common linker options that reduce code size and linking time in Release mode. Namely:
+# --gc-sections: Linktime garbage collection, discards unused sections from the final output
+# --strip-all  : Similar to running `strip`, discards the symbol table from the final output
+# --as-needed  : Only includes libraries that are actually needed in the final output.
+
+macro(LinkerGC target)
+  if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
+    target_link_options(${target} PRIVATE
+      "LINKER:--gc-sections"
+      "LINKER:--strip-all"
+      "LINKER:--as-needed")
+  endif()
+endmacro()

--- a/Data/AppConfig/CMakeLists.txt
+++ b/Data/AppConfig/CMakeLists.txt
@@ -15,13 +15,10 @@ foreach(GEN_CONFIG_SRC ${GEN_CONFIG_SOURCES})
   get_filename_component(CONFIG_NAME ${GEN_CONFIG_SRC} NAME_WLE)
 
   # Configure it
-  configure_file(
-    ${GEN_CONFIG_SRC}
-    ${CMAKE_BINARY_DIR}/Data/AppConfig/${CONFIG_NAME})
+  configure_file(${GEN_CONFIG_SRC} ${CMAKE_BINARY_DIR}/Data/AppConfig/${CONFIG_NAME})
 
   # Then install the configured json
-  install(
-    FILES ${CMAKE_BINARY_DIR}/Data/AppConfig/${CONFIG_NAME}
+  install(FILES ${CMAKE_BINARY_DIR}/Data/AppConfig/${CONFIG_NAME}
     DESTINATION ${DATA_DIRECTORY}/AppConfig/
     COMPONENT Runtime)
 endforeach()

--- a/Data/binfmts/CMakeLists.txt
+++ b/Data/binfmts/CMakeLists.txt
@@ -3,13 +3,10 @@ function(GenBinFmt Name)
   get_filename_component(FMT_NAME ${Name} NAME_WE)
 
   # Configure it
-  configure_file(
-    ${Name}
-    ${CMAKE_BINARY_DIR}/Data/binfmts/${FMT_NAME})
+  configure_file(${Name} ${CMAKE_BINARY_DIR}/Data/binfmts/${FMT_NAME})
 
   # Then install the configured binfmt
-  install(
-    FILES ${CMAKE_BINARY_DIR}/Data/binfmts/${FMT_NAME}
+  install(FILES ${CMAKE_BINARY_DIR}/Data/binfmts/${FMT_NAME}
     DESTINATION ${CMAKE_INSTALL_PREFIX}/share/binfmts/
     COMPONENT Runtime)
 endfunction()
@@ -18,8 +15,7 @@ if (NOT USE_LEGACY_BINFMTMISC)
   configure_file(FEX-x86.conf.in ${CMAKE_BINARY_DIR}/Data/binfmts/FEX-x86.conf)
   configure_file(FEX-x86_64.conf.in ${CMAKE_BINARY_DIR}/Data/binfmts/FEX-x86_64.conf)
 
-  install(
-    FILES ${CMAKE_BINARY_DIR}/Data/binfmts/FEX-x86.conf ${CMAKE_BINARY_DIR}/Data/binfmts/FEX-x86_64.conf
+  install(FILES ${CMAKE_BINARY_DIR}/Data/binfmts/FEX-x86.conf ${CMAKE_BINARY_DIR}/Data/binfmts/FEX-x86_64.conf
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/binfmt.d/
     COMPONENT Runtime)
 else()

--- a/FEXCore/CMakeLists.txt
+++ b/FEXCore/CMakeLists.txt
@@ -25,16 +25,15 @@ include(CheckIncludeFileCXX)
 include(CheckCXXSourceCompiles)
 
 if (EXISTS ${CMAKE_CURRENT_DIR}/External/vixl/)
-    # Useful to have for freestanding libFEXCore
-    add_subdirectory(External/vixl/)
-    include_directories(External/vixl/src/)
+  # Useful to have for freestanding libFEXCore
+  add_subdirectory(External/vixl/)
+  include_directories(External/vixl/src/)
 endif()
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/git_version.h.in
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/git_version.h.in
   ${CMAKE_BINARY_DIR}/generated/git_version.h)
 
 include_directories(${CMAKE_BINARY_DIR}/generated)

--- a/FEXCore/Source/CMakeLists.txt
+++ b/FEXCore/Source/CMakeLists.txt
@@ -103,21 +103,20 @@ endif()
 set(LIBS fmt::fmt xxHash::xxhash FEXHeaderUtils CodeEmitter cephes_128bit)
 
 if (ENABLE_VIXL_DISASSEMBLER OR ENABLE_VIXL_SIMULATOR)
-  list (APPEND LIBS vixl)
+  list(APPEND LIBS vixl)
 endif()
 
 if (NOT MINGW)
-  list (APPEND LIBS dl)
+  list(APPEND LIBS dl)
 else()
-  list (APPEND LIBS synchronization)
+  list(APPEND LIBS synchronization)
   if (ARCHITECTURE_arm64ec)
-    list (APPEND LIBS mincore)
+    list(APPEND LIBS mincore)
   endif()
 endif()
 
 # Generate config
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/Interface/Config/Config.json.in
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Interface/Config/Config.json.in
   ${CMAKE_BINARY_DIR}/generated/Config/Config.json)
 
 # Generate IR include file
@@ -135,8 +134,7 @@ add_custom_command(
   COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_generator.py"
     "${INPUT_NAME}" "${OUTPUT_NAME}" "${OUTPUT_DISPATCHER_NAME}")
 
-set_source_files_properties(${OUTPUT_NAME} PROPERTIES
-  GENERATED TRUE)
+set_source_files_properties(${OUTPUT_NAME} PROPERTIES GENERATED TRUE)
 
 # Generate IR documentation
 set(OUTPUT_IR_DOC "${CMAKE_BINARY_DIR}/IR.md")
@@ -148,8 +146,7 @@ add_custom_command(
   COMMAND "python3" "${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/json_ir_doc_generator.py"
     "${INPUT_NAME}" "${OUTPUT_IR_DOC}")
 
-set_source_files_properties(${OUTPUT_IR_NAME} PROPERTIES
-  GENERATED TRUE)
+set_source_files_properties(${OUTPUT_IR_NAME} PROPERTIES GENERATED TRUE)
 
 # Create the target
 add_custom_target(IR_INC
@@ -222,8 +219,7 @@ function(AddDefaultOptionsToTarget Name)
   target_compile_definitions(${Name} PRIVATE ${DEFINES})
   add_dependencies(${Name} CONFIG_INC IR_INC)
 
-  target_compile_options(${Name}
-    PRIVATE
+  target_compile_options(${Name} PRIVATE
     -Wall
     -Werror=cast-qual
     -Werror=ignored-qualifiers
@@ -234,23 +230,14 @@ function(AddDefaultOptionsToTarget Name)
     -fwrapv)
 
   if (GCC_COLOR)
-    target_compile_options(${Name}
-      PRIVATE
-      "-fdiagnostics-color=always")
-  endif()
-  if (CLANG_COLOR)
-    target_compile_options(${Name}
-      PRIVATE
-      "-fcolor-diagnostics")
+    target_compile_options(${Name} PRIVATE "-fdiagnostics-color=always")
   endif()
 
-  if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-    target_link_options(${Name}
-      PRIVATE
-      "LINKER:--gc-sections"
-      "LINKER:--strip-all"
-      "LINKER:--as-needed")
+  if (CLANG_COLOR)
+    target_compile_options(${Name} PRIVATE "-fcolor-diagnostics")
   endif()
+
+  LinkerGC(${Name})
 endfunction()
 
 # Build FEXCore_Base static library
@@ -287,10 +274,9 @@ AddLibrary(${PROJECT_NAME} STATIC)
 AddLibrary(${PROJECT_NAME}_shared SHARED)
 
 if (NOT MINGW AND NOT BUILD_STEAM_SUPPORT)
-  install(TARGETS ${PROJECT_NAME}_shared
-    LIBRARY
-      DESTINATION ${CMAKE_INSTALL_LIBDIR}
-      COMPONENT Libraries)
+  install(TARGETS ${PROJECT_NAME}_shared LIBRARY
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT Libraries)
 endif()
 
 # Meta-library to link jemalloc libraries enabled in the build configuration.

--- a/FEXCore/unittests/APITests/CMakeLists.txt
+++ b/FEXCore/unittests/APITests/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS *.cpp)
 
-set (LIBS fmt::fmt vixl Catch2::Catch2WithMain FEXCore_Base JemallocLibs)
+set(LIBS fmt::fmt vixl Catch2::Catch2WithMain FEXCore_Base JemallocLibs)
 foreach(TEST ${TESTS})
   get_filename_component(TEST_NAME ${TEST} NAME_WLE)
   add_executable(FEXCore_Tests_${TEST_NAME} ${TEST})
@@ -10,8 +10,7 @@ foreach(TEST ${TESTS})
   catch_discover_tests(FEXCore_Tests_${TEST_NAME} TEST_SUFFIX ".${TEST_NAME}.FEXCore_Tests")
 endforeach()
 
-add_custom_target(
-  fexcore_apitests
+add_custom_target(fexcore_apitests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "\.*.FEXCore_Tests$$")

--- a/FEXCore/unittests/Emitter/CMakeLists.txt
+++ b/FEXCore/unittests/Emitter/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS *.cpp)
 
-set (LIBS fmt::fmt vixl Catch2::Catch2WithMain FEXCore_Base JemallocLibs)
+set(LIBS fmt::fmt vixl Catch2::Catch2WithMain FEXCore_Base JemallocLibs)
 foreach(TEST ${TESTS})
   get_filename_component(TEST_NAME ${TEST} NAME_WLE)
   add_executable(Emitter_${TEST_NAME} ${TEST})
@@ -10,8 +10,7 @@ foreach(TEST ${TESTS})
   catch_discover_tests(Emitter_${TEST_NAME} TEST_SUFFIX ".${TEST_NAME}.Emitter")
 endforeach()
 
-add_custom_target(
-  emitter_tests
+add_custom_target(emitter_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "\.*.Emitter$$")

--- a/FEXHeaderUtils/CMakeLists.txt
+++ b/FEXHeaderUtils/CMakeLists.txt
@@ -1,8 +1,7 @@
 add_library(FEXHeaderUtils INTERFACE)
 
 # Check for syscall support here
-check_cxx_source_compiles(
-  "
+check_cxx_source_compiles("
   #include <sched.h>
   int main() {
   return ::getcpu(nullptr, nullptr);
@@ -11,10 +10,9 @@ check_cxx_source_compiles(
 if (HAS_SYSCALL_GETCPU)
   message(STATUS "Has getcpu helper")
   target_compile_definitions(FEXHeaderUtils INTERFACE HAS_SYSCALL_GETCPU=1)
-endif ()
+endif()
 
-check_cxx_source_compiles(
-  "
+check_cxx_source_compiles("
   #include <unistd.h>
   int main() {
   return ::gettid();
@@ -23,10 +21,9 @@ check_cxx_source_compiles(
 if (HAS_SYSCALL_GETTID)
   message(STATUS "Has gettid helper")
   target_compile_definitions(FEXHeaderUtils INTERFACE HAS_SYSCALL_GETTID=1)
-endif ()
+endif()
 
-check_cxx_source_compiles(
-  "
+check_cxx_source_compiles("
   #include <signal.h>
   int main() {
   return ::tgkill(0, 0, 0);
@@ -35,10 +32,9 @@ check_cxx_source_compiles(
 if (HAS_SYSCALL_TGKILL)
   message(STATUS "Has tgkill helper")
   target_compile_definitions(FEXHeaderUtils INTERFACE HAS_SYSCALL_TGKILL=1)
-endif ()
+endif()
 
-check_cxx_source_compiles(
-  "
+check_cxx_source_compiles("
   #include <sys/stat.h>
   int main() {
   return ::statx(0, nullptr, 0, 0, nullptr);
@@ -47,10 +43,9 @@ check_cxx_source_compiles(
 if (HAS_SYSCALL_STATX)
   message(STATUS "Has statx helper")
   target_compile_definitions(FEXHeaderUtils INTERFACE HAS_SYSCALL_STATX=1)
-endif ()
+endif()
 
-check_cxx_source_compiles(
-  "
+check_cxx_source_compiles("
   #include <stdio.h>
   int main() {
   return ::renameat2(0, nullptr, 0, nullptr, 0);
@@ -59,6 +54,6 @@ check_cxx_source_compiles(
 if (HAS_SYSCALL_RENAMEAT2)
   message(STATUS "Has renameat2 helper")
   target_compile_definitions(FEXHeaderUtils INTERFACE HAS_SYSCALL_RENAMEAT2=1)
-endif ()
+endif()
 
 target_include_directories(FEXHeaderUtils INTERFACE .)

--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -11,7 +11,7 @@ set(SRCS
   VolatileMetadata.cpp)
 
 if (NOT MINGW)
-  list (APPEND SRCS
+  list(APPEND SRCS
     FEXServerClient.cpp
     FileFormatCheck.cpp)
 endif()

--- a/Source/Steam/CMakeLists.txt
+++ b/Source/Steam/CMakeLists.txt
@@ -1,28 +1,20 @@
-add_executable(FEXCompatTool
-  CompatTool.cpp)
+set(LIBS FEXCore Common CommonTools JemallocLibs)
 
-target_link_libraries(FEXCompatTool
-  PRIVATE
-  FEXCore Common CommonTools JemallocLibs)
+add_executable(FEXCompatTool CompatTool.cpp)
 
-install(TARGETS FEXCompatTool
-  RUNTIME
-    DESTINATION /
-    COMPONENT Runtime
-)
+target_link_libraries(FEXCompatTool PRIVATE ${LIBS})
 
-add_executable(FEXServerManager
-  ServerManager.cpp)
+install(TARGETS FEXCompatTool RUNTIME
+  DESTINATION /
+  COMPONENT Runtime)
 
-target_link_libraries(FEXServerManager
-  PRIVATE
-  FEXCore Common CommonTools JemallocLibs)
+add_executable(FEXServerManager ServerManager.cpp)
 
-install(TARGETS FEXServerManager
-  RUNTIME
-    DESTINATION bin
-    COMPONENT Runtime
-)
+target_link_libraries(FEXServerManager PRIVATE ${LIBS})
+
+install(TARGETS FEXServerManager RUNTIME
+  DESTINATION bin
+  COMPONENT Runtime)
 
 # Description json gets installed into root of depot
 install(FILES emulator.json

--- a/Source/Tools/CodeSizeValidation/CMakeLists.txt
+++ b/Source/Tools/CodeSizeValidation/CMakeLists.txt
@@ -1,11 +1,6 @@
 list(APPEND LIBS FEXCore Common CommonTools JemallocLibs)
 
 add_executable(CodeSizeValidation Main.cpp)
-target_include_directories(CodeSizeValidation
-  PRIVATE
-    ${CMAKE_BINARY_DIR}/generated)
+target_include_directories(CodeSizeValidation PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
-target_link_libraries(CodeSizeValidation
-  PRIVATE
-    ${LIBS}
-    ${PTHREAD_LIB})
+target_link_libraries(CodeSizeValidation PRIVATE ${LIBS} ${PTHREAD_LIB})

--- a/Source/Tools/FEXBash/CMakeLists.txt
+++ b/Source/Tools/FEXBash/CMakeLists.txt
@@ -1,20 +1,9 @@
 add_executable(FEXBash FEXBash.cpp)
 
-target_link_libraries(FEXBash
-  PRIVATE
-    FEXCore
-    Common
-    JemallocLibs)
+target_link_libraries(FEXBash PRIVATE FEXCore Common JemallocLibs)
 
-if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(FEXBash
-    PRIVATE
-      "LINKER:--gc-sections"
-      "LINKER:--strip-all"
-      "LINKER:--as-needed")
-endif()
+LinkerGC(FEXBash)
 
-install(TARGETS FEXBash
-  RUNTIME
-    DESTINATION bin
-    COMPONENT Runtime)
+install(TARGETS FEXBash RUNTIME
+  DESTINATION bin
+  COMPONENT Runtime)

--- a/Source/Tools/FEXConfig/CMakeLists.txt
+++ b/Source/Tools/FEXConfig/CMakeLists.txt
@@ -13,15 +13,8 @@ else()
 endif()
 target_sources(FEXConfig PRIVATE ${QT_RESOURCES})
 
-if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(FEXConfig
-    PRIVATE
-      "LINKER:--gc-sections"
-      "LINKER:--strip-all"
-      "LINKER:--as-needed")
-endif()
+LinkerGC(FEXConfig)
 
-install(TARGETS FEXConfig
-  RUNTIME
+install(TARGETS FEXConfig RUNTIME
   DESTINATION bin
   COMPONENT Runtime)

--- a/Source/Tools/FEXGDBReader/CMakeLists.txt
+++ b/Source/Tools/FEXGDBReader/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_library(FEXGDBReader SHARED FEXGDBReader.cpp)
 
-install(TARGETS FEXGDBReader
-  RUNTIME
+install(TARGETS FEXGDBReader RUNTIME
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/gdb
   COMPONENT Development)
 

--- a/Source/Tools/FEXGetConfig/CMakeLists.txt
+++ b/Source/Tools/FEXGetConfig/CMakeLists.txt
@@ -2,16 +2,9 @@ add_executable(FEXGetConfig Main.cpp)
 
 list(APPEND LIBS Common JemallocDummy)
 
-if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(FEXGetConfig
-    PRIVATE
-      "LINKER:--gc-sections"
-      "LINKER:--strip-all"
-      "LINKER:--as-needed")
-endif()
+LinkerGC(FEXGetConfig)
 
-install(TARGETS FEXGetConfig
-  RUNTIME
+install(TARGETS FEXGetConfig RUNTIME
   DESTINATION bin
   COMPONENT Runtime)
 

--- a/Source/Tools/FEXInterpreter/CMakeLists.txt
+++ b/Source/Tools/FEXInterpreter/CMakeLists.txt
@@ -1,4 +1,5 @@
-list(APPEND LIBS FEXCore Common JemallocLibs)
+list(APPEND LIBS FEXCore Common JemallocLibs LinuxEmulation
+  CommonTools ${PTHREAD_LIB} fmt::fmt)
 
 set(DEFINES)
 if (ENABLE_VIXL_SIMULATOR)
@@ -18,30 +19,15 @@ set_target_properties(FEX PROPERTIES
   CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN TRUE)
 
-target_include_directories(FEX
-  PRIVATE
-    ${CMAKE_BINARY_DIR}/generated)
+target_include_directories(FEX PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
-target_link_libraries(FEX
-  PRIVATE
-    ${LIBS}
-    LinuxEmulation
-    CommonTools
-    ${PTHREAD_LIB}
-    fmt::fmt)
+target_link_libraries(FEX PRIVATE ${LIBS})
 
 target_compile_options(FEX PRIVATE ${FEX_TUNE_COMPILE_FLAGS})
 
-if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(FEX
-    PRIVATE
-      "LINKER:--gc-sections"
-      "LINKER:--strip-all"
-      "LINKER:--as-needed")
-endif()
+LinkerGC(FEX)
 
-install(TARGETS FEX
-  RUNTIME
+install(TARGETS FEX RUNTIME
     DESTINATION bin
     COMPONENT Runtime)
 

--- a/Source/Tools/FEXOfflineCompiler/CMakeLists.txt
+++ b/Source/Tools/FEXOfflineCompiler/CMakeLists.txt
@@ -1,25 +1,17 @@
 add_executable(FEXOfflineCompiler Main.cpp)
 
-target_link_libraries(FEXOfflineCompiler
-  PRIVATE
-    Common
-    CommonTools
-    cpp-optparse
-    FEXCore
-    JemallocLibs
-    LinuxEmulation
-    ${PTHREAD_LIB}
-    fmt::fmt)
+target_link_libraries(FEXOfflineCompiler PRIVATE
+  Common
+  CommonTools
+  cpp-optparse
+  FEXCore
+  JemallocLibs
+  LinuxEmulation
+  ${PTHREAD_LIB}
+  fmt::fmt)
 
-if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(FEXOfflineCompiler
-    PRIVATE
-      "LINKER:--gc-sections"
-      "LINKER:--strip-all"
-      "LINKER:--as-needed")
-endif()
+LinkerGC(FEXOfflineCompiler)
 
-install(TARGETS FEXOfflineCompiler
-  RUNTIME
-    DESTINATION bin
-    COMPONENT Runtime)
+install(TARGETS FEXOfflineCompiler RUNTIME
+  DESTINATION bin
+  COMPONENT Runtime)

--- a/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
+++ b/Source/Tools/FEXRootFSFetcher/CMakeLists.txt
@@ -1,17 +1,10 @@
 add_executable(FEXRootFSFetcher Main.cpp XXFileHash.cpp)
-list(APPEND LIBS FEXCore Common JemallocDummy xxHash::xxhash)
+list(APPEND LIBS FEXCore Common JemallocDummy xxHash::xxhash ${PTHREAD_LIB})
 
-if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(FEXRootFSFetcher
-    PRIVATE
-      "LINKER:--gc-sections"
-      "LINKER:--strip-all"
-      "LINKER:--as-needed")
-endif()
+LinkerGC(FEXRootFSFetcher)
 
-install(TARGETS FEXRootFSFetcher
-  RUNTIME
+install(TARGETS FEXRootFSFetcher RUNTIME
   DESTINATION bin
   COMPONENT Runtime)
 
-target_link_libraries(FEXRootFSFetcher PRIVATE ${LIBS} ${PTHREAD_LIB})
+target_link_libraries(FEXRootFSFetcher PRIVATE ${LIBS})

--- a/Source/Tools/FEXServer/CMakeLists.txt
+++ b/Source/Tools/FEXServer/CMakeLists.txt
@@ -6,20 +6,12 @@ add_executable(FEXServer
   ProcessPipe.cpp
   SquashFS.cpp)
 
-target_include_directories(FEXServer PRIVATE
-  ${CMAKE_BINARY_DIR}/generated)
+target_include_directories(FEXServer PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
 target_link_libraries(FEXServer PRIVATE FEXCore Common CommonTools JemallocDummy ${PTHREAD_LIB})
 
-if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(FEXServer
-    PRIVATE
-      "LINKER:--gc-sections"
-      "LINKER:--strip-all"
-      "LINKER:--as-needed")
-endif()
+LinkerGC(FEXServer)
 
-install(TARGETS FEXServer
-  RUNTIME
+install(TARGETS FEXServer RUNTIME
   DESTINATION bin
   COMPONENT Runtime)

--- a/Source/Tools/LinuxEmulation/CMakeLists.txt
+++ b/Source/Tools/LinuxEmulation/CMakeLists.txt
@@ -62,8 +62,7 @@ add_library(LinuxEmulation STATIC
   LinuxSyscalls/Syscalls/NotImplemented.cpp
   LinuxSyscalls/Syscalls/Stubs.cpp)
 
-target_compile_options(LinuxEmulation
-PRIVATE
+target_compile_options(LinuxEmulation PRIVATE
   -Wall
   -Werror=cast-qual
   -Werror=ignored-qualifiers
@@ -77,24 +76,20 @@ set_target_properties(LinuxEmulation PROPERTIES
   CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN TRUE)
 
-target_include_directories(LinuxEmulation
-PRIVATE
+target_include_directories(LinuxEmulation PRIVATE
   ${CMAKE_BINARY_DIR}/generated
   ${CMAKE_CURRENT_SOURCE_DIR}/
   ${PROJECT_SOURCE_DIR}/External/drm-headers/include/)
 
-target_include_directories(LinuxEmulation
-  INTERFACE
+target_include_directories(LinuxEmulation INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/)
 
-target_link_libraries(LinuxEmulation
-  PRIVATE
+target_link_libraries(LinuxEmulation PRIVATE
   Common
   CommonTools)
 
-target_link_libraries(LinuxEmulation
-  INTERFACE
-  FEXCore)
+target_link_libraries(LinuxEmulation INTERFACE FEXCore)
+
 set(HEADERS_TO_VERIFY
   # These need to match structs to 32bit structs
   LinuxSyscalls/x32/Types.h          x86_32
@@ -143,23 +138,19 @@ foreach(Index RANGE 0 ${ARG_COUNT} 2)
   set(TEST_NAME "${TEST_DESC}/Test_verify_${HEADER}")
   set(TEST_NAME_ARCH "${TEST_DESC}/Test_verify_arch_${HEADER}")
 
-  add_test(
-    NAME ${TEST_NAME}_x86_64
+  add_test(NAME ${TEST_NAME}_x86_64
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
     COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/StructPackVerifier.py" "-c1" "x86_64" "${REL_HEADER}" ${ARGS})
 
-  add_test(
-    NAME ${TEST_NAME}_aarch64
+  add_test(NAME ${TEST_NAME}_aarch64
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
     COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/StructPackVerifier.py" "-c1" "aarch64" "${REL_HEADER}" ${ARGS})
 
-  add_test(
-    NAME ${TEST_NAME_ARCH}_x86_64
+  add_test(NAME ${TEST_NAME_ARCH}_x86_64
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
     COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/StructPackVerifier.py" "-c1" "x86_64" "-c2" "${TEST_TYPE}" "${REL_HEADER}" ${ARGS})
 
-  add_test(
-    NAME ${TEST_NAME_ARCH}_aarch64
+  add_test(NAME ${TEST_NAME_ARCH}_aarch64
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
     COMMAND "python3" "${CMAKE_SOURCE_DIR}/Scripts/StructPackVerifier.py" "-c1" "aarch64" "-c2" "${TEST_TYPE}" "${REL_HEADER}" ${ARGS})
 
@@ -169,8 +160,7 @@ foreach(Index RANGE 0 ${ARG_COUNT} 2)
   set_property(TEST ${TEST_NAME_ARCH}_aarch64 APPEND PROPERTY DEPENDS "${HEADER}")
 endforeach()
 
-add_custom_target(
-  struct_verifier
+add_custom_target(struct_verifier
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "Test_verify*")

--- a/Source/Tools/TestHarnessRunner/CMakeLists.txt
+++ b/Source/Tools/TestHarnessRunner/CMakeLists.txt
@@ -1,6 +1,6 @@
-list(APPEND LIBS FEXCore Common JemallocLibs)
+list(APPEND LIBS FEXCore Common JemallocLibs ${PTHREAD_LIB})
 
-set (SRCS TestHarnessRunner.cpp)
+set(SRCS TestHarnessRunner.cpp)
 if (NOT MINGW)
   list(APPEND SRCS TestHarnessRunner/HostRunner.cpp)
   list(APPEND LIBS LinuxEmulation CommonTools)
@@ -12,11 +12,6 @@ if (ENABLE_VIXL_SIMULATOR)
   target_compile_definitions(TestHarnessRunner PRIVATE "-DVIXL_SIMULATOR=1")
 endif()
 
-target_include_directories(TestHarnessRunner
-  PRIVATE
-    ${CMAKE_BINARY_DIR}/generated)
+target_include_directories(TestHarnessRunner PRIVATE ${CMAKE_BINARY_DIR}/generated)
 
-target_link_libraries(TestHarnessRunner
-  PRIVATE
-    ${LIBS}
-    ${PTHREAD_LIB})
+target_link_libraries(TestHarnessRunner PRIVATE ${LIBS})

--- a/Source/Tools/pidof/CMakeLists.txt
+++ b/Source/Tools/pidof/CMakeLists.txt
@@ -1,21 +1,13 @@
 add_executable(FEXpidof pidof.cpp)
 
-target_link_libraries(FEXpidof
-  PRIVATE
+target_link_libraries(FEXpidof PRIVATE
   cpp-optparse
   JemallocDummy
   fmt::fmt
   range-v3::range-v3)
 
-if (CMAKE_BUILD_TYPE MATCHES "RELEASE")
-  target_link_options(FEXpidof
-    PRIVATE
-      "LINKER:--gc-sections"
-      "LINKER:--strip-all"
-      "LINKER:--as-needed")
-endif()
+LinkerGC(FEXpidof)
 
-install(TARGETS FEXpidof
-  RUNTIME
-    DESTINATION bin
-    COMPONENT Runtime)
+install(TARGETS FEXpidof RUNTIME
+  DESTINATION bin
+  COMPONENT Runtime)

--- a/Source/Windows/ARM64EC/CMakeLists.txt
+++ b/Source/Windows/ARM64EC/CMakeLists.txt
@@ -2,29 +2,25 @@ add_library(arm64ecfex SHARED
   Module.cpp
   Module.S
   libarm64ecfex.def
-  $<TARGET_OBJECTS:FEXCore_object>
-)
+  $<TARGET_OBJECTS:FEXCore_object>)
+
 patch_library_wine(arm64ecfex)
 
 target_include_directories(arm64ecfex PRIVATE
   "${CMAKE_SOURCE_DIR}/Source/Windows/include/"
   "${CMAKE_SOURCE_DIR}/Source/"
-  "${CMAKE_SOURCE_DIR}/Source/Windows/"
-)
+  "${CMAKE_SOURCE_DIR}/Source/Windows/")
 
-target_link_libraries(arm64ecfex
-  PRIVATE
+target_link_libraries(arm64ecfex PRIVATE
   FEXCore_Base
   Common
   CommonTools
   CommonWindows
   CommonWindowsRuntime
-  ntdll_ex
-)
+  ntdll_ex)
 
 target_link_options(arm64ecfex PRIVATE -static -nostdlib -nostartfiles -nodefaultlibs -lc++ -lc++abi -lunwind)
 target_link_libraries(arm64ecfex PRIVATE ${LIBGCC_PATH})
-install(TARGETS arm64ecfex
-  RUNTIME
+install(TARGETS arm64ecfex RUNTIME
   DESTINATION ${CMAKE_INSTALL_LIBDIR}
   COMPONENT Runtime)

--- a/Source/Windows/CMakeLists.txt
+++ b/Source/Windows/CMakeLists.txt
@@ -1,11 +1,9 @@
 function(build_implib name)
   set(name_ex ${name}_ex)
   add_custom_target(${name_ex}lib ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lib${name_ex}.a)
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name_ex}.a
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${name_ex}.a
     COMMAND ${CMAKE_DLLTOOL} -d ${CMAKE_CURRENT_SOURCE_DIR}/Defs/${name}.def -k -l lib${name_ex}.a
-    COMMENT "Building lib${name_ex}.a"
-  )
+    COMMENT "Building lib${name_ex}.a")
 
   add_library(${name_ex} SHARED IMPORTED)
   set_property(TARGET ${name_ex} PROPERTY IMPORTED_IMPLIB ${CMAKE_CURRENT_BINARY_DIR}/lib${name_ex}.a)
@@ -13,15 +11,13 @@ function(build_implib name)
 endfunction()
 
 function(patch_library_wine target)
-  add_custom_command(
-    TARGET ${target} POST_BUILD
-    COMMAND dd bs=32 count=1 seek=2 conv=notrunc if=${CMAKE_SOURCE_DIR}/Source/Windows/wine_builtin.bin of=$<TARGET_FILE:${target}>
-  )
+  add_custom_command(TARGET ${target} POST_BUILD
+    COMMAND dd bs=32 count=1 seek=2 conv=notrunc if=${CMAKE_SOURCE_DIR}/Source/Windows/wine_builtin.bin of=$<TARGET_FILE:${target}>)
 endfunction()
 
 execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -print-libgcc-file-name
-                OUTPUT_VARIABLE LIBGCC_PATH
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
+  OUTPUT_VARIABLE LIBGCC_PATH
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 build_implib(ntdll)
 build_implib(wow64)

--- a/Source/Windows/Common/CMakeLists.txt
+++ b/Source/Windows/Common/CMakeLists.txt
@@ -4,13 +4,14 @@ add_subdirectory(WinAPI)
 
 target_link_libraries(CommonWindowsRuntime FEXCore_Base JemallocLibs)
 target_compile_options(CommonWindowsRuntime PRIVATE -Wno-inconsistent-dllimport)
-target_include_directories(CommonWindowsRuntime PRIVATE
-  "${CMAKE_SOURCE_DIR}/Source/Windows/include/"
-)
+target_include_directories(CommonWindowsRuntime PRIVATE "${CMAKE_SOURCE_DIR}/Source/Windows/include/")
 
-add_library(CommonWindows STATIC CPUFeatures.cpp SHMStats.cpp InvalidationTracker.cpp ImageTracker.cpp Logging.cpp)
+add_library(CommonWindows STATIC
+  CPUFeatures.cpp
+  SHMStats.cpp
+  InvalidationTracker.cpp
+  ImageTracker.cpp
+  Logging.cpp)
 
 target_link_libraries(CommonWindows FEXCore_Base)
-target_include_directories(CommonWindows PRIVATE
-  "${CMAKE_SOURCE_DIR}/Source/Windows/include/"
-)
+target_include_directories(CommonWindows PRIVATE "${CMAKE_SOURCE_DIR}/Source/Windows/include/")

--- a/Source/Windows/WOW64/CMakeLists.txt
+++ b/Source/Windows/WOW64/CMakeLists.txt
@@ -1,30 +1,26 @@
 add_library(wow64fex SHARED
   Module.cpp
   libwow64fex.def
-  $<TARGET_OBJECTS:FEXCore_object>
-)
+  $<TARGET_OBJECTS:FEXCore_object>)
+
 patch_library_wine(wow64fex)
 
 target_include_directories(wow64fex PRIVATE
   "${CMAKE_SOURCE_DIR}/Source/Windows/include/"
   "${CMAKE_SOURCE_DIR}/Source/Windows/"
-  "${CMAKE_SOURCE_DIR}/Source/"
-)
+  "${CMAKE_SOURCE_DIR}/Source/")
 
-target_link_libraries(wow64fex
-  PRIVATE
+target_link_libraries(wow64fex PRIVATE
   FEXCore_Base
   Common
   CommonTools
   CommonWindows
   CommonWindowsRuntime
   wow64_ex
-  ntdll_ex
-)
+  ntdll_ex)
 
 target_link_options(wow64fex PRIVATE -static -nostdlib -nostartfiles -nodefaultlibs -lc++ -lc++abi -lunwind)
 target_link_libraries(wow64fex PRIVATE ${LIBGCC_PATH})
-install(TARGETS wow64fex
-  RUNTIME
+install(TARGETS wow64fex RUNTIME
   DESTINATION ${CMAKE_INSTALL_LIBDIR}
   COMPONENT Runtime)

--- a/ThunkLibs/Generator/CMakeLists.txt
+++ b/ThunkLibs/Generator/CMakeLists.txt
@@ -5,8 +5,7 @@ find_package(OpenSSL REQUIRED COMPONENTS Crypto)
 if (NOT CLANG_RESOURCE_DIR)
   find_program(CLANG_EXEC_PATH clang REQUIRED)
 
-  execute_process(
-    COMMAND ${CLANG_EXEC_PATH} -print-resource-dir
+  execute_process(COMMAND ${CLANG_EXEC_PATH} -print-resource-dir
     OUTPUT_VARIABLE CLANG_RESOURCE_DIR
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -5,12 +5,12 @@ include(${FEX_PROJECT_SOURCE_DIR}/Data/CMake/version_to_variables.cmake)
 option(ENABLE_CLANG_THUNKS "Enable building thunks with clang" FALSE)
 
 if (ENABLE_CLANG_THUNKS)
-  set (LD_OVERRIDE "-fuse-ld=lld")
+  set(LD_OVERRIDE "-fuse-ld=lld")
   add_link_options(${LD_OVERRIDE})
 endif()
 
 if (NOT X86_DEV_ROOTFS)
-  message(FATAL_ERROR "X86_DEV_ROOTFS must be set (use \"/\" to ignore)")
+  message(FATAL_ERROR "X86_DEV_ROOTFS must be set(use \"/\" to ignore)")
 endif()
 
 find_program(CCACHE_PROGRAM ccache)
@@ -24,9 +24,9 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(CMAKE_CXX_STANDARD 20)
 
   # This gets passed in from the main cmake project
-  set (DATA_DIRECTORY "" CACHE PATH "Global data directory (override)")
+  set(DATA_DIRECTORY "" CACHE PATH "Global data directory (override)")
   if (NOT DATA_DIRECTORY)
-    set (DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/fex-emu")
+    set(DATA_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/fex-emu")
   endif()
 
   set(TARGET_TYPE SHARED)
@@ -34,8 +34,7 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
   # uninstall target
   if(NOT TARGET uninstall)
-    configure_file(
-      "${FEX_PROJECT_SOURCE_DIR}/Data/CMake/cmake_uninstall.cmake.in"
+    configure_file("${FEX_PROJECT_SOURCE_DIR}/Data/CMake/cmake_uninstall.cmake.in"
       "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cmake_uninstall.cmake"
       IMMEDIATE @ONLY)
 
@@ -60,7 +59,7 @@ function(generate NAME SOURCE_FILE)
   target_include_directories(${NAME}-guest-deps INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
   if (BITNESS EQUAL 32)
     target_compile_definitions(${NAME}-guest-deps INTERFACE IS_32BIT_THUNK)
-  endif ()
+  endif()
   # Shorthand for the include directories added after calling this function.
   # This is not evaluated directly, hence directories added after return are still picked up
   set(prop "$<TARGET_PROPERTY:${NAME}-guest-deps,INTERFACE_INCLUDE_DIRECTORIES>")
@@ -90,25 +89,24 @@ function(generate NAME SOURCE_FILE)
       # Expand include directories to space-separated list of -isystem parameters
       "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
     VERBATIM
-    COMMAND_EXPAND_LISTS
-    )
+    COMMAND_EXPAND_LISTS)
 
   list(APPEND OUTPUTS "${OUTFILE}")
   set(GEN_${NAME} ${OUTPUTS} PARENT_SCOPE)
 endfunction()
 
 function(add_guest_lib NAME SONAME)
-  set (SOURCE_FILE ../lib${NAME}/lib${NAME}_Guest.cpp)
+  set(SOURCE_FILE ../lib${NAME}/lib${NAME}_Guest.cpp)
   get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
 
-  set (SOURCE_LDS_FILE ../lib${NAME}/lib${NAME}_Guest.lds)
+  set(SOURCE_LDS_FILE ../lib${NAME}/lib${NAME}_Guest.lds)
   get_filename_component(SOURCE_LDS_FILE_ABS "${SOURCE_LDS_FILE}" ABSOLUTE)
 
-  set (SOURCE_LDS_32_FILE ../lib${NAME}/lib${NAME}_Guest_32.lds)
+  set(SOURCE_LDS_32_FILE ../lib${NAME}/lib${NAME}_Guest_32.lds)
   get_filename_component(SOURCE_LDS_32_FILE_ABS "${SOURCE_LDS_32_FILE}" ABSOLUTE)
 
   if (NOT EXISTS "${SOURCE_FILE_ABS}")
-    set (SOURCE_FILE ../lib${NAME}/Guest.cpp)
+    set(SOURCE_FILE ../lib${NAME}/Guest.cpp)
     get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
     if (NOT EXISTS "${SOURCE_FILE_ABS}")
       message (FATAL_ERROR "Thunk source file for Guest lib ${NAME} doesn't exist!")

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 20)
 option(ENABLE_CLANG_THUNKS "Enable building thunks with clang" FALSE)
 
 if (ENABLE_CLANG_THUNKS)
-  set (LD_OVERRIDE "-fuse-ld=lld")
+  set(LD_OVERRIDE "-fuse-ld=lld")
   add_link_options(${LD_OVERRIDE})
 endif()
 
@@ -21,7 +21,7 @@ function(generate NAME SOURCE_FILE GUEST_BITNESS)
   target_include_directories(${NAME}-${GUEST_BITNESS}-deps INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
   if (GUEST_BITNESS EQUAL 32)
     target_compile_definitions(${NAME}-${GUEST_BITNESS}-deps INTERFACE IS_32BIT_THUNK)
-  endif ()
+  endif()
   # Shorthand for the include directories added after calling this function.
   # This is not evaluated directly, hence directories added after return are still picked up
   set(prop "$<TARGET_PROPERTY:${NAME}-${GUEST_BITNESS}-deps,INTERFACE_INCLUDE_DIRECTORIES>")
@@ -42,9 +42,9 @@ function(generate NAME SOURCE_FILE GUEST_BITNESS)
 
   file(MAKE_DIRECTORY "${OUTFOLDER}")
 
-  set (BITNESS_FLAGS "")
+  set(BITNESS_FLAGS "")
   if (GUEST_BITNESS EQUAL 32)
-    set (BITNESS_FLAGS "-for-32bit-guest")
+    set(BITNESS_FLAGS "-for-32bit-guest")
   endif()
 
   add_custom_command(
@@ -57,18 +57,17 @@ function(generate NAME SOURCE_FILE GUEST_BITNESS)
       # Expand include directories to space-separated list of -isystem parameters
       "$<$<BOOL:${prop}>:;-isystem$<JOIN:${prop},;-isystem>>"
     VERBATIM
-    COMMAND_EXPAND_LISTS
-    )
+    COMMAND_EXPAND_LISTS)
 
   list(APPEND OUTPUTS "${OUTFILE}")
   set(GEN_${NAME} ${OUTPUTS} PARENT_SCOPE)
 endfunction()
 
 function(add_host_lib NAME GUEST_BITNESS)
-  set (SOURCE_FILE ../lib${NAME}/lib${NAME}_Host.cpp)
+  set(SOURCE_FILE ../lib${NAME}/lib${NAME}_Host.cpp)
     get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
   if (NOT EXISTS "${SOURCE_FILE_ABS}")
-    set (SOURCE_FILE ../lib${NAME}/Host.cpp)
+    set(SOURCE_FILE ../lib${NAME}/Host.cpp)
     get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
     if (NOT EXISTS "${SOURCE_FILE_ABS}")
       message (FATAL_ERROR "Thunk source file for Host lib ${NAME} doesn't exist!")
@@ -98,7 +97,7 @@ function(add_host_lib NAME GUEST_BITNESS)
   endif()
 endfunction()
 
-set (BITNESS_LIST "64")
+set(BITNESS_LIST "64")
 foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
   #add_host_lib(fex_malloc_symbols ${GUEST_BITNESS})
 
@@ -120,7 +119,7 @@ foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
   add_host_lib(drm ${GUEST_BITNESS})
 endforeach()
 
-set (BITNESS_LIST "32;64")
+set(BITNESS_LIST "32;64")
 foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
   if (BUILD_FEX_LINUX_TESTS)
     generate(libfex_thunk_test ${CMAKE_CURRENT_SOURCE_DIR}/../libfex_thunk_test/libfex_thunk_test_interface.cpp ${GUEST_BITNESS})

--- a/unittests/32Bit_ASM/CMakeLists.txt
+++ b/unittests/32Bit_ASM/CMakeLists.txt
@@ -30,8 +30,7 @@ foreach(ASM_SRC ${ASM_SOURCES})
   add_custom_command(OUTPUT ${TMP_FILE}
     DEPENDS "${ASM_SRC}"
     COMMAND "cp" ARGS "${ASM_SRC}" "${TMP_FILE}"
-    COMMAND "sed" ARGS "-i" "-e" "\'1s;^;BITS 32\\norg 10000h\\nmov eax, 0x17\\nmov ds, ax\\nmov es, ax\\n;\'" "-e" "\'\$\$a\\ret\\n\'" "${TMP_FILE}"
-    )
+    COMMAND "sed" ARGS "-i" "-e" "\'1s;^;BITS 32\\norg 10000h\\nmov eax, 0x17\\nmov ds, ax\\nmov es, ax\\n;\'" "-e" "\'\$\$a\\ret\\n\'" "${TMP_FILE}")
 
   set(OUTPUT_NAME "${OUTPUT_ASM_FOLDER}/${ASM_NAME}.bin")
   set(OUTPUT_CONFIG_NAME "${OUTPUT_ASM_FOLDER}/${ASM_NAME}.config.bin")
@@ -53,22 +52,19 @@ foreach(ASM_SRC ${ASM_SOURCES})
     list(APPEND TEST_ARGS
       "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=1 FEX_MULTIBLOCK=0 FEX_TSOENABLED=0"   "jit_1"     "jit"
       "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=500 FEX_MULTIBLOCK=0 FEX_TSOENABLED=0" "jit_500"   "jit"
-      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=500 FEX_MULTIBLOCK=1 FEX_TSOENABLED=0" "jit_500_m" "jit"
-      )
+      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=500 FEX_MULTIBLOCK=1 FEX_TSOENABLED=0" "jit_500_m" "jit")
   endif()
 
   if (ENABLE_VIXL_SIMULATOR)
     set(CPU_CLASS Simulator)
   elseif (ARCHITECTURE_x86_64)
-    list(APPEND TEST_ARGS
-      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1" "host" "host"
-      )
+    list(APPEND TEST_ARGS "FEX_SILENTLOG=0 FEX_DUMPGPRS=1" "host" "host")
   endif()
 
   if (NOT MINGW)
-    set (LAUNCH_PROGRAM "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner")
+    set(LAUNCH_PROGRAM "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner")
   else()
-    set (LAUNCH_PROGRAM "wine" "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner.exe")
+    set(LAUNCH_PROGRAM "wine" "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner.exe")
   endif()
 
   list(LENGTH TEST_ARGS ARG_COUNT)
@@ -113,8 +109,7 @@ endforeach()
 add_custom_target(32bit_asm_files ALL
   DEPENDS "${ASM_DEPENDS}")
 
-add_custom_target(
-  32bit_asm_tests
+add_custom_target(32bit_asm_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   DEPENDS 32bit_asm_files

--- a/unittests/APITests/CMakeLists.txt
+++ b/unittests/APITests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set (TESTS
+set(TESTS
   Allocator
   ArgumentParser
   ExtendedVolatileMetadata
@@ -6,8 +6,7 @@ set (TESTS
   FileMappingBaseAddress
   Filesystem
   InterruptableConditionVariable
-  StringUtils
-  )
+  StringUtils)
 
 list(APPEND LIBS Common FEXCore JemallocLibs)
 
@@ -19,8 +18,7 @@ foreach(API_TEST ${TESTS})
     TEST_SUFFIX ".${API_TEST}.APITest")
 endforeach()
 
-add_custom_target(
-  api_tests
+add_custom_target(api_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "\.*.APITest")

--- a/unittests/ASM/CMakeLists.txt
+++ b/unittests/ASM/CMakeLists.txt
@@ -54,22 +54,19 @@ foreach(ASM_SRC ${ASM_SOURCES})
     list(APPEND TEST_ARGS
       "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=1 FEX_MULTIBLOCK=0 FEX_TSOENABLED=0"   "jit_1"     "jit"
       "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=500 FEX_MULTIBLOCK=0 FEX_TSOENABLED=0" "jit_500"   "jit"
-      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=500 FEX_MULTIBLOCK=1 FEX_TSOENABLED=0" "jit_500_m" "jit"
-      )
+      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1 FEX_MAXINST=500 FEX_MULTIBLOCK=1 FEX_TSOENABLED=0" "jit_500_m" "jit")
   endif()
 
   if (ENABLE_VIXL_SIMULATOR)
     set(CPU_CLASS Simulator)
   elseif (ARCHITECTURE_x86_64)
-    list(APPEND TEST_ARGS
-      "FEX_SILENTLOG=0 FEX_DUMPGPRS=1" "host" "host"
-      )
+    list(APPEND TEST_ARGS "FEX_SILENTLOG=0 FEX_DUMPGPRS=1" "host" "host")
   endif()
 
   if (NOT MINGW)
-    set (LAUNCH_PROGRAM "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner")
+    set(LAUNCH_PROGRAM "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner")
   else()
-    set (LAUNCH_PROGRAM "wine" "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner.exe")
+    set(LAUNCH_PROGRAM "wine" "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner.exe")
   endif()
 
   list(LENGTH TEST_ARGS ARG_COUNT)
@@ -116,19 +113,16 @@ foreach(ASM_SRC ${ASM_SOURCES})
 
 endforeach()
 
-add_custom_target(asm_files ALL
-  DEPENDS "${ASM_DEPENDS}")
+add_custom_target(asm_files ALL DEPENDS "${ASM_DEPENDS}")
 
-add_custom_target(
-  64bit_asm_tests
+add_custom_target(64bit_asm_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   DEPENDS asm_files
   DEPENDS "${CMAKE_BINARY_DIR}/Bin/TestHarnessRunner"
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "\.*64Bit\.*.asm$$")
 
-add_custom_target(
-  asm_tests
+add_custom_target(asm_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   DEPENDS asm_files

--- a/unittests/FEXLinuxTests/CMakeLists.txt
+++ b/unittests/FEXLinuxTests/CMakeLists.txt
@@ -8,8 +8,7 @@ ExternalProject_Add(FEXLinuxTests
   "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${X86_64_TOOLCHAIN_FILE}"
   "-DBITNESS=64"
   INSTALL_COMMAND ""
-  BUILD_ALWAYS ON
-  )
+  BUILD_ALWAYS ON)
 
 ExternalProject_Add(FEXLinuxTests_32
   PREFIX FEXLinuxTests_32
@@ -20,8 +19,7 @@ ExternalProject_Add(FEXLinuxTests_32
   "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${X86_32_TOOLCHAIN_FILE}"
   "-DBITNESS=32"
   INSTALL_COMMAND ""
-  BUILD_ALWAYS ON
-  )
+  BUILD_ALWAYS ON)
 
 # this kind of sucks, but reglob
 file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS tests/*.cpp)
@@ -95,28 +93,22 @@ if(TEST thunk_testlib.64.jit.flt)
 endif()
 
 # Only emulated
-add_custom_target(
-  fex_linux_tests
+add_custom_target(fex_linux_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "30" ${TEST_JOB_FLAG} "-R" "\.*\.jit\.flt$$"
-  DEPENDS FEXLinuxTests FEXLinuxTests_32 FEX
-  )
+  DEPENDS FEXLinuxTests FEXLinuxTests_32 FEX)
 
 # Only host
-add_custom_target(
-  fex_linux_tests_host
+add_custom_target(fex_linux_tests_host
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "30" ${TEST_JOB_FLAG} "-R" "\.*\.host\.flt$$"
-  DEPENDS FEXLinuxTests FEXLinuxTests_32
-  )
+  DEPENDS FEXLinuxTests FEXLinuxTests_32)
 
 # Both host and emulated
-add_custom_target(
-  fex_linux_tests_all
+add_custom_target(fex_linux_tests_all
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "30" ${TEST_JOB_FLAG} "-R" "\.*\.flt$$"
-  DEPENDS FEXLinuxTests FEXLinuxTests_32 FEX
-  )
+  DEPENDS FEXLinuxTests FEXLinuxTests_32 FEX)

--- a/unittests/InstructionCountCI/CMakeLists.txt
+++ b/unittests/InstructionCountCI/CMakeLists.txt
@@ -25,9 +25,9 @@ foreach(JSON_SRC ${JSON_SOURCES})
   list(APPEND JSON_DEPENDS "${OUTPUT_JSON_NAME}")
 
   if (NOT MINGW_BUILD)
-    set (LAUNCH_PROGRAM "${CMAKE_BINARY_DIR}/Bin/CodeSizeValidation")
+    set(LAUNCH_PROGRAM "${CMAKE_BINARY_DIR}/Bin/CodeSizeValidation")
   else()
-    set (LAUNCH_PROGRAM "wine" "${CMAKE_BINARY_DIR}/Bin/CodeSizeValidation.exe")
+    set(LAUNCH_PROGRAM "wine" "${CMAKE_BINARY_DIR}/Bin/CodeSizeValidation.exe")
   endif()
 
   file(RELATIVE_PATH JSON_PATH_RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${JSON_SRC})
@@ -49,15 +49,13 @@ endforeach()
 add_custom_target(instcountci_test_files ALL
   DEPENDS "${JSON_DEPENDS}")
 
-add_custom_target(
-  instcountci_tests
+add_custom_target(instcountci_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   DEPENDS instcountci_test_files
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "InstCountCI/\.*.instcountci$$")
 
-add_custom_target(
-  instcountci_update_tests
+add_custom_target(instcountci_update_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "InstCountCI/\.*new_numbers$$")

--- a/unittests/POSIX/CMakeLists.txt
+++ b/unittests/POSIX/CMakeLists.txt
@@ -23,8 +23,7 @@ foreach(POSIX_TEST ${POSIX_TESTS})
   set_property(TEST "${TEST_NAME}.jit.posix" APPEND PROPERTY ENVIRONMENT "FEX_OUTPUTLOG=stderr;FEX_SILENTLOG=0;FEX_MAXINST=500")
 endforeach()
 
-add_custom_target(
-  posix_tests
+add_custom_target(posix_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "\.*.posix")

--- a/unittests/ThunkFunctionalTests/CMakeLists.txt
+++ b/unittests/ThunkFunctionalTests/CMakeLists.txt
@@ -2,9 +2,9 @@ set(FUNCTIONAL_DEPENDS "")
 
 function(AddThunksTest Bin ThunksFile)
   if (NOT ThunksFile)
-    set (TEST_NAME ThunkFunctionalTest-NoThunks-${Bin})
+    set(TEST_NAME ThunkFunctionalTest-NoThunks-${Bin})
   else()
-    set (TEST_NAME ThunkFunctionalTest-Thunks-${Bin})
+    set(TEST_NAME ThunkFunctionalTest-Thunks-${Bin})
   endif()
 
   add_test(NAME ${TEST_NAME}
@@ -28,22 +28,19 @@ endfunction()
 AddTest("/usr/bin/glxinfo" "GLThunks.json")
 AddTest("/usr/bin/vulkaninfo" "VulkanThunks.json")
 
-add_custom_target(
-  thunk_functional_tests_nothunks
+add_custom_target(thunk_functional_tests_nothunks
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "ThunkFunctionalTest-NoThunks-\.*"
   DEPENDS "${FUNCTIONAL_DEPENDS}")
 
-add_custom_target(
-  thunk_functional_tests_thunks
+add_custom_target(thunk_functional_tests_thunks
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "ThunkFunctionalTest-Thunks-\.*"
   DEPENDS "${FUNCTIONAL_DEPENDS}")
 
-add_custom_target(
-  thunk_functional_tests
+add_custom_target(thunk_functional_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "ThunkFunctionalTest\.*"

--- a/unittests/ThunkLibs/CMakeLists.txt
+++ b/unittests/ThunkLibs/CMakeLists.txt
@@ -4,8 +4,7 @@ target_link_libraries(thunkgentest PRIVATE fmt::fmt)
 target_link_libraries(thunkgentest PRIVATE thunkgenlib)
 catch_discover_tests(thunkgentest TEST_SUFFIX ".ThunkGen")
 
-add_custom_target(
-  thunkgen_tests
+add_custom_target(thunkgen_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "\.*.ThunkGen")

--- a/unittests/Utilities/CMakeLists.txt
+++ b/unittests/Utilities/CMakeLists.txt
@@ -1,9 +1,7 @@
-add_executable(DeleteOldSHMRegions
-  DeleteOldSHMRegions.cpp)
+add_executable(DeleteOldSHMRegions DeleteOldSHMRegions.cpp)
 
 set_target_properties(DeleteOldSHMRegions PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/TestUtilities")
-add_custom_target(
-  remove_old_shm_regions
+add_custom_target(remove_old_shm_regions
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/TestUtilities/"
   USES_TERMINAL
   COMMAND "DeleteOldSHMRegions")

--- a/unittests/gcc-target-tests-32/CMakeLists.txt
+++ b/unittests/gcc-target-tests-32/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # Careful. Globbing can't see changes to the contents of files
 # Need to do a fresh clean to see changes
 file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/External/fex-gcc-target-tests-bins/32/*)
@@ -29,8 +28,7 @@ foreach(TEST ${TESTS})
   endforeach()
 endforeach()
 
-add_custom_target(
-  gcc_target_tests_32
+add_custom_target(gcc_target_tests_32
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "40" ${TEST_JOB_FLAG} "-R" "\.*.gcc-target-32$$")

--- a/unittests/gcc-target-tests-64/CMakeLists.txt
+++ b/unittests/gcc-target-tests-64/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # Careful. Globbing can't see changes to the contents of files
 # Need to do a fresh clean to see changes
 file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/External/fex-gcc-target-tests-bins/64/*)
@@ -29,8 +28,7 @@ foreach(TEST ${TESTS})
   endforeach()
 endforeach()
 
-add_custom_target(
-  gcc_target_tests_64
+add_custom_target(gcc_target_tests_64
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "40" ${TEST_JOB_FLAG} "-R" "\.*.gcc-target-64$$")

--- a/unittests/gvisor-tests/CMakeLists.txt
+++ b/unittests/gvisor-tests/CMakeLists.txt
@@ -1,10 +1,8 @@
-
 # Careful. Globbing can't see changes to the contents of files
 # Need to do a fresh clean to see changes
 file(GLOB_RECURSE TESTS CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/External/fex-gvisor-tests-bins/*_test)
 
 foreach(TEST ${TESTS})
-
   string(REPLACE "/fex-gvisor-tests-bins/" ";" TEST_NAME_LIST ${TEST})
   list(GET TEST_NAME_LIST 1 TEST_NAME)
   string(REPLACE "/" "-" TEST_NAME ${TEST_NAME})
@@ -25,8 +23,7 @@ endforeach()
 
 set(RM_DIR_COMMAND "rm $ENV{FEX_ROOTFS}/tmp 2> /dev/null || true")
 
-add_custom_target(
-  gvisor_tests
+add_custom_target(gvisor_tests
   VERBATIM
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL


### PR DESCRIPTION
I may have gotten carried away.

- I missed some stuff for end parenthesis because I accidentally
  searched within project files instead of the entire directory (so some
  thunk/test/windows stuff was missed), cleaned those up.
- `INTERFACE`, `PUBLIC`, `PRIVATE`, `RUNTIME`, `LIBRARY` should be on
  the same line as the target name. (I should really invest in making a
  style guide...)
- Some short statements were unnecessarily split across multiple
  lines--cleaned those up
- Made a common `LinkerGC` module that applies gc-sections etc. to a
  target in Release mode
- Usually for functions you want to have something on the first line,
  e.g. `FILES`/`DIRECTORY` for install, or the target/a positional
  argument, etc etc. Not always though, notably for some custom_command
  calls

TODO:
- What's with the `list(APPEND LIBS...)` stuff? It's used really
  inconsistently, sometimes not at all, sometimes it looks like there're
  duplicates? A more thorough cleanup is in order there.

Signed-off-by: crueter <crueter@eden-emu.dev>
