### PR TITLE
Revert "CodeCache: Use defaulted dtor for ExecutableFileInfo"

### DIFF
--- a/FEXCore/Source/Interface/Core/CodeCache.cpp
+++ b/FEXCore/Source/Interface/Core/CodeCache.cpp
@@ -11,6 +11,7 @@
 #include <Interface/IR/PassManager.h>
 
 #include <FEXCore/Core/Thunks.h>
+#include <FEXCore/HLE/SourcecodeResolver.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 
 #include <FEXHeaderUtils/Filesystem.h>
@@ -29,6 +30,7 @@ ExecutableFileInfo::ExecutableFileInfo(fextl::unique_ptr<HLE::SourcecodeMap> Map
   , FileId(FileId)
   , Filename(Filename) {}
 #endif
+ExecutableFileInfo::~ExecutableFileInfo() = default;
 
 fextl::string CodeMap::GetBaseFilename(const ExecutableFileInfo& MainExecutable, bool AddNombSuffix) {
   auto FileId = MainExecutable.FileId;

--- a/FEXCore/include/FEXCore/Core/CodeCache.h
+++ b/FEXCore/include/FEXCore/Core/CodeCache.h
@@ -8,7 +8,6 @@
 #include <FEXCore/fextl/string.h>
 #include <FEXCore/fextl/vector.h>
 #include <FEXCore/fextl/robin_map.h>
-#include <FEXCore/HLE/SourcecodeResolver.h>
 
 #include <atomic>
 #include <cstdint>
@@ -32,6 +31,8 @@ enum class GuestRelocationType : uint32_t { Rel32, Rel64 };
 
 // Generic information associated with an executable file.
 struct ExecutableFileInfo {
+  ~ExecutableFileInfo();
+
 #if __clang_major__ < 16
   // Workaround for broken aggregate-initialization with std::piecewise_construct
   ExecutableFileInfo(fextl::unique_ptr<HLE::SourcecodeMap>, uint64_t, fextl::string);


### PR DESCRIPTION
Couldn't reproduce WoA build failures reported in #5164; current `main` builds fine without this, so remove the false header dependency.
