### PR TITLE
CI: Don't specify `shell: bash` every time

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,9 +36,6 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
 
     - name : submodule checkout
@@ -51,91 +48,72 @@ jobs:
       run: rm -Rf ${{runner.workspace}}/build
 
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DBUILD_FEX_LINUX_TESTS=True -DBUILD_THUNKS=True -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
+      run: |
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True \
+          -DENABLE_X86_HOST_DEBUG=True -DBUILD_FEX_LINUX_TESTS=True -DBUILD_THUNKS=True \
+          -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      shell: bash
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
     - name: Install
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: cmake --build . --config $BUILD_TYPE --target install
 
     - name: gcc target tests 64
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the gvisor tests
       run: cmake --build . --config $BUILD_TYPE --target gcc_target_tests_64
 
     - name: GCC64 Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC64.log || true
 
     - name: gcc target tests 32
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the gvisor tests
       run: cmake --build . --config $BUILD_TYPE --target gcc_target_tests_32
 
     - name: GCC32 Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC32.log || true
 
     - name: APITest tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: cmake --build . --config $BUILD_TYPE --target api_tests
 
     - name: APITest Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_APITests.log || true
 
     - name: FEXCore APITest tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: cmake --build . --config $BUILD_TYPE --target fexcore_apitests
 
     - name: FEXCore APITest Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
 
     - name: ARMEmitter tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: cmake --build . --config $BUILD_TYPE --target emitter_tests
 
     - name: ARMEmitter Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ARMEmitterTests.log || true
 
     - name: FEXLinuxTests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       env:
         # These tests require non-portable install due to thunks.
         FEX_PORTABLE: 0
@@ -143,99 +121,83 @@ jobs:
 
     - name: FEXLinuxTests Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
 
     - name: Thunkgen tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: cmake --build . --config $BUILD_TYPE --target thunkgen_tests
 
     - name: Thunkgen Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ThunkgenTests.log || true
 
     - name: Test GL No-Thunks
       if: matrix.arch[1] == 'x64'
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       env:
         DISPLAY: ":0"
       run: cmake --build . --config $BUILD_TYPE --target thunk_functional_tests_nothunks
 
     - name: No thunks Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_NoThunkResults.log || true
 
     - name: Test GL Thunks
       if: matrix.arch[1] == 'x64'
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       env:
         DISPLAY: ":0"
       run: cmake --build . --config $BUILD_TYPE --target thunk_functional_tests_thunks
 
     - name: Thunks Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ThunkResults.log || true
 
     - name: ASM Tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the unit tests
       run: cmake --build . --config $BUILD_TYPE --target asm_tests
 
     - name: ASM Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM.log || true
 
     - name: Posix Tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the posixtest
       run: cmake --build . --config $BUILD_TYPE --target posix_tests
 
     - name: Posix Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_Posix.log || true
 
     - name: gvisor tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the gvisor tests
       run: cmake --build . --config $BUILD_TYPE --target gvisor_tests
 
     - name: GVisor Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GVisor.log || true
 
     - name: Struct verifier tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: cmake --build . --config $BUILD_TYPE --target struct_verifier
 
     - name: Struct verifier Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_StructVerifier.log || true
 
     - name: Truncate test results
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       # Cap out the log files at 20M in case something crash spins and dumps fault text
       # ASM tests get quite close to 10MB
@@ -243,7 +205,6 @@ jobs:
 
     - name: Remove old SHM regions
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config $BUILD_TYPE --target remove_old_shm_regions
 

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -43,9 +43,6 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
 
     - name : submodule checkout
@@ -58,115 +55,93 @@ jobs:
       run: rm -Rf ${{runner.workspace}}/build
 
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DBUILD_FEX_LINUX_TESTS=True -DENABLE_GLIBC_ALLOCATOR_HOOK_FAULT=True -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
+      run: |
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False \
+          -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DBUILD_FEX_LINUX_TESTS=True \
+          -DENABLE_GLIBC_ALLOCATOR_HOOK_FAULT=True -DENABLE_JEMALLOC_GLIBC_ALLOC=False \
+          -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      shell: bash
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
     - name: Install
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: cmake --build . --config $BUILD_TYPE --target install
 
     - name: gcc target tests 64
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the gvisor tests
       run: cmake --build . --config $BUILD_TYPE --target gcc_target_tests_64
 
     - name: GCC64 Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC64.log || true
 
     - name: gcc target tests 32
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the gvisor tests
       run: cmake --build . --config $BUILD_TYPE --target gcc_target_tests_32
 
     - name: GCC32 Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC32.log || true
 
     - name: APITest tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: cmake --build . --config $BUILD_TYPE --target api_tests
 
     - name: APITest Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_APITests.log || true
 
     - name: FEXCore APITest tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: cmake --build . --config $BUILD_TYPE --target fexcore_apitests
 
     - name: FEXCore APITest Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
 
     - name: FEXLinuxTests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: cmake --build . --config $BUILD_TYPE --target fex_linux_tests_all
 
     - name: FEXLinuxTests Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
 
     - name: ASM Tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the unit tests
       run: cmake --build . --config $BUILD_TYPE --target asm_tests
 
     - name: ASM Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM.log || true
 
     - name: Posix Tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the posixtest
       run: cmake --build . --config $BUILD_TYPE --target posix_tests
 
     - name: Posix Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_Posix.log || true
 
     - name: Truncate test results
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       # Cap out the log files at 20M in case something crash spins and dumps fault text
       # ASM tests get quite close to 10MB
@@ -174,7 +149,6 @@ jobs:
 
     - name: Remove old SHM regions
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config $BUILD_TYPE --target remove_old_shm_regions
 
@@ -184,7 +158,7 @@ jobs:
 
     - name: Upload results
       if: ${{ always() }}
-      uses: 'actions/upload-artifact@v4'
+      uses: actions/upload-artifact@v4
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}

--- a/.github/workflows/hostrunner.yml
+++ b/.github/workflows/hostrunner.yml
@@ -36,9 +36,6 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
 
     - name : submodule checkout
@@ -51,41 +48,30 @@ jobs:
       run: rm -Rf ${{runner.workspace}}/build
 
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
+      run: |
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False \
+          -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      shell: bash
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
     - name: ASM Tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the unit tests
       run: cmake --build . --config $BUILD_TYPE --target asm_tests
 
     - name: ASM Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM.log || true
 
     - name: Truncate test results
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       # Cap out the log files at 20M in case something crash spins and dumps fault text
       # ASM tests get quite close to 10MB
@@ -97,7 +83,7 @@ jobs:
 
     - name: Upload results
       if: ${{ always() }}
-      uses: 'actions/upload-artifact@v4'
+      uses: actions/upload-artifact@v4
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}

--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -35,9 +35,6 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
 
     - name : submodule checkout
@@ -50,8 +47,6 @@ jobs:
       run: rm -Rf ${{runner.workspace}}/build
 
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Set vixl_sim x86
@@ -65,57 +60,43 @@ jobs:
         echo "VIXL_SIM_ENABLED=False" >> $GITHUB_ENV
 
     - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=$VIXL_SIM_ENABLED -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       env:
         FEX_DISABLETELEMETRY: 1
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE --target CodeSizeValidation instcountci_test_files
 
     - name: Instruction Count Tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the unit tests
       run: cmake --build . --config $BUILD_TYPE --target instcountci_tests
 
     - name: Instruction Count Test Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_InstCountCI.log || true
 
     - name: Update local repo instcount
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config $BUILD_TYPE --target instcountci_update_tests
 
     - name: Get instcountCI diff
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{github.workspace}}/
       run: git diff --output=${{runner.workspace}}/build/InstCountCI.diff
 
     - name: Check if InstCountCI Diff exists
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{github.workspace}}/
       # Check if the file is empty
       run: sh -c "! test -s ${{runner.workspace}}/build/InstCountCI.diff"
 
     - name: Truncate test results
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       # Cap out the log files at 20M in case something crash spins and dumps fault text
       # ASM tests get quite close to 10MB
@@ -127,7 +108,7 @@ jobs:
 
     - name: Upload results
       if: ${{ always() }}
-      uses: 'actions/upload-artifact@v4'
+      uses: actions/upload-artifact@v4
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}
@@ -136,7 +117,7 @@ jobs:
 
     - name: Upload results InstCountCI
       if: ${{ always() }}
-      uses: 'actions/upload-artifact@v4'
+      uses: actions/upload-artifact@v4
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-instcountci

--- a/.github/workflows/mingw_build.yml
+++ b/.github/workflows/mingw_build.yml
@@ -50,9 +50,6 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
 
     - name : submodule checkout
@@ -65,23 +62,14 @@ jobs:
       run: rm -Rf ${{runner.workspace}}/build
 
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/Data/CMake/toolchain_mingw.cmake -DMINGW_TRIPLE=$MINGW_TRIPLE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
@@ -91,7 +79,7 @@ jobs:
 
     - name: Upload results
       if: ${{ always() }}
-      uses: 'actions/upload-artifact@v4'
+      uses: actions/upload-artifact@v4
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}

--- a/.github/workflows/steamrt4.yml
+++ b/.github/workflows/steamrt4.yml
@@ -53,23 +53,25 @@ jobs:
       run: distrobox enter --name steamrt4 -- cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
-      shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: distrobox enter --name steamrt4 -- cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DBUILD_STEAM_SUPPORT=True -DENABLE_LTO=True -DENABLE_ASSERTIONS=False -DBUILD_THUNKS=True -DBUILD_FEXCONFIG=False -DBUILD_TESTING=False -DENABLE_CLANG_THUNKS=True -DUSE_LINKER=lld -DCMAKE_INSTALL_PREFIX=/usr
+      run: |
+        distrobox enter --name steamrt4 -- cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -G Ninja -DBUILD_STEAM_SUPPORT=True -DENABLE_LTO=True -DENABLE_ASSERTIONS=False -DBUILD_THUNKS=True \
+          -DBUILD_FEXCONFIG=False -DBUILD_TESTING=False -DENABLE_CLANG_THUNKS=True -DUSE_LINKER=lld \
+          -DCMAKE_INSTALL_PREFIX=/usr
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: distrobox enter --name steamrt4 -- cmake --build . --config $BUILD_TYPE
 
     - name: install
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       env:
         DESTDIR: ${{runner.workspace}}/install
       run: distrobox enter --name steamrt4 -- cmake --build . --config $BUILD_TYPE -t install
+
     - name: Upload libraries
-      uses: 'actions/upload-artifact@v4'
+      uses: actions/upload-artifact@v4
       timeout-minutes: 1
       with:
         overwrite: true

--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -37,9 +37,6 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
 
     - name : submodule checkout
@@ -52,41 +49,28 @@ jobs:
       run: rm -Rf ${{runner.workspace}}/build
 
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=True -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      shell: bash
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
     - name: ASM Tests - SVE256
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       # Execute the unit tests
       run: cmake --build . --config $BUILD_TYPE --target asm_tests
 
     - name: ASM Test SVE256 Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM_SVE256Bit.log || true
 
     - name: ASM Tests - SVE128
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       env:
         FEX_FORCESVEWIDTH: "128"
       # Execute the unit tests
@@ -94,13 +78,11 @@ jobs:
 
     - name: ASM Test 128-bit Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM_SVE128Bit.log || true
 
     - name: ASM Tests - ASIMD
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       env:
         FEX_HOSTFEATURES: "disablesve"
       # Execute the unit tests
@@ -108,13 +90,11 @@ jobs:
 
     - name: ASM Test ASIMD Results move
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM_ASIMD.log || true
 
     - name: Truncate test results
       if: ${{ always() }}
-      shell: bash
       working-directory: ${{runner.workspace}}/build
       # Cap out the log files at 20M in case something crash spins and dumps fault text
       # ASM tests get quite close to 10MB
@@ -126,7 +106,7 @@ jobs:
 
     - name: Upload results
       if: ${{ always() }}
-      uses: 'actions/upload-artifact@v4'
+      uses: actions/upload-artifact@v4
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}

--- a/.github/workflows/wine_dll_artifacts.yml
+++ b/.github/workflows/wine_dll_artifacts.yml
@@ -46,12 +46,20 @@ jobs:
     - name: Configure CMake arm64ec
       shell: bash
       working-directory: ${{runner.workspace}}/build_arm64ec
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/Data/CMake/toolchain_mingw.cmake -DMINGW_TRIPLE=arm64ec-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=/usr -DTUNE_ARCH=generic -DTUNE_CPU=none
+      run: |
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/Data/CMake/toolchain_mingw.cmake \
+          -DMINGW_TRIPLE=arm64ec-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows -G Ninja \
+          -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=/usr \
+          -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=/usr -DTUNE_ARCH=generic -DTUNE_CPU=none
 
     - name: Configure CMake wow64
       shell: bash
       working-directory: ${{runner.workspace}}/build_wow64
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/Data/CMake/toolchain_mingw.cmake -DMINGW_TRIPLE=aarch64-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=/usr -DTUNE_ARCH=generic -DTUNE_CPU=none
+      run: |
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/Data/CMake/toolchain_mingw.cmake \
+          -DMINGW_TRIPLE=aarch64-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows -G Ninja \
+          -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=/usr \
+          -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=/usr -DTUNE_ARCH=generic -DTUNE_CPU=none
 
     - name: Build arm64ec
       working-directory: ${{runner.workspace}}/build_arm64ec
@@ -78,7 +86,7 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE -t install
 
     - name: Upload libraries
-      uses: 'actions/upload-artifact@v4'
+      uses: actions/upload-artifact@v4
       timeout-minutes: 1
       with:
         overwrite: true


### PR DESCRIPTION
Bash is already the default on Linux runners.

Just a bit cleaner and less lines. Also cleaned out some unneeded
comments from the template.

Signed-off-by: crueter <crueter@eden-emu.dev>