### PR TITLE
unittests: add exhaustive UCOMISS/UCOMISD flag tests

### DIFF
--- a/unittests/ASM/OpSize/66_2E_full.asm
+++ b/unittests/ASM/OpSize/66_2E_full.asm
@@ -1,0 +1,80 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x4200",
+    "RCX": "0x0300",
+    "RDX": "0x0200",
+    "RSI": "0x4700",
+    "RDI": "0x4200",
+    "R8":  "0x4200"
+  }
+}
+%endif
+
+; Exhaustive UCOMISD flag tests covering all 5 flag outcomes.
+; Tests double-precision variant of UCOMISS.
+;
+; LAHF result in AH:
+;   a == b:    0x42, a < b: 0x03, a > b: 0x02, unordered: 0x47
+
+mov rdx, 0xe0000000
+
+mov rax, 0x3FF0000000000000   ; 1.0
+mov [rdx + 0], rax
+mov rax, 0x4010000000000000   ; 4.0
+mov [rdx + 8], rax
+mov rax, 0x7FF8000000000000   ; QNaN
+mov [rdx + 16], rax
+mov rax, 0x0000000000000000   ; +0.0
+mov [rdx + 24], rax
+mov rax, 0x8000000000000000   ; -0.0
+mov [rdx + 32], rax
+mov rax, 0x7FF0000000000000   ; +Inf
+mov [rdx + 40], rax
+
+; Test 1: a == b (4.0 vs 4.0)
+movsd xmm0, [rdx + 8]
+ucomisd xmm0, [rdx + 8]
+mov rax, 0
+lahf
+mov rbx, rax
+
+; Test 2: a < b (1.0 vs 4.0)
+movsd xmm0, [rdx + 0]
+ucomisd xmm0, [rdx + 8]
+mov rax, 0
+lahf
+mov rcx, rax
+
+; Test 3: a > b (4.0 vs 1.0)
+movsd xmm0, [rdx + 8]
+ucomisd xmm0, [rdx + 0]
+mov rax, 0
+lahf
+mov rdx, rax
+
+; Test 4: unordered (1.0 vs NaN)
+mov rax, 0xe0000000
+movsd xmm0, [rax + 0]
+ucomisd xmm0, [rax + 16]
+mov rsi, 0
+lahf
+mov rsi, rax
+
+; Test 5: +0.0 == -0.0
+mov rax, 0xe0000000
+movsd xmm0, [rax + 24]
+ucomisd xmm0, [rax + 32]
+mov rdi, 0
+lahf
+mov rdi, rax
+
+; Test 6: +Inf == +Inf
+mov rax, 0xe0000000
+movsd xmm0, [rax + 40]
+ucomisd xmm0, [rax + 40]
+mov r8, 0
+lahf
+mov r8, rax
+
+hlt

--- a/unittests/ASM/TwoByte/0F_2E_full.asm
+++ b/unittests/ASM/TwoByte/0F_2E_full.asm
@@ -1,0 +1,83 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX": "0x4200",
+    "RCX": "0x0300",
+    "RDX": "0x0200",
+    "RSI": "0x4700",
+    "RDI": "0x4200",
+    "R8":  "0x4200"
+  }
+}
+%endif
+
+; Exhaustive UCOMISS flag tests covering all 5 flag outcomes.
+; Existing 0F_2E.asm only tests a<b and NaN.
+;
+; LAHF result in AH (bit 0=CF, bit 2=PF, bit 6=ZF, bit 1=always 1):
+;   a == b:    CF=0, ZF=1, PF=0 -> AH=0x42 -> RAX=0x4200
+;   a < b:     CF=1, ZF=0, PF=0 -> AH=0x03 -> RAX=0x0300
+;   a > b:     CF=0, ZF=0, PF=0 -> AH=0x02 -> RAX=0x0200
+;   unordered: CF=1, ZF=1, PF=1 -> AH=0x47 -> RAX=0x4700
+
+mov rdx, 0xe0000000
+
+mov eax, 0x3f800000   ; 1.0
+mov [rdx + 0], eax
+mov eax, 0x40800000   ; 4.0
+mov [rdx + 4], eax
+mov eax, 0x7fc00000   ; QNaN
+mov [rdx + 8], eax
+mov eax, 0x00000000   ; +0.0
+mov [rdx + 12], eax
+mov eax, 0x80000000   ; -0.0
+mov [rdx + 16], eax
+mov eax, 0x7f800000   ; +Inf
+mov [rdx + 20], eax
+
+; Test 1: a == b (4.0 vs 4.0)
+movss xmm0, [rdx + 4]
+ucomiss xmm0, [rdx + 4]
+mov rax, 0
+lahf
+mov rbx, rax
+
+; Test 2: a < b (1.0 vs 4.0)
+movss xmm0, [rdx + 0]
+ucomiss xmm0, [rdx + 4]
+mov rax, 0
+lahf
+mov rcx, rax
+
+; Test 3: a > b (4.0 vs 1.0)
+movss xmm0, [rdx + 4]
+ucomiss xmm0, [rdx + 0]
+mov rax, 0
+lahf
+mov rdx, rax
+
+; Test 4: unordered (1.0 vs NaN)
+mov rax, 0xe0000000
+movss xmm0, [rax + 0]
+ucomiss xmm0, [rax + 8]
+mov rsi, 0
+lahf
+mov rsi, rax
+
+; Test 5: +0.0 == -0.0
+mov rax, 0xe0000000
+movss xmm0, [rax + 12]
+ucomiss xmm0, [rax + 16]
+mov rdi, 0
+lahf
+mov rdi, rax
+
+; Test 6: +Inf == +Inf
+mov rax, 0xe0000000
+movss xmm0, [rax + 20]
+ucomiss xmm0, [rax + 20]
+mov r8, 0
+lahf
+mov r8, rax
+
+hlt


### PR DESCRIPTION
## Summary

Adds comprehensive flag-setting tests for UCOMISS and UCOMISD that cover all possible comparison outcomes:

| Test Case | CF | ZF | PF | LAHF (AH) |
|-----------|----|----|-----|-----------|
| a == b | 0 | 1 | 0 | 0x42 |
| a < b | 1 | 0 | 0 | 0x03 |
| a > b | 0 | 0 | 0 | 0x02 |
| Unordered (NaN) | 1 | 1 | 1 | 0x47 |
| +0.0 == -0.0 | 0 | 1 | 0 | 0x42 |
| +Inf == +Inf | 0 | 1 | 0 | 0x42 |

The existing tests (`0F_2E.asm`, `66_2E.asm`) only cover `a < b` and `NaN`, missing the `a > b`, `a == b`, signed zero equality, and infinity edge cases that are critical for correct x86 control flow emulation.

## New files

- `TwoByte/0F_2E_full.asm` — UCOMISS with all 6 test cases (single-precision)
- `OpSize/66_2E_full.asm` — UCOMISD with all 6 test cases (double-precision)

## Test plan

- [ ] Both test files pass in the FEX test harness
- [ ] Flag results match x86 hardware behavior for all 6 comparison outcomes