### PR TITLE
CI: Remove redundant runner.workspace and working-directory directives

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,177 +36,146 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
+      run: python3 Scripts/CI_FetchRootFS.py
 
-    - name : submodule checkout
+    - name: Checkout Submodules
       # Need to update submodules
       run: |
         git submodule sync --recursive
         git submodule update --init --depth 1
 
     - name: Clean Build Environment
-      run: rm -Rf ${{runner.workspace}}/build
+      run: rm -Rf build
 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      run: cmake -E make_directory build
 
     - name: Configure CMake
-      working-directory: ${{runner.workspace}}/build
       run: |
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True \
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True \
           -DENABLE_X86_HOST_DEBUG=True -DBUILD_FEX_LINUX_TESTS=True -DBUILD_THUNKS=True \
-          -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
+          -DCMAKE_INSTALL_PREFIX="$PWD"/build/install
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build build --config $BUILD_TYPE
 
     - name: Install
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target install
+      run: cmake --build build --config $BUILD_TYPE --target install
 
     - name: gcc target tests 64
-      working-directory: ${{runner.workspace}}/build
       # Execute the gvisor tests
-      run: cmake --build . --config $BUILD_TYPE --target gcc_target_tests_64
+      run: cmake --build build --config $BUILD_TYPE --target gcc_target_tests_64
 
     - name: GCC64 Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC64.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GCC64.log || true
 
     - name: gcc target tests 32
-      working-directory: ${{runner.workspace}}/build
       # Execute the gvisor tests
-      run: cmake --build . --config $BUILD_TYPE --target gcc_target_tests_32
+      run: cmake --build build --config $BUILD_TYPE --target gcc_target_tests_32
 
     - name: GCC32 Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC32.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GCC32.log || true
 
     - name: APITest tests
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target api_tests
+      run: cmake --build build --config $BUILD_TYPE --target api_tests
 
     - name: APITest Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_APITests.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_APITests.log || true
 
     - name: FEXCore APITest tests
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target fexcore_apitests
+      run: cmake --build build --config $BUILD_TYPE --target fexcore_apitests
 
     - name: FEXCore APITest Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
 
     - name: ARMEmitter tests
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target emitter_tests
+      run: cmake --build build --config $BUILD_TYPE --target emitter_tests
 
     - name: ARMEmitter Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ARMEmitterTests.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ARMEmitterTests.log || true
 
     - name: FEXLinuxTests
-      working-directory: ${{runner.workspace}}/build
       env:
         # These tests require non-portable install due to thunks.
         FEX_PORTABLE: 0
-      run: cmake --build . --config $BUILD_TYPE --target fex_linux_tests_all
+      run: cmake --build build --config $BUILD_TYPE --target fex_linux_tests_all
 
     - name: FEXLinuxTests Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
 
     - name: Thunkgen tests
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target thunkgen_tests
+      run: cmake --build build --config $BUILD_TYPE --target thunkgen_tests
 
     - name: Thunkgen Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ThunkgenTests.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ThunkgenTests.log || true
 
     - name: Test GL No-Thunks
       if: matrix.arch[1] == 'x64'
-      working-directory: ${{runner.workspace}}/build
       env:
         DISPLAY: ":0"
-      run: cmake --build . --config $BUILD_TYPE --target thunk_functional_tests_nothunks
+      run: cmake --build build --config $BUILD_TYPE --target thunk_functional_tests_nothunks
 
     - name: No thunks Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_NoThunkResults.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_NoThunkResults.log || true
 
     - name: Test GL Thunks
       if: matrix.arch[1] == 'x64'
-      working-directory: ${{runner.workspace}}/build
       env:
         DISPLAY: ":0"
-      run: cmake --build . --config $BUILD_TYPE --target thunk_functional_tests_thunks
+      run: cmake --build build --config $BUILD_TYPE --target thunk_functional_tests_thunks
 
     - name: Thunks Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ThunkResults.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ThunkResults.log || true
 
     - name: ASM Tests
-      working-directory: ${{runner.workspace}}/build
       # Execute the unit tests
-      run: cmake --build . --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --config $BUILD_TYPE --target asm_tests
 
     - name: ASM Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM.log || true
 
     - name: Posix Tests
-      working-directory: ${{runner.workspace}}/build
       # Execute the posixtest
-      run: cmake --build . --config $BUILD_TYPE --target posix_tests
+      run: cmake --build build --config $BUILD_TYPE --target posix_tests
 
     - name: Posix Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_Posix.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_Posix.log || true
 
     - name: gvisor tests
-      working-directory: ${{runner.workspace}}/build
       # Execute the gvisor tests
-      run: cmake --build . --config $BUILD_TYPE --target gvisor_tests
+      run: cmake --build build --config $BUILD_TYPE --target gvisor_tests
 
     - name: GVisor Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GVisor.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GVisor.log || true
 
     - name: Struct verifier tests
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target struct_verifier
+      run: cmake --build build --config $BUILD_TYPE --target struct_verifier
 
     - name: Struct verifier Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_StructVerifier.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_StructVerifier.log || true
 
     - name: Truncate test results
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
       # Cap out the log files at 20M in case something crash spins and dumps fault text
       # ASM tests get quite close to 10MB
-      run: truncate --size="<20M" ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log || true
+      run: truncate --size="<20M" build/Testing/Temporary/LastTest_*.log || true
 
     - name: Remove old SHM regions
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target remove_old_shm_regions
+      run: cmake --build build --config $BUILD_TYPE --target remove_old_shm_regions
 
     - name: Set runner name
       if: ${{ always() }}
@@ -218,5 +187,5 @@ jobs:
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log
+        path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
         retention-days: 3

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -43,114 +43,95 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
+      run: python3 Scripts/CI_FetchRootFS.py
 
-    - name : submodule checkout
+    - name: Checkout Submodules
       # Need to update submodules
       run: |
         git submodule sync --recursive
         git submodule update --init --depth 1
 
     - name: Clean Build Environment
-      run: rm -Rf ${{runner.workspace}}/build
+      run: rm -Rf build
 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      run: cmake -E make_directory build
 
     - name: Configure CMake
-      working-directory: ${{runner.workspace}}/build
       run: |
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False \
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False \
           -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DBUILD_FEX_LINUX_TESTS=True \
           -DENABLE_GLIBC_ALLOCATOR_HOOK_FAULT=True -DENABLE_JEMALLOC_GLIBC_ALLOC=False \
-          -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
+          -DCMAKE_INSTALL_PREFIX="$PWD"/build/install
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build build --config $BUILD_TYPE
 
     - name: Install
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target install
+      run: cmake --build build --config $BUILD_TYPE --target install
 
     - name: gcc target tests 64
-      working-directory: ${{runner.workspace}}/build
       # Execute the gvisor tests
-      run: cmake --build . --config $BUILD_TYPE --target gcc_target_tests_64
+      run: cmake --build build --config $BUILD_TYPE --target gcc_target_tests_64
 
     - name: GCC64 Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC64.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GCC64.log || true
 
     - name: gcc target tests 32
-      working-directory: ${{runner.workspace}}/build
       # Execute the gvisor tests
-      run: cmake --build . --config $BUILD_TYPE --target gcc_target_tests_32
+      run: cmake --build build --config $BUILD_TYPE --target gcc_target_tests_32
 
     - name: GCC32 Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_GCC32.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GCC32.log || true
 
     - name: APITest tests
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target api_tests
+      run: cmake --build build --config $BUILD_TYPE --target api_tests
 
     - name: APITest Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_APITests.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_APITests.log || true
 
     - name: FEXCore APITest tests
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target fexcore_apitests
+      run: cmake --build build --config $BUILD_TYPE --target fexcore_apitests
 
     - name: FEXCore APITest Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
 
     - name: FEXLinuxTests
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target fex_linux_tests_all
+      run: cmake --build build --config $BUILD_TYPE --target fex_linux_tests_all
 
     - name: FEXLinuxTests Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
 
     - name: ASM Tests
-      working-directory: ${{runner.workspace}}/build
       # Execute the unit tests
-      run: cmake --build . --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --config $BUILD_TYPE --target asm_tests
 
     - name: ASM Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM.log || true
 
     - name: Posix Tests
-      working-directory: ${{runner.workspace}}/build
       # Execute the posixtest
-      run: cmake --build . --config $BUILD_TYPE --target posix_tests
+      run: cmake --build build --config $BUILD_TYPE --target posix_tests
 
     - name: Posix Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_Posix.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_Posix.log || true
 
     - name: Truncate test results
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
       # Cap out the log files at 20M in case something crash spins and dumps fault text
       # ASM tests get quite close to 10MB
-      run: truncate --size="<20M" ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log || true
+      run: truncate --size="<20M" build/Testing/Temporary/LastTest_*.log || true
 
     - name: Remove old SHM regions
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target remove_old_shm_regions
+      run: cmake --build build --config $BUILD_TYPE --target remove_old_shm_regions
 
     - name: Set runner name
       if: ${{ always() }}
@@ -162,6 +143,6 @@ jobs:
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log
+        path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
         retention-days: 3
 

--- a/.github/workflows/hostrunner.yml
+++ b/.github/workflows/hostrunner.yml
@@ -36,46 +36,41 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
+      run: python3 Scripts/CI_FetchRootFS.py
 
-    - name : submodule checkout
+    - name: Checkout Submodules
       # Need to update submodules
       run: |
         git submodule sync --recursive
         git submodule update --init --depth 1
 
     - name: Clean Build Environment
-      run: rm -Rf ${{runner.workspace}}/build
+      run: rm -Rf build
 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      run: cmake -E make_directory build
 
     - name: Configure CMake
-      working-directory: ${{runner.workspace}}/build
       run: |
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False \
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False \
           -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build build --config $BUILD_TYPE
 
     - name: ASM Tests
-      working-directory: ${{runner.workspace}}/build
       # Execute the unit tests
-      run: cmake --build . --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --config $BUILD_TYPE --target asm_tests
 
     - name: ASM Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM.log || true
 
     - name: Truncate test results
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
       # Cap out the log files at 20M in case something crash spins and dumps fault text
       # ASM tests get quite close to 10MB
-      run: truncate --size="<20M" ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log || true
+      run: truncate --size="<20M" build/Testing/Temporary/LastTest_*.log || true
 
     - name: Set runner name
       if: ${{ always() }}
@@ -87,6 +82,6 @@ jobs:
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log
+        path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
         retention-days: 3
 

--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -35,19 +35,19 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
+      run: python3 Scripts/CI_FetchRootFS.py
 
-    - name : submodule checkout
+    - name: Checkout Submodules
       # Need to update submodules
       run: |
         git submodule sync --recursive
         git submodule update --init --depth 1
 
     - name: Clean Build Environment
-      run: rm -Rf ${{runner.workspace}}/build
+      run: rm -Rf build
 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      run: cmake -E make_directory build
 
     - name: Set vixl_sim x86
       if: matrix.arch[1] == 'x64'
@@ -60,41 +60,36 @@ jobs:
         echo "VIXL_SIM_ENABLED=False" >> $GITHUB_ENV
 
     - name: Configure CMake
-      working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=$VIXL_SIM_ENABLED -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=$VIXL_SIM_ENABLED \
+          -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
       env:
         FEX_DISABLETELEMETRY: 1
-      run: cmake --build . --config $BUILD_TYPE --target CodeSizeValidation instcountci_test_files
+      run: cmake --build build --config $BUILD_TYPE --target CodeSizeValidation instcountci_test_files
 
     - name: Instruction Count Tests
-      working-directory: ${{runner.workspace}}/build
       # Execute the unit tests
-      run: cmake --build . --config $BUILD_TYPE --target instcountci_tests
+      run: cmake --build build --config $BUILD_TYPE --target instcountci_tests
 
     - name: Instruction Count Test Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_InstCountCI.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_InstCountCI.log || true
 
     - name: Update local repo instcount
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE --target instcountci_update_tests
+      run: cmake --build build --config $BUILD_TYPE --target instcountci_update_tests
 
     - name: Check InstCountCI diff
       if: ${{ always() }}
-      working-directory: ${{github.workspace}}/
       run: git --no-pager diff --exit-code HEAD
 
     - name: Truncate test results
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
       # Cap out the log files at 20M in case something crash spins and dumps fault text
       # ASM tests get quite close to 10MB
-      run: truncate --size="<20M" ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log || true
+      run: truncate --size="<20M" build/Testing/Temporary/LastTest_*.log || true
 
     - name: Set runner name
       if: ${{ always() }}
@@ -106,5 +101,5 @@ jobs:
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log
+        path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
         retention-days: 3

--- a/.github/workflows/mingw_build.yml
+++ b/.github/workflows/mingw_build.yml
@@ -50,25 +50,25 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
+      run: python3 Scripts/CI_FetchRootFS.py
 
-    - name : submodule checkout
+    - name: Checkout Submodules
       # Need to update submodules
       run: |
         git submodule sync --recursive
         git submodule update --init --depth 1
 
     - name: Clean Build Environment
-      run: rm -Rf ${{runner.workspace}}/build
+      run: rm -Rf build
 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      run: cmake -E make_directory build
 
     - name: Configure CMake
-      working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/Data/CMake/toolchain_mingw.cmake -DMINGW_TRIPLE=$MINGW_TRIPLE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/build/install
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/Data/CMake/toolchain_mingw.cmake \
+        -DMINGW_TRIPLE=$MINGW_TRIPLE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True -DBUILD_TESTING=False \
+        -DCMAKE_INSTALL_PREFIX="$PWD"/build/install
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build build --config $BUILD_TYPE

--- a/.github/workflows/steamrt4.yml
+++ b/.github/workflows/steamrt4.yml
@@ -27,15 +27,15 @@ jobs:
     - name: Set runner label
       run: echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
 
-    - name : submodule checkout
+    - name: Checkout Submodules
       run: |
         git submodule sync --recursive
         git submodule update --init --depth 1
 
     - name: Clean Build Environment
       run: |
-        rm -Rf ${{runner.workspace}}/build
-        cmake -E make_directory ${{runner.workspace}}/build
+        rm -Rf build
+        cmake -E make_directory build
 
     # Setup everything required.
     - name : distrobox setup
@@ -50,25 +50,20 @@ jobs:
           libstdc++-14-dev-amd64-cross libgcc-14-dev-amd64-cross
 
     - name: Create Build Environment
-      run: distrobox enter --name steamrt4 -- cmake -E make_directory ${{runner.workspace}}/build
+      run: distrobox enter --name steamrt4 -- cmake -E make_directory build
 
     - name: Configure CMake
-      working-directory: ${{runner.workspace}}/build
       run: |
-        distrobox enter --name steamrt4 -- cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+        distrobox enter --name steamrt4 -- cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -G Ninja -DBUILD_STEAM_SUPPORT=True -DENABLE_LTO=True -DENABLE_ASSERTIONS=False -DBUILD_THUNKS=True \
           -DBUILD_FEXCONFIG=False -DBUILD_TESTING=False -DENABLE_CLANG_THUNKS=True -DUSE_LINKER=lld \
           -DCMAKE_INSTALL_PREFIX=/usr
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      run: distrobox enter --name steamrt4 -- cmake --build . --config $BUILD_TYPE
+      run: distrobox enter --name steamrt4 -- cmake --build build --config $BUILD_TYPE
 
     - name: install
-      working-directory: ${{runner.workspace}}/build
-      env:
-        DESTDIR: ${{runner.workspace}}/install
-      run: distrobox enter --name steamrt4 -- cmake --build . --config $BUILD_TYPE -t install
+      run: DESTDIR="$PWD"/install distrobox enter --name steamrt4 -- cmake --build build --config $BUILD_TYPE -t install
 
     - name: Upload libraries
       uses: actions/upload-artifact@v4
@@ -76,6 +71,6 @@ jobs:
       with:
         overwrite: true
         name: steamrt4_steampipe_depot
-        path: ${{runner.workspace}}/install/*
+        path: ${{ github.workspace }}/install/*
         retention-days: 60
         compression-level: 9

--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -37,68 +37,59 @@ jobs:
         echo "FEX_ROOTFS=$HOME/Rootfs/" >> $GITHUB_ENV
 
     - name: Update RootFS cache
-      run: $GITHUB_WORKSPACE/Scripts/CI_FetchRootFS.py
+      run: python3 Scripts/CI_FetchRootFS.py
 
-    - name : submodule checkout
+    - name: Checkout Submodules
       # Need to update submodules
       run: |
         git submodule sync --recursive
         git submodule update --init --depth 1
 
     - name: Clean Build Environment
-      run: rm -Rf ${{runner.workspace}}/build
+      run: rm -Rf build
 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      run: cmake -E make_directory build
 
     - name: Configure CMake
-      working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=True -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=True -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build build --config $BUILD_TYPE
 
     - name: ASM Tests - SVE256
-      working-directory: ${{runner.workspace}}/build
       # Execute the unit tests
-      run: cmake --build . --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --config $BUILD_TYPE --target asm_tests
 
     - name: ASM Test SVE256 Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM_SVE256Bit.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM_SVE256Bit.log || true
 
     - name: ASM Tests - SVE128
-      working-directory: ${{runner.workspace}}/build
       env:
         FEX_FORCESVEWIDTH: "128"
       # Execute the unit tests
-      run: cmake --build . --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --config $BUILD_TYPE --target asm_tests
 
     - name: ASM Test 128-bit Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM_SVE128Bit.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM_SVE128Bit.log || true
 
     - name: ASM Tests - ASIMD
-      working-directory: ${{runner.workspace}}/build
       env:
         FEX_HOSTFEATURES: "disablesve"
       # Execute the unit tests
-      run: cmake --build . --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --config $BUILD_TYPE --target asm_tests
 
     - name: ASM Test ASIMD Results move
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
-      run: mv ${{runner.workspace}}/build/Testing/Temporary/LastTest.log ${{runner.workspace}}/build/Testing/Temporary/LastTest_ASM_ASIMD.log || true
+      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM_ASIMD.log || true
 
     - name: Truncate test results
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
       # Cap out the log files at 20M in case something crash spins and dumps fault text
       # ASM tests get quite close to 10MB
-      run: truncate --size="<20M" ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log || true
+      run: truncate --size="<20M" build/Testing/Temporary/LastTest_*.log || true
 
     - name: Set runner name
       if: ${{ always() }}
@@ -110,6 +101,6 @@ jobs:
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log
+        path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
         retention-days: 3
 

--- a/.github/workflows/wine_dll_artifacts.yml
+++ b/.github/workflows/wine_dll_artifacts.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Add MingGW to PATH
       run: echo "$HOME/llvm-mingw/build/bin/" >> $GITHUB_PATH
 
-    - name : submodule checkout
+    - name: Checkout Submodules
       # Need to update submodules
       run: |
         git submodule sync --recursive
@@ -30,60 +30,44 @@ jobs:
 
     - name: Clean install directory
       run: |
-        rm -Rf ${{runner.workspace}}/build_install
-        mkdir ${{runner.workspace}}/build_install
+        rm -Rf build_install
+        mkdir build_install
 
     - name: Clean Build Environment
       run: |
-        rm -Rf ${{runner.workspace}}/build_arm64ec
-        rm -Rf ${{runner.workspace}}/build_wow64
+        rm -Rf build_wow64
+        rm -Rf build_arm64ec
 
-    - name: Create Build Environment arm64ec
+    - name: Create Build Environment
       run: |
-        cmake -E make_directory ${{runner.workspace}}/build_arm64ec
-        cmake -E make_directory ${{runner.workspace}}/build_wow64
+        cmake -E make_directory build_arm64ec
+        cmake -E make_directory build_wow64
 
-    - name: Configure CMake arm64ec
-      shell: bash
-      working-directory: ${{runner.workspace}}/build_arm64ec
+    - name: Configure CMake (arm64ec)
       run: |
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/Data/CMake/toolchain_mingw.cmake \
+        cmake -S . -B build_arm64ec -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=Data/CMake/toolchain_mingw.cmake \
           -DMINGW_TRIPLE=arm64ec-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows -G Ninja \
-          -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=/usr \
+          -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False \
           -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=/usr -DTUNE_ARCH=generic -DTUNE_CPU=none
 
-    - name: Configure CMake wow64
-      shell: bash
-      working-directory: ${{runner.workspace}}/build_wow64
+    - name: Configure CMake (wow64)
       run: |
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/Data/CMake/toolchain_mingw.cmake \
+        cmake -S . -B build_wow64 -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=Data/CMake/toolchain_mingw.cmake \
           -DMINGW_TRIPLE=aarch64-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows -G Ninja \
-          -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False -DCMAKE_INSTALL_PREFIX=/usr \
+          -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False \
           -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=/usr -DTUNE_ARCH=generic -DTUNE_CPU=none
 
-    - name: Build arm64ec
-      working-directory: ${{runner.workspace}}/build_arm64ec
-      shell: bash
-      run: cmake --build . --config $BUILD_TYPE
+    - name: Build (arm64ec)
+      run: cmake --build build_arm64ec --config $BUILD_TYPE
 
-    - name: install arm64ec
-      working-directory: ${{runner.workspace}}/build_arm64ec
-      shell: bash
-      env:
-        DESTDIR: ${{runner.workspace}}/build_install
-      run: cmake --build . --config $BUILD_TYPE -t install
+    - name: Install (arm64ec)
+      run: DESTDIR="$PWD"/build_install cmake --build build_arm64ec --config $BUILD_TYPE -t install
 
-    - name: Build wow64
-      working-directory: ${{runner.workspace}}/build_wow64
-      shell: bash
-      run: cmake --build . --config $BUILD_TYPE
+    - name: Build (wow64)
+      run: cmake --build build_wow64 --config $BUILD_TYPE
 
-    - name: install wow64
-      working-directory: ${{runner.workspace}}/build_wow64
-      shell: bash
-      env:
-        DESTDIR: ${{runner.workspace}}/build_install
-      run: cmake --build . --config $BUILD_TYPE -t install
+    - name: Install (wow64)
+      run: DESTDIR="$PWD"/build_install cmake --build build_wow64 --config $BUILD_TYPE -t install
 
     - name: Upload libraries
       uses: actions/upload-artifact@v4
@@ -91,6 +75,6 @@ jobs:
       with:
         overwrite: true
         name: wine_dll_artifacts
-        path: ${{runner.workspace}}/build_install/usr/lib/wine/aarch64-windows/lib*.dll
+        path: ${{ github.workspace }}/build_install/usr/lib/wine/aarch64-windows/lib*.dll
         retention-days: 60
         compression-level: 9


### PR DESCRIPTION
Generally speaking, `${{ runner.workspace }}`/`${{ github.workspace }}`/`$GITHUB_WORKSPACE` are unnecessary, and can actually cause problems when mixing and matching. Artifact uploads still use this though since they seemingly refuse to work with relative paths (?)

`working-directory` can also cause problems and can generally be replaced trivially with `cmake -S . -B build` or the like. Some of the test moves may benefit from `working-directory: ${{ runner.workspace }}/build/Testing/Temporary`, but that will be solved in a separate PR.

Also, try to avoid explicit env directives unless it's cleaner to include them. In cases like `DESTDIR` it's better to put it in-line

Separated from #5246 for reviewer's ease.

Signed-off-by: crueter <crueter@eden-emu.dev>
