### PR TITLE
OpcodeDispatcher: Explicitly calculate flags after _TelemetrySetValue

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4101,6 +4101,8 @@ void OpDispatchBuilder::CheckLegacySegmentRead(Ref NewNode, uint32_t SegmentReg)
 
   // Will set the telemetry value if NewNode is != 0
   _TelemetrySetValue(NewNode, TelemIndex);
+  // Telemetry will dirty flags, and user code does not expect LoadSource to clobber flags, fix that up here as this is an edge case.
+  CalculateDeferredFlags();
 #endif
 }
 
@@ -4139,6 +4141,8 @@ void OpDispatchBuilder::CheckLegacySegmentWrite(Ref NewNode, uint32_t SegmentReg
 
   // Will set the telemetry value if NewNode is != 0
   _TelemetrySetValue(NewNode, TelemIndex);
+  // Telemetry will dirty flags, and user code does not expect LoadSource to clobber flags, fix that up here as this is an edge case.
+  CalculateDeferredFlags();
 #endif
 }
 


### PR DESCRIPTION
Opcode handlers are written with the assumption that LoadSource will not touch flags and this would be an annoying assumption to change. As this is such an edge case anyway just don't defer flags and force a load of the saved value before _TelemetrySetValue (which are implicitly saved before it).

Fixes the following snippet in upc.exe:
```
AND        word ptr [ESP + ECX*0x1 + 0x80000000],DX
BTR        CX,DX
ADC        CX,word ptr SS:[EAX + ECX*0x1 + 0x80000000]
```

Probably wants a unit test