### PR TITLE
FEXCore: Update CPU frequency to be 64-bit

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -141,7 +141,7 @@ constexpr uint32_t FAMILY_IDENTIFIER = GenerateFamily(CPUFamily {
 #endif
 
 #ifdef ARCHITECTURE_arm64
-uint32_t GetCycleCounterFrequency() {
+uint64_t GetCycleCounterFrequency() {
   uint64_t Result {};
   __asm("mrs %[Res], CNTFRQ_EL0" : [Res] "=r"(Result));
   return Result;
@@ -408,7 +408,7 @@ void CPUIDEmu::SetupHostHybridFlag() {
 }
 
 #else
-uint32_t GetCycleCounterFrequency() {
+uint64_t GetCycleCounterFrequency() {
   return 0;
 }
 
@@ -813,7 +813,7 @@ FEXCore::CPUID::FunctionResults CPUIDEmu::Function_0Dh(uint32_t Leaf) const {
 FEXCore::CPUID::FunctionResults CPUIDEmu::Function_15h(uint32_t Leaf) const {
   FEXCore::CPUID::FunctionResults Res {};
   // TSC frequency = ECX * EBX / EAX
-  uint32_t FrequencyHz = GetCycleCounterFrequency();
+  uint64_t FrequencyHz = GetCycleCounterFrequency();
   if (FrequencyHz) {
     Res.eax = 1;
     Res.ebx = 1U << CTX->Config.TSCScale;

--- a/FEXCore/Source/Interface/Core/CPUID.h
+++ b/FEXCore/Source/Interface/Core/CPUID.h
@@ -14,7 +14,7 @@ namespace Context {
   class ContextImpl;
 }
 
-uint32_t GetCycleCounterFrequency();
+uint64_t GetCycleCounterFrequency();
 
 // Debugging define to switch what family of CPU we execute as.
 // Might be useful if an application makes an assumption about a CPU.

--- a/FEXCore/Source/Utils/SpinWaitLock.cpp
+++ b/FEXCore/Source/Utils/SpinWaitLock.cpp
@@ -5,7 +5,7 @@ namespace FEXCore::Utils::SpinWaitLock {
 #ifdef ARCHITECTURE_arm64
 constexpr uint64_t NanosecondsInSecond = 1'000'000'000ULL;
 
-static uint32_t GetCycleCounterFrequency() {
+static uint64_t GetCycleCounterFrequency() {
   uint64_t Result {};
   __asm("mrs %[Res], CNTFRQ_EL0" : [Res] "=r"(Result));
   return Result;
@@ -21,7 +21,7 @@ static uint64_t CalculateCyclesPerNanosecond() {
   return NanosecondsInSecond / CounterFrequency;
 }
 
-uint32_t CycleCounterFrequency = GetCycleCounterFrequency();
+uint64_t CycleCounterFrequency = GetCycleCounterFrequency();
 uint64_t CyclesPerNanosecond = CalculateCyclesPerNanosecond();
 #endif
 } // namespace FEXCore::Utils::SpinWaitLock

--- a/FEXCore/Source/Utils/SpinWaitLock.h
+++ b/FEXCore/Source/Utils/SpinWaitLock.h
@@ -50,7 +50,7 @@ namespace FEXCore::Utils::SpinWaitLock {
 #define SPINLOOP_32BIT SPINLOOP_BODY(ldar, w)
 #define SPINLOOP_64BIT SPINLOOP_BODY(ldar, x)
 
-extern uint32_t CycleCounterFrequency;
+extern uint64_t CycleCounterFrequency;
 extern uint64_t CyclesPerNanosecond;
 
 ///< Get the raw cycle counter which is synchronizing.


### PR DESCRIPTION
This annoyed by by trying to do math on a 32-bit value and it overflowing. Just make it 64-bit.