### PR TITLE
Config: Properly follow XDG directory specifications

### DIFF
--- a/FEXCore/Scripts/config_generator.py
+++ b/FEXCore/Scripts/config_generator.py
@@ -156,7 +156,7 @@ def print_man_environment_tail():
     "APP_CONFIG_LOCATION",
     [
     "Allows the user to override where FEX looks for configuration files",
-    "By default FEX will look in {$HOME, $XDG_CONFIG_HOME}/.fex-emu/",
+    "By default FEX will look in ${XDG_CONFIG_HOME, $HOME/.config}/fex-emu/",
     "This will override the full path",
     "If FEX_PORTABLE is declared then relative paths are also supported",
     "For FEX: Relative to the FEX binary",
@@ -168,7 +168,7 @@ def print_man_environment_tail():
     "APP_CONFIG",
     [
     "Allows the user to override where FEX looks for only the application config file",
-    "By default FEX will look in {$HOME, $XDG_CONFIG_HOME}/.fex-emu/Config.json",
+    "By default FEX will look in ${XDG_CONFIG_HOME, $HOME/.config}/fex-emu/Config.json",
     "This will override this file location",
     "One must be careful with this option as it will override any applications that load with execve as well"
     "If you need to support applications that execve then use FEX_APP_CONFIG_LOCATION instead"
@@ -182,7 +182,7 @@ def print_man_environment_tail():
     "APP_DATA_LOCATION",
     [
     "Allows the user to override where FEX looks for data files",
-    "By default FEX will look in {$HOME, $XDG_DATA_HOME}/.fex-emu/",
+    "By default FEX will look in {$XDG_DATA_HOME, $HOME/.local/share}/fex-emu/",
     "This will override the full path",
     "This is the folder where FEX stores generated files like IR cache"
     ],
@@ -204,7 +204,7 @@ def print_man_environment_tail():
     "APP_CACHE_LOCATION",
     [
     "Allows the user to override where FEX stores and loads cache files",
-    "By default FEX will look in $XDG_CACHE_HOME/fex-emu/ or $HOME/.cache/fex-emu/",
+    "By default FEX will look in ${XDG_CACHE_HOME, $HOME/.cache}/fex-emu/",
     "This will override the full path, trailing forward-slash is expected to exist",
     ],
     "''", True)
@@ -234,7 +234,7 @@ FEX is very much work in progress, so expect things to change.
 def print_man_tail():
     tail ='''.Sh FILES
 .Bl -tag -width "$prefix/share/fex-emu/GuestThunks" -compact
-.It Pa $XDG_HOME_DIR/.fex-emu
+.It Pa $XDG_CONFIG_DIR/fex-emu
 Default FEX user configuration directory
 .It Pa $prefix/share/fex-emu/AppConfig
 System level application configuration files

--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -127,9 +127,9 @@
           "\teg: ~/RootFS/Debian_x86_64",
           "Or this can be a name of a rootfs",
           "If the named rootfs exists in the FEX data folder then it will use that one",
-          "\teg: $HOME/.fex-emu/RootFS/<RootFS name>/",
-          "Or if you have XDG_DATA_HOME the config will search in that directory",
-          "\teg: $XDG_DATA_HOME/.fex-emu/RootFS/<RootFS name>/"
+          "\teg: $XDG_DATA_HOME/fex-emu/RootFS/<RootFS name>/",
+          "If XDG_DATA_HOME is unset, ~/.local/share will be used in its place.",
+          "\teg: $HOME/.local/share/fex-emu/RootFS/<RootFS name>/"
         ]
       },
       "ThunkHostLibs": {
@@ -155,9 +155,9 @@
           "\teg: ~/MyThunkConfig.json",
           "Or this can be a named of a Thunk config file",
           "If the named config file exists in the FEX data folder folder the it will use that one",
-          "\teg: $HOME/.fex-emu/ThunkConfigs/<ThunkConfig name>",
-          "Or if you have XDG_DATA_HOME the config will search in that directory",
-          "\teg: $XDG_DATA_HOME/.fex-emu/ThunkConfigs/<ThunkConfig name>"
+          "\teg: $XDG_DATA_HOME/fex-emu/ThunkConfigs/<ThunkConfig name>",
+          "If XDG_DATA_HOME is unset, ~/.local/share will be used in its place.",
+          "\teg: $HOME/.local/share/fex-emu/ThunkConfigs/<ThunkConfig name>"
         ]
       },
       "Env": {
@@ -387,7 +387,7 @@
         "Default": "",
         "Desc": [
           "Redirects the telemetry folder that FEX usually writes to.",
-          "By default telemetry data is stored in {$FEX_APP_DATA_LOCATION,{$XDG_DATA_HOME,$HOME}/.fex-emu/Telemetry/}"
+          "By default telemetry data is stored in {$FEX_APP_DATA_LOCATION,{$XDG_DATA_HOME,$HOME}/fex-emu/Telemetry/}"
         ]
       },
       "ProfileStats": {

--- a/Scripts/InstallFEX.py
+++ b/Scripts/InstallFEX.py
@@ -293,17 +293,21 @@ def GetRootFSPath():
         if HomeDir == None:
             HomeDir = "."
 
-        Path = HomeDir
+        Path = HomeDir + "/.local/share"
         DataXDG = os.getenv("XDG_DATA_HOME")
         if DataXDG != None:
             Path = DataXDG
 
-        Path = Path + "/.fex-emu"
+        Path = Path + "/fex-emu"
 
         DataOverride = os.getenv("FEX_APP_DATA_LOCATION")
 
         if DataOverride != None:
             Path = DataOverride
+
+        LegacyDir = HomeDir + "/.fex-emu"
+        if os.path.isdir(LegacyDir):
+            Path = LegacyDir
 
         _RootFSPath = Path + "/RootFS/"
 
@@ -420,4 +424,4 @@ def main():
     ExitWithStatus(0)
 
 if __name__ == "__main__":
-	sys.exit(main())
+    sys.exit(main())


### PR DESCRIPTION
Closes #4369

Previously, FEX would use `$HOME/.fex-emu` for its data and config if
`XDG_CONFIG_HOME` and/or `XDG_DATA_HOME` were unset. This doesn't follow
XDG, so instead we do a fallback to `$HOME/.config` and
`$HOME/.local/share` respectively if XDG env vars are unset. Also,
pre-emptively creates those directories since `~/.local/share` and
`~/.config` existing is technically not a guarantee if XDG dirs are unset.

Signed-off-by: crueter <crueter@eden-emu.dev>
