### PR TITLE
Config: Fixes bad vector to string cast

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.cpp
+++ b/FEXCore/Source/Interface/Config/Config.cpp
@@ -307,12 +307,10 @@ constexpr char ContainerManager[] = "/run/host/container-manager";
 fextl::string FindContainer() {
   // We only support pressure-vessel at the moment
   if (FHU::Filesystem::Exists(ContainerManager)) {
-    fextl::vector<char> Manager {};
+    fextl::string Manager {};
     if (FEXCore::FileLoading::LoadFile(Manager, ContainerManager)) {
       // Trim the whitespace, may contain a newline
-      fextl::string ManagerStr = Manager.data();
-      ManagerStr = FEXCore::StringUtils::Trim(ManagerStr);
-      return ManagerStr;
+      return FEXCore::StringUtils::Trim(Manager);
     }
   }
   return {};
@@ -321,12 +319,10 @@ fextl::string FindContainer() {
 fextl::string FindContainerPrefix() {
   // We only support pressure-vessel at the moment
   if (FHU::Filesystem::Exists(ContainerManager)) {
-    fextl::vector<char> Manager {};
+    fextl::string Manager {};
     if (FEXCore::FileLoading::LoadFile(Manager, ContainerManager)) {
       // Trim the whitespace, may contain a newline
-      fextl::string ManagerStr = Manager.data();
-      ManagerStr = FEXCore::StringUtils::Trim(ManagerStr);
-      if (strncmp(ManagerStr.data(), "pressure-vessel", Manager.size()) == 0) {
+      if (FEXCore::StringUtils::Trim(Manager) == "pressure-vessel") {
         // We are running inside of pressure vessel
         // Our $CMAKE_INSTALL_PREFIX paths are now inside of /run/host/$CMAKE_INSTALL_PREFIX
         return "/run/host/";


### PR DESCRIPTION
Turns out casting a vector of data to a string is a bad idea, who knew?! This bug was exposed by the rpmalloc PR because the `/run/host/container-manager` file isn't null terminated. So the cast fextl::string through std::vector::data had the /potential/ to not be null terminated.

This was just a bug hiding in the code, convert it over to use fextl::string directly and avoid the entire dance.

Fixes #5236