### PR TITLE
FEX: Pass VA/PA to CPUID and have cpuinfo populate from cpuid

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -1089,9 +1089,9 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_8000_0007h(uint32_t Leaf) con
 // Virtual and physical address sizes
 FEXCore::CPUID::FunctionResults CPUIDEmu::Function_8000_0008h(uint32_t Leaf) const {
   FEXCore::CPUID::FunctionResults Res {};
-  Res.eax = (48 << 0) | // PhysAddrSize = 48-bit
-            (48 << 8) | // LinAddrSize = 48-bit
-            (0 << 16);  // GuestPhysAddrSize == PhysAddrSize
+  Res.eax = (HostPA << 0) | // PhysAddrSize
+            (HostVA << 8) | // LinAddrSize
+            (0 << 16);      // GuestPhysAddrSize == PhysAddrSize
 
   Res.ebx = (0 << 2) |                               // XSaveErPtr: Saving and restoring error pointers
             (0 << 1) |                               // IRPerf: Instructions retired count support
@@ -1220,7 +1220,7 @@ FEXCore::CPUID::XCRResults CPUIDEmu::XCRFunction_0h() const {
   return Res;
 }
 
-CPUIDEmu::CPUIDEmu(const FEXCore::Context::ContextImpl* ctx)
+CPUIDEmu::CPUIDEmu(const FEXCore::Context::ContextImpl* ctx, const FEXCore::HostFeatures& Features)
   : CTX {ctx}
   , SupportsCPUIndexInTPIDRRO {CTX->HostFeatures.SupportsCPUIndexInTPIDRRO}
   , GetCPUID {GetCPUID_Syscall} {
@@ -1236,5 +1236,9 @@ CPUIDEmu::CPUIDEmu(const FEXCore::Context::ContextImpl* ctx)
     GetCPUID = GetCPUID_TPIDRRO;
   }
 #endif
+  // Claim 48-bit VA if not set.
+  HostVA = Features.HostVA ?: 48;
+  // Claim 40-bit PA if not set.
+  HostPA = Features.HostPA ?: 40;
 }
 } // namespace FEXCore

--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -10,6 +10,7 @@
 #include <utility>
 
 namespace FEXCore {
+struct HostFeatures;
 namespace Context {
   class ContextImpl;
 }
@@ -30,7 +31,7 @@ private:
   constexpr static uint32_t CPUID_VENDOR_AMD3 = 0x444D4163; // "cAMD"
 
 public:
-  CPUIDEmu(const FEXCore::Context::ContextImpl* ctx);
+  CPUIDEmu(const FEXCore::Context::ContextImpl* ctx, const FEXCore::HostFeatures& Features);
 
   // X86 cacheline size effectively has to be hardcoded to 64
   // if we report anything differently then applications are likely to break
@@ -514,5 +515,7 @@ private:
 
   using GetCPUIDPtr = uint32_t (*)();
   GetCPUIDPtr GetCPUID;
+
+  uint8_t HostVA, HostPA;
 };
 } // namespace FEXCore

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -77,7 +77,7 @@ $end_info$
 namespace FEXCore::Context {
 ContextImpl::ContextImpl(const FEXCore::HostFeatures& Features)
   : HostFeatures {Features}
-  , CPUID {this}
+  , CPUID {this, Features}
   , CodeCache {*this} {
   if (!Config.Is64BitMode()) {
     // When operating in 32-bit mode, the virtual memory we care about is only the lower 32-bits.

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -52,5 +52,11 @@ struct HostFeatures {
   // MIDR information
   // Also used for determining number of CPU cores for CPUID
   fextl::vector<uint32_t> CPUMIDRs;
+
+  // Host virtual memory size.
+  uint8_t HostVA {};
+
+  // Host physical memory size.
+  uint8_t HostPA {};
 };
 } // namespace FEXCore

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -459,6 +459,9 @@ fextl::string GenerateCPUInfo(FEXCore::Context::Context* ctx, uint32_t CPUCores)
   const auto FrequencyString = fextl::fmt::format("{:.3f}", FrequencyMhz);
   const auto BogomipsString = fextl::fmt::format("{:.2f}", Bogomips);
 
+  const auto MemoryString =
+    fextl::fmt::format("address sizes\t: {} bits physical, {} bits virtual", res_8000_0008.eax & 0xFF, (res_8000_0008.eax >> 8) & 0xFF);
+
   for (int i = 0; i < CPUCores; ++i) {
     cpu_stream << "processor\t: " << i << std::endl; // Logical id
     cpu_stream << "vendor_id\t: " << vendorid.Str << std::endl;
@@ -496,11 +499,10 @@ fextl::string GenerateCPUInfo(FEXCore::Context::Context* ctx, uint32_t CPUCores)
     // These next four aren't necessarily correct
     cpu_stream << "TLB size\t: 2560 4K pages" << std::endl;
     cpu_stream << "clflush size\t: 64" << std::endl;
-    cpu_stream << "cache_alignment\t : 64" << std::endl;
+    cpu_stream << "cache_alignment\t: 64" << std::endl;
 
-    // Cortex-A is 40 or 44 bits physical, and 48/52 virtual
-    // Choose the lesser configuration
-    cpu_stream << "address sizes\t: 40 bits physical, 48 bits virtual" << std::endl;
+    // Virtual and Physical memory size calculated by CPUID.
+    cpu_stream << MemoryString << std::endl;
 
     // No power management but required to report
     cpu_stream << "power management: " << std::endl;


### PR DESCRIPTION
Previously we were hardcoding 48-bit, which is reasonable. Query the VA space from the frontend and pass it back to CPUID instead. Then populate cpuinfo information from CPUID.