### PR TITLE
CMake: Also search for `include-what-you-use` if IWYU is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,7 +543,8 @@ endif()
 message(STATUS "FEX version strings: git describe: '${GIT_DESCRIBE_STRING}'. git short hash: '${GIT_SHORT_HASH}'")
 
 if (ENABLE_IWYU)
-  find_program(IWYU_EXE "iwyu")
+  find_program(IWYU_EXE
+    NAMES iwyu include-what-you-use)
   if (IWYU_EXE)
     message(STATUS "IWYU enabled")
     set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "${IWYU_EXE}")


### PR DESCRIPTION
Gentoo installs it as this, unsure about others but should "guarantee"
compatibility here

Signed-off-by: crueter <crueter@eden-emu.dev>
