### PR TITLE
Linux: Updates minimum altstack requirements

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -48,7 +48,7 @@ __attribute__((naked)) static void sigrestore() {
 }
 #endif
 
-constexpr static uint32_t X86_MINSIGSTKSZ = 0x2000U;
+constexpr static uint32_t X86_MINSIGSTKSZ = 2048;
 
 static FEX::HLE::ThreadStateObject* GetThreadFromAltStack(const stack_t& alt_stack) {
   // The thread object lives just before the alt-stack begin.
@@ -1183,7 +1183,7 @@ uint64_t SignalDelegator::RegisterGuestSigAltStack(FEX::HLE::ThreadStateObject* 
       return 0;
     }
 
-    // stack size needs to be MINSIGSTKSZ (0x2000)
+    // stack size needs to be at least X86_MINSIGSTKSZ
     if (ss->ss_size < X86_MINSIGSTKSZ) {
       return -ENOMEM;
     }

--- a/unittests/FEXLinuxTests/tests/syscalls/syscall_sigaltstack.cpp
+++ b/unittests/FEXLinuxTests/tests/syscalls/syscall_sigaltstack.cpp
@@ -1,0 +1,20 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/syscall.h>
+
+TEST_CASE("sysaltstack - minimum") {
+  char test[4096];
+  constexpr size_t EXPECTED_MIN = 2048;
+
+  stack_t stack {
+    .ss_sp = test,
+    .ss_flags = 0,
+    .ss_size = 0,
+  };
+  for (size_t i = 1; i < sizeof(test); ++i) {
+    stack.ss_size = i;
+    CHECK(sigaltstack(&stack, nullptr) == (i < EXPECTED_MIN ? -1 : 0));
+  }
+}


### PR DESCRIPTION
Turns out the Linux kernel's definition of `MINSIGSTKSZ` and glibc's definition of `MINSIGSTKSZ` don't match.

The linux kernel has a massive comment about it in `arch/x86/kernel/signal.c`.

Also adds a unittest for it.

For #5206