### PR TITLE
FEXCore: Initial support for large page size code buffers

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -349,15 +349,20 @@ namespace CPU {
     return *Buffer.LookupCache;
   }
 
-  CodeBuffer::CodeBuffer(size_t Size)
-    : AllocatedSize(Size) {
-    Ptr = static_cast<uint8_t*>(FEXCore::Allocator::VirtualAlloc(Size, true));
-    LOGMAN_THROW_A_FMT(!!Ptr, "Couldn't allocate code buffer");
+  CodeBuffer::CodeBuffer(size_t Size, uint32_t PageSize)
+    : AllocatedSize(Size)
+    , PageSize {PageSize} {
+    Ptr = static_cast<uint8_t*>(FEXCore::Allocator::VirtualAllocWithLargePageSupport(Size, PageSize, true));
+    LOGMAN_THROW_A_FMT(Ptr != MAP_FAILED, "Couldn't allocate code buffer");
+
+    if (PageSize == FEXCore::Utils::FEX_PAGE_SIZE) {
+      // Try and use THP when set to minimum page size.
+      FEXCore::Allocator::VirtualTHP(Ptr, Size);
+    }
 
     // Protect the last page of the allocated buffer to trigger SIGSEGV on write access
-    uintptr_t LastPageAddr = AlignDown(reinterpret_cast<uintptr_t>(Ptr) + Size - 1, FEXCore::Utils::FEX_PAGE_SIZE);
-    if (!FEXCore::Allocator::VirtualProtect(reinterpret_cast<void*>(LastPageAddr), FEXCore::Utils::FEX_PAGE_SIZE,
-                                            FEXCore::Allocator::ProtectOptions::None)) {
+    uintptr_t LastPageAddr = AlignDown(reinterpret_cast<uintptr_t>(Ptr) + Size - 1, PageSize);
+    if (!FEXCore::Allocator::VirtualProtect(reinterpret_cast<void*>(LastPageAddr), PageSize, FEXCore::Allocator::ProtectOptions::None)) {
       LogMan::Msg::EFmt("Failed to mprotect last page of code buffer.");
     }
 
@@ -368,6 +373,64 @@ namespace CPU {
 
   CodeBuffer::~CodeBuffer() {
     FEXCore::Allocator::VirtualFree(Ptr, AllocatedSize);
+  }
+
+  CodeBufferManager::CodeBufferManager() {
+#ifndef _WIN32
+    // Check for supported large-page sizes
+    constexpr std::array<uint32_t, 4> testing_sizes = {
+      14, // 16KB
+      16, // 64KB
+      21, // 2MB
+      25, // 32MB
+    };
+
+    for (auto size : testing_sizes) {
+      uint32_t map_flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB;
+      map_flags |= size << MAP_HUGE_SHIFT;
+      const size_t page_size = 1ULL << size;
+      auto Ptr = ::mmap(nullptr, page_size, PROT_NONE, map_flags, -1, 0);
+      if (Ptr != MAP_FAILED) {
+        // huge page size is supported.
+        SupportedLargePages |= (1U << size);
+        munmap(Ptr, page_size);
+      }
+    }
+#endif
+  }
+
+  uint32_t CodeBufferManager::FindLargestPageSizeForAllocation(size_t AllocationSize) {
+    // TODO: Enable once FEX's allocator support huge-pages.
+#if 0
+    // Scan from largest page size to smallest.
+    uint32_t TestingLargePages = SupportedLargePages;
+    for (uint32_t i = std::countl_zero(TestingLargePages); i < 32; ++i) {
+      if (!TestingLargePages) {
+        // Nothing remaining.
+        break;
+      }
+
+      const uint32_t TestBit = (0x8000'0000U >> i);
+
+      if ((TestingLargePages & TestBit) == 0) {
+        // Not supported.
+        continue;
+      }
+
+      const uint32_t log2_enc = (31 - i);
+      const uint32_t page_size = 1U << log2_enc;
+      if (page_size <= AllocationSize) {
+        // Page size fits within the allocation size requested.
+        return page_size;
+      }
+
+      // Clear the bit.
+      TestingLargePages &= ~TestBit;
+    }
+#endif
+
+    // 4kb page size always supported.
+    return FEXCore::Utils::FEX_PAGE_SIZE;
   }
 
   auto CodeBufferManager::AllocateNew(size_t Size) -> fextl::shared_ptr<CodeBuffer> {
@@ -396,7 +459,9 @@ namespace CPU {
     }
 #endif
 
-    auto Buffer = fextl::make_shared<CodeBuffer>(Size);
+    const auto page_size = FindLargestPageSizeForAllocation(Size);
+    Size += page_size;
+    auto Buffer = fextl::make_shared<CodeBuffer>(Size, page_size);
 
     Latest = Buffer;
     LatestOffset = 0;
@@ -435,7 +500,7 @@ namespace CPU {
     auto CheckCodeBuffer = [](CodeBuffer& Buffer, uintptr_t Address) {
       // The last page of the code buffer is protected, so we need to exclude it from the valid range
       // when checking if the address is in the code buffer.
-      uintptr_t LastPageAddr = AlignDown(reinterpret_cast<uintptr_t>(Buffer.Ptr) + Buffer.AllocatedSize - 1, FEXCore::Utils::FEX_PAGE_SIZE);
+      uintptr_t LastPageAddr = AlignDown(reinterpret_cast<uintptr_t>(Buffer.Ptr) + Buffer.AllocatedSize - 1, Buffer.PageSize);
       return (Address >= reinterpret_cast<uintptr_t>(Buffer.Ptr) && Address < LastPageAddr);
     };
 

--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -44,10 +44,12 @@ namespace CPU {
   struct CodeBuffer {
     uint8_t* Ptr;
     size_t AllocatedSize; // including guard page; see UsableSize()
+    const uint32_t PageSize;
 
     fextl::unique_ptr<GuestToHostMap> LookupCache;
 
-    CodeBuffer(size_t Size);
+    CodeBuffer(size_t Size, uint32_t PageSize);
+
     CodeBuffer(const CodeBuffer&) = delete;
     CodeBuffer& operator=(const CodeBuffer&) = delete;
     CodeBuffer(CodeBuffer&& oth) = delete;
@@ -57,7 +59,7 @@ namespace CPU {
 
     /// Returns the number of bytes available for storing code
     size_t UsableSize() const {
-      return AllocatedSize - FEXCore::Utils::FEX_PAGE_SIZE;
+      return AllocatedSize - PageSize;
     }
   };
 
@@ -72,6 +74,8 @@ namespace CPU {
    */
   class CodeBufferManager {
   public:
+    CodeBufferManager();
+
     // Get the CodeBuffer that was most recently allocated.
     // This is the only CodeBuffer that data may be written to.
     fextl::shared_ptr<CodeBuffer> GetLatest();
@@ -92,6 +96,8 @@ namespace CPU {
     fextl::shared_ptr<CodeBuffer> Latest;
 
     fextl::shared_ptr<CodeBuffer> AllocateNew(size_t Size);
+    uint32_t FindLargestPageSizeForAllocation(size_t Size);
+    uint32_t SupportedLargePages {};
   };
 
   class CPUBackend {

--- a/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
+++ b/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
@@ -2,7 +2,9 @@
 #pragma once
 #include <FEXCore/Utils/CompilerDefs.h>
 #include <FEXCore/Utils/EnumOperators.h>
+#include <FEXCore/Utils/MathUtils.h>
 #include <FEXCore/Utils/LogManager.h>
+#include <FEXCore/Utils/TypeDefines.h>
 
 #ifndef _WIN32
 #include <stdlib.h>
@@ -28,6 +30,7 @@ enum class ProtectOptions : uint32_t {
 FEX_DEF_NUM_OPS(ProtectOptions)
 
 #ifdef _WIN32
+#define MAP_FAILED ((void*)-1)
 inline void* VirtualAlloc(void* Base, size_t Size, bool Execute = false, bool Commit = true) {
   // Allocate top-down to avoid polluting the lower VA space, as even on 64-bit some programs (i.e. LuaJIT) require allocations below 4GB.
   DWORD Flags = (Commit ? MEM_COMMIT : 0) | MEM_RESERVE | MEM_TOP_DOWN;
@@ -37,15 +40,24 @@ inline void* VirtualAlloc(void* Base, size_t Size, bool Execute = false, bool Co
     Parameter.Type = MemExtendedParameterAttributeFlags;
     Parameter.ULong64 = MEM_EXTENDED_PARAMETER_EC_CODE;
   };
-  return ::VirtualAlloc2(nullptr, Base, Size, Flags, Execute ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE, Execute ? &Parameter : nullptr,
-                         Execute ? 1 : 0);
+  auto Ptr = ::VirtualAlloc2(nullptr, Base, Size, Flags, Execute ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE, Execute ? &Parameter : nullptr,
+                             Execute ? 1 : 0);
 #else
-  return ::VirtualAlloc(Base, Size, Flags, Execute ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE);
+  auto Ptr = ::VirtualAlloc(Base, Size, Flags, Execute ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE);
 #endif
+  if (Ptr == nullptr) {
+    return MAP_FAILED;
+  }
+  return Ptr;
 }
 
 inline void* VirtualAlloc(size_t Size, bool Execute = false, bool Commit = true) {
   return VirtualAlloc(nullptr, Size, Execute, Commit);
+}
+
+inline void* VirtualAllocWithLargePageSupport(size_t Size, size_t huge_page_size, bool Execute = false, bool Commit = true) {
+  // Win32 doesn't support selecting huge-page size.
+  return VirtualAlloc(Size, Execute, Commit);
 }
 
 inline void VirtualFree(void* Ptr, size_t Size) {
@@ -83,6 +95,7 @@ inline bool VirtualProtect(void* Ptr, size_t Size, ProtectOptions options) {
 }
 
 inline void VirtualName(const char*, void*, size_t) {}
+inline void VirtualTHP(void* Ptr, size_t Size) {}
 
 #else
 using MMAP_Hook = void* (*)(void*, size_t, int, int, int, off_t);
@@ -102,11 +115,24 @@ inline void* VirtualAlloc(void* Base, size_t Size, bool Execute = false, bool Co
   return FEXCore::Allocator::mmap(Base, Size, PROT_READ | PROT_WRITE | (Execute ? PROT_EXEC : 0), MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 }
 
+inline void* VirtualAllocWithLargePageSupport(size_t Size, size_t huge_page_size, bool Execute = false, bool Commit = true) {
+  uint32_t map_flags = MAP_PRIVATE | MAP_ANONYMOUS;
+  if (huge_page_size != FEXCore::Utils::FEX_PAGE_SIZE) {
+    // Allocate with huge page support only if requested.
+    map_flags |= MAP_HUGETLB | (FEXCore::ilog2(huge_page_size) << MAP_HUGE_SHIFT);
+  }
+  return FEXCore::Allocator::mmap(nullptr, Size, PROT_READ | PROT_WRITE | (Execute ? PROT_EXEC : 0), map_flags, -1, 0);
+}
+
 inline void VirtualFree(void* Ptr, size_t Size) {
   FEXCore::Allocator::munmap(Ptr, Size);
 }
 inline void VirtualDontNeed(void* Ptr, size_t Size, bool Recommit = true) {
   ::madvise(reinterpret_cast<void*>(Ptr), Size, MADV_DONTNEED);
+}
+
+inline void VirtualTHP(void* Ptr, size_t Size) {
+  ::madvise(reinterpret_cast<void*>(Ptr), Size, MADV_HUGEPAGE);
 }
 inline bool VirtualProtect(void* Ptr, size_t Size, ProtectOptions options) {
   int prot {PROT_NONE};


### PR DESCRIPTION
Some CPUs are affected by not being able to keep their pipelines fed when running at a 4kb page size. To help alleviate this, we can allocate large page size supporting buffers.

This can happen either directly with mmap, or with madvise and THP. Huge pages aren't always supported through mmap, so have a fallback for madvise so it at least tries to operate when possible.

mmap path is also disabled right now as FEX's VMA allocator doesn't support huge pages yet, so leaning heavily on the madvise implementation right now.