### PR TITLE
JIT: Ensure code cache consistency by zero-initializing padding bytes

### DIFF
--- a/CodeEmitter/CodeEmitter/Buffer.h
+++ b/CodeEmitter/CodeEmitter/Buffer.h
@@ -53,6 +53,7 @@ public:
     if (!CurrentAlignment) {
       return;
     }
+    std::memset(CurrentOffset, 0, Size - CurrentAlignment);
     CurrentOffset += Size - CurrentAlignment;
   }
 

--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -1083,12 +1083,11 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
 
       // NOTE: 16-byte alignment of the new cursor offset must be preserved for block linking records
       SetBuffer(CurrentCodeBuffer->Ptr, CurrentCodeBuffer->AllocatedSize);
-      SetCursorOffset(AlignUp(CodeBuffers.LatestOffset, 16));
+      SetCursorOffset(CodeBuffers.LatestOffset);
+      Align16B();
       if ((GetCursorOffset() + TempSize) > CurrentCodeBuffer->UsableSize()) {
         CTX->ClearCodeCache(ThreadState);
       }
-
-      Align16B();
 
       CodeBuffers.LatestOffset = GetCursorOffset();
     }


### PR DESCRIPTION
Code caches are required to produce consistent results across runs (given unchanged input code maps), so this padding data must be initialized explicitly.