### PR TITLE
unittests/ASM: Adds unittests for undocumented x87 instruction encodings

### DIFF
--- a/unittests/ASM/X87/D8_D0.asm
+++ b/unittests/ASM/X87/D8_D0.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX":  "0x1"
+  }
+}
+%endif
+
+finit
+fld1
+fldz
+fcom st1
+
+fnstsw ax
+cmp ah, 0x31
+je good
+mov rax, 0
+hlt
+good:
+mov rax, 1
+hlt

--- a/unittests/ASM/X87/DC_D0.asm
+++ b/unittests/ASM/X87/DC_D0.asm
@@ -1,0 +1,23 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX":  "0x1"
+  }
+}
+%endif
+
+; Tests undocumented fcom implementation at 0xdc, 0xd0+i
+finit
+fld1
+fldz
+; fcom st1
+db 0xdc, 0xd1
+
+fnstsw ax
+cmp ah, 0x31
+je good
+mov rax, 0
+hlt
+good:
+mov rax, 1
+hlt

--- a/unittests/ASM/X87/DC_D9.asm
+++ b/unittests/ASM/X87/DC_D9.asm
@@ -1,0 +1,19 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6":  ["0x8000000000000000", "0x3FFF"],
+    "MM7":  ["0x8000000000000000", "0x3FFF"]
+  }
+}
+%endif
+
+; Only tests pop behaviour
+; Tests undocumented fcomp implementation at 0xdc, 0xd8+i
+finit
+fld1
+fldz
+; fcomp
+db 0xdc, 0xd9
+fld1
+
+hlt


### PR DESCRIPTION
For more information:
https://en.wikipedia.org/wiki/List_of_x86_instructions#cite_note-x87_alias-346

For #5289