### PR TITLE
JIT: Support avoiding spilling CPU flags

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.h
@@ -135,10 +135,10 @@ protected:
   // Returning REG_INVALID if there was no mapping.
   FEXCore::X86State::X86Reg GetX86RegRelationToARMReg(ARMEmitter::Register Reg);
 
-  void SpillStaticRegs(ARMEmitter::Register TmpReg, bool FPRs = true, uint32_t GPRSpillMask = ~0U, uint32_t FPRSpillMask = ~0U);
+  void SpillStaticRegs(ARMEmitter::Register TmpReg, bool FPRs = true, uint32_t GPRSpillMask = ~0U, uint32_t FPRSpillMask = ~0U, bool NZCV = true);
   void FillStaticRegs(bool FPRs = true, uint32_t GPRFillMask = ~0U, uint32_t FPRFillMask = ~0U,
                       std::optional<ARMEmitter::Register> OptionalReg = std::nullopt,
-                      std::optional<ARMEmitter::Register> OptionalReg2 = std::nullopt);
+                      std::optional<ARMEmitter::Register> OptionalReg2 = std::nullopt, bool NZCV = true);
 
   // Register 0-18 + 29 + 30 are caller saved
   static constexpr uint32_t CALLER_GPR_MASK = 0b0110'0000'0000'0111'1111'1111'1111'1111U;

--- a/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
@@ -322,7 +322,7 @@ DEF_OP(Thunk) {
   // X0: CTX
   // X1: Args (from guest stack)
 
-  SpillStaticRegs(TMP1); // spill to ctx before ra64 spill
+  SpillStaticRegs(TMP1, true, ~0U, ~0U, false); // spill to ctx before ra64 spill
 
   PushDynamicRegs(TMP1);
 
@@ -337,7 +337,7 @@ DEF_OP(Thunk) {
 
   PopDynamicRegs();
 
-  FillStaticRegs(); // load from ctx after ra64 refill
+  FillStaticRegs(true, ~0U, ~0U, std::nullopt, std::nullopt, false); // load from ctx after ra64 refill
 }
 
 DEF_OP(ValidateCode) {


### PR DESCRIPTION
When thunks are jumping out, games are jumping /entirely/ out of their controlled code, which means we don't need to save and restore NZCV,PF,AF.

Some CPUs don't fully rename direct accesses to this register which adds up during thunking. FPCR is also in the same situation where it'll force pipeline flushes and isn't renamed away, but we can't really avoid that.

Improves performance at least in Detroit: Become human where the game spends ~48% CPU time inside of the thunk trampoline for `vkUpdateDescriptorSets`.

I plan on a follow-up PR where I converge all these options into a struct argument instead, but that's a follow-up since I don't want to burn a bunch of time right now.