### PR TITLE
Config: Fix issue with config overrides

### DIFF
--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -634,7 +634,7 @@ fextl::string GetDataDirectory(bool Global, const PortableInformation& PortableI
 
 fextl::string GetConfigDirectory(bool Global, const PortableInformation& PortableInfo) {
   const char* ConfigOverride = getenv("FEX_APP_CONFIG_LOCATION");
-  if (PortableInfo.IsPortable && (Global || !ConfigOverride)) {
+  if (PortableInfo.IsPortable && Global) {
     return fextl::fmt::format("{}/fex-emu/", PortableInfo.InterpreterPath);
   } else if (ConfigOverride && !Global) {
     fextl::string AppConfigStr = ConfigOverride;


### PR DESCRIPTION
Accidentally was checking for Config override in the combination of portable config and `FEX_APP_CONFIG_LOCATION`.

Fixes an early crash in PV.