### PR TITLE
CI: Refactor tests to use a composite action

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -26,8 +26,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set runner label
-      run: echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+    - name: Set runner info
+      run: |
+        echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+        echo "runner_name=$(hostname)" >> $GITHUB_ENV
 
     - name: Set rootfs paths
       run: |
@@ -59,124 +61,115 @@ jobs:
     - name: Install
       run: cmake --build build --target install
 
-    - name: gcc target tests 64
-      # Execute the gvisor tests
-      run: cmake --build build --target gcc_target_tests_64
-
-    - name: GCC64 Test Results move
+    # GCC tests
+    - name: GCC64 Target Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GCC64.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: gcc_target_tests_64
+        log-name: GCC64
 
-    - name: gcc target tests 32
-      # Execute the gvisor tests
-      run: cmake --build build --target gcc_target_tests_32
-
-    - name: GCC32 Test Results move
+    - name: GCC32 Target Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GCC32.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: gcc_target_tests_32
+        log-name: GCC32
 
-    - name: APITest tests
-      run: cmake --build build --target api_tests
-
-    - name: APITest Test Results move
+    # API tests
+    - name: API Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_APITests.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: api_tests
+        log-name: APITests
 
-    - name: FEXCore APITest tests
-      run: cmake --build build --target fexcore_apitests
-
-    - name: FEXCore APITest Test Results move
+    - name: FEXCore API Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: fexcore_apitests
+        log-name: FEXCoreAPITests
 
-    - name: ARMEmitter tests
-      run: cmake --build build --target emitter_tests
-
-    - name: ARMEmitter Test Results move
+    # ARM emission tests
+    - name: ARM Emitter Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ARMEmitterTests.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: emitter_tests
+        log-name: ARMEmitterTests
 
-    - name: FEXLinuxTests
+    # Linux  tests
+    - name: FEX Linux Tests
+      if: ${{ always() }}
+      uses: ./.github/workflows/test
+      with:
+        target: fex_linux_tests_all
+        log-name: FEXLinuxTests
       env:
-        # These tests require non-portable install due to thunks.
         FEX_PORTABLE: 0
-      run: cmake --build build --target fex_linux_tests_all
 
-    - name: FEXLinuxTests Results move
-      if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
-
+    # Thunking
     - name: Thunkgen tests
-      run: cmake --build build --target thunkgen_tests
-
-    - name: Thunkgen Results move
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ThunkgenTests.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: thunkgen_tests
+        log-name: ThunkgenTests
 
     - name: Test GL No-Thunks
-      if: matrix.arch[1] == 'x64'
+      if: ${{ always() && matrix.arch[1] == 'x64' }}
+      uses: ./.github/workflows/test
+      with:
+        target: thunk_functional_tests_nothunks
+        log-name: NoThunkResults
       env:
-        DISPLAY: ":0"
-      run: cmake --build build --target thunk_functional_tests_nothunks
-
-    - name: No thunks Results move
-      if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_NoThunkResults.log || true
+        DISPLAY: ':0'
 
     - name: Test GL Thunks
-      if: matrix.arch[1] == 'x64'
+      if: ${{ always() && matrix.arch[1] == 'x64' }}
+      uses: ./.github/workflows/test
+      with:
+        target: thunk_functional_tests_thunks
+        log-name: ThunkResults
       env:
-        DISPLAY: ":0"
-      run: cmake --build build --target thunk_functional_tests_thunks
+        DISPLAY: ':0'
 
-    - name: Thunks Results move
-      if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ThunkResults.log || true
-
+    # ASM tests
     - name: ASM Tests
-      # Execute the unit tests
-      run: cmake --build build --target asm_tests
-
-    - name: ASM Test Results move
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: asm_tests
+        log-name: ASM
 
-    - name: Posix Tests
-      # Execute the posixtest
-      run: cmake --build build --target posix_tests
-
-    - name: Posix Test Results move
+    # POSIX tests
+    - name: POSIX Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_Posix.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: posix_tests
+        log-name: Posix
 
-    - name: gvisor tests
-      # Execute the gvisor tests
-      run: cmake --build build --target gvisor_tests
-
-    - name: GVisor Test Results move
+    # GVisor tests
+    - name: GVisor Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GVisor.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: gvisor_tests
+        log-name: GVisor
 
+    # Struct verifier tests
     - name: Struct verifier tests
-      run: cmake --build build --target struct_verifier
-
-    - name: Struct verifier Test Results move
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_StructVerifier.log || true
-
-    - name: Truncate test results
-      if: ${{ always() }}
-      # Cap out the log files at 20M in case something crash spins and dumps fault text
-      # ASM tests get quite close to 10MB
-      run: truncate --size="<20M" build/Testing/Temporary/LastTest_*.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: struct_verifier
+        log-name: StructVerifier
 
     - name: Remove old SHM regions
       if: ${{ always() }}
       run: cmake --build build --target remove_old_shm_regions
-
-    - name: Set runner name
-      if: ${{ always() }}
-      run: echo "runner_name=$(hostname)" >> $GITHUB_ENV
 
     - name: Upload results
       if: ${{ always() }}

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -33,8 +33,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set runner label
-      run: echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+    - name: Set runner info
+      run: |
+        echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+        echo "runner_name=$(hostname)" >> $GITHUB_ENV
 
     - name: Set rootfs paths
       run: |
@@ -67,72 +69,63 @@ jobs:
     - name: Install
       run: cmake --build build --target install
 
-    - name: gcc target tests 64
-      # Execute the gvisor tests
-      run: cmake --build build --target gcc_target_tests_64
-
-    - name: GCC64 Test Results move
+    # GCC tests
+    - name: GCC64 Target Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GCC64.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: gcc_target_tests_64
+        log-name: GCC64
 
-    - name: gcc target tests 32
-      # Execute the gvisor tests
-      run: cmake --build build --target gcc_target_tests_32
-
-    - name: GCC32 Test Results move
+    - name: GCC32 Target Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_GCC32.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: gcc_target_tests_32
+        log-name: GCC32
 
-    - name: APITest tests
-      run: cmake --build build --target api_tests
-
-    - name: APITest Test Results move
+    # API Tests
+    - name: API Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_APITests.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: api_tests
+        log-name: APITests
 
-    - name: FEXCore APITest tests
-      run: cmake --build build --target fexcore_apitests
-
-    - name: FEXCore APITest Test Results move
+    - name: FEXCore API Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXCoreAPITests.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: fexcore_apitests
+        log-name: FEXCoreAPITests
 
-    - name: FEXLinuxTests
-      run: cmake --build build --target fex_linux_tests_all
-
-    - name: FEXLinuxTests Results move
+    # Linux tests
+    - name: FEX Linux Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_FEXLinuxTests.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: fex_linux_tests_all
+        log-name: FEXLinuxTests
 
+    # ASM Tests
     - name: ASM Tests
-      # Execute the unit tests
-      run: cmake --build build --target asm_tests
-
-    - name: ASM Test Results move
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: asm_tests
+        log-name: ASM
 
-    - name: Posix Tests
-      # Execute the posixtest
-      run: cmake --build build --target posix_tests
-
-    - name: Posix Test Results move
+    # POSIX Tests
+    - name: POSIX Tests
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_Posix.log || true
-
-    - name: Truncate test results
-      if: ${{ always() }}
-      # Cap out the log files at 20M in case something crash spins and dumps fault text
-      # ASM tests get quite close to 10MB
-      run: truncate --size="<20M" build/Testing/Temporary/LastTest_*.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: posix_tests
+        log-name: Posix
 
     - name: Remove old SHM regions
       if: ${{ always() }}
       run: cmake --build build --target remove_old_shm_regions
-
-    - name: Set runner name
-      if: ${{ always() }}
-      run: echo "runner_name=$(hostname)" >> $GITHUB_ENV
 
     - name: Upload results
       if: ${{ always() }}

--- a/.github/workflows/hostrunner.yml
+++ b/.github/workflows/hostrunner.yml
@@ -26,8 +26,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set runner label
-      run: echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+    - name: Set runner info
+      run: |
+        echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+        echo "runner_name=$(hostname)" >> $GITHUB_ENV
 
     - name: Set rootfs paths
       run: |
@@ -55,23 +57,13 @@ jobs:
     - name: Build
       run: cmake --build build
 
+    # ASM tests
     - name: ASM Tests
-      # Execute the unit tests
-      run: cmake --build build --target asm_tests
-
-    - name: ASM Test Results move
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM.log || true
-
-    - name: Truncate test results
-      if: ${{ always() }}
-      # Cap out the log files at 20M in case something crash spins and dumps fault text
-      # ASM tests get quite close to 10MB
-      run: truncate --size="<20M" build/Testing/Temporary/LastTest_*.log || true
-
-    - name: Set runner name
-      if: ${{ always() }}
-      run: echo "runner_name=$(hostname)" >> $GITHUB_ENV
+      uses: ./.github/workflows/test
+      with:
+        target: asm_tests
+        log-name: ASM
 
     - name: Upload results
       if: ${{ always() }}

--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -25,8 +25,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set runner label
-      run: echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+    - name: Set runner info
+      run: |
+        echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+        echo "runner_name=$(hostname)" >> $GITHUB_ENV
 
     - name: Set rootfs paths
       run: |
@@ -67,12 +69,11 @@ jobs:
       run: cmake --build build --target CodeSizeValidation instcountci_test_files
 
     - name: Instruction Count Tests
-      # Execute the unit tests
-      run: cmake --build build --target instcountci_tests
-
-    - name: Instruction Count Test Results move
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_InstCountCI.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: instcountci_tests
+        log-name: InstCountCI
 
     - name: Update local repo instcount
       if: ${{ always() }}
@@ -81,16 +82,6 @@ jobs:
     - name: Check InstCountCI diff
       if: ${{ always() }}
       run: git --no-pager diff --exit-code HEAD
-
-    - name: Truncate test results
-      if: ${{ always() }}
-      # Cap out the log files at 20M in case something crash spins and dumps fault text
-      # ASM tests get quite close to 10MB
-      run: truncate --size="<20M" build/Testing/Temporary/LastTest_*.log || true
-
-    - name: Set runner name
-      if: ${{ always() }}
-      run: echo "runner_name=$(hostname)" >> $GITHUB_ENV
 
     - name: Upload results
       if: ${{ always() }}

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -1,0 +1,24 @@
+name: Run Test and Store Logs
+
+inputs:
+  target:
+    description: 'The test target to run'
+    required: true
+  log-name:
+    description: 'The name suffix of the resulting log file'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run Tests
+      shell: bash
+      run: cmake --build build --target ${{ inputs.target }}
+
+    - name: Move and Truncate Results
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        LAST_LOG="build/Testing/Temporary/LastTest"
+        truncate --size="<20M" "$LAST_LOG".log || true
+        mv "$LAST_LOG".log "${LAST_LOG}_${{ inputs.log-name }}".log || true

--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -27,8 +27,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set runner label
-      run: echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+    - name: Set runner info
+      run: |
+        echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
+        echo "runner_name=$(hostname)" >> $GITHUB_ENV
 
     - name: Set rootfs paths
       run: |
@@ -49,48 +51,37 @@ jobs:
       run: rm -Rf build
 
     - name: Configure CMake
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=True -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_LTO=False -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=True -DENABLE_LTO=False \
+          -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
     - name: Build
       run: cmake --build build
 
     - name: ASM Tests - SVE256
-      # Execute the unit tests
-      run: cmake --build build --target asm_tests
-
-    - name: ASM Test SVE256 Results move
       if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM_SVE256Bit.log || true
+      uses: ./.github/workflows/test
+      with:
+        target: asm_tests
+        log-name: ASM_SVE256Bit
 
     - name: ASM Tests - SVE128
+      if: ${{ always() }}
+      uses: ./.github/workflows/test
       env:
         FEX_FORCESVEWIDTH: "128"
-      # Execute the unit tests
-      run: cmake --build build --target asm_tests
-
-    - name: ASM Test 128-bit Results move
-      if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM_SVE128Bit.log || true
+      with:
+        target: asm_tests
+        log-name: ASM_SVE128Bit
 
     - name: ASM Tests - ASIMD
+      if: ${{ always() }}
+      uses: ./.github/workflows/test
       env:
         FEX_HOSTFEATURES: "disablesve"
-      # Execute the unit tests
-      run: cmake --build build --target asm_tests
-
-    - name: ASM Test ASIMD Results move
-      if: ${{ always() }}
-      run: mv build/Testing/Temporary/LastTest.log build/Testing/Temporary/LastTest_ASM_ASIMD.log || true
-
-    - name: Truncate test results
-      if: ${{ always() }}
-      # Cap out the log files at 20M in case something crash spins and dumps fault text
-      # ASM tests get quite close to 10MB
-      run: truncate --size="<20M" build/Testing/Temporary/LastTest_*.log || true
-
-    - name: Set runner name
-      if: ${{ always() }}
-      run: echo "runner_name=$(hostname)" >> $GITHUB_ENV
+      with:
+        target: asm_tests
+        log-name: ASM_ASIMD
 
     - name: Upload results
       if: ${{ always() }}
@@ -100,4 +91,3 @@ jobs:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
         path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
         retention-days: 3
-


### PR DESCRIPTION
Significantly reduces the constant duplication of test run steps. Port
of #5246, but differs in that the composite action now truncates the log
file in-place.

Signed-off-by: crueter <crueter@eden-emu.dev>
