### PR TITLE
x86(32-bit): Implement ARPL (0x63)

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -1039,6 +1039,35 @@ void OpDispatchBuilder::TESTOp(OpcodeArgs, uint32_t SrcIndex) {
   InvalidateAF();
 }
 
+void OpDispatchBuilder::ARPLOp(OpcodeArgs) {
+  // ARPL r/m16, r16
+  // If the RPL field in the destination selector is less privileged than the
+  // RPL field in the source selector, then adjust destination RPL to match
+  // source RPL and set ZF=1. Otherwise ZF=0 and destination is unchanged.
+  //
+  // Only ZF is modified by ARPL.
+  constexpr auto Size = OpSize::i16Bit;
+
+  Ref Dest = LoadSourceGPR_WithOpSize(Op, Op->Dest, Size, Op->Flags, {.AllowUpperGarbage = true});
+  Ref Src = LoadSourceGPR_WithOpSize(Op, Op->Src[0], Size, Op->Flags, {.AllowUpperGarbage = true});
+
+  // RPL is the low two bits of the selector.
+  Ref DestRPL = _And(Size, Dest, Constant(0x3));
+  Ref SrcRPL = _And(Size, Src, Constant(0x3));
+
+  // NeedUpdate is 1 when DestRPL < SrcRPL, else 0.
+  Ref NeedUpdate = _Select(OpSize::i32Bit, Size, CondClass::ULT, DestRPL, SrcRPL, Constant(1), Constant(0));
+  SetRFLAG<FEXCore::X86State::RFLAG_ZF_RAW_LOC>(NeedUpdate);
+
+  // Compute adjusted destination selector: (Dest & ~3) | SrcRPL.
+  Ref Cleared = _And(Size, Dest, Constant(0xFFFC));
+  Ref NewDest = _Or(Size, Cleared, SrcRPL);
+
+  // Conditionally select updated selector based on NeedUpdate.
+  Ref FinalDest = _Select(Size, OpSize::i32Bit, CondClass::NEQ, NeedUpdate, Constant(0), NewDest, Dest);
+  StoreResultGPR_WithOpSize(Op, Op->Dest, FinalDest, Size);
+}
+
 void OpDispatchBuilder::MOVSXDOp(OpcodeArgs) {
   // This instruction is a bit special
   // if SrcSize == 2

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -356,6 +356,7 @@ public:
   void CALLFARIndirectOp(OpcodeArgs);
   void RETFARIndirectOp(OpcodeArgs);
   void TESTOp(OpcodeArgs, uint32_t SrcIndex);
+  void ARPLOp(OpcodeArgs);
   void MOVSXDOp(OpcodeArgs);
   void MOVSXOp(OpcodeArgs);
   void MOVZXOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -124,7 +124,7 @@ constexpr std::array<X86InstInfo[2], ENTRY_MAX> Primary_ArchSelect_LUT = {{
   },
   // ENTRY_63
   {
-    {"ARPL",   TYPE_INVALID, FLAGS_NONE, 0, { .OpDispatch = nullptr } },
+    {"ARPL",   TYPE_INST, GenFlagsSameSize(SIZE_16BIT) | FLAGS_MODRM, 0, { .OpDispatch = &IR::OpDispatchBuilder::ARPLOp } },
     {"MOVSXD", TYPE_INST, GenFlagsDstSize(SIZE_64BIT) | FLAGS_MODRM, 0, { .OpDispatch = &IR::OpDispatchBuilder::MOVSXDOp } },
   },
   // ENTRY_9A
@@ -436,4 +436,3 @@ const std::array<X86InstInfo, MAX_PRIMARY_TABLE_SIZE> BaseOps = []() consteval {
 }();
 
 }
-


### PR DESCRIPTION
Implements ARPL (0x63) in 32-bit mode.

This is a generic x86 correctness fix (not app-specific). Downstream, this addressed a SIGILL in 32-bit guest code when running Wine+FEX on ARM64.

Fixes #5133.