### PR TITLE
Linux/x32: Fixes sign extension in ftruncate

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
@@ -242,7 +242,6 @@ void RegisterCommon(FEX::HLE::SyscallHandler* Handler) {
   REGISTER_SYSCALL_IMPL(fsync, SyscallPassthrough1<SYSCALL_DEF(fsync)>);
   REGISTER_SYSCALL_IMPL(fdatasync, SyscallPassthrough1<SYSCALL_DEF(fdatasync)>);
   REGISTER_SYSCALL_IMPL(truncate, SyscallPassthrough2<SYSCALL_DEF(truncate)>);
-  REGISTER_SYSCALL_IMPL(ftruncate, SyscallPassthrough2<SYSCALL_DEF(ftruncate)>);
   REGISTER_SYSCALL_IMPL(getcwd, SyscallPassthrough2<SYSCALL_DEF(getcwd)>);
   REGISTER_SYSCALL_IMPL(chdir, SyscallPassthrough1<SYSCALL_DEF(chdir)>);
   REGISTER_SYSCALL_IMPL(fchdir, SyscallPassthrough1<SYSCALL_DEF(fchdir)>);
@@ -420,6 +419,7 @@ namespace x64 {
   void RegisterPassthrough(FEX::HLE::SyscallHandler* Handler) {
     using namespace FEXCore::IR;
     RegisterCommon(Handler);
+    REGISTER_SYSCALL_IMPL_X64(ftruncate, SyscallPassthrough2<SYSCALL_DEF(ftruncate)>);
     REGISTER_SYSCALL_IMPL_X64(ioctl, SyscallPassthrough3<SYSCALL_DEF(ioctl)>);
     REGISTER_SYSCALL_IMPL_X64(pread_64, SyscallPassthrough4<SYSCALL_DEF(pread_64)>);
     REGISTER_SYSCALL_IMPL_X64(pwrite_64, SyscallPassthrough4<SYSCALL_DEF(pwrite_64)>);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
@@ -988,5 +988,10 @@ void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
       uint64_t Result = ::vmsplice(fd, Host_iovec.data(), nr_segs, flags);
       SYSCALL_ERRNO();
     });
+
+  REGISTER_SYSCALL_IMPL_X32(ftruncate, [](FEXCore::Core::CpuStateFrame* Frame, int fd, compat_off_t length) -> uint64_t {
+    uint64_t Result = ::syscall(SYSCALL_DEF(ftruncate), fd, static_cast<int64_t>(length));
+    SYSCALL_ERRNO();
+  });
 }
 } // namespace FEX::HLE::x32


### PR DESCRIPTION
We were passing through 32-bit signed values to the 64-bit handler, which isn't valid and we need to make sure to sign extend.

I don't think this fixes anything because negative values aren't valid, but a negative could have been interpreted as a large positive without this.