### PR TITLE
FEXCore/Allocator: Remove unique_ptr behaviour from Alloc64

### DIFF
--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -43,7 +43,7 @@ using GLIBC_MALLOC_Hook = void* (*)(size_t, const void* caller);
 using GLIBC_REALLOC_Hook = void* (*)(void*, size_t, const void* caller);
 using GLIBC_FREE_Hook = void (*)(void*, const void* caller);
 
-fextl::unique_ptr<Alloc::HostAllocator> Alloc64 {};
+Alloc::HostAllocator* Alloc64 {};
 
 void* FEX_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
   void* Result = Alloc64->Mmap(addr, length, prot, flags, fd, offset);
@@ -99,7 +99,7 @@ void ClearHooks() {
   FEXCore::Allocator::mmap = ::mmap;
   FEXCore::Allocator::munmap = ::munmap;
 
-  Alloc::OSAllocator::ReleaseAllocatorWorkaround(std::move(Alloc64));
+  Alloc::OSAllocator::ReleaseAllocatorWorkaround(Alloc64);
 }
 #pragma GCC diagnostic pop
 

--- a/FEXCore/Source/Utils/Allocator/HostAllocator.h
+++ b/FEXCore/Source/Utils/Allocator/HostAllocator.h
@@ -51,14 +51,15 @@ public:
 } // namespace Alloc
 
 namespace Alloc::OSAllocator {
-fextl::unique_ptr<Alloc::HostAllocator> Create64BitAllocator();
-fextl::unique_ptr<Alloc::HostAllocator> Create64BitAllocatorWithRegions(fextl::vector<FEXCore::Allocator::MemoryRegion>& Regions);
-static inline void ReleaseAllocatorWorkaround(fextl::unique_ptr<Alloc::HostAllocator> Allocator) {
+Alloc::HostAllocator* Create64BitAllocator();
+Alloc::HostAllocator* Create64BitAllocatorWithRegions(fextl::vector<FEXCore::Allocator::MemoryRegion>& Regions);
+static inline void ReleaseAllocatorWorkaround(Alloc::HostAllocator* Allocator) {
   // XXX: This is currently a leak.
   // We can't work around this yet until static initializers that allocate memory are completely removed from our codebase
   // The allocator is also intrusively allocated, so the unique_ptr tries to double free the HostAllocator object.
   // Luckily we only remove this on process shutdown, so the kernel will do the cleanup for us
-  Allocator.release();
+  //
+  // delete Allocator;
 }
 
 } // namespace Alloc::OSAllocator


### PR DESCRIPTION
Even though we leak `Alloc64` on shutdown, that isn't good enough to avoid the `atexit` handler deallocating memory. So we need to use a raw pointer and leak it.

Removes an `atexit` registration that contributes to crashing on exit.