### PR TITLE
[cmake] Use a Find module for xxhash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,9 @@ set(CMAKE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_LINKER_FLAGS_RELWITHDEBINFO} -fno
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer")
 set(CMAKE_LINKER_FLAGS_RELEASE "${CMAKE_LINKER_FLAGS_RELEASE} -fomit-frame-pointer")
 
+## Modules ##
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMakeModules/)
+
 include_directories(External/robin-map/include/)
 
 include(CTest)
@@ -325,10 +328,8 @@ find_package(Python 3.9 REQUIRED COMPONENTS Interpreter)
 
 set(BUILD_SHARED_LIBS OFF)
 
-pkg_search_module(xxhash IMPORTED_TARGET xxhash libxxhash)
-if (TARGET PkgConfig::xxhash AND NOT CMAKE_CROSSCOMPILING)
-  add_library(xxHash::xxhash ALIAS PkgConfig::xxhash)
-else()
+find_package(xxhash MODULE QUIET)
+if (NOT TARGET xxHash::xxhash)
   set(XXHASH_BUNDLED_MODE TRUE)
   set(XXHASH_BUILD_XXHSUM FALSE)
   add_subdirectory(External/xxhash/cmake_unofficial/)

--- a/CMakeModules/Findxxhash.cmake
+++ b/CMakeModules/Findxxhash.cmake
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+
+include(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig QUIET)
+pkg_search_module(xxhash QUIET IMPORTED_TARGET xxhash libxxhash)
+find_package_handle_standard_args(xxhash
+    REQUIRED_VARS xxhash_LINK_LIBRARIES
+    VERSION_VAR xxhash_VERSION
+)
+
+if (xxhash_FOUND AND NOT TARGET xxHash::xxhash)
+    if (TARGET PkgConfig::xxhash)
+        add_library(xxHash::xxhash ALIAS PkgConfig::xxhash)
+    else()
+        add_library(xxHash::xxhash ALIAS xxhash)
+    endif()
+endif()


### PR DESCRIPTION
Port of #5159

Find modules are preferred for pkgconfig/otherwise non-CMake libraries.
Let's use that here for xxHash.

Signed-off-by: crueter <crueter@eden-emu.dev>
