### PR TITLE
CI: Enforce SPDX headers on newly changed files

### DIFF
--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+
+name: Check license headers
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  license_header:
+    runs-on: [self-hosted, X64]
+    if: github.repository == 'FEX-Emu/FEX'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout through merge base
+        uses: rmacklin/fetch-through-merge-base@v0
+        timeout-minutes: 3
+        with:
+          base_ref: ${{ github.event.pull_request.base.ref }}
+          head_ref: ${{ github.event.pull_request.head.sha }}
+          deepen_length: 500
+
+      - name: Check license headers
+        run: Scripts/license-header.sh

--- a/Scripts/license-header.sh
+++ b/Scripts/license-header.sh
@@ -1,0 +1,70 @@
+#!/bin/sh -e
+
+# SPDX-License-Identifier: MIT
+
+# This script has been adapted from
+# https://git.crueter.xyz/scripts/license-header/src/branch/master/.ci/license-header.sh
+
+# Files to exclude (e.g. third-party files and scripts)
+# You should specify these as a relative path to the root of the repository.
+_exclude=""
+
+# License identifier, get this from REUSE
+_license="MIT"
+
+_header="SPDX-License-Identifier: $_license"
+
+# Contains files that need a license header.
+BAD_FILES=""
+
+BASE=$(git merge-base main HEAD)
+FILES=$(git diff --name-only "$BASE")
+
+for file in $FILES; do
+	[ -f "$file" ] || continue
+
+	# skip files that are third party
+	excluded=false
+	for pattern in $EXCLUDE_FILES; do
+		case "$file" in
+			*"$pattern"*) excluded=true; break ;;
+		esac
+	done
+
+	[ "$excluded" = "false" ] || continue
+
+	# Some file types just don't need headers.
+	case "$file" in
+		*.cmake | *.sh | *CMakeLists.txt | *.py | *.yml | *.cpp | *.c | *.h | *.qml) ;;
+		*) continue ;;
+	esac
+
+	content="$(head -n5 <"$file")"
+
+	if ! echo "$content" | grep -qe "$_header"; then
+		BAD_FILES="$BAD_FILES $file"
+	fi
+done
+
+if [ -z "$BAD_FILES" ]; then
+	echo "-- All good."
+	exit
+else
+	echo
+	echo "-- The following files have incorrect license headers:"
+
+	for file in $BAD_FILES; do echo "-- * $file"; done
+	cat <<-EOF
+
+	-- The following license header should be added to the start of these offending files as a comment:
+
+	=== BEGIN ===
+	$_header
+	===  END  ===
+
+    If some of the code in this PR is not being contributed by the original author,
+    the files which have been exclusively changed by that code can be ignored.
+    If this happens, this PR requirement can be bypassed once all other files are addressed.
+
+	EOF
+fi


### PR DESCRIPTION
Just the identifier, year can be easily retrofitted by changing one
variable. This script will receive updates in the future, so can be
implanted when those occur.

Not sure if retroactively applying headers is a good idea, but that
would be a separate PR.

Signed-off-by: crueter <crueter@eden-emu.dev>
