### PR TITLE
Windows: Fix RtlWaitOnAddress signature

### DIFF
--- a/Source/Windows/Common/WinAPI/Sync.cpp
+++ b/Source/Windows/Common/WinAPI/Sync.cpp
@@ -14,7 +14,10 @@
 #include "../Priv.h"
 
 WINBOOL WaitOnAddress(volatile void* Address, void* CompareAddress, SIZE_T AddressSize, DWORD dwMilliseconds) {
-  return RtlWaitOnAddress(Address, CompareAddress, AddressSize, dwMilliseconds) == STATUS_SUCCESS;
+  LARGE_INTEGER Time;
+  // A negative value indicates a relative time measured in 100ns intervals.
+  Time.QuadPart = static_cast<ULONGLONG>(dwMilliseconds) * -10000;
+  return RtlWaitOnAddress(const_cast<void*>(Address), CompareAddress, AddressSize, dwMilliseconds == INFINITE ? nullptr : &Time) == STATUS_SUCCESS;
 }
 
 void WakeByAddressAll(PVOID Address) {

--- a/Source/Windows/include/winternl.h
+++ b/Source/Windows/include/winternl.h
@@ -564,9 +564,9 @@ NTSTATUS WINAPI RtlWow64SuspendThread(HANDLE, ULONG*);
 void WINAPI RtlAcquireSRWLockShared(RTL_SRWLOCK*);
 void WINAPI RtlReleaseSRWLockShared(RTL_SRWLOCK*);
 BOOLEAN WINAPI RtlTryAcquireSRWLockShared(RTL_SRWLOCK*);
-void WINAPI RtlWakeAddressAll(void*);
-BOOL WINAPI RtlWaitOnAddress(volatile void*, void*, SIZE_T, DWORD);
-void WINAPI RtlWakeAddressSingle(void*);
+void WINAPI RtlWakeAddressAll(const void*);
+NTSTATUS WINAPI RtlWaitOnAddress(const void*, const void*, SIZE_T, const LARGE_INTEGER*);
+void WINAPI RtlWakeAddressSingle(const void*);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This led to loops of segfaults that wine handled behind the scenes.