### PR TITLE
CI: Move noisy build targets generation to a separate step

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -55,6 +55,11 @@ jobs:
           -DENABLE_X86_HOST_DEBUG=True -DBUILD_FEX_LINUX_TESTS=True -DBUILD_THUNKS=True \
           -DCMAKE_INSTALL_PREFIX="$PWD"/build/install
 
+    # These steps make a lot of noise but rarely fail.
+    # Put them in a separate step to make normal build logs easier to parse
+    - name: Noisy Build Targets
+      run: cmake --build build --target asm_files 32bit_asm_files JemallocLibs Catch2 vixl cephes_128bit
+
     - name: Build
       run: cmake --build build
 

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -63,6 +63,11 @@ jobs:
           -DENABLE_GLIBC_ALLOCATOR_HOOK_FAULT=True -DENABLE_JEMALLOC_GLIBC_ALLOC=False \
           -DCMAKE_INSTALL_PREFIX="$PWD"/build/install
 
+    # These steps make a lot of noise but rarely fail.
+    # Put them in a separate step to make normal build logs easier to parse
+    - name: Noisy Build Targets
+      run: cmake --build build --target asm_files 32bit_asm_files JemallocLibs Catch2 vixl cephes_128bit
+
     - name: Build
       run: cmake --build build
 

--- a/.github/workflows/hostrunner.yml
+++ b/.github/workflows/hostrunner.yml
@@ -54,6 +54,11 @@ jobs:
         cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_LTO=False \
           -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
+    # These steps make a lot of noise but rarely fail.
+    # Put them in a separate step to make normal build logs easier to parse
+    - name: Noisy Build Targets
+      run: cmake --build build --target asm_files 32bit_asm_files JemallocLibs Catch2 vixl cephes_128bit
+
     - name: Build
       run: cmake --build build
 

--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -55,6 +55,11 @@ jobs:
         cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja -DENABLE_VIXL_SIMULATOR=True -DENABLE_LTO=False \
           -DENABLE_VIXL_DISASSEMBLER=True -DENABLE_ASSERTIONS=True -DENABLE_X86_HOST_DEBUG=True
 
+    # These steps make a lot of noise but rarely fail.
+    # Put them in a separate step to make normal build logs easier to parse
+    - name: Noisy Build Targets
+      run: cmake --build build --target asm_files 32bit_asm_files JemallocLibs Catch2 vixl cephes_128bit
+
     - name: Build
       run: cmake --build build
 


### PR DESCRIPTION
As requested by neobrain. Makes log parsing easier because you can see
the "noisy" and usually unchanging targets in one step
(which usually succeed, I hope), and the more error-prone "the rest of FEX"
build in separate steps. Makes parsing FEX build errors easier

Signed-off-by: crueter <crueter@eden-emu.dev>
