### PR TITLE
FEXCore: Disable 48-bit VA optimization

### DIFF
--- a/FEXCore/Source/Interface/Core/CodeCache.cpp
+++ b/FEXCore/Source/Interface/Core/CodeCache.cpp
@@ -633,9 +633,10 @@ bool CodeCache::ApplyCodeRelocations(uint64_t GuestEntry, std::span<std::byte> C
       if (Pointer == ~0ULL) {
         return false;
       }
-      // Pointers are required to fit within 48-bit VA space.
+      // TODO: Pointers are required to fit within 48-bit VA space.
+      // But forcing 6-byte broke relocations.
       Emitter.LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Register(Reloc.NamedThunkMove.RegisterIndex), Pointer,
-                           CPU::Arm64Emitter::PadType::DOPAD, 6);
+                           CPU::Arm64Emitter::PadType::DOPAD);
       break;
     }
     case FEXCore::CPU::RelocationTypes::RELOC_GUEST_RIP_LITERAL: {
@@ -644,9 +645,9 @@ bool CodeCache::ApplyCodeRelocations(uint64_t GuestEntry, std::span<std::byte> C
     }
     case FEXCore::CPU::RelocationTypes::RELOC_GUEST_RIP_MOVE: {
       uint64_t Pointer = Reloc.GuestRIP.GuestRIP + GuestEntry;
-      // Pointers are required to fit within 48-bit VA space.
-      Emitter.LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Register(Reloc.GuestRIP.RegisterIndex), Pointer,
-                           CPU::Arm64Emitter::PadType::DOPAD, 6);
+      // TODO: Pointers are required to fit within 48-bit VA space.
+      // But forcing 6-byte broke relocations.
+      Emitter.LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Register(Reloc.GuestRIP.RegisterIndex), Pointer, CPU::Arm64Emitter::PadType::DOPAD);
       break;
     }
 

--- a/FEXCore/Source/Interface/Core/JIT/Arm64Relocations.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/Arm64Relocations.cpp
@@ -29,7 +29,8 @@ void Arm64JITCore::InsertNamedThunkRelocation(ARMEmitter::Register Reg, const IR
   uint64_t Pointer = reinterpret_cast<uint64_t>(EmitterCTX->ThunkHandler->LookupThunk(Sum));
 
   // Pointers are required to fit within 48-bit VA space.
-  LoadConstant(ARMEmitter::Size::i64Bit, Reg, Pointer, FEXCore::CPU::Arm64Emitter::PadType::AUTOPAD, 6);
+  // TODO: Force 6-byte `MaxSize`, with zext extension to 64-bit. Current code not smart enough to handle negatives.
+  LoadConstant(ARMEmitter::Size::i64Bit, Reg, Pointer, FEXCore::CPU::Arm64Emitter::PadType::AUTOPAD);
   Relocations.emplace_back(MoveABI);
 }
 


### PR DESCRIPTION
This breaks relocations currently due to not handling negatives and also an interesting overwriting problem.

Not that big of a deal, it's only a minor optimization anyway.

Fixes #5227