### PR TITLE
CPUBackend: Enable Transparent Huge Pages on JIT buffers

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -363,6 +363,9 @@ namespace CPU {
 
     FEXCore::Allocator::VirtualName("FEXMemJIT", reinterpret_cast<void*>(Ptr), Size);
 
+    // Huge-pages reduce the amount of iTLB misses dramatically when it works.
+    FEXCore::Allocator::VirtualTHP(reinterpret_cast<void*>(Ptr), Size);
+
     LookupCache = fextl::make_unique<GuestToHostMap>();
   }
 

--- a/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
+++ b/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
@@ -83,6 +83,7 @@ inline bool VirtualProtect(void* Ptr, size_t Size, ProtectOptions options) {
 }
 
 inline void VirtualName(const char*, void*, size_t) {}
+inline void VirtualTHP(void* Ptr, size_t Size) {}
 
 #else
 using MMAP_Hook = void* (*)(void*, size_t, int, int, int, off_t);
@@ -121,6 +122,10 @@ inline bool VirtualProtect(void* Ptr, size_t Size, ProtectOptions options) {
   }
 
   return ::mprotect(Ptr, Size, prot) == 0;
+}
+
+inline void VirtualTHP(void* Ptr, size_t Size) {
+  ::madvise(Ptr, Size, MADV_HUGEPAGE);
 }
 
 #endif


### PR DESCRIPTION
If/When this works, the amount of iTLB misses drop dramatically, which reduces L2 TLB pressure, which just improves performance for our CPU cores that have itty-bitty L1 iTLB entry counts.

We can't use `mmap(MAP_HUGETLB)` directly for terrible reasons, so we are required to lean on madvise instead.