### PR TITLE
FEXCore: Switch constant emission to default to `NoPad`

### DIFF
--- a/FEXCore/Source/Interface/Core/Addressing.cpp
+++ b/FEXCore/Source/Interface/Core/Addressing.cpp
@@ -11,7 +11,7 @@ Ref LoadEffectiveAddress(IREmitter* IREmit, const AddressMode& A, IR::OpSize GPR
   Ref Tmp = A.Base;
 
   if (A.Offset) {
-    Tmp = Tmp ? IREmit->Add(GPRSize, Tmp, A.Offset) : IREmit->Constant(A.Offset, IR::ConstPad::NoPad);
+    Tmp = Tmp ? IREmit->Add(GPRSize, Tmp, A.Offset) : IREmit->Constant(A.Offset);
   }
 
   if (A.Index) {
@@ -21,7 +21,7 @@ Ref LoadEffectiveAddress(IREmitter* IREmit, const AddressMode& A, IR::OpSize GPR
       if (Tmp) {
         Tmp = IREmit->_AddShift(GPRSize, Tmp, A.Index, ShiftType::LSL, Log2);
       } else {
-        Tmp = IREmit->_Lshl(GPRSize, A.Index, IREmit->Constant(Log2, IR::ConstPad::NoPad));
+        Tmp = IREmit->_Lshl(GPRSize, A.Index, IREmit->Constant(Log2));
       }
     } else {
       Tmp = Tmp ? IREmit->Add(GPRSize, Tmp, A.Index) : A.Index;
@@ -40,7 +40,7 @@ Ref LoadEffectiveAddress(IREmitter* IREmit, const AddressMode& A, IR::OpSize GPR
     } else if (A.Offset) {
       uint64_t X = A.Offset;
       X &= (1ull << Bits) - 1;
-      Tmp = IREmit->Constant(X, IR::ConstPad::NoPad);
+      Tmp = IREmit->Constant(X);
     }
   }
 
@@ -48,7 +48,7 @@ Ref LoadEffectiveAddress(IREmitter* IREmit, const AddressMode& A, IR::OpSize GPR
     Tmp = Tmp ? IREmit->Add(GPRSize, Tmp, A.Segment) : A.Segment;
   }
 
-  return Tmp ?: IREmit->Constant(0, IR::ConstPad::NoPad);
+  return Tmp ?: IREmit->Constant(0);
 }
 
 AddressMode SelectAddressMode(IREmitter* IREmit, const AddressMode& A, IR::OpSize GPRSize, bool HostSupportsTSOImm9, bool AtomicTSO,
@@ -102,7 +102,7 @@ AddressMode SelectAddressMode(IREmitter* IREmit, const AddressMode& A, IR::OpSiz
 
     return {
       .Base = LoadEffectiveAddress(IREmit, B, GPRSize, true /* AddSegmentBase */, false),
-      .Index = IREmit->Constant(A.Offset, ConstPad::NoPad),
+      .Index = IREmit->Constant(A.Offset),
       .IndexType = MemOffsetType::SXTX,
       .IndexScale = 1,
     };
@@ -135,7 +135,7 @@ AddressMode SelectAddressMode(IREmitter* IREmit, const AddressMode& A, IR::OpSiz
 
         return {
           .Base = LoadEffectiveAddress(IREmit, B, GPRSize, true /* AddSegmentBase */, false),
-          .Index = IREmit->Constant(A.Offset, ConstPad::NoPad),
+          .Index = IREmit->Constant(A.Offset),
           .IndexType = MemOffsetType::SXTX,
           .IndexScale = 1,
         };

--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -117,7 +117,7 @@ public:
     // Choose to pad or not depending on if code-caching is enabled.
     AUTOPAD,
   };
-  void LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, uint64_t Constant, PadType Pad, int MaxBytes = 0);
+  void LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, uint64_t Constant, PadType Pad = PadType::NOPAD, int MaxBytes = 0);
 
 protected:
   FEXCore::Context::ContextImpl* EmitterCTX;

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -970,15 +970,13 @@ void ContextImpl::AddThunkTrampolineIRHandler(uintptr_t Entrypoint, uintptr_t Gu
 
       // Thunk entry-points don't get cached, don't need to be padded.
       if (GPRSize == IR::OpSize::i64Bit) {
-        IR::Ref R = emit->_StoreRegister(emit->Constant(Entrypoint, IR::ConstPad::NoPad), GPRSize);
+        IR::Ref R = emit->_StoreRegister(emit->Constant(Entrypoint), GPRSize);
         R->Reg = IR::PhysicalRegister(IR::RegClass::GPRFixed, X86State::REG_R11).Raw;
       } else {
-        emit->_StoreContextFPR(GPRSize,
-                               emit->_VCastFromGPR(IR::OpSize::i64Bit, IR::OpSize::i64Bit, emit->Constant(Entrypoint, IR::ConstPad::NoPad)),
+        emit->_StoreContextFPR(GPRSize, emit->_VCastFromGPR(IR::OpSize::i64Bit, IR::OpSize::i64Bit, emit->Constant(Entrypoint)),
                                offsetof(Core::CPUState, mm[0][0]));
       }
-      emit->_ExitFunction(IR::OpSize::i64Bit, emit->Constant(GuestThunkEntrypoint, IR::ConstPad::NoPad), IR::BranchHint::None,
-                          emit->Invalid(), emit->Invalid());
+      emit->_ExitFunction(IR::OpSize::i64Bit, emit->Constant(GuestThunkEntrypoint), IR::BranchHint::None, emit->Invalid(), emit->Invalid());
     },
     ThunkHandler, (void*)GuestThunkEntrypoint);
 

--- a/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/Dispatcher/Dispatcher.cpp
@@ -188,7 +188,7 @@ void Dispatcher::EmitDispatcher() {
     if (std::popcount(VirtualMemorySize) == 1) {
       and_(ARMEmitter::Size::i64Bit, TMP4, RipReg.R(), VirtualMemorySize - 1);
     } else {
-      LoadConstant(ARMEmitter::Size::i64Bit, TMP4, VirtualMemorySize, CPU::Arm64Emitter::PadType::NOPAD);
+      LoadConstant(ARMEmitter::Size::i64Bit, TMP4, VirtualMemorySize);
       and_(ARMEmitter::Size::i64Bit, TMP4, RipReg.R(), TMP4);
     }
 
@@ -261,7 +261,7 @@ void Dispatcher::EmitDispatcher() {
 
 #ifdef _M_ARM_64EC
     ldr(TMP2, ARMEmitter::XReg::x18, TEB_CPU_AREA_OFFSET);
-    LoadConstant(ARMEmitter::Size::i32Bit, TMP1, 1, CPU::Arm64Emitter::PadType::NOPAD);
+    LoadConstant(ARMEmitter::Size::i32Bit, TMP1, 1);
     strb(TMP1.W(), TMP2, CPU_AREA_IN_SYSCALL_CALLBACK_OFFSET);
 #endif
 
@@ -429,7 +429,7 @@ void Dispatcher::EmitDispatcher() {
       PopCalleeSavedRegisters();
       ret();
     } else {
-      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, 0, CPU::Arm64Emitter::PadType::NOPAD);
+      LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, 0);
       ldr(ARMEmitter::XReg::x1, ARMEmitter::Reg::r1);
     }
   }
@@ -488,7 +488,7 @@ void Dispatcher::EmitDispatcher() {
 
     // Now push the callback return trampoline to the guest stack
     // Guest will be misaligned because calling a thunk won't correct the guest's stack once we call the callback from the host
-    LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, CTX->SignalDelegation->GetThunkCallbackRET(), CPU::Arm64Emitter::PadType::NOPAD);
+    LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, CTX->SignalDelegation->GetThunkCallbackRET());
 
     ldr(ARMEmitter::XReg::x2, STATE_PTR(CpuStateFrame, State.gregs[X86State::REG_RSP]));
     sub(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r2, ARMEmitter::Reg::r2, CTX->Config.Is64BitMode ? 16 : 12);

--- a/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
@@ -1297,7 +1297,7 @@ DEF_OP(MaskGenerateFromBitWidth) {
   auto Op = IROp->C<IR::IROp_MaskGenerateFromBitWidth>();
   auto BitWidth = GetReg(Op->BitWidth);
 
-  LoadConstant(ARMEmitter::Size::i64Bit, TMP1, -1, CPU::Arm64Emitter::PadType::NOPAD);
+  LoadConstant(ARMEmitter::Size::i64Bit, TMP1, -1);
   cmp(ARMEmitter::Size::i64Bit, BitWidth, 0);
   lslv(ARMEmitter::Size::i64Bit, TMP2, TMP1, BitWidth);
   csinv(ARMEmitter::Size::i64Bit, GetReg(Node), TMP1, TMP2, ARMEmitter::Condition::CC_EQ);

--- a/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
@@ -271,7 +271,7 @@ DEF_OP(Syscall) {
   // Still without overwriting registers that matter
   // 16bit LoadConstant to be a single instruction
   // This gives the signal handler a value to check to see if we are in a syscall at all
-  LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, GPRSpillMask & 0xFFFF, CPU::Arm64Emitter::PadType::NOPAD);
+  LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, GPRSpillMask & 0xFFFF);
   str(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CpuStateFrame, InSyscallInfo));
 
   uint64_t SPOffset = AlignUp(FEXCore::HLE::SyscallArguments::MAX_ARGS * 8, 16);
@@ -362,29 +362,29 @@ DEF_OP(ValidateCode) {
 
   EmitCheck(8, [&]() {
     ldr(TMP1, Base, Offset);
-    LoadConstant(ARMEmitter::Size::i64Bit, TMP2, *(const uint64_t*)(OldCode + Offset), CPU::Arm64Emitter::PadType::NOPAD);
+    LoadConstant(ARMEmitter::Size::i64Bit, TMP2, *(const uint64_t*)(OldCode + Offset));
   });
 
   EmitCheck(4, [&]() {
     ldr(TMP1.W(), Base, Offset);
-    LoadConstant(ARMEmitter::Size::i32Bit, TMP2, *(const uint32_t*)(OldCode + Offset), CPU::Arm64Emitter::PadType::NOPAD);
+    LoadConstant(ARMEmitter::Size::i32Bit, TMP2, *(const uint32_t*)(OldCode + Offset));
   });
 
   EmitCheck(2, [&]() {
     ldrh(TMP1.W(), Base, Offset);
-    LoadConstant(ARMEmitter::Size::i32Bit, TMP2, *(const uint16_t*)(OldCode + Offset), CPU::Arm64Emitter::PadType::NOPAD);
+    LoadConstant(ARMEmitter::Size::i32Bit, TMP2, *(const uint16_t*)(OldCode + Offset));
   });
 
   EmitCheck(1, [&]() {
     ldrb(TMP1.W(), Base, Offset);
-    LoadConstant(ARMEmitter::Size::i32Bit, TMP2, *(const uint8_t*)(OldCode + Offset), CPU::Arm64Emitter::PadType::NOPAD);
+    LoadConstant(ARMEmitter::Size::i32Bit, TMP2, *(const uint8_t*)(OldCode + Offset));
   });
 
   ARMEmitter::ForwardLabel End;
-  LoadConstant(ARMEmitter::Size::i32Bit, Dst, 0, CPU::Arm64Emitter::PadType::NOPAD);
+  LoadConstant(ARMEmitter::Size::i32Bit, Dst, 0);
   b_OrRestart(&End);
   BindOrRestart(&Fail);
-  LoadConstant(ARMEmitter::Size::i32Bit, Dst, 1, CPU::Arm64Emitter::PadType::NOPAD);
+  LoadConstant(ARMEmitter::Size::i32Bit, Dst, 1);
   BindOrRestart(&End);
 }
 

--- a/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/EncryptionOps.cpp
@@ -135,7 +135,7 @@ DEF_OP(VAESKeyGenAssist) {
   if (Op->RCON) {
     tbl(Dst.Q(), Dst.Q(), Swizzle.Q());
 
-    LoadConstant(ARMEmitter::Size::i64Bit, TMP1, static_cast<uint64_t>(Op->RCON) << 32, CPU::Arm64Emitter::PadType::NOPAD);
+    LoadConstant(ARMEmitter::Size::i64Bit, TMP1, static_cast<uint64_t>(Op->RCON) << 32);
     dup(ARMEmitter::SubRegSize::i64Bit, VTMP2.Q(), TMP1);
     eor(Dst.Q(), Dst.Q(), VTMP2.Q());
   } else {

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -758,14 +758,14 @@ void Arm64JITCore::EmitTFCheck() {
   uint64_t Constant {};
   memcpy(&Constant, &State, sizeof(State));
 
-  LoadConstant(ARMEmitter::Size::i64Bit, TMP1, Constant, CPU::Arm64Emitter::PadType::NOPAD);
+  LoadConstant(ARMEmitter::Size::i64Bit, TMP1, Constant);
   str(TMP1, STATE, offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData));
   ldr(TMP1, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.Common.GuestSignal_SIGTRAP));
   br(TMP1);
 
   (void)Bind(&l_TFBlocked);
   // If TF was blocked for this instruction, unblock it for the next.
-  LoadConstant(ARMEmitter::Size::i32Bit, TMP1, 0b11, CPU::Arm64Emitter::PadType::NOPAD);
+  LoadConstant(ARMEmitter::Size::i32Bit, TMP1, 0b11);
   strb(TMP1, STATE_PTR(CpuStateFrame, State.flags[X86State::RFLAG_TF_RAW_LOC]));
   (void)Bind(&l_TFUnset);
 }
@@ -805,7 +805,7 @@ void Arm64JITCore::EmitEntryPoint(ARMEmitter::BackwardLabel& HeaderLabel, bool C
     if (ARMEmitter::IsImmAddSub(TotalSpillSlotsSize)) {
       sub(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::rsp, ARMEmitter::Reg::rsp, TotalSpillSlotsSize);
     } else {
-      LoadConstant(ARMEmitter::Size::i64Bit, TMP1, TotalSpillSlotsSize, CPU::Arm64Emitter::PadType::NOPAD);
+      LoadConstant(ARMEmitter::Size::i64Bit, TMP1, TotalSpillSlotsSize);
       sub(ARMEmitter::Size::i64Bit, ARMEmitter::XReg::rsp, ARMEmitter::XReg::rsp, TMP1, ARMEmitter::ExtendedType::LSL_64, 0);
     }
   }
@@ -1163,7 +1163,7 @@ void Arm64JITCore::ResetStack() {
     add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::rsp, ARMEmitter::Reg::rsp, TotalSpillSlotsSize);
   } else {
     // Too big to fit in a 12bit immediate
-    LoadConstant(ARMEmitter::Size::i64Bit, TMP1, TotalSpillSlotsSize, CPU::Arm64Emitter::PadType::NOPAD);
+    LoadConstant(ARMEmitter::Size::i64Bit, TMP1, TotalSpillSlotsSize);
     add(ARMEmitter::Size::i64Bit, ARMEmitter::XReg::rsp, ARMEmitter::XReg::rsp, TMP1, ARMEmitter::ExtendedType::LSL_64, 0);
   }
 }

--- a/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
@@ -378,7 +378,7 @@ DEF_OP(SpillRegister) {
     switch (OpSize) {
     case IR::OpSize::i8Bit: {
       if (SlotOffset > LSByteMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         strb(Src, ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         strb(Src, ARMEmitter::Reg::rsp, SlotOffset);
@@ -387,7 +387,7 @@ DEF_OP(SpillRegister) {
     }
     case IR::OpSize::i16Bit: {
       if (SlotOffset > LSHalfMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         strh(Src, ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         strh(Src, ARMEmitter::Reg::rsp, SlotOffset);
@@ -396,7 +396,7 @@ DEF_OP(SpillRegister) {
     }
     case IR::OpSize::i32Bit: {
       if (SlotOffset > LSWordMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         str(Src.W(), ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         str(Src.W(), ARMEmitter::Reg::rsp, SlotOffset);
@@ -405,7 +405,7 @@ DEF_OP(SpillRegister) {
     }
     case IR::OpSize::i64Bit: {
       if (SlotOffset > LSDWordMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         str(Src.X(), ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         str(Src.X(), ARMEmitter::Reg::rsp, SlotOffset);
@@ -420,7 +420,7 @@ DEF_OP(SpillRegister) {
     switch (OpSize) {
     case IR::OpSize::i32Bit: {
       if (SlotOffset > LSWordMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         str(Src.S(), ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         str(Src.S(), ARMEmitter::Reg::rsp, SlotOffset);
@@ -429,7 +429,7 @@ DEF_OP(SpillRegister) {
     }
     case IR::OpSize::i64Bit: {
       if (SlotOffset > LSDWordMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         str(Src.D(), ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         str(Src.D(), ARMEmitter::Reg::rsp, SlotOffset);
@@ -438,7 +438,7 @@ DEF_OP(SpillRegister) {
     }
     case IR::OpSize::i128Bit: {
       if (SlotOffset > LSQWordMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         str(Src.Q(), ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         str(Src.Q(), ARMEmitter::Reg::rsp, SlotOffset);
@@ -467,7 +467,7 @@ DEF_OP(FillRegister) {
     switch (OpSize) {
     case IR::OpSize::i8Bit: {
       if (SlotOffset > LSByteMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         ldrb(Dst, ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         ldrb(Dst, ARMEmitter::Reg::rsp, SlotOffset);
@@ -476,7 +476,7 @@ DEF_OP(FillRegister) {
     }
     case IR::OpSize::i16Bit: {
       if (SlotOffset > LSHalfMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         ldrh(Dst, ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         ldrh(Dst, ARMEmitter::Reg::rsp, SlotOffset);
@@ -485,7 +485,7 @@ DEF_OP(FillRegister) {
     }
     case IR::OpSize::i32Bit: {
       if (SlotOffset > LSWordMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         ldr(Dst.W(), ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         ldr(Dst.W(), ARMEmitter::Reg::rsp, SlotOffset);
@@ -494,7 +494,7 @@ DEF_OP(FillRegister) {
     }
     case IR::OpSize::i64Bit: {
       if (SlotOffset > LSDWordMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         ldr(Dst.X(), ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         ldr(Dst.X(), ARMEmitter::Reg::rsp, SlotOffset);
@@ -509,7 +509,7 @@ DEF_OP(FillRegister) {
     switch (OpSize) {
     case IR::OpSize::i32Bit: {
       if (SlotOffset > LSWordMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         ldr(Dst.S(), ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         ldr(Dst.S(), ARMEmitter::Reg::rsp, SlotOffset);
@@ -518,7 +518,7 @@ DEF_OP(FillRegister) {
     }
     case IR::OpSize::i64Bit: {
       if (SlotOffset > LSDWordMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         ldr(Dst.D(), ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         ldr(Dst.D(), ARMEmitter::Reg::rsp, SlotOffset);
@@ -527,7 +527,7 @@ DEF_OP(FillRegister) {
     }
     case IR::OpSize::i128Bit: {
       if (SlotOffset > LSQWordMaxUnsignedOffset) {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, SlotOffset);
         ldr(Dst.Q(), ARMEmitter::Reg::rsp, TMP1.R(), ARMEmitter::ExtendedType::LSL_64, 0);
       } else {
         ldr(Dst.Q(), ARMEmitter::Reg::rsp, SlotOffset);
@@ -609,7 +609,7 @@ ARMEmitter::Register Arm64JITCore::ApplyMemOperand(IR::OpSize AccessSize, ARMEmi
     if (Const == 0) {
       return Base;
     }
-    LoadConstant(ARMEmitter::Size::i64Bit, Tmp, Const, CPU::Arm64Emitter::PadType::NOPAD);
+    LoadConstant(ARMEmitter::Size::i64Bit, Tmp, Const);
     add(ARMEmitter::Size::i64Bit, Tmp, Base, Tmp, ARMEmitter::ShiftType::LSL, FEXCore::ilog2(OffsetScale));
   } else {
     auto RegOffset = GetReg(Offset);
@@ -1213,7 +1213,7 @@ DEF_OP(VLoadVectorGatherMasked) {
         AddrReg = GetReg(Op->AddrBase);
       } else {
         ///< OpcodeDispatcher didn't provide a Base address while SVE requires one.
-        LoadConstant(ARMEmitter::Size::i64Bit, AddrReg, 0, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, AddrReg, 0);
       }
       MemDst = ARMEmitter::SVEMemOperand(AddrReg.X(), VectorIndexLow.Z(), ModType, SVEScale);
     }
@@ -1299,7 +1299,7 @@ DEF_OP(VLoadVectorGatherMaskedQPS) {
           AddrReg = *BaseAddr;
         } else {
           ///< OpcodeDispatcher didn't provide a Base address while SVE requires one.
-          LoadConstant(ARMEmitter::Size::i64Bit, AddrReg, 0, CPU::Arm64Emitter::PadType::NOPAD);
+          LoadConstant(ARMEmitter::Size::i64Bit, AddrReg, 0);
         }
         MemDst = ARMEmitter::SVEMemOperand(AddrReg.X(), VectorIndex.Z(), ModType, SVEScale);
       }

--- a/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
@@ -73,7 +73,7 @@ DEF_OP(Break) {
   uint64_t Constant {};
   memcpy(&Constant, &State, sizeof(State));
 
-  LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, Constant, CPU::Arm64Emitter::PadType::NOPAD);
+  LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, Constant);
   str(ARMEmitter::XReg::x1, STATE, offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData));
 
   switch (Op->Reason.Signal) {
@@ -234,7 +234,7 @@ DEF_OP(ProcessorID) {
   // 16bit LoadConstant to be a single instruction
   // We must always spill at least one register (x8) so this value always has a bit set
   // This gives the signal handler a value to check to see if we are in a syscall at all
-  LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, SpillMask & 0xFFFF, CPU::Arm64Emitter::PadType::NOPAD);
+  LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, SpillMask & 0xFFFF);
   str(ARMEmitter::XReg::x0, STATE, offsetof(FEXCore::Core::CpuStateFrame, InSyscallInfo));
 
   // Allocate some temporary space for storing the uint32_t CPU and Node IDs
@@ -247,7 +247,7 @@ DEF_OP(ProcessorID) {
 #else
   constexpr auto GetCPUSyscallNum = SYS_getcpu;
 #endif
-  LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r8, GetCPUSyscallNum, CPU::Arm64Emitter::PadType::NOPAD);
+  LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r8, GetCPUSyscallNum);
 
   // CPU pointer in x0
   add(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r0, ARMEmitter::Reg::rsp, 0);
@@ -307,7 +307,7 @@ DEF_OP(MonoBackpatcherWrite) {
 
 #ifdef _M_ARM_64EC
   ldr(TMP2, ARMEmitter::XReg::x18, TEB_CPU_AREA_OFFSET);
-  LoadConstant(ARMEmitter::Size::i32Bit, TMP1, 1, CPU::Arm64Emitter::PadType::NOPAD);
+  LoadConstant(ARMEmitter::Size::i32Bit, TMP1, 1);
   strb(TMP1.W(), TMP2, CPU_AREA_IN_SYSCALL_CALLBACK_OFFSET);
 #endif
 

--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -939,7 +939,7 @@ DEF_OP(VectorImm) {
     LOGMAN_THROW_A_FMT(Op->ShiftAmount == 0, "SVE VectorImm doesn't support a shift");
     if (ElementSize > IR::OpSize::i8Bit && (Op->Immediate & 0x80)) {
       // SVE dup uses sign extension where VectorImm wants zext
-      LoadConstant(ARMEmitter::Size::i64Bit, TMP1, Op->Immediate, CPU::Arm64Emitter::PadType::NOPAD);
+      LoadConstant(ARMEmitter::Size::i64Bit, TMP1, Op->Immediate);
       dup(SubRegSize, Dst.Z(), TMP1);
     } else {
       dup_imm(SubRegSize, Dst.Z(), static_cast<int8_t>(Op->Immediate));
@@ -947,7 +947,7 @@ DEF_OP(VectorImm) {
   } else {
     if (ElementSize == IR::OpSize::i64Bit) {
       // movi with 64bit element size doesn't do what we want here
-      LoadConstant(ARMEmitter::Size::i64Bit, TMP1, static_cast<uint64_t>(Op->Immediate) << Op->ShiftAmount, CPU::Arm64Emitter::PadType::NOPAD);
+      LoadConstant(ARMEmitter::Size::i64Bit, TMP1, static_cast<uint64_t>(Op->Immediate) << Op->ShiftAmount);
       dup(SubRegSize, Dst.Q(), TMP1.R());
     } else {
       movi(SubRegSize, Dst.Q(), Op->Immediate, Op->ShiftAmount);
@@ -2521,7 +2521,7 @@ DEF_OP(VUShl) {
         movi(SubRegSize, VTMP1.Q(), MaxShift);
         umin(SubRegSize, VTMP1.Q(), VTMP1.Q(), ShiftVector.Q());
       } else {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, MaxShift, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, MaxShift);
         dup(SubRegSize, VTMP1.Q(), TMP1.R());
 
         // UMIN is silly on Adv.SIMD and doesn't have a variant that handles 64-bit elements
@@ -2577,7 +2577,7 @@ DEF_OP(VUShr) {
         movi(SubRegSize, VTMP1.Q(), MaxShift);
         umin(SubRegSize, VTMP1.Q(), VTMP1.Q(), ShiftVector.Q());
       } else {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, MaxShift, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, MaxShift);
         dup(SubRegSize, VTMP1.Q(), TMP1.R());
 
         // UMIN is silly on Adv.SIMD and doesn't have a variant that handles 64-bit elements
@@ -2636,7 +2636,7 @@ DEF_OP(VSShr) {
         movi(SubRegSize, VTMP1.Q(), MaxShift);
         umin(SubRegSize, VTMP1.Q(), VTMP1.Q(), ShiftVector.Q());
       } else {
-        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, MaxShift, CPU::Arm64Emitter::PadType::NOPAD);
+        LoadConstant(ARMEmitter::Size::i64Bit, TMP1, MaxShift);
         dup(SubRegSize, VTMP1.Q(), TMP1.R());
 
         // UMIN is silly on Adv.SIMD and doesn't have a variant that handles 64-bit elements

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -845,7 +845,7 @@ void OpDispatchBuilder::AVX128_MOVMSK(OpcodeArgs, IR::OpSize ElementSize) {
     // Inserting the full lower 32-bits offset 31 so the sign bit ends up at offset 63.
     GPR = _Bfi(OpSize::i64Bit, 32, 31, GPR, GPR);
     // Shift right to only get the two sign bits we care about.
-    return _Lshr(OpSize::i64Bit, GPR, Constant(62, ConstPad::NoPad));
+    return _Lshr(OpSize::i64Bit, GPR, Constant(62));
   };
 
   auto Mask4Byte = [this](Ref Src) {
@@ -1838,7 +1838,7 @@ void OpDispatchBuilder::AVX128_VPERMD(OpcodeArgs) {
   RefPair Result {};
 
   Ref IndexMask = _VectorImm(OpSize::i128Bit, OpSize::i32Bit, 0b111);
-  Ref AddConst = Constant(0x03020100, ConstPad::NoPad);
+  Ref AddConst = Constant(0x03020100);
   Ref Repeating3210 = _VDupFromGPR(OpSize::i128Bit, OpSize::i32Bit, AddConst);
 
   Result.Low = DoPerm(Src, Indices.Low, IndexMask, Repeating3210);
@@ -2035,7 +2035,7 @@ OpDispatchBuilder::RefPair OpDispatchBuilder::AVX128_VPGatherImpl(OpcodeArgs, Op
   if (BaseAddr && VSIB.Displacement) {
     BaseAddr = Add(OpSize::i64Bit, BaseAddr, VSIB.Displacement);
   } else if (VSIB.Displacement) {
-    BaseAddr = Constant(VSIB.Displacement, ConstPad::NoPad);
+    BaseAddr = Constant(VSIB.Displacement);
   } else if (!BaseAddr) {
     BaseAddr = Invalid();
   }
@@ -2133,7 +2133,7 @@ OpDispatchBuilder::RefPair OpDispatchBuilder::AVX128_VPGatherQPSImpl(OpcodeArgs,
   if (BaseAddr && VSIB.Displacement) {
     BaseAddr = Add(OpSize::i64Bit, BaseAddr, VSIB.Displacement);
   } else if (VSIB.Displacement) {
-    BaseAddr = Constant(VSIB.Displacement, ConstPad::NoPad);
+    BaseAddr = Constant(VSIB.Displacement);
   } else if (!BaseAddr) {
     BaseAddr = Invalid();
   }

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -28,7 +28,7 @@ constexpr std::array<uint32_t, 17> FlagOffsets = {
 
 void OpDispatchBuilder::ZeroPF_AF() {
   // PF is stored inverted, so invert it when we zero.
-  SetRFLAG<FEXCore::X86State::RFLAG_PF_RAW_LOC>(Constant(1, ConstPad::NoPad));
+  SetRFLAG<FEXCore::X86State::RFLAG_PF_RAW_LOC>(Constant(1));
   SetAF(0);
 }
 
@@ -247,7 +247,7 @@ void OpDispatchBuilder::CalculateAF(Ref Src1, Ref Src2) {
   // We store the XOR of the arguments. At read time, we XOR with the
   // appropriate bit of the result (available as the PF flag) and extract the
   // appropriate bit. Again 64-bit to avoid masking.
-  Ref XorRes = Src1 == Src2 ? Constant(0, ConstPad::NoPad) : _Xor(OpSize::i64Bit, Src1, Src2);
+  Ref XorRes = Src1 == Src2 ? Constant(0) : _Xor(OpSize::i64Bit, Src1, Src2);
   SetRFLAG<FEXCore::X86State::RFLAG_AF_RAW_LOC>(XorRes);
 }
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -41,13 +41,13 @@ void OpDispatchBuilder::SetX87FTW(Ref FTW) {
 
   // Invert FTW and clear the odd bits. Even bits are 1 if the pair
   // is not equal to 11, and odd bits are 0.
-  FTW = _Andn(OpSize::i32Bit, Constant(0x55555555, ConstPad::NoPad), FTW);
+  FTW = _Andn(OpSize::i32Bit, Constant(0x55555555), FTW);
 
   // All that's left is to compact away the odd bits. That is a Morton
   // deinterleave operation, which has a standard solution. See
   // https://stackoverflow.com/questions/3137266/how-to-de-interleave-bits-unmortonizing
-  FTW = _And(OpSize::i32Bit, _Orlshr(OpSize::i32Bit, FTW, FTW, 1), Constant(0x33333333, ConstPad::NoPad));
-  FTW = _And(OpSize::i32Bit, _Orlshr(OpSize::i32Bit, FTW, FTW, 2), Constant(0x0f0f0f0f, ConstPad::NoPad));
+  FTW = _And(OpSize::i32Bit, _Orlshr(OpSize::i32Bit, FTW, FTW, 1), Constant(0x33333333));
+  FTW = _And(OpSize::i32Bit, _Orlshr(OpSize::i32Bit, FTW, FTW, 2), Constant(0x0f0f0f0f));
   FTW = _Orlshr(OpSize::i32Bit, FTW, FTW, 4);
 
   // ...and that's it. StoreContext implicitly does the final masking.
@@ -107,16 +107,16 @@ void OpDispatchBuilder::FILD(OpcodeArgs) {
   SaveNZCV();
 
   // Extract sign and make integer absolute
-  auto zero = Constant(0, ConstPad::NoPad);
+  auto zero = Constant(0);
   _SubNZCV(OpSize::i64Bit, Data, zero);
-  auto sign = _NZCVSelect(OpSize::i64Bit, CondClass::SLT, Constant(0x8000, ConstPad::NoPad), zero);
+  auto sign = _NZCVSelect(OpSize::i64Bit, CondClass::SLT, Constant(0x8000), zero);
   auto absolute = _Neg(OpSize::i64Bit, Data, CondClass::MI);
 
   // left justify the absolute integer
-  auto shift = Sub(OpSize::i64Bit, Constant(63, ConstPad::NoPad), _FindMSB(IR::OpSize::i64Bit, absolute));
+  auto shift = Sub(OpSize::i64Bit, Constant(63), _FindMSB(IR::OpSize::i64Bit, absolute));
   auto shifted = _Lshl(OpSize::i64Bit, absolute, shift);
 
-  auto adjusted_exponent = Sub(OpSize::i64Bit, Constant(0x3fff + 63, ConstPad::NoPad), shift);
+  auto adjusted_exponent = Sub(OpSize::i64Bit, Constant(0x3fff + 63), shift);
   auto zeroed_exponent = _Select(OpSize::i64Bit, OpSize::i64Bit, CondClass::EQ, absolute, zero, zero, adjusted_exponent);
   auto upper = _Or(OpSize::i64Bit, sign, zeroed_exponent);
 
@@ -159,11 +159,11 @@ void OpDispatchBuilder::FIST(OpcodeArgs, bool Truncate) {
     // Extract the 80-bit float value to check for special cases
     // Get the upper 64 bits which contain sign and exponent and then the exponent from upper.
     Ref Upper = _VExtractToGPR(OpSize::i128Bit, OpSize::i64Bit, Data, 1);
-    Ref Exponent = _And(OpSize::i64Bit, Upper, Constant(0x7fff, ConstPad::NoPad));
+    Ref Exponent = _And(OpSize::i64Bit, Upper, Constant(0x7fff));
 
     // Check for NaN/Infinity: exponent = 0x7fff
     SaveNZCV();
-    _TestNZ(OpSize::i64Bit, Exponent, Constant(0x7fff, ConstPad::NoPad));
+    _TestNZ(OpSize::i64Bit, Exponent, Constant(0x7fff));
     Ref IsSpecial = _NZCVSelect01(CondClass::EQ);
 
     // For overflow detection, check if exponent indicates a value >= 2^15
@@ -340,17 +340,17 @@ Ref OpDispatchBuilder::GetX87FTW_Helper() {
   // https://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
   Ref X = _LoadContextGPR(OpSize::i8Bit, offsetof(FEXCore::Core::CPUState, AbridgedFTW));
   X = _Orlshl(OpSize::i32Bit, X, X, 4);
-  X = _And(OpSize::i32Bit, X, Constant(0x0f0f0f0f, ConstPad::NoPad));
+  X = _And(OpSize::i32Bit, X, Constant(0x0f0f0f0f));
   X = _Orlshl(OpSize::i32Bit, X, X, 2);
-  X = _And(OpSize::i32Bit, X, Constant(0x33333333, ConstPad::NoPad));
+  X = _And(OpSize::i32Bit, X, Constant(0x33333333));
   X = _Orlshl(OpSize::i32Bit, X, X, 1);
-  X = _And(OpSize::i32Bit, X, Constant(0x55555555, ConstPad::NoPad));
+  X = _And(OpSize::i32Bit, X, Constant(0x55555555));
   X = _Orlshl(OpSize::i32Bit, X, X, 1);
 
   // The above sequence sets valid to 11 and empty to 00, so invert to finalize.
   static_assert(static_cast<uint8_t>(FPState::X87Tag::Valid) == 0b00);
   static_assert(static_cast<uint8_t>(FPState::X87Tag::Empty) == 0b11);
-  return _Xor(OpSize::i32Bit, X, Constant(0xffff, ConstPad::NoPad));
+  return _Xor(OpSize::i32Bit, X, Constant(0xffff));
 }
 
 void OpDispatchBuilder::X87FNSTENV(OpcodeArgs) {
@@ -387,33 +387,33 @@ void OpDispatchBuilder::X87FNSTENV(OpcodeArgs) {
     _StoreMemGPR(Size, Mem, FCW, Size);
   }
 
-  { _StoreMemGPR(Size, ReconstructFSW_Helper(), Mem, Constant(IR::OpSizeToSize(Size) * 1, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1); }
+  { _StoreMemGPR(Size, ReconstructFSW_Helper(), Mem, Constant(IR::OpSizeToSize(Size) * 1), Size, MemOffsetType::SXTX, 1); }
 
-  auto ZeroConst = Constant(0, ConstPad::NoPad);
+  auto ZeroConst = Constant(0);
 
   {
     // FTW
-    _StoreMemGPR(Size, GetX87FTW_Helper(), Mem, Constant(IR::OpSizeToSize(Size) * 2, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+    _StoreMemGPR(Size, GetX87FTW_Helper(), Mem, Constant(IR::OpSizeToSize(Size) * 2), Size, MemOffsetType::SXTX, 1);
   }
 
   {
     // Instruction Offset
-    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 3, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 3), Size, MemOffsetType::SXTX, 1);
   }
 
   {
     // Instruction CS selector (+ Opcode)
-    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 4, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 4), Size, MemOffsetType::SXTX, 1);
   }
 
   {
     // Data pointer offset
-    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 5, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 5), Size, MemOffsetType::SXTX, 1);
   }
 
   {
     // Data pointer selector
-    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 6, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 6), Size, MemOffsetType::SXTX, 1);
   }
 }
 
@@ -485,44 +485,43 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
     _StoreMemGPR(Size, Mem, FCW, Size);
   }
 
-  { _StoreMemGPR(Size, ReconstructFSW_Helper(), Mem, Constant(IR::OpSizeToSize(Size) * 1, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1); }
+  { _StoreMemGPR(Size, ReconstructFSW_Helper(), Mem, Constant(IR::OpSizeToSize(Size) * 1), Size, MemOffsetType::SXTX, 1); }
 
-  auto ZeroConst = Constant(0, ConstPad::NoPad);
+  auto ZeroConst = Constant(0);
 
   {
     // FTW
-    _StoreMemGPR(Size, GetX87FTW_Helper(), Mem, Constant(IR::OpSizeToSize(Size) * 2, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+    _StoreMemGPR(Size, GetX87FTW_Helper(), Mem, Constant(IR::OpSizeToSize(Size) * 2), Size, MemOffsetType::SXTX, 1);
   }
 
   {
     // Instruction Offset
-    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 3, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 3), Size, MemOffsetType::SXTX, 1);
   }
 
   {
     // Instruction CS selector (+ Opcode)
-    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 4, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 4), Size, MemOffsetType::SXTX, 1);
   }
 
   {
     // Data pointer offset
-    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 5, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 5), Size, MemOffsetType::SXTX, 1);
   }
 
   {
     // Data pointer selector
-    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 6, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+    _StoreMemGPR(Size, ZeroConst, Mem, Constant(IR::OpSizeToSize(Size) * 6), Size, MemOffsetType::SXTX, 1);
   }
 
-  auto SevenConst = Constant(7, ConstPad::NoPad);
+  auto SevenConst = Constant(7);
   const auto LoadSize = ReducedPrecisionMode ? OpSize::i64Bit : OpSize::i128Bit;
   for (int i = 0; i < 7; ++i) {
     Ref data = _LoadContextFPRIndexed(Top, LoadSize, MMBaseOffset(), IR::OpSizeToSize(OpSize::i128Bit));
     if (ReducedPrecisionMode) {
       data = _F80CVTTo(data, OpSize::i64Bit);
     }
-    _StoreMemFPR(OpSize::i128Bit, data, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (10 * i), ConstPad::NoPad), OpSize::i8Bit,
-                 MemOffsetType::SXTX, 1);
+    _StoreMemFPR(OpSize::i128Bit, data, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (10 * i)), OpSize::i8Bit, MemOffsetType::SXTX, 1);
     Top = _And(OpSize::i32Bit, Add(OpSize::i32Bit, Top, 1), SevenConst);
   }
 
@@ -534,11 +533,9 @@ void OpDispatchBuilder::X87FNSAVE(OpcodeArgs) {
   // ST7 broken in to two parts
   // Lower 64bits [63:0]
   // upper 16 bits [79:64]
-  _StoreMemFPR(OpSize::i64Bit, data, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (7 * 10), ConstPad::NoPad), OpSize::i8Bit,
-               MemOffsetType::SXTX, 1);
+  _StoreMemFPR(OpSize::i64Bit, data, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (7 * 10)), OpSize::i8Bit, MemOffsetType::SXTX, 1);
   auto topBytes = _VDupElement(OpSize::i128Bit, OpSize::i16Bit, data, 4);
-  _StoreMemFPR(OpSize::i16Bit, topBytes, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (7 * 10) + 8, ConstPad::NoPad), OpSize::i8Bit,
-               MemOffsetType::SXTX, 1);
+  _StoreMemFPR(OpSize::i16Bit, topBytes, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (7 * 10) + 8), OpSize::i8Bit, MemOffsetType::SXTX, 1);
 
   // reset to default
   FNINIT(Op);
@@ -555,28 +552,27 @@ void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
     // ignore the rounding precision, we're always 64-bit in F64.
     // extract rounding mode
     Ref roundingMode = NewFCW;
-    auto roundShift = Constant(10, ConstPad::NoPad);
-    auto roundMask = Constant(3, ConstPad::NoPad);
+    auto roundShift = Constant(10);
+    auto roundMask = Constant(3);
     roundingMode = _Lshr(OpSize::i32Bit, roundingMode, roundShift);
     roundingMode = _And(OpSize::i32Bit, roundingMode, roundMask);
     _SetRoundingMode(roundingMode, false, roundingMode);
   }
 
-  auto NewFSW = _LoadMemGPR(Size, Mem, Constant(IR::OpSizeToSize(Size) * 1, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+  auto NewFSW = _LoadMemGPR(Size, Mem, Constant(IR::OpSizeToSize(Size) * 1), Size, MemOffsetType::SXTX, 1);
   Ref Top = ReconstructX87StateFromFSW_Helper(NewFSW);
   {
     // FTW
-    SetX87FTW(_LoadMemGPR(Size, Mem, Constant(IR::OpSizeToSize(Size) * 2, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1));
+    SetX87FTW(_LoadMemGPR(Size, Mem, Constant(IR::OpSizeToSize(Size) * 2), Size, MemOffsetType::SXTX, 1));
   }
 
-  auto SevenConst = Constant(7, ConstPad::NoPad);
-  auto low = Constant(~0ULL, ConstPad::NoPad);
-  auto high = Constant(0xFFFF, ConstPad::NoPad);
+  auto SevenConst = Constant(7);
+  auto low = Constant(~0ULL);
+  auto high = Constant(0xFFFF);
   Ref Mask = _VLoadTwoGPRs(low, high);
   const auto StoreSize = ReducedPrecisionMode ? OpSize::i64Bit : OpSize::i128Bit;
   for (int i = 0; i < 7; ++i) {
-    Ref Reg = _LoadMemFPR(OpSize::i128Bit, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (10 * i), ConstPad::NoPad), OpSize::i8Bit,
-                          MemOffsetType::SXTX, 1);
+    Ref Reg = _LoadMemFPR(OpSize::i128Bit, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (10 * i)), OpSize::i8Bit, MemOffsetType::SXTX, 1);
     // Mask off the top bits
     Reg = _VAnd(OpSize::i128Bit, OpSize::i128Bit, Reg, Mask);
     if (ReducedPrecisionMode) {
@@ -592,10 +588,8 @@ void OpDispatchBuilder::X87FRSTOR(OpcodeArgs) {
   // ST7 broken in to two parts
   // Lower 64bits [63:0]
   // upper 16 bits [79:64]
-  Ref Reg =
-    _LoadMemFPR(OpSize::i64Bit, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (10 * 7), ConstPad::NoPad), OpSize::i8Bit, MemOffsetType::SXTX, 1);
-  Ref RegHigh = _LoadMemFPR(OpSize::i16Bit, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (10 * 7) + 8, ConstPad::NoPad), OpSize::i8Bit,
-                            MemOffsetType::SXTX, 1);
+  Ref Reg = _LoadMemFPR(OpSize::i64Bit, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (10 * 7)), OpSize::i8Bit, MemOffsetType::SXTX, 1);
+  Ref RegHigh = _LoadMemFPR(OpSize::i16Bit, Mem, Constant((IR::OpSizeToSize(Size) * 7) + (10 * 7) + 8), OpSize::i8Bit, MemOffsetType::SXTX, 1);
   Reg = _VInsElement(OpSize::i128Bit, OpSize::i16Bit, 4, 0, Reg, RegHigh);
   if (ReducedPrecisionMode) {
     Reg = _F80CVT(OpSize::i64Bit, Reg); // Convert to double precision
@@ -624,13 +618,13 @@ void OpDispatchBuilder::FXCH(OpcodeArgs) {
   if (Offset != 0) {
     _F80StackXchange(Offset);
   }
-  SetRFLAG<FEXCore::X86State::X87FLAG_C1_LOC>(Constant(0, ConstPad::NoPad));
+  SetRFLAG<FEXCore::X86State::X87FLAG_C1_LOC>(Constant(0));
 }
 
 void OpDispatchBuilder::X87FYL2X(OpcodeArgs, bool IsFYL2XP1) {
   if (IsFYL2XP1) {
     // create an add between top of stack and 1.
-    Ref One = ReducedPrecisionMode ? _VCastFromGPR(OpSize::i64Bit, OpSize::i64Bit, Constant(0x3FF0000000000000, ConstPad::NoPad)) :
+    Ref One = ReducedPrecisionMode ? _VCastFromGPR(OpSize::i64Bit, OpSize::i64Bit, Constant(0x3FF0000000000000)) :
                                      LoadAndCacheNamedVectorConstant(OpSize::i128Bit, NamedVectorConstant::NAMED_VECTOR_X87_ONE);
     _F80AddValue(0, One);
   }
@@ -671,7 +665,7 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs, IR::OpSize Width, bool Integer, OpDisp
 
   if (WhichFlags == FCOMIFlags::FLAGS_X87) {
     SetRFLAG<FEXCore::X86State::X87FLAG_C0_LOC>(HostFlag_CF);
-    SetRFLAG<FEXCore::X86State::X87FLAG_C1_LOC>(Constant(0, ConstPad::NoPad));
+    SetRFLAG<FEXCore::X86State::X87FLAG_C1_LOC>(Constant(0));
     SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(HostFlag_Unordered);
     SetRFLAG<FEXCore::X86State::X87FLAG_C3_LOC>(HostFlag_ZF);
   } else {
@@ -681,7 +675,7 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs, IR::OpSize Width, bool Integer, OpDisp
 
     // PF is stored inverted, so invert from the host flag.
     // TODO: This could perhaps be optimized?
-    auto PF = _Xor(OpSize::i32Bit, HostFlag_Unordered, Constant(1, ConstPad::NoPad));
+    auto PF = _Xor(OpSize::i32Bit, HostFlag_Unordered, Constant(1));
     SetRFLAG<FEXCore::X86State::RFLAG_PF_RAW_LOC>(PF);
   }
 
@@ -706,7 +700,7 @@ void OpDispatchBuilder::FTST(OpcodeArgs) {
   HostFlag_ZF = _Or(OpSize::i32Bit, HostFlag_ZF, HostFlag_Unordered);
 
   SetRFLAG<FEXCore::X86State::X87FLAG_C0_LOC>(HostFlag_CF);
-  SetRFLAG<FEXCore::X86State::X87FLAG_C1_LOC>(Constant(0, ConstPad::NoPad));
+  SetRFLAG<FEXCore::X86State::X87FLAG_C1_LOC>(Constant(0));
   SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(HostFlag_Unordered);
   SetRFLAG<FEXCore::X86State::X87FLAG_C3_LOC>(HostFlag_ZF);
 
@@ -717,7 +711,7 @@ void OpDispatchBuilder::FTST(OpcodeArgs) {
 void OpDispatchBuilder::X87OpHelper(OpcodeArgs, FEXCore::IR::IROps IROp, bool ZeroC2) {
   DeriveOp(Result, IROp, _F80SCALEStack());
   if (ZeroC2) {
-    SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(Constant(0, ConstPad::NoPad));
+    SetRFLAG<FEXCore::X86State::X87FLAG_C2_LOC>(Constant(0));
   }
 }
 
@@ -743,7 +737,7 @@ void OpDispatchBuilder::X87ModifySTP(OpcodeArgs, bool Inc) {
 Ref OpDispatchBuilder::ReconstructFSW_Helper(Ref T) {
   // Start with the top value
   auto Top = T ? T : GetX87Top();
-  Ref FSW = _Lshl(OpSize::i64Bit, Top, Constant(11, ConstPad::NoPad));
+  Ref FSW = _Lshl(OpSize::i64Bit, Top, Constant(11));
 
   // We must construct the FSW from our various bits
   auto C0 = GetRFLAG(FEXCore::X86State::X87FLAG_C0_LOC);
@@ -775,20 +769,20 @@ void OpDispatchBuilder::X87FNSTSW(OpcodeArgs) {
 
 void OpDispatchBuilder::FNCLEX(OpcodeArgs) {
   // Clear the exception flag bit
-  SetRFLAG<FEXCore::X86State::X87FLAG_IE_LOC>(_Constant(0, ConstPad::NoPad));
+  SetRFLAG<FEXCore::X86State::X87FLAG_IE_LOC>(_Constant(0));
 }
 
 void OpDispatchBuilder::FNINIT(OpcodeArgs) {
   _SyncStackToSlow(); // Invalidate x87 register caches
 
-  auto Zero = Constant(0, ConstPad::NoPad);
+  auto Zero = Constant(0);
 
   if (ReducedPrecisionMode) {
     _SetRoundingMode(Zero, false, Zero);
   }
 
   // Init FCW to 0x037F
-  auto NewFCW = Constant(0x037F, ConstPad::NoPad);
+  auto NewFCW = Constant(0x037F);
   _StoreContextGPR(OpSize::i16Bit, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 
   // Set top to zero
@@ -867,7 +861,7 @@ void OpDispatchBuilder::X87FXAM(OpcodeArgs) {
   auto TopValid = _StackValidTag(0);
 
   // In the case of top being invalid then C3:C2:C0 is 0b101
-  auto C3 = Select01(OpSize::i32Bit, CondClass::NEQ, TopValid, Constant(1, ConstPad::NoPad));
+  auto C3 = Select01(OpSize::i32Bit, CondClass::NEQ, TopValid, Constant(1));
 
   auto C2 = TopValid;
   auto C0 = C3; // Mirror C3 until something other than zero is supported

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -36,12 +36,12 @@ void OpDispatchBuilder::X87LDENVF64(OpcodeArgs) {
   _SetRoundingMode(roundingMode, false, roundingMode);
   _StoreContextGPR(OpSize::i16Bit, NewFCW, offsetof(FEXCore::Core::CPUState, FCW));
 
-  auto NewFSW = _LoadMemGPR(Size, Mem, Constant(IR::OpSizeToSize(Size), ConstPad::NoPad), Size, MemOffsetType::SXTX, 1);
+  auto NewFSW = _LoadMemGPR(Size, Mem, Constant(IR::OpSizeToSize(Size)), Size, MemOffsetType::SXTX, 1);
   ReconstructX87StateFromFSW_Helper(NewFSW);
 
   {
     // FTW
-    SetX87FTW(_LoadMemGPR(Size, Mem, Constant(IR::OpSizeToSize(Size) * 2, ConstPad::NoPad), Size, MemOffsetType::SXTX, 1));
+    SetX87FTW(_LoadMemGPR(Size, Mem, Constant(IR::OpSizeToSize(Size) * 2), Size, MemOffsetType::SXTX, 1));
   }
 }
 
@@ -86,7 +86,7 @@ void OpDispatchBuilder::FBSTPF64(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::FLDF64_Const(OpcodeArgs, uint64_t Num) {
-  auto Data = _VCastFromGPR(OpSize::i64Bit, OpSize::i64Bit, Constant(Num, ConstPad::NoPad));
+  auto Data = _VCastFromGPR(OpSize::i64Bit, OpSize::i64Bit, Constant(Num));
   _PushStack(Data, Data, OpSize::i64Bit);
 }
 
@@ -376,21 +376,21 @@ void OpDispatchBuilder::X87FXTRACTF64(OpcodeArgs) {
   Ref Gpr = _VExtractToGPR(OpSize::i64Bit, OpSize::i64Bit, Node, 0);
 
   // zero case
-  Ref ExpZV = _VCastFromGPR(OpSize::i64Bit, OpSize::i64Bit, Constant(0xfff0'0000'0000'0000UL, ConstPad::NoPad));
+  Ref ExpZV = _VCastFromGPR(OpSize::i64Bit, OpSize::i64Bit, Constant(0xfff0'0000'0000'0000UL));
   Ref SigZV = Node;
 
   // non zero case
   Ref ExpNZ = _Bfe(OpSize::i64Bit, 11, 52, Gpr);
-  ExpNZ = Sub(OpSize::i64Bit, ExpNZ, Constant(1023, ConstPad::NoPad));
+  ExpNZ = Sub(OpSize::i64Bit, ExpNZ, Constant(1023));
   Ref ExpNZV = _Float_FromGPR_S(OpSize::i64Bit, OpSize::i64Bit, ExpNZ);
 
-  Ref SigNZ = _And(OpSize::i64Bit, Gpr, Constant(0x800f'ffff'ffff'ffffLL, ConstPad::NoPad));
-  SigNZ = _Or(OpSize::i64Bit, SigNZ, Constant(0x3ff0'0000'0000'0000LL, ConstPad::NoPad));
+  Ref SigNZ = _And(OpSize::i64Bit, Gpr, Constant(0x800f'ffff'ffff'ffffLL));
+  SigNZ = _Or(OpSize::i64Bit, SigNZ, Constant(0x3ff0'0000'0000'0000LL));
   Ref SigNZV = _VCastFromGPR(OpSize::i64Bit, OpSize::i64Bit, SigNZ);
 
   // Comparison and select to push onto stack
   SaveNZCV();
-  _TestNZ(OpSize::i64Bit, Gpr, Constant(0x7fff'ffff'ffff'ffffUL, ConstPad::NoPad));
+  _TestNZ(OpSize::i64Bit, Gpr, Constant(0x7fff'ffff'ffff'ffffUL));
 
   Ref Sig = _NZCVSelectV(OpSize::i64Bit, CondClass::EQ, SigZV, SigNZV);
   Ref Exp = _NZCVSelectV(OpSize::i64Bit, CondClass::EQ, ExpZV, ExpNZV);

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -936,7 +936,7 @@
         ]
       },
 
-      "GPR = Constant i64:$Constant, ConstPad:$Pad, i32:$MaxBytes{0}": {
+      "GPR = Constant i64:$Constant, ConstPad:$Pad{IR::ConstPad::NoPad}, i32:$MaxBytes{0}": {
         "Desc": ["Generates a 64bit constant inside of a GPR",
                  "Unsupported to create a constant in FPR"
                 ],

--- a/FEXCore/Source/Interface/IR/IREmitter.h
+++ b/FEXCore/Source/Interface/IR/IREmitter.h
@@ -109,10 +109,10 @@ public:
     return _Jump(InvalidNode);
   }
   IRPair<IROp_CondJump> _CondJump(Ref ssa0, CondClass cond = CondClass::NEQ) {
-    return _CondJump(ssa0, _Constant(0, ConstPad::NoPad), InvalidNode, InvalidNode, cond, GetOpSize(ssa0));
+    return _CondJump(ssa0, _Constant(0), InvalidNode, InvalidNode, cond, GetOpSize(ssa0));
   }
   IRPair<IROp_CondJump> _CondJump(Ref ssa0, Ref ssa1, Ref ssa2, CondClass cond = CondClass::NEQ) {
-    return _CondJump(ssa0, _Constant(0, ConstPad::NoPad), ssa1, ssa2, cond, GetOpSize(ssa0));
+    return _CondJump(ssa0, _Constant(0), ssa1, ssa2, cond, GetOpSize(ssa0));
   }
 
   IRPair<IROp_LoadContext> _LoadContextGPR(OpSize ByteSize, uint32_t Offset) {
@@ -184,7 +184,7 @@ public:
   }
 
   IRPair<IROp_Select> To01(FEXCore::IR::OpSize CompareSize, OrderedNode* Cmp1) {
-    return Select01(CompareSize, CondClass::NEQ, Cmp1, Constant(0, ConstPad::NoPad));
+    return Select01(CompareSize, CondClass::NEQ, Cmp1, Constant(0));
   }
 
   IRPair<IROp_NZCVSelect> _NZCVSelect01(CondClass Cond) {
@@ -203,7 +203,7 @@ public:
       Src2 = -Src2;
     }
 
-    auto Dest = _Add(Size, Src1, Constant(Src2, ConstPad::NoPad));
+    auto Dest = _Add(Size, Src1, Constant(Src2));
     Dest.first->Header.Op = Op;
     return Dest;
   }
@@ -249,7 +249,7 @@ public:
   Ref ConstantRefs[32];
   uint32_t NrConstants;
 
-  Ref Constant(int64_t Value, ConstPad Pad, int32_t MaxBytes = 0) {
+  Ref Constant(int64_t Value, ConstPad Pad = IR::ConstPad::NoPad, int32_t MaxBytes = 0) {
     const ConstantData Data {
       .Value = Value,
       .Pad = Pad,

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -514,8 +514,8 @@ bool ConstrainedRAPass::TryPostRAMerge(Ref LastNode, Ref CodeNode, IROp_Header* 
     if (CPUID->DoesXCRFunctionReportConstantData(ConstantFunction)) {
       const auto Result = CPUID->RunXCRFunction(ConstantFunction);
       IREmit->SetWriteCursorBefore(CodeNode);
-      IREmit->_Constant(Result.eax, ConstPad::NoPad).Node->Reg = PhysicalRegister(Op->OutEAX).Raw;
-      IREmit->_Constant(Result.edx, ConstPad::NoPad).Node->Reg = PhysicalRegister(Op->OutEDX).Raw;
+      IREmit->_Constant(Result.eax).Node->Reg = PhysicalRegister(Op->OutEAX).Raw;
+      IREmit->_Constant(Result.edx).Node->Reg = PhysicalRegister(Op->OutEDX).Raw;
       IREmit->RemovePostRA(CodeNode);
       return false;
     }
@@ -533,10 +533,10 @@ bool ConstrainedRAPass::TryPostRAMerge(Ref LastNode, Ref CodeNode, IROp_Header* 
 
       IREmit->SetWriteCursorBefore(CodeNode);
       IREmit->_Fence(IR::FenceType::Inst);
-      IREmit->_Constant(Result.eax, ConstPad::NoPad).Node->Reg = PhysicalRegister(Op->OutEAX).Raw;
-      IREmit->_Constant(Result.ebx, ConstPad::NoPad).Node->Reg = PhysicalRegister(Op->OutEBX).Raw;
-      IREmit->_Constant(Result.ecx, ConstPad::NoPad).Node->Reg = PhysicalRegister(Op->OutECX).Raw;
-      IREmit->_Constant(Result.edx, ConstPad::NoPad).Node->Reg = PhysicalRegister(Op->OutEDX).Raw;
+      IREmit->_Constant(Result.eax).Node->Reg = PhysicalRegister(Op->OutEAX).Raw;
+      IREmit->_Constant(Result.ebx).Node->Reg = PhysicalRegister(Op->OutEBX).Raw;
+      IREmit->_Constant(Result.ecx).Node->Reg = PhysicalRegister(Op->OutECX).Raw;
+      IREmit->_Constant(Result.edx).Node->Reg = PhysicalRegister(Op->OutEDX).Raw;
       IREmit->RemovePostRA(CodeNode);
       return false;
     }

--- a/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
@@ -387,11 +387,11 @@ inline void X87StackOptimization::Reset() {
 inline Ref X87StackOptimization::GetConstant(ssize_t Offset) {
   if (Offset < 0 || Offset >= X87StackOptimization::ConstantPool.size()) {
     // not dealt by pool
-    return IREmit->_Constant(Offset, ConstPad::NoPad);
+    return IREmit->_Constant(Offset);
   }
   if (ConstantPool[Offset] == nullptr) {
 
-    ConstantPool[Offset] = IREmit->_Constant(Offset, ConstPad::NoPad);
+    ConstantPool[Offset] = IREmit->_Constant(Offset);
   }
   return ConstantPool[Offset];
 }


### PR DESCRIPTION
Most constants don't need to be padded for relocations. So now that these have all been audited, switch to defaulting to NoPad to reduce verbosity.

The number of constant that need to be explicitly padded are now marked and with all the prior changes, this allows bisecting if something has gone wrong.