### PR TITLE
FEX: Disable THP on key allocations that consume memory

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -364,7 +364,7 @@ namespace CPU {
     FEXCore::Allocator::VirtualName("FEXMemJIT", reinterpret_cast<void*>(Ptr), Size);
 
     // Huge-pages reduce the amount of iTLB misses dramatically when it works.
-    FEXCore::Allocator::VirtualTHP(reinterpret_cast<void*>(Ptr), Size);
+    FEXCore::Allocator::VirtualTHPControl(reinterpret_cast<void*>(Ptr), Size, FEXCore::Allocator::THPControl::Enable);
 
     LookupCache = fextl::make_unique<GuestToHostMap>();
   }

--- a/FEXCore/Source/Interface/Core/LookupCache.cpp
+++ b/FEXCore/Source/Interface/Core/LookupCache.cpp
@@ -41,6 +41,9 @@ LookupCache::LookupCache(FEXCore::Context::ContextImpl* CTX)
   PagePointer = reinterpret_cast<uintptr_t>(FEXCore::Allocator::VirtualAlloc(TotalCacheSize, false, false));
   LOGMAN_THROW_A_FMT(PagePointer != -1ULL, "Failed to allocate PagePointer");
 
+  // Disable THP on the Lookup cache.
+  FEXCore::Allocator::VirtualTHPControl(reinterpret_cast<void*>(PagePointer), TotalCacheSize, FEXCore::Allocator::THPControl::Disable);
+
   FEXCore::Allocator::VirtualName("FEXMem_Lookup", reinterpret_cast<void*>(PagePointer),
                                   ctx->Config.VirtualMemSize / FEXCore::Utils::FEX_PAGE_SIZE * 8 + CODE_SIZE);
   CTX->SyscallHandler->MarkOvercommitRange(PagePointer, TotalCacheSize);

--- a/FEXCore/Source/Utils/AllocatorHooks.cpp
+++ b/FEXCore/Source/Utils/AllocatorHooks.cpp
@@ -109,6 +109,9 @@ static void* FEX_rp_mmap(size_t size, size_t alignment, size_t* offset, size_t* 
 #define PR_SET_VMA_ANON_NAME 0
 #endif
     prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, ptr, map_size, global_config.page_name);
+
+    // Disable HUGEPAGE on allocation from rpmalloc.
+    madvise(ptr, map_size, MADV_NOHUGEPAGE);
   }
 
   if (ptr == nullptr) {

--- a/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
+++ b/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
@@ -27,6 +27,11 @@ enum class ProtectOptions : uint32_t {
 };
 FEX_DEF_NUM_OPS(ProtectOptions)
 
+enum class THPControl {
+  Enable,
+  Disable,
+};
+
 #ifdef _WIN32
 inline void* VirtualAlloc(void* Base, size_t Size, bool Execute = false, bool Commit = true) {
   // Allocate top-down to avoid polluting the lower VA space, as even on 64-bit some programs (i.e. LuaJIT) require allocations below 4GB.
@@ -83,7 +88,7 @@ inline bool VirtualProtect(void* Ptr, size_t Size, ProtectOptions options) {
 }
 
 inline void VirtualName(const char*, void*, size_t) {}
-inline void VirtualTHP(void* Ptr, size_t Size) {}
+inline void VirtualTHPControl(void* Ptr, size_t Size, THPControl Control) {}
 
 #else
 using MMAP_Hook = void* (*)(void*, size_t, int, int, int, off_t);
@@ -124,8 +129,8 @@ inline bool VirtualProtect(void* Ptr, size_t Size, ProtectOptions options) {
   return ::mprotect(Ptr, Size, prot) == 0;
 }
 
-inline void VirtualTHP(void* Ptr, size_t Size) {
-  ::madvise(Ptr, Size, MADV_HUGEPAGE);
+inline void VirtualTHPControl(void* Ptr, size_t Size, THPControl Control) {
+  ::madvise(Ptr, Size, Control == THPControl::Enable ? MADV_HUGEPAGE : MADV_NOHUGEPAGE);
 }
 
 #endif

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.cpp
@@ -189,6 +189,9 @@ FEX::HLE::ThreadStateObject* ThreadManager::CreateThread(uint64_t InitialRIP, ui
 
   FEXCore::Allocator::VirtualName("FEXMem_CallRetStacks", reinterpret_cast<void*>(AllocBase), CALLRET_STACK_ALLOC_SIZE);
 
+  // Disable HUGEPAGE on callret stacks.
+  FEXCore::Allocator::VirtualTHPControl(reinterpret_cast<void*>(AllocBase), CALLRET_STACK_ALLOC_SIZE, FEXCore::Allocator::THPControl::Disable);
+
   // Set the base used for invalidation to the start past the guard pages
   ThreadStateObject->Thread->CallRetStackBase = reinterpret_cast<void*>(AllocBase + FEXCore::Utils::FEX_PAGE_SIZE);
   ::mprotect(ThreadStateObject->Thread->CallRetStackBase, FEXCore::Core::InternalThreadState::CALLRET_STACK_SIZE, PROT_READ | PROT_WRITE);


### PR DESCRIPTION
Disables THP on some key locations that are fairly sparse
- rpmalloc
  - This is the big one as this allocates some heavy sparse buffers.
- CallRet stacks
  - These get in the hundreds of megabytes, while not being sparse they trend towards only using a handful of pages and ballooning to 2MB per thread is quite heavy.
- Lookup cache
  - L1 specifically gets hit here which adds a decent chunk of overhead due to sparsity.

Win32 for all of these also aren't handled, but that will need to be a followup.