### PR TITLE
FEXCore: Early exit for invalid VEX.vvvv on 32-bit

### DIFF
--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -769,13 +769,23 @@ bool Decoder::NormalOpHeader(const FEXCore::X86Tables::X86InstInfo* Info, uint16
 
     if (Op == 0xC5) { // Two byte VEX
       pp = Byte1 & 0b11;
-      options.vvvv = 15 - ((Byte1 & 0b01111000) >> 3);
+      const uint8_t vvvv = ((Byte1 & 0b01111000) >> 3);
+      if (!BlockInfo.Is64BitMode && vvvv <= 0b0111) {
+        // Invalid on 32-bit, can't use the high registers.
+        return false;
+      }
+      options.vvvv = 15 - vvvv;
       options.L = (Byte1 & 0b100) != 0;
     } else { // 0xC4 = Three byte VEX
       const uint8_t Byte2 = ReadByte();
       pp = Byte2 & 0b11;
       map_select = Byte1 & 0b11111;
-      options.vvvv = 15 - ((Byte2 & 0b01111000) >> 3);
+      const uint8_t vvvv = ((Byte2 & 0b01111000) >> 3);
+      if (!BlockInfo.Is64BitMode && vvvv <= 0b0111) {
+        // Invalid on 32-bit, can't use the high registers.
+        return false;
+      }
+      options.vvvv = 15 - vvvv;
       options.w = (Byte2 & 0b10000000) != 0;
       options.L = (Byte2 & 0b100) != 0;
       if ((Byte1 & 0b01000000) == 0) {

--- a/unittests/FEXLinuxTests/tests/signal/invalid_vex.32.cpp
+++ b/unittests/FEXLinuxTests/tests/signal/invalid_vex.32.cpp
@@ -1,0 +1,41 @@
+#include "invalid_util.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <signal.h>
+#include <sys/mman.h>
+#include <stdint.h>
+#include <cstdlib>
+
+extern "C" void IntInstruction();
+
+#pragma GCC diagnostic ignored "-Wattributes" // Suppress warning in case control-flow checks aren't enabled
+__attribute__((naked, nocf_check)) static void InvalidINT() {
+  __asm volatile(R"(
+  IntInstruction:
+  // vaddss xmm0,xmm15,xmm2
+  .byte 0xc5, 0x82, 0x58, 0xc2;
+  ret;
+  )");
+}
+
+unsigned long EXPECTED_RIP = reinterpret_cast<unsigned long>(&IntInstruction);
+
+TEST_CASE("Signals: Invalid VEX.vvvv") {
+  capturing_handler_skip = 4;
+  struct sigaction act {};
+  act.sa_sigaction = CapturingHandler;
+  act.sa_flags = SA_SIGINFO;
+  sigaction(SIGSEGV, &act, nullptr);
+  sigaction(SIGTRAP, &act, nullptr);
+  sigaction(SIGILL, &act, nullptr);
+
+  InvalidINT();
+
+#ifndef REG_RIP
+#define REG_RIP REG_EIP
+#endif
+
+  REQUIRE(from_handler.has_value());
+  CHECK(from_handler->mctx.gregs[REG_RIP] == EXPECTED_RIP);
+}


### PR DESCRIPTION
Otherwise we hit an assert in FEXCore backend with code discovery hitting things that look like AVX.

Fixes a crash in Uplay.

Also adds a test to just ensure that the instruction faults out and is captured instead of crashing in FEX itself.