### PR TITLE
CI: Clean up syntax assertions and remove redundant log-name parameter

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -57,14 +57,12 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: gcc_target_tests_64
-        log-name: GCC64
 
     - name: GCC32 Target Tests
       if: ${{ always() }}
       uses: ./.github/workflows/test
       with:
         target: gcc_target_tests_32
-        log-name: GCC32
 
     # API tests
     - name: API Tests
@@ -72,14 +70,12 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: api_tests
-        log-name: APITests
 
     - name: FEXCore API Tests
       if: ${{ always() }}
       uses: ./.github/workflows/test
       with:
         target: fexcore_apitests
-        log-name: FEXCoreAPITests
 
     # ARM emission tests
     - name: ARM Emitter Tests
@@ -87,7 +83,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: emitter_tests
-        log-name: ARMEmitterTests
 
     # Linux  tests
     - name: FEX Linux Tests
@@ -95,7 +90,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: fex_linux_tests_all
-        log-name: FEXLinuxTests
       env:
         FEX_PORTABLE: 0
 
@@ -105,14 +99,12 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: thunkgen_tests
-        log-name: ThunkgenTests
 
     - name: Test GL No-Thunks
       if: ${{ always() && matrix.arch[1] == 'x64' }}
       uses: ./.github/workflows/test
       with:
         target: thunk_functional_tests_nothunks
-        log-name: NoThunkResults
       env:
         DISPLAY: ':0'
 
@@ -121,7 +113,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: thunk_functional_tests_thunks
-        log-name: ThunkResults
       env:
         DISPLAY: ':0'
 
@@ -131,7 +122,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: asm_tests
-        log-name: ASM
 
     # POSIX tests
     - name: POSIX Tests
@@ -139,7 +129,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: posix_tests
-        log-name: Posix
 
     # GVisor tests
     - name: GVisor Tests
@@ -147,7 +136,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: gvisor_tests
-        log-name: GVisor
 
     # Struct verifier tests
     - name: Struct verifier tests
@@ -155,7 +143,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: struct_verifier
-        log-name: StructVerifier
 
     - name: Remove old SHM regions
       if: ${{ always() }}
@@ -167,5 +154,5 @@ jobs:
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
+        path: results/*.log
         retention-days: 3

--- a/.github/workflows/glibc_fault.yml
+++ b/.github/workflows/glibc_fault.yml
@@ -65,14 +65,12 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: gcc_target_tests_64
-        log-name: GCC64
 
     - name: GCC32 Target Tests
       if: ${{ always() }}
       uses: ./.github/workflows/test
       with:
         target: gcc_target_tests_32
-        log-name: GCC32
 
     # API Tests
     - name: API Tests
@@ -80,14 +78,12 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: api_tests
-        log-name: APITests
 
     - name: FEXCore API Tests
       if: ${{ always() }}
       uses: ./.github/workflows/test
       with:
         target: fexcore_apitests
-        log-name: FEXCoreAPITests
 
     # Linux tests
     - name: FEX Linux Tests
@@ -95,7 +91,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: fex_linux_tests_all
-        log-name: FEXLinuxTests
 
     # ASM Tests
     - name: ASM Tests
@@ -103,7 +98,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: asm_tests
-        log-name: ASM
 
     # POSIX Tests
     - name: POSIX Tests
@@ -111,7 +105,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: posix_tests
-        log-name: Posix
 
     - name: Remove old SHM regions
       if: ${{ always() }}
@@ -123,6 +116,6 @@ jobs:
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
+        path: results/*.log
         retention-days: 3
 

--- a/.github/workflows/hostrunner.yml
+++ b/.github/workflows/hostrunner.yml
@@ -53,7 +53,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: asm_tests
-        log-name: ASM
 
     - name: Upload results
       if: ${{ always() }}
@@ -61,6 +60,6 @@ jobs:
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
+        path: results/*.log
         retention-days: 3
 

--- a/.github/workflows/instcountci.yml
+++ b/.github/workflows/instcountci.yml
@@ -56,7 +56,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: instcountci_tests
-        log-name: InstCountCI
 
     - name: Update local repo instcount
       if: ${{ always() }}
@@ -72,5 +71,5 @@ jobs:
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
+        path: results/*.log
         retention-days: 3

--- a/.github/workflows/setup-env/action.yml
+++ b/.github/workflows/setup-env/action.yml
@@ -1,4 +1,5 @@
 name: Setup Build Environment
+description: Setup RootFS and build environment
 
 inputs:
   setup-rootfs:

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -1,11 +1,8 @@
 name: Run Test and Store Logs
-
+description: Run a test and store the log.
 inputs:
   target:
     description: 'The test target to run'
-    required: true
-  log-name:
-    description: 'The name suffix of the resulting log file'
     required: true
 
 runs:
@@ -19,6 +16,6 @@ runs:
       if: ${{ always() }}
       shell: bash
       run: |
-        LAST_LOG="build/Testing/Temporary/LastTest"
-        truncate --size="<20M" "$LAST_LOG".log || true
-        mv "$LAST_LOG".log "${LAST_LOG}_${{ inputs.log-name }}".log || true
+        mkdir -p results
+        mv build/Testing/Temporary/LastTest.log results/${{ inputs.target }}.log || true
+        truncate --size="<20M" results/${{ inputs.target }}.log || true

--- a/.github/workflows/vixl_simulator.yml
+++ b/.github/workflows/vixl_simulator.yml
@@ -53,7 +53,6 @@ jobs:
       uses: ./.github/workflows/test
       with:
         target: asm_tests
-        log-name: ASM_SVE256Bit
 
     - name: ASM Tests - SVE128
       if: ${{ always() }}
@@ -62,7 +61,6 @@ jobs:
         FEX_FORCESVEWIDTH: "128"
       with:
         target: asm_tests
-        log-name: ASM_SVE128Bit
 
     - name: ASM Tests - ASIMD
       if: ${{ always() }}
@@ -71,7 +69,6 @@ jobs:
         FEX_HOSTFEATURES: "disablesve"
       with:
         target: asm_tests
-        log-name: ASM_ASIMD
 
     - name: Upload results
       if: ${{ always() }}
@@ -79,5 +76,5 @@ jobs:
       timeout-minutes: 1
       with:
         name: Results-${{ env.runner_name }}-${{ env.runner_label }}
-        path: ${{ github.workspace }}/build/Testing/Temporary/LastTest_*.log
+        path: results/*.log
         retention-days: 3

--- a/.github/workflows/wine_build/action.yml
+++ b/.github/workflows/wine_build/action.yml
@@ -1,4 +1,5 @@
 name: Wine DLL Build
+description: Build a wow64 or arm64ec Wine DLL
 
 inputs:
   target:


### PR DESCRIPTION
Now logs are uploaded directly as the name of the test  instead of a
separate name.

Signed-off-by: crueter <crueter@eden-emu.dev>
