### PR TITLE
CI: Use a composite action for Wine DLL builds

### DIFF
--- a/.github/workflows/wine_build/action.yml
+++ b/.github/workflows/wine_build/action.yml
@@ -1,0 +1,34 @@
+name: Wine DLL Build
+
+inputs:
+  target:
+    description: 'The target (arm64ec or wow64)'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Clean Build Environment
+      shell: bash
+      run: rm -Rf build_${{ inputs.target }}
+
+    - name: Configure CMake
+      shell: bash
+      run: |
+        case "${{ inputs.target }}" in
+          wow64) _cc=aarch64 ;;
+          arm64ec) _cc=arm64ec ;;
+        esac
+
+        cmake -S . -B build_${{ inputs.target }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=Data/CMake/toolchain_mingw.cmake \
+          -DMINGW_TRIPLE=${_cc}-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows -G Ninja \
+          -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False \
+          -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=/usr -DTUNE_ARCH=generic -DTUNE_CPU=none
+
+    - name: Build
+      shell: bash
+      run: cmake --build build_${{ inputs.target }}
+
+    - name: Install
+      shell: bash
+      run: DESTDIR="$PWD"/install cmake --build build_${{ inputs.target }} -t install

--- a/.github/workflows/wine_dll_artifacts.yml
+++ b/.github/workflows/wine_dll_artifacts.yml
@@ -29,36 +29,18 @@ jobs:
         git submodule update --init --depth 1
 
     - name: Clean install directory
-      run: rm -Rf build_install
-
-    - name: Clean Build Environment
-      run: rm -Rf build_wow64 build_arm64ec
-
-    - name: Configure CMake (arm64ec)
       run: |
-        cmake -S . -B build_arm64ec -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=Data/CMake/toolchain_mingw.cmake \
-          -DMINGW_TRIPLE=arm64ec-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows -G Ninja \
-          -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False \
-          -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=/usr -DTUNE_ARCH=generic -DTUNE_CPU=none
-
-    - name: Configure CMake (wow64)
-      run: |
-        cmake -S . -B build_wow64 -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=Data/CMake/toolchain_mingw.cmake \
-          -DMINGW_TRIPLE=aarch64-w64-mingw32 -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-windows -G Ninja \
-          -DENABLE_LTO=False -DENABLE_ASSERTIONS=False -DENABLE_JEMALLOC_GLIBC_ALLOC=False \
-          -DBUILD_TESTING=False -DCMAKE_INSTALL_PREFIX=/usr -DTUNE_ARCH=generic -DTUNE_CPU=none
-
-    - name: Build (arm64ec)
-      run: cmake --build build_arm64ec
-
-    - name: Install (arm64ec)
-      run: DESTDIR="$PWD"/build_install cmake --build build_arm64ec -t install
+        rm -Rf install
 
     - name: Build (wow64)
-      run: cmake --build build_wow64
+      uses: ./.github/workflows/wine_build
+      with:
+        target: wow64
 
-    - name: Install (wow64)
-      run: DESTDIR="$PWD"/build_install cmake --build build_wow64 -t install
+    - name: Build (arm64ec)
+      uses: ./.github/workflows/wine_build
+      with:
+        target: arm64ec
 
     - name: Upload libraries
       uses: actions/upload-artifact@v4
@@ -66,6 +48,6 @@ jobs:
       with:
         overwrite: true
         name: wine_dll_artifacts
-        path: ${{ github.workspace }}/build_install/usr/lib/wine/aarch64-windows/lib*.dll
+        path: ${{ github.workspace }}/install/usr/lib/wine/aarch64-windows/lib*.dll
         retention-days: 60
         compression-level: 9


### PR DESCRIPTION
Less duplication and less work.

Signed-off-by: crueter <crueter@eden-emu.dev>
