### PR TITLE
Config: Remove stdout from OutputLog

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -371,7 +371,7 @@
         "Default": "server",
         "Desc": [
           "File to write FEX output to.",
-          "[stdout, stderr, server, <Filename>]"
+          "[stderr, server, <Filename>]"
         ]
       },
       "TelemetryDirectory": {

--- a/Source/Tools/FEXConfig/main.qml
+++ b/Source/Tools/FEXConfig/main.qml
@@ -448,12 +448,12 @@ ApplicationWindow {
                             id: loggingComboBox
                             property string configValue: ConfigModel.has("OutputLog", refreshCache) ? ConfigModel.getString("OutputLog", refreshCache) : ""
 
-                            currentIndex: configValue === "" ? -1 : configValue == "server" ? 0 : configValue == "stderr" ? 1 : configValue == "stdout" ? 2 : 3
+                            currentIndex: configValue === "" ? -1 : configValue == "server" ? 0 : configValue == "stderr" ? 1 : 2
 
                             onActivated: {
                                 configDirty = true
-                                var configNames = [ "server", "stderr", "stdout" ]
-                                if (currentIndex != -1 && currentIndex < 3) {
+                                var configNames = [ "server", "stderr" ]
+                                if (currentIndex != -1 && currentIndex < 2) {
                                     ConfigModel.setString("OutputLog", configNames[currentIndex])
                                 } else {
                                     // Set by text field below
@@ -463,13 +463,12 @@ ApplicationWindow {
                             model: ListModel {
                                 ListElement { text: "FEXServer" }
                                 ListElement { text: "stderr" }
-                                ListElement { text: "stdout" }
                                 ListElement { text: qsTr("File...") }
                             }
                         }
 
                         ConfigTextFieldForPath {
-                            visible: loggingComboBox.currentIndex === 3
+                            visible: loggingComboBox.currentIndex === 2
                             config: "OutputLog"
                         }
                     }

--- a/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
+++ b/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
@@ -118,8 +118,6 @@ void Init() {
     auto LogFD = OutputFD;
     if (LogFile == "stderr") {
       LogFD = dup(STDERR_FILENO);
-    } else if (LogFile == "stdout") {
-      LogFD = dup(STDOUT_FILENO);
     } else if (LogFile == "server") {
       Logging::FEXServer::FEXServerFD = FEXServerClient::RequestLogFD(FEXServerClient::GetServerFD());
       if (FEXServer::FEXServerFD != -1) {


### PR DESCRIPTION
This just causes problems with scripts. Don't allow people to output to stdout, use stderr instead.