### PR TITLE
FEXCore: Default to a larger CodeBuffer size when code caching is enabled

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+#include "FEXCore/Config/Config.h"
 #include "Interface/Context/Context.h"
 #include "Interface/Core/CPUBackend.h"
 #include "Interface/Core/LookupCache.h"
@@ -407,7 +408,13 @@ namespace CPU {
 
   fextl::shared_ptr<CodeBuffer> CodeBufferManager::GetLatest() {
     if (!Latest) {
-      AllocateNew(INITIAL_CODE_SIZE);
+      if (FEXCore::Config::Get_ENABLECODECACHINGWIP()) {
+        // Start with a larger code buffer to avoid resizes that would discard
+        // code loaded from caches
+        AllocateNew(MAX_CODE_SIZE);
+      } else {
+        AllocateNew(INITIAL_CODE_SIZE);
+      }
     }
     return Latest;
   }


### PR DESCRIPTION
The current CodeBuffer regrowth code discards any existing contents. This is undesirable with code caching, since those contents can't be re-fetched from the disk cache and instead need to be recompiled at runtime.

Additionally, FEXOfflineCompiler obviously should never discard compiled code.

Using a large enough CodeBuffer right away reduces the likelihood that FEX runs into such scenarios. We'll have a more comprehensive solution for this, but for now this facilitates testing.
