### PR TITLE
CMake: Split version/commit identifier to two lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,8 +540,8 @@ else()
   set(GIT_SHORT_HASH "${OVERRIDE_HASH}")
 endif()
 
-message(STATUS "FEX version strings: git describe: '${GIT_DESCRIBE_STRING}'. git short hash: '${GIT_SHORT_HASH}'")
-
+message(STATUS "FEX Version: ${GIT_DESCRIBE_STRING}")
+message(STATUS "FEX Commit: ${GIT_SHORT_HASH}")
 if (ENABLE_IWYU)
   find_program(IWYU_EXE "iwyu")
   if (IWYU_EXE)


### PR DESCRIPTION
Something something style

Signed-off-by: crueter <crueter@eden-emu.dev>
