### PR TITLE
CodeCache: Remove an assumption about git hash length

### DIFF
--- a/FEXCore/Source/Interface/Core/CodeCache.cpp
+++ b/FEXCore/Source/Interface/Core/CodeCache.cpp
@@ -351,8 +351,8 @@ bool CodeCache::LoadData(Core::InternalThreadState* Thread, std::byte* MappedCac
     return false;
   }
 
-  char ExpectedVersion[8] = GIT_SHORT_HASH;
-  ranges::fill(ranges::find(ExpectedVersion, 0), std::end(ExpectedVersion), 0);
+  constexpr std::string_view ExpectedVersion = GIT_SHORT_HASH;
+  static_assert(ExpectedVersion.size() <= sizeof(header.FEXVersion));
   if (!ranges::equal(header.FEXVersion, ExpectedVersion)) {
     LogMan::Msg::IFmt("Cache generated from old FEX version {}, current is {}; skipping", fmt::join(header.FEXVersion, ""),
                       fmt::join(ExpectedVersion, ""));


### PR DESCRIPTION
Our short hash is typically 7-characters in length, but due to hash conflicts it can be more than that.

Remove a single assumption that the hash size is 8-bytes.

Gets the case working that the hash length is 8-characters, but doesn't attempt going further than that. As this fixes the compiler error I had due to a hash conflict.