### PR TITLE
gitignore: ignore CMakeLists.txt.user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out/
 *.pyc
 .cache
 .idea/
+CMakeLists.txt.user


### PR DESCRIPTION
I can't tell you how many times I've accidentally committed this file.
It's used by Qt Creator

Signed-off-by: crueter <crueter@eden-emu.dev>
