### PR TITLE
CI: Update actions deps

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set runner info
       run: |
@@ -173,7 +173,7 @@ jobs:
 
     - name: Upload results
       if: ${{ always() }}
-      uses: 'actions/upload-artifact@v4'
+      uses: actions/upload-artifact@v6
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set runner info
       run: |
@@ -129,7 +129,7 @@ jobs:
 
     - name: Upload results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}

--- a/.github/workflows/hostrunner.yml
+++ b/.github/workflows/hostrunner.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set runner info
       run: |
@@ -67,7 +67,7 @@ jobs:
 
     - name: Upload results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}

--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set runner info
       run: |
@@ -85,7 +85,7 @@ jobs:
 
     - name: Upload results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}

--- a/.github/workflows/mingw_build.yml
+++ b/.github/workflows/mingw_build.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set runner label
       run: echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV

--- a/.github/workflows/steamrt4.yml
+++ b/.github/workflows/steamrt4.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set runner label
       run: echo "runner_label=${{ matrix.arch[1] }}" >> $GITHUB_ENV
@@ -61,7 +61,7 @@ jobs:
       run: DESTDIR="$PWD"/install distrobox enter --name steamrt4 -- cmake --build build -t install
 
     - name: Upload libraries
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       timeout-minutes: 1
       with:
         overwrite: true

--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set runner info
       run: |
@@ -85,7 +85,7 @@ jobs:
 
     - name: Upload results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}

--- a/.github/workflows/wine_dll_artifacts.yml
+++ b/.github/workflows/wine_dll_artifacts.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Add MingGW to PATH
       run: echo "$HOME/llvm-mingw/build/bin/" >> $GITHUB_PATH
@@ -61,7 +61,7 @@ jobs:
       run: DESTDIR="$PWD"/build_install cmake --build build_wow64 -t install
 
     - name: Upload libraries
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       timeout-minutes: 1
       with:
         overwrite: true


### PR DESCRIPTION
Checkout and upload-artifact. They contain general bug fixes and update
the Node runtime such that they should be generally faster. Note that
this requires Node.js 24, if that's a dealbreaker for the runners feel
free to close.

Signed-off-by: crueter <crueter@eden-emu.dev>
