### PR TITLE
x87: Implement FCOM/FCOMP st(i) decoding fixes

### DIFF
--- a/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
@@ -17,7 +17,7 @@ using namespace IR;
 // All OPDReg versions need it
 #define OPDReg(op, reg) ((1 << 15) | ((op - 0xD8) << 8) | (reg << 3))
 #define OPD(op, modrmop) (((op - 0xD8) << 8) | modrmop)
-constexpr std::array<DispatchTableEntry, 133> X87F64OpTable = {{
+constexpr std::array<DispatchTableEntry, 135> X87F64OpTable = {{
   {OPDReg(0xD8, 0) | 0x00, 8, &OpDispatchBuilder::Bind<&OpDispatchBuilder::FADDF64, OpSize::i32Bit, false, OpDispatchBuilder::OpResult::RES_ST0>},
 
   {OPDReg(0xD8, 1) | 0x00, 8, &OpDispatchBuilder::Bind<&OpDispatchBuilder::FMULF64, OpSize::i32Bit, false, OpDispatchBuilder::OpResult::RES_ST0>},
@@ -285,7 +285,7 @@ constexpr std::array<DispatchTableEntry, 133> X87F64OpTable = {{
    &OpDispatchBuilder::Bind<&OpDispatchBuilder::FCOMIF64, OpSize::f80Bit, false, OpDispatchBuilder::FCOMIFlags::FLAGS_RFLAGS, false>},
 }};
 
-constexpr std::array<DispatchTableEntry, 133> X87F80OpTable = {{
+constexpr std::array<DispatchTableEntry, 135> X87F80OpTable = {{
   {OPDReg(0xD8, 0) | 0x00, 8, &OpDispatchBuilder::Bind<&OpDispatchBuilder::FADD, OpSize::i32Bit, false, OpDispatchBuilder::OpResult::RES_ST0>},
 
   {OPDReg(0xD8, 1) | 0x00, 8, &OpDispatchBuilder::Bind<&OpDispatchBuilder::FMUL, OpSize::i32Bit, false, OpDispatchBuilder::OpResult::RES_ST0>},


### PR DESCRIPTION
Ports two commits from our downstream Winlator/FEX integration:

- x87: support 0xDC D0/D8 FCOM/FCOMP st(i)
- x87: fix dispatch table sizes after adding FCOM/FCOMP

These are generic x87 correctness fixes (not WoW-specific) and help avoid SIGILL/incorrect dispatch when guest code reaches these encodings.

Downstream context: This was observed while running 32-bit Windows apps under Wine+FEX on ARM64.

Fixes #5133.