### PR TITLE
Core: Use long commit hash instead of abbreviating

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,25 +523,34 @@ else()
   set(GIT_DESCRIBE_STRING "${OVERRIDE_VERSION}")
 endif()
 
-set(GIT_SHORT_HASH "Unknown")
+set(GIT_HASH "Unknown")
 
 if (OVERRIDE_HASH STREQUAL "detect")
   find_package(Git)
 
   if (GIT_FOUND)
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --short=7 HEAD
+      COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-      OUTPUT_VARIABLE GIT_SHORT_HASH
+      OUTPUT_VARIABLE GIT_HASH
       ERROR_QUIET
       OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()
 else()
-  set(GIT_SHORT_HASH "${OVERRIDE_HASH}")
+  set(GIT_HASH "${OVERRIDE_HASH}")
 endif()
 
-message(STATUS "FEX Version: ${GIT_DESCRIBE_STRING}")
-message(STATUS "FEX Commit: ${GIT_SHORT_HASH}")
+message(STATUS "FEX version: ${GIT_DESCRIBE_STRING}")
+message(STATUS "FEX commit: ${GIT_HASH}")
+
+# Prepends 0x to every two-character sequence in the hash,
+# OR the final character of the hash, to plumb it for C++ usage. e.g.:
+# -DOVERRIDE_HASH=123456aa => 0x12, 0x34, 0x56, 0xaa,
+# -DOVERRIDE_HASH=12345678a => 0x12, 0x34, 0x56, 0x78, 0xa,
+string(REGEX
+  REPLACE "(..|.$)" "0x\\1, "
+  GIT_HASH_ARRAY "${GIT_HASH}")
+
 if (ENABLE_IWYU)
   find_program(IWYU_EXE
     NAMES iwyu include-what-you-use)

--- a/FEXCore/Source/Interface/Core/CodeCache.cpp
+++ b/FEXCore/Source/Interface/Core/CodeCache.cpp
@@ -234,11 +234,12 @@ uint64_t CodeCache::ComputeCodeMapId(std::string_view Filename, int FD) {
 struct CodeCacheHeader {
   std::array<char, 4> Magic = ExpectedMagic;
   uint32_t FormatVersion = 1;
-  char FEXVersion[8] = {};
+  uint8_t FEXVersion[20] = {};
   uint32_t NumBlocks;
   uint32_t NumCodePages;
   uint32_t CodeBufferSize;
   uint32_t NumRelocations;
+  uint32_t padding;
   uint64_t SerializedBaseAddress;
   // TODO: Consider including information from LookupCache.BlockLinks
 
@@ -255,9 +256,8 @@ bool CodeCache::SaveData(Core::InternalThreadState& Thread, int fd, const Execut
 
   // Write file header
   CodeCacheHeader header {};
-  constexpr std::string_view git_hash = GIT_SHORT_HASH;
-  static_assert(git_hash.size() <= sizeof(header.FEXVersion));
-  std::ranges::copy(git_hash, header.FEXVersion);
+  static_assert(GIT_HASH.size() == sizeof(header.FEXVersion));
+  std::ranges::copy(GIT_HASH, header.FEXVersion);
   header.NumBlocks = LookupCache.BlockList.size();
   header.NumCodePages = LookupCache.CodePages.size();
   header.CodeBufferSize = CTX.LatestOffset;
@@ -353,11 +353,9 @@ bool CodeCache::LoadData(Core::InternalThreadState* Thread, std::byte* MappedCac
     return false;
   }
 
-  char ExpectedVersion[8] = GIT_SHORT_HASH;
-  ranges::fill(ranges::find(ExpectedVersion, 0), std::end(ExpectedVersion), 0);
-  if (!ranges::equal(header.FEXVersion, ExpectedVersion)) {
-    LogMan::Msg::IFmt("Cache generated from old FEX version {}, current is {}; skipping", fmt::join(header.FEXVersion, ""),
-                      fmt::join(ExpectedVersion, ""));
+  if (!ranges::equal(header.FEXVersion, GIT_HASH)) {
+    LogMan::Msg::IFmt("Cache generated from old FEX version {:02x}, current is {:02x}; skipping", fmt::join(header.FEXVersion, ""),
+                      fmt::join(GIT_HASH, ""));
     return false;
   }
 

--- a/FEXCore/include/git_version.h.in
+++ b/FEXCore/include/git_version.h.in
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#define GIT_SHORT_HASH "@GIT_SHORT_HASH@"
+#include <array>
+#include <cstdint>
+
+static constexpr std::array<uint8_t, 20> GIT_HASH = {@GIT_HASH_ARRAY@};
 #define GIT_DESCRIBE_STRING "@GIT_DESCRIBE_STRING@"

--- a/Source/Steam/VERSIONS.txt.in
+++ b/Source/Steam/VERSIONS.txt.in
@@ -1,2 +1,2 @@
 FEX describe	@GIT_DESCRIBE_STRING@
-FEX bash	@GIT_SHORT_HASH@
+FEX bash	@GIT_HASH@


### PR DESCRIPTION
Fixes #5230

Basically just stores it as an array of `uint8_t`.
Hopefully FEX never reaches SHA1 collisions so
this should (TM) never collide.

Signed-off-by: crueter <crueter@eden-emu.dev>
