### PR TITLE
Windows: Invalidate code in freed memory after the free syscall

### DIFF
--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -793,12 +793,10 @@ void NotifyMemoryFree(void* Address, SIZE_T Size, ULONG FreeType, BOOL After, NT
 
   if (!After) {
     ThreadCreationMutex.lock();
-    if (FreeType & MEM_DECOMMIT) {
-      InvalidationTracker->InvalidateAlignedInterval(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), true);
-    } else if (FreeType & MEM_RELEASE) {
-      InvalidationTracker->InvalidateContainingSection(reinterpret_cast<uint64_t>(Address), true);
-    }
   } else {
+    if (!Status) {
+      InvalidationTracker->InvalidateAlignedInterval(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), true);
+    }
     ThreadCreationMutex.unlock();
   }
 }

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -966,12 +966,10 @@ void BTCpuNotifyMemoryProtect(void* Address, SIZE_T Size, ULONG NewProt, BOOL Af
 void BTCpuNotifyMemoryFree(void* Address, SIZE_T Size, ULONG FreeType, BOOL After, ULONG Status) {
   if (!After) {
     ThreadCreationMutex.lock();
-    if (!Size) {
-      InvalidationTracker->InvalidateContainingSection(reinterpret_cast<uint64_t>(Address), true);
-    } else if (FreeType & MEM_DECOMMIT) {
+  } else {
+    if (!Status) {
       InvalidationTracker->InvalidateAlignedInterval(reinterpret_cast<uint64_t>(Address), static_cast<uint64_t>(Size), true);
     }
-  } else {
     ThreadCreationMutex.unlock();
   }
 }


### PR DESCRIPTION
Windows will populate Size/Address with those of the underlying free region. This is important for cross-process free operations, where the the 'before' callback is still called after the memory is freed so querying the size of the section (which is not freed) fails.