### PR TITLE
CI: Remove redundant build mkdir and `--config`

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -47,9 +47,6 @@ jobs:
     - name: Clean Build Environment
       run: rm -Rf build
 
-    - name: Create Build Environment
-      run: cmake -E make_directory build
-
     - name: Configure CMake
       run: |
         cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False -DENABLE_ASSERTIONS=True \
@@ -57,14 +54,14 @@ jobs:
           -DCMAKE_INSTALL_PREFIX="$PWD"/build/install
 
     - name: Build
-      run: cmake --build build --config $BUILD_TYPE
+      run: cmake --build build
 
     - name: Install
-      run: cmake --build build --config $BUILD_TYPE --target install
+      run: cmake --build build --target install
 
     - name: gcc target tests 64
       # Execute the gvisor tests
-      run: cmake --build build --config $BUILD_TYPE --target gcc_target_tests_64
+      run: cmake --build build --target gcc_target_tests_64
 
     - name: GCC64 Test Results move
       if: ${{ always() }}
@@ -72,28 +69,28 @@ jobs:
 
     - name: gcc target tests 32
       # Execute the gvisor tests
-      run: cmake --build build --config $BUILD_TYPE --target gcc_target_tests_32
+      run: cmake --build build --target gcc_target_tests_32
 
     - name: GCC32 Test Results move
       if: ${{ always() }}
       run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GCC32.log || true
 
     - name: APITest tests
-      run: cmake --build build --config $BUILD_TYPE --target api_tests
+      run: cmake --build build --target api_tests
 
     - name: APITest Test Results move
       if: ${{ always() }}
       run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_APITests.log || true
 
     - name: FEXCore APITest tests
-      run: cmake --build build --config $BUILD_TYPE --target fexcore_apitests
+      run: cmake --build build --target fexcore_apitests
 
     - name: FEXCore APITest Test Results move
       if: ${{ always() }}
       run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
 
     - name: ARMEmitter tests
-      run: cmake --build build --config $BUILD_TYPE --target emitter_tests
+      run: cmake --build build --target emitter_tests
 
     - name: ARMEmitter Test Results move
       if: ${{ always() }}
@@ -103,14 +100,14 @@ jobs:
       env:
         # These tests require non-portable install due to thunks.
         FEX_PORTABLE: 0
-      run: cmake --build build --config $BUILD_TYPE --target fex_linux_tests_all
+      run: cmake --build build --target fex_linux_tests_all
 
     - name: FEXLinuxTests Results move
       if: ${{ always() }}
       run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
 
     - name: Thunkgen tests
-      run: cmake --build build --config $BUILD_TYPE --target thunkgen_tests
+      run: cmake --build build --target thunkgen_tests
 
     - name: Thunkgen Results move
       if: ${{ always() }}
@@ -120,7 +117,7 @@ jobs:
       if: matrix.arch[1] == 'x64'
       env:
         DISPLAY: ":0"
-      run: cmake --build build --config $BUILD_TYPE --target thunk_functional_tests_nothunks
+      run: cmake --build build --target thunk_functional_tests_nothunks
 
     - name: No thunks Results move
       if: ${{ always() }}
@@ -130,7 +127,7 @@ jobs:
       if: matrix.arch[1] == 'x64'
       env:
         DISPLAY: ":0"
-      run: cmake --build build --config $BUILD_TYPE --target thunk_functional_tests_thunks
+      run: cmake --build build --target thunk_functional_tests_thunks
 
     - name: Thunks Results move
       if: ${{ always() }}
@@ -138,7 +135,7 @@ jobs:
 
     - name: ASM Tests
       # Execute the unit tests
-      run: cmake --build build --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --target asm_tests
 
     - name: ASM Test Results move
       if: ${{ always() }}
@@ -146,7 +143,7 @@ jobs:
 
     - name: Posix Tests
       # Execute the posixtest
-      run: cmake --build build --config $BUILD_TYPE --target posix_tests
+      run: cmake --build build --target posix_tests
 
     - name: Posix Test Results move
       if: ${{ always() }}
@@ -154,14 +151,14 @@ jobs:
 
     - name: gvisor tests
       # Execute the gvisor tests
-      run: cmake --build build --config $BUILD_TYPE --target gvisor_tests
+      run: cmake --build build --target gvisor_tests
 
     - name: GVisor Test Results move
       if: ${{ always() }}
       run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GVisor.log || true
 
     - name: Struct verifier tests
-      run: cmake --build build --config $BUILD_TYPE --target struct_verifier
+      run: cmake --build build --target struct_verifier
 
     - name: Struct verifier Test Results move
       if: ${{ always() }}
@@ -175,7 +172,7 @@ jobs:
 
     - name: Remove old SHM regions
       if: ${{ always() }}
-      run: cmake --build build --config $BUILD_TYPE --target remove_old_shm_regions
+      run: cmake --build build --target remove_old_shm_regions
 
     - name: Set runner name
       if: ${{ always() }}

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -54,9 +54,6 @@ jobs:
     - name: Clean Build Environment
       run: rm -Rf build
 
-    - name: Create Build Environment
-      run: cmake -E make_directory build
-
     - name: Configure CMake
       run: |
         cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False \
@@ -65,14 +62,14 @@ jobs:
           -DCMAKE_INSTALL_PREFIX="$PWD"/build/install
 
     - name: Build
-      run: cmake --build build --config $BUILD_TYPE
+      run: cmake --build build
 
     - name: Install
-      run: cmake --build build --config $BUILD_TYPE --target install
+      run: cmake --build build --target install
 
     - name: gcc target tests 64
       # Execute the gvisor tests
-      run: cmake --build build --config $BUILD_TYPE --target gcc_target_tests_64
+      run: cmake --build build --target gcc_target_tests_64
 
     - name: GCC64 Test Results move
       if: ${{ always() }}
@@ -80,28 +77,28 @@ jobs:
 
     - name: gcc target tests 32
       # Execute the gvisor tests
-      run: cmake --build build --config $BUILD_TYPE --target gcc_target_tests_32
+      run: cmake --build build --target gcc_target_tests_32
 
     - name: GCC32 Test Results move
       if: ${{ always() }}
       run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GCC32.log || true
 
     - name: APITest tests
-      run: cmake --build build --config $BUILD_TYPE --target api_tests
+      run: cmake --build build --target api_tests
 
     - name: APITest Test Results move
       if: ${{ always() }}
       run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_APITests.log || true
 
     - name: FEXCore APITest tests
-      run: cmake --build build --config $BUILD_TYPE --target fexcore_apitests
+      run: cmake --build build --target fexcore_apitests
 
     - name: FEXCore APITest Test Results move
       if: ${{ always() }}
       run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
 
     - name: FEXLinuxTests
-      run: cmake --build build --config $BUILD_TYPE --target fex_linux_tests_all
+      run: cmake --build build --target fex_linux_tests_all
 
     - name: FEXLinuxTests Results move
       if: ${{ always() }}
@@ -109,7 +106,7 @@ jobs:
 
     - name: ASM Tests
       # Execute the unit tests
-      run: cmake --build build --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --target asm_tests
 
     - name: ASM Test Results move
       if: ${{ always() }}
@@ -117,7 +114,7 @@ jobs:
 
     - name: Posix Tests
       # Execute the posixtest
-      run: cmake --build build --config $BUILD_TYPE --target posix_tests
+      run: cmake --build build --target posix_tests
 
     - name: Posix Test Results move
       if: ${{ always() }}
@@ -131,7 +128,7 @@ jobs:
 
     - name: Remove old SHM regions
       if: ${{ always() }}
-      run: cmake --build build --config $BUILD_TYPE --target remove_old_shm_regions
+      run: cmake --build build --target remove_old_shm_regions
 
     - name: Set runner name
       if: ${{ always() }}

--- a/.github/workflows/hostrunner.yml
+++ b/.github/workflows/hostrunner.yml
@@ -47,20 +47,17 @@ jobs:
     - name: Clean Build Environment
       run: rm -Rf build
 
-    - name: Create Build Environment
-      run: cmake -E make_directory build
-
     - name: Configure CMake
       run: |
         cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False \
           -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
     - name: Build
-      run: cmake --build build --config $BUILD_TYPE
+      run: cmake --build build
 
     - name: ASM Tests
       # Execute the unit tests
-      run: cmake --build build --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --target asm_tests
 
     - name: ASM Test Results move
       if: ${{ always() }}

--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -46,9 +46,6 @@ jobs:
     - name: Clean Build Environment
       run: rm -Rf build
 
-    - name: Create Build Environment
-      run: cmake -E make_directory build
-
     - name: Set vixl_sim x86
       if: matrix.arch[1] == 'x64'
       run: |
@@ -67,11 +64,11 @@ jobs:
     - name: Build
       env:
         FEX_DISABLETELEMETRY: 1
-      run: cmake --build build --config $BUILD_TYPE --target CodeSizeValidation instcountci_test_files
+      run: cmake --build build --target CodeSizeValidation instcountci_test_files
 
     - name: Instruction Count Tests
       # Execute the unit tests
-      run: cmake --build build --config $BUILD_TYPE --target instcountci_tests
+      run: cmake --build build --target instcountci_tests
 
     - name: Instruction Count Test Results move
       if: ${{ always() }}
@@ -79,7 +76,7 @@ jobs:
 
     - name: Update local repo instcount
       if: ${{ always() }}
-      run: cmake --build build --config $BUILD_TYPE --target instcountci_update_tests
+      run: cmake --build build --target instcountci_update_tests
 
     - name: Check InstCountCI diff
       if: ${{ always() }}

--- a/.github/workflows/mingw_build.yml
+++ b/.github/workflows/mingw_build.yml
@@ -61,9 +61,6 @@ jobs:
     - name: Clean Build Environment
       run: rm -Rf build
 
-    - name: Create Build Environment
-      run: cmake -E make_directory build
-
     - name: Configure CMake
       run: |
         cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/Data/CMake/toolchain_mingw.cmake \
@@ -71,4 +68,4 @@ jobs:
         -DCMAKE_INSTALL_PREFIX="$PWD"/build/install
 
     - name: Build
-      run: cmake --build build --config $BUILD_TYPE
+      run: cmake --build build

--- a/.github/workflows/steamrt4.yml
+++ b/.github/workflows/steamrt4.yml
@@ -33,9 +33,7 @@ jobs:
         git submodule update --init --depth 1
 
     - name: Clean Build Environment
-      run: |
-        rm -Rf build
-        cmake -E make_directory build
+      run: rm -Rf build
 
     # Setup everything required.
     - name : distrobox setup
@@ -49,9 +47,6 @@ jobs:
           libstdc++-14-dev-i386-cross libgcc-14-dev-i386-cross \
           libstdc++-14-dev-amd64-cross libgcc-14-dev-amd64-cross
 
-    - name: Create Build Environment
-      run: distrobox enter --name steamrt4 -- cmake -E make_directory build
-
     - name: Configure CMake
       run: |
         distrobox enter --name steamrt4 -- cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
@@ -60,10 +55,10 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=/usr
 
     - name: Build
-      run: distrobox enter --name steamrt4 -- cmake --build build --config $BUILD_TYPE
+      run: distrobox enter --name steamrt4 -- cmake --build build
 
     - name: install
-      run: DESTDIR="$PWD"/install distrobox enter --name steamrt4 -- cmake --build build --config $BUILD_TYPE -t install
+      run: DESTDIR="$PWD"/install distrobox enter --name steamrt4 -- cmake --build build -t install
 
     - name: Upload libraries
       uses: actions/upload-artifact@v4

--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -48,18 +48,15 @@ jobs:
     - name: Clean Build Environment
       run: rm -Rf build
 
-    - name: Create Build Environment
-      run: cmake -E make_directory build
-
     - name: Configure CMake
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=True -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
     - name: Build
-      run: cmake --build build --config $BUILD_TYPE
+      run: cmake --build build
 
     - name: ASM Tests - SVE256
       # Execute the unit tests
-      run: cmake --build build --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --target asm_tests
 
     - name: ASM Test SVE256 Results move
       if: ${{ always() }}
@@ -69,7 +66,7 @@ jobs:
       env:
         FEX_FORCESVEWIDTH: "128"
       # Execute the unit tests
-      run: cmake --build build --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --target asm_tests
 
     - name: ASM Test 128-bit Results move
       if: ${{ always() }}
@@ -79,7 +76,7 @@ jobs:
       env:
         FEX_HOSTFEATURES: "disablesve"
       # Execute the unit tests
-      run: cmake --build build --config $BUILD_TYPE --target asm_tests
+      run: cmake --build build --target asm_tests
 
     - name: ASM Test ASIMD Results move
       if: ${{ always() }}

--- a/.github/workflows/wine_dll_artifacts.yml
+++ b/.github/workflows/wine_dll_artifacts.yml
@@ -29,19 +29,10 @@ jobs:
         git submodule update --init --depth 1
 
     - name: Clean install directory
-      run: |
-        rm -Rf build_install
-        mkdir build_install
+      run: rm -Rf build_install
 
     - name: Clean Build Environment
-      run: |
-        rm -Rf build_wow64
-        rm -Rf build_arm64ec
-
-    - name: Create Build Environment
-      run: |
-        cmake -E make_directory build_arm64ec
-        cmake -E make_directory build_wow64
+      run: rm -Rf build_wow64 build_arm64ec
 
     - name: Configure CMake (arm64ec)
       run: |
@@ -58,16 +49,16 @@ jobs:
           -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=/usr -DTUNE_ARCH=generic -DTUNE_CPU=none
 
     - name: Build (arm64ec)
-      run: cmake --build build_arm64ec --config $BUILD_TYPE
+      run: cmake --build build_arm64ec
 
     - name: Install (arm64ec)
-      run: DESTDIR="$PWD"/build_install cmake --build build_arm64ec --config $BUILD_TYPE -t install
+      run: DESTDIR="$PWD"/build_install cmake --build build_arm64ec -t install
 
     - name: Build (wow64)
-      run: cmake --build build_wow64 --config $BUILD_TYPE
+      run: cmake --build build_wow64
 
     - name: Install (wow64)
-      run: DESTDIR="$PWD"/build_install cmake --build build_wow64 --config $BUILD_TYPE -t install
+      run: DESTDIR="$PWD"/build_install cmake --build build_wow64 -t install
 
     - name: Upload libraries
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
CMake already handles the mkdir step implicitly with `-B build`. Same
with build type, where setting `CMAKE_BUILD_TYPE` will propagate it as
such to the build commands. The only exception to this is the MSBuild
generator, which we don't use here.

Signed-off-by: crueter <crueter@eden-emu.dev>
