### PR TITLE
Implement FSTPNCE (D9 D8+i) undocumented x87 alias

### DIFF
--- a/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/X87Tables.cpp
@@ -71,7 +71,7 @@ constexpr std::array<DispatchTableEntry, 140> X87F64OpTable = {{
   {OPD(0xD9, 0xC8), 8, &OpDispatchBuilder::FXCH},
   {OPD(0xD9, 0xD0), 1, &OpDispatchBuilder::NOPOp}, // FNOP
   // D1 = Invalid
-  // D8 = Invalid
+  {OPD(0xD9, 0xD8), 8, &OpDispatchBuilder::Bind<&OpDispatchBuilder::FSTToStack>}, // FSTPNCE
   {OPD(0xD9, 0xE0), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::X87OpHelper, OP_F80STACKCHANGESIGN, false>},
   {OPD(0xD9, 0xE1), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::X87OpHelper, OP_F80STACKABS, false>},
   // E2 = Invalid
@@ -343,7 +343,7 @@ constexpr std::array<DispatchTableEntry, 140> X87F80OpTable = {{
   {OPD(0xD9, 0xC8), 8, &OpDispatchBuilder::FXCH},
   {OPD(0xD9, 0xD0), 1, &OpDispatchBuilder::NOPOp}, // FNOP
   // D1 = Invalid
-  // D8 = Invalid
+  {OPD(0xD9, 0xD8), 8, &OpDispatchBuilder::Bind<&OpDispatchBuilder::FSTToStack>}, // FSTPNCE
   {OPD(0xD9, 0xE0), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::X87OpHelper, OP_F80STACKCHANGESIGN, false>},
   {OPD(0xD9, 0xE1), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::X87OpHelper, OP_F80STACKABS, false>},
   // E2 = Invalid
@@ -601,7 +601,7 @@ auto GenerateX87TableLambda = [](const auto DispatchTable) consteval {
       {OPD(0xD9, 0xD0), 1, X86InstInfo{"FNOP",  TYPE_X87, FLAGS_NONE, 0}},
       {OPD(0xD9, 0xD1), 7, X86InstInfo{"",      TYPE_INVALID, FLAGS_NONE, 0}},
       //  / 3
-      {OPD(0xD9, 0xD8), 8, X86InstInfo{"",      TYPE_INVALID, FLAGS_NONE, 0}},
+      {OPD(0xD9, 0xD8), 8, X86InstInfo{"FSTPNCE", TYPE_X87, FLAGS_SF_MOD_DST | FLAGS_POP, 0}},
       //  / 4
       {OPD(0xD9, 0xE0), 1, X86InstInfo{"FCHS", TYPE_X87, FLAGS_NONE, 0}},
       {OPD(0xD9, 0xE1), 1, X86InstInfo{"FABS", TYPE_X87, FLAGS_NONE, 0}},

--- a/unittests/ASM/X87/D9_D8.asm
+++ b/unittests/ASM/X87/D9_D8.asm
@@ -1,0 +1,51 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM6": ["0x8000000000000000", "0x4001"],
+    "MM7": ["0x8000000000000000", "0x3FFF"]
+  }
+}
+%endif
+
+; Tests undocumented FSTPNCE (D9 D8+i) instruction.
+; FSTPNCE behaves as FSTP ST(i) - stores ST(0) to ST(i) and pops.
+; Raw byte encoding required since assemblers don't recognize this mnemonic.
+;
+; Related: issue #5296
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+; FSTPNCE ST(1) = db 0xD9, 0xD9
+; This stores ST(0) (1.0) into ST(1), then pops.
+; After pop, old ST(1) (which now holds 1.0) becomes ST(0).
+db 0xD9, 0xD9
+
+lea rdx, [rel data3]
+fld tword [rdx + 8 * 0]
+
+; Expected stack: ST(0)=4.0 (MM7), ST(1)=1.0... wait.
+; Let me trace:
+;   fld 2.0 -> ST(0)=2.0
+;   fld 1.0 -> ST(0)=1.0, ST(1)=2.0
+;   FSTPNCE ST(1) -> ST(1) = ST(0) = 1.0, then pop -> ST(0)=1.0
+;   fld 4.0 -> ST(0)=4.0, ST(1)=1.0
+; Result: MM7=[4.0], MM6=[1.0]
+; 4.0 in x87: exponent=0x4001, mantissa=0x8000000000000000
+; 1.0 in x87: exponent=0x3FFF, mantissa=0x8000000000000000
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 1.0
+  dq 0
+data3:
+  dt 4.0
+  dq 0

--- a/unittests/ASM/X87/D9_D8_2.asm
+++ b/unittests/ASM/X87/D9_D8_2.asm
@@ -1,0 +1,53 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM5": ["0x8000000000000000", "0x4001"],
+    "MM6": ["0x8000000000000000", "0x3FFF"],
+    "MM7": ["0xC000000000000000", "0x4000"]
+  }
+}
+%endif
+
+; Tests undocumented FSTPNCE with ST(2) target.
+; Verifies the register index extraction (OP & 7) works for non-ST(1) targets.
+;
+; Related: issue #5296
+
+lea rdx, [rel data]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data2]
+fld tword [rdx + 8 * 0]
+
+lea rdx, [rel data3]
+fld tword [rdx + 8 * 0]
+
+; FSTPNCE ST(2) = db 0xD9, 0xDA
+; Stack before: ST(0)=1.0, ST(1)=3.0, ST(2)=2.0
+; Store ST(0) (1.0) into ST(2), then pop.
+; After pop: ST(0)=3.0, ST(1)=1.0
+db 0xD9, 0xDA
+
+lea rdx, [rel data4]
+fld tword [rdx + 8 * 0]
+
+; Final stack: ST(0)=4.0, ST(1)=3.0, ST(2)=1.0
+; 4.0: exponent=0x4001, mantissa=0x8000000000000000
+; 3.0: exponent=0x4000, mantissa=0xC000000000000000
+; 1.0: exponent=0x3FFF, mantissa=0x8000000000000000
+
+hlt
+
+align 8
+data:
+  dt 2.0
+  dq 0
+data2:
+  dt 3.0
+  dq 0
+data3:
+  dt 1.0
+  dq 0
+data4:
+  dt 4.0
+  dq 0


### PR DESCRIPTION
## Summary

Implements the undocumented FSTPNCE (Float Store and Pop, No Check Exception) instruction at opcode D9 D8-DF. This aliases to FSTP ST(i) - stores ST(0) to the target register and pops the stack.

Three changes in `X87Tables.cpp`:
- F64 dispatch table: Route `D9 D8+i` to `FSTToStack` handler
- Non-F64 dispatch table: Same routing
- Info table: `TYPE_INVALID` -> `TYPE_X87` with `FLAGS_SF_MOD_DST | FLAGS_POP`

Added two test files using raw byte encoding (`db 0xD9, 0xD9` / `db 0xD9, 0xDA`) since assemblers don't recognize this mnemonic:
- `D9_D8.asm`: Tests FSTPNCE ST(1)
- `D9_D8_2.asm`: Tests FSTPNCE ST(2) to verify register index extraction via `OP & 7`

Partially addresses #5296.

## Note on exception behavior

FSTPNCE ("No Check Exception") differs from FSTP in that it does not generate stack underflow exceptions. Since FEX's `FSTToStack` handler doesn't currently generate x87 stack fault exceptions, aliasing to the same handler is correct.

## Test plan

- [ ] Both test files pass in the FEX test harness
- [ ] Programs using FSTPNCE (e.g., some old DOS/Win16 apps via Wine) no longer hit "invalid opcode"