### PR TITLE
FEX: Ensure VDSO and Stack are pushed as high in the VA space as possible

### DIFF
--- a/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
+++ b/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
@@ -168,6 +168,8 @@ fextl::unique_ptr<FEX::HLE::MemAllocator> InitAllocator(bool Is64Bit) {
   // Now that the upper 32-bit address space is blocked for future allocations,
   // exhaust all of jemalloc's remaining internal allocations that it reserved before.
   // TODO: It's unclear how reliably this exhausts those reserves
+  // TODO: This will likely consume one arena inside the 32-bit VA space.
+  //   - (HdkR): I've noticed jemalloc consuming an 8MB arena commonly.
   FEXCore::Allocator::YesIKnowImNotSupposedToUseTheGlibcAllocator glibc;
   void* data;
   do {


### PR DESCRIPTION
On 36-bit VA systems the stack was ending up /wherever/ when it should be at the top of the VA space (usually).

Additionally VDSO was getting mapped anywhere on 64-bit, so push that to the top of the VA space as well.

Also removes a check for old kernels not supporting MAP_FIXED_NOREPLACE.