### PR TITLE
Tests/ASM: Add FISTTP unit tests for 16, 32, 64-bit as well as negatives

### DIFF
--- a/unittests/ASM/X87/FISTTP_16bit.asm
+++ b/unittests/ASM/X87/FISTTP_16bit.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0",
+    "RBX": "1"
+  }
+}
+%endif
+
+; Test FISTTP with 16-bit integer store
+; FISTTP always truncates toward zero, ignoring rounding control word
+
+finit
+fld qword [rel .value]
+
+; Convert to int16 using truncation - 1.9 should become 1, not 2
+fisttp word [rel .result]
+
+fstsw ax
+and rax, 1
+
+; Load result to verify truncation worked
+movzx rbx, word [rel .result]
+
+hlt
+
+align 4096
+.value: dq 1.9
+.result: dw 0

--- a/unittests/ASM/X87/FISTTP_16bit_neg.asm
+++ b/unittests/ASM/X87/FISTTP_16bit_neg.asm
@@ -1,0 +1,27 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0",
+    "RBX": "0xFFFF"
+  }
+}
+%endif
+
+; Test FISTTP with negative value - truncation toward zero
+; -1.9 should become -1 (0xFFFF in 16-bit two's complement), not -2
+
+finit
+fld qword [rel .value]
+
+fisttp word [rel .result]
+
+fstsw ax
+and rax, 1
+
+movzx rbx, word [rel .result]
+
+hlt
+
+align 4096
+.value: dq -1.9
+.result: dw 0

--- a/unittests/ASM/X87/FISTTP_32bit.asm
+++ b/unittests/ASM/X87/FISTTP_32bit.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0",
+    "RBX": "1"
+  }
+}
+%endif
+
+; Test FISTTP with 32-bit integer store
+; FISTTP always truncates toward zero, ignoring rounding control word
+
+finit
+fld qword [rel .value]
+
+; Convert to int32 using truncation - 1.9 should become 1, not 2
+fisttp dword [rel .result]
+
+fstsw ax
+and rax, 1
+
+; Load result to verify truncation worked
+mov ebx, dword [rel .result]
+
+hlt
+
+align 4096
+.value: dq 1.9
+.result: dd 0

--- a/unittests/ASM/X87/FISTTP_32bit_neg.asm
+++ b/unittests/ASM/X87/FISTTP_32bit_neg.asm
@@ -1,0 +1,27 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0",
+    "RBX": "0xFFFFFFFF"
+  }
+}
+%endif
+
+; Test FISTTP with negative value - truncation toward zero
+; -1.9 should become -1 (0xFFFFFFFF in 32-bit two's complement), not -2
+
+finit
+fld qword [rel .value]
+
+fisttp dword [rel .result]
+
+fstsw ax
+and rax, 1
+
+mov ebx, dword [rel .result]
+
+hlt
+
+align 4096
+.value: dq -1.9
+.result: dd 0

--- a/unittests/ASM/X87/FISTTP_64bit.asm
+++ b/unittests/ASM/X87/FISTTP_64bit.asm
@@ -1,0 +1,29 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0",
+    "RBX": "1"
+  }
+}
+%endif
+
+; Test FISTTP with 64-bit integer store
+; FISTTP always truncates toward zero, ignoring rounding control word
+
+finit
+fld qword [rel .value]
+
+; Convert to int64 using truncation - 1.9 should become 1, not 2
+fisttp qword [rel .result]
+
+fstsw ax
+and rax, 1
+
+; Load result to verify truncation worked
+mov rbx, qword [rel .result]
+
+hlt
+
+align 4096
+.value: dq 1.9
+.result: dq 0

--- a/unittests/ASM/X87/FISTTP_64bit_neg.asm
+++ b/unittests/ASM/X87/FISTTP_64bit_neg.asm
@@ -1,0 +1,27 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0",
+    "RBX": "0xFFFFFFFFFFFFFFFF"
+  }
+}
+%endif
+
+; Test FISTTP with negative value - truncation toward zero
+; -1.9 should become -1 (0xFFFFFFFFFFFFFFFF in 64-bit two's complement), not -2
+
+finit
+fld qword [rel .value]
+
+fisttp qword [rel .result]
+
+fstsw ax
+and rax, 1
+
+mov rbx, qword [rel .result]
+
+hlt
+
+align 4096
+.value: dq -1.9
+.result: dq 0


### PR DESCRIPTION
FISTTP was not covered by previous Unit-Tests. Added 6 Tests covering 16, 32 and 64-bit integer store variants as well as their negative counterparts to verify truncation towards 0.

Closes #779