### PR TITLE
CI: Remove unnecessary upload steps

### DIFF
--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -108,13 +108,3 @@ jobs:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
         path: ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log
         retention-days: 3
-
-    - name: Upload results InstCountCI
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      timeout-minutes: 1
-      with:
-        name: Results-${{ env.runner_name }}-${{ env.runner_label }}-instcountci
-        path: ${{runner.workspace}}/build/InstCountCI.diff
-        retention-days: 3
-

--- a/.github/workflows/mingw_build.yml
+++ b/.github/workflows/mingw_build.yml
@@ -72,17 +72,3 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
-
-    - name: Set runner name
-      if: ${{ always() }}
-      run: echo "runner_name=$(hostname)" >> $GITHUB_ENV
-
-    - name: Upload results
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      timeout-minutes: 1
-      with:
-        name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{runner.workspace}}/build/Testing/Temporary/LastTest_*.log
-        retention-days: 3
-


### PR DESCRIPTION
MinGW doesn't do any tests. Also forgot to remove the InstCountCI diff.

Signed-off-by: crueter <crueter@eden-emu.dev>
