### PR TITLE
FEXCore: Move two functions to the frontend

### DIFF
--- a/FEXCore/Source/Utils/Threads.cpp
+++ b/FEXCore/Source/Utils/Threads.cpp
@@ -5,10 +5,6 @@
 
 #include <pthread.h>
 #include <unistd.h>
-#ifndef _WIN32
-#include <sys/signal.h>
-#include <sys/syscall.h>
-#endif
 
 namespace FEXCore::Threads {
 static fextl::unique_ptr<FEXCore::Threads::Thread> CreateThread_Default(ThreadFunc Func, void* Arg) {
@@ -34,22 +30,5 @@ void FEXCore::Threads::Thread::CleanupAfterFork() {
 
 void FEXCore::Threads::Thread::SetInternalPointers(const Pointers& _Ptrs) {
   Ptrs = _Ptrs;
-}
-
-uint64_t SetSignalMask(uint64_t Mask) {
-#ifndef _WIN32
-  ::syscall(SYS_rt_sigprocmask, SIG_SETMASK, &Mask, &Mask, 8);
-  return Mask;
-#else
-  return 0;
-#endif
-}
-
-void SetThreadName(const char* name) {
-#ifndef _WIN32
-  pthread_setname_np(pthread_self(), name);
-#else
-  // TODO:
-#endif
 }
 } // namespace FEXCore::Threads

--- a/FEXCore/include/FEXCore/Utils/Threads.h
+++ b/FEXCore/include/FEXCore/Utils/Threads.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <FEXCore/fextl/memory.h>
-#include <cstdint>
 
 namespace FEXCore::Threads {
 using ThreadFunc = void* (*)(void* user_ptr);
@@ -38,15 +37,4 @@ public:
   // Set API functions
   static void SetInternalPointers(const Pointers& _Ptrs);
 };
-
-/**
- * @brief Sets the calling thread's signal mask to the one provided
- *
- * @param Mask The new 64-bit signal mask to set
- *
- * @return The previous signal mask
- */
-uint64_t SetSignalMask(uint64_t Mask);
-
-void SetThreadName(const char* name);
 } // namespace FEXCore::Threads

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/GdbServer.cpp
@@ -1472,16 +1472,16 @@ void GdbServer::GdbServerLoop() {
   CloseListenSocket();
 }
 static void* ThreadHandler(void* Arg) {
-  FEXCore::Threads::SetThreadName("FEX:gdbserver");
+  HLE::ThreadManager::SetThreadName("FEX:gdbserver");
   auto This = reinterpret_cast<FEX::GdbServer*>(Arg);
   This->GdbServerLoop();
   return nullptr;
 }
 
 void GdbServer::StartThread() {
-  uint64_t OldMask = FEXCore::Threads::SetSignalMask(~0ULL);
+  uint64_t OldMask = HLE::ThreadManager::SetSignalMask(~0ULL);
   gdbServerThread = FEXCore::Threads::Thread::Create(ThreadHandler, this);
-  FEXCore::Threads::SetSignalMask(OldMask);
+  HLE::ThreadManager::SetSignalMask(OldMask);
 }
 
 void GdbServer::OpenListenSocket() {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -160,6 +160,15 @@ void ThreadManager::StatAlloc::UnlockAfterFork(FEXCore::Core::InternalThreadStat
   ThreadObject->Thread->ThreadStats = AllocateSlot(ThreadObject->ThreadInfo.TID);
 }
 
+uint64_t ThreadManager::SetSignalMask(uint64_t Mask) {
+  ::syscall(SYSCALL_DEF(rt_sigprocmask), SIG_SETMASK, &Mask, &Mask, 8);
+  return Mask;
+}
+
+void ThreadManager::SetThreadName(const char* name) {
+  pthread_setname_np(pthread_self(), name);
+}
+
 constexpr size_t CALLRET_STACK_ALLOC_SIZE = FEXCore::Core::InternalThreadState::CALLRET_STACK_SIZE + 2 * FEXCore::Utils::FEX_PAGE_SIZE;
 
 FEX::HLE::ThreadStateObject* ThreadManager::CreateThread(uint64_t InitialRIP, uint64_t StackPointer, const FEXCore::Core::CPUState* NewThreadState,

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -167,6 +167,16 @@ public:
     Stat.CleanupForExit();
   }
 
+  /**
+   * @brief Sets the calling thread's signal mask to the one provided
+   *
+   * @param Mask The new 64-bit signal mask to set
+   *
+   * @return The previous signal mask
+   */
+  static uint64_t SetSignalMask(uint64_t Mask);
+  static void SetThreadName(const char* name);
+
   ///< Returns the ThreadStateObject from a CpuStateFrame object.
   static inline FEX::HLE::ThreadStateObject* GetStateObjectFromCPUState(FEXCore::Core::CpuStateFrame* Frame) {
     return static_cast<FEX::HLE::ThreadStateObject*>(Frame->Thread->FrontendPtr);


### PR DESCRIPTION
Only used in the frontend and is OS specific.