### PR TITLE
unittests: add x87 FISTP m64int rounding tests

### DIFF
--- a/unittests/ASM/X87/Rounding_Bankers_64bit.asm
+++ b/unittests/ASM/X87/Rounding_Bankers_64bit.asm
@@ -1,0 +1,65 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000000000000",
+    "RBX": "0x0000000000000002",
+    "RCX": "0x0000000000000002",
+    "RDX": "0x0000000000000004",
+    "RSI": "0xFFFFFFFFFFFFFFFE",
+    "RDI": "0xFFFFFFFFFFFFFFFE"
+  }
+}
+%endif
+
+; FISTP m64int banker's rounding (round-to-nearest-even) edge cases.
+; Default x87 rounding mode (RC=00 in FCW).
+; At exact midpoints, the result rounds to the nearest EVEN integer.
+;
+; Related: issue #779
+
+; 0.5 -> 0 (nearest even)
+finit
+fld qword [rel val_0_5]
+fistp qword [rel tmp]
+mov rax, [rel tmp]
+
+; 1.5 -> 2 (nearest even)
+finit
+fld qword [rel val_1_5]
+fistp qword [rel tmp]
+mov rbx, [rel tmp]
+
+; 2.5 -> 2 (nearest even)
+finit
+fld qword [rel val_2_5]
+fistp qword [rel tmp]
+mov rcx, [rel tmp]
+
+; 3.5 -> 4 (nearest even)
+finit
+fld qword [rel val_3_5]
+fistp qword [rel tmp]
+mov rdx, [rel tmp]
+
+; -1.5 -> -2 (nearest even)
+finit
+fld qword [rel val_n1_5]
+fistp qword [rel tmp]
+mov rsi, [rel tmp]
+
+; -2.5 -> -2 (nearest even)
+finit
+fld qword [rel val_n2_5]
+fistp qword [rel tmp]
+mov rdi, [rel tmp]
+
+hlt
+
+align 8
+val_0_5:  dq 0.5
+val_1_5:  dq 1.5
+val_2_5:  dq 2.5
+val_3_5:  dq 3.5
+val_n1_5: dq -1.5
+val_n2_5: dq -2.5
+tmp:      dq 0

--- a/unittests/ASM/X87/Rounding_FISTP_64bit.asm
+++ b/unittests/ASM/X87/Rounding_FISTP_64bit.asm
@@ -1,0 +1,102 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000000000002",
+    "RBX": "0x0000000000000001",
+    "RCX": "0x0000000000000002",
+    "RDX": "0x0000000000000001",
+    "RSI": "0xFFFFFFFFFFFFFFFE",
+    "RDI": "0xFFFFFFFFFFFFFFFF",
+    "R8":  "0xFFFFFFFFFFFFFFFF",
+    "R9":  "0xFFFFFFFFFFFFFFFF"
+  }
+}
+%endif
+
+%include "x87cw.mac"
+
+mov rsp, 0xe000_1000
+
+; FISTP m64int rounding mode tests.
+; Tests all 4 rounding modes with 64-bit integer store.
+; Existing Rounding.asm only covers fist(p) with 16/32-bit destinations;
+; this test covers the 64-bit (m64int) case.
+;
+; Value under test: 1.5
+;   RC=00 nearest-even  -> 2  (rounds to even)
+;   RC=01 round-down    -> 1  (floor)
+;   RC=10 round-up      -> 2  (ceil)
+;   RC=11 toward-zero   -> 1  (truncate)
+;
+; Value under test: -1.5
+;   RC=00 nearest-even  -> -2 (rounds to even)
+;   RC=01 round-down    -> -2 (floor toward -inf)
+;   RC=10 round-up      -> -1 (ceil toward +inf)
+;   RC=11 toward-zero   -> -1 (truncate toward 0)
+
+; --- Positive 1.5 ---
+
+; Round to nearest (RC=00): 1.5 -> 2
+finit
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld qword [rel val_1_5]
+fistp qword [rel tmp]
+mov rax, [rel tmp]
+
+; Round down (RC=01): 1.5 -> 1
+finit
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld qword [rel val_1_5]
+fistp qword [rel tmp]
+mov rbx, [rel tmp]
+
+; Round up (RC=10): 1.5 -> 2
+finit
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld qword [rel val_1_5]
+fistp qword [rel tmp]
+mov rcx, [rel tmp]
+
+; Round toward zero (RC=11): 1.5 -> 1
+finit
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld qword [rel val_1_5]
+fistp qword [rel tmp]
+mov rdx, [rel tmp]
+
+; --- Negative -1.5 ---
+
+; Round to nearest (RC=00): -1.5 -> -2
+finit
+set_cw_precision_rounding x87_prec_80, x87_round_nearest
+fld qword [rel val_n1_5]
+fistp qword [rel tmp]
+mov rsi, [rel tmp]
+
+; Round down (RC=01): -1.5 -> -2
+finit
+set_cw_precision_rounding x87_prec_80, x87_round_down
+fld qword [rel val_n1_5]
+fistp qword [rel tmp]
+mov rdi, [rel tmp]
+
+; Round up (RC=10): -1.5 -> -1
+finit
+set_cw_precision_rounding x87_prec_80, x87_round_up
+fld qword [rel val_n1_5]
+fistp qword [rel tmp]
+mov r8, [rel tmp]
+
+; Round toward zero (RC=11): -1.5 -> -1
+finit
+set_cw_precision_rounding x87_prec_80, x87_round_towards_zero
+fld qword [rel val_n1_5]
+fistp qword [rel tmp]
+mov r9, [rel tmp]
+
+hlt
+
+align 8
+val_1_5:  dq 1.5
+val_n1_5: dq -1.5
+tmp:      dq 0


### PR DESCRIPTION
## Summary

- Adds `Rounding_Bankers_64bit.asm`: Tests banker's rounding (round-to-nearest-even) at exact midpoints using `FISTP m64int`. Verifies the tie-breaking rule where exact `.5` values round to the nearest **even** integer (0.5→0, 1.5→2, 2.5→2, 3.5→4, -1.5→-2, -2.5→-2).

- Adds `Rounding_FISTP_64bit.asm`: Tests all 4 x87 rounding modes (nearest, down, up, toward-zero) with `FISTP m64int` for both positive and negative 1.5. The existing `Rounding.asm` only covers 16-bit and 32-bit `FIST`/`FISTP` destinations; this extends coverage to the 64-bit integer case.

## Motivation

The 64-bit integer store path (`FISTP m64int`) has different encoding and codegen from the 16/32-bit paths but had no dedicated rounding mode tests. These tests help catch rounding regressions, particularly banker's rounding edge cases (related: #779).

## Test plan

- Both test files follow the existing FEX unittest format with `%ifdef CONFIG` / `RegData` headers
- `Rounding_FISTP_64bit.asm` uses the `x87cw.mac` include for precision/rounding mode macros
- Expected values verified against x86 hardware behavior