### PR TITLE
FEXServer: Try both fusermount and fusermount3

### DIFF
--- a/Source/Tools/FEXServer/SquashFS.cpp
+++ b/Source/Tools/FEXServer/SquashFS.cpp
@@ -202,16 +202,20 @@ void UnmountRootFS() {
 
   if (pid == 0) {
     const char* argv[5];
-    argv[0] = "fusermount";
+    argv[0] = "fusermount3";
     argv[1] = "-u";
     argv[2] = "-q";
     argv[3] = MountFolder.c_str();
     argv[4] = nullptr;
 
     if (execvp(argv[0], (char* const*)argv) == -1) {
-      fprintf(stderr, "fusermount failed to execute. You may have an mount living at '%s' to clean up now\n", MountFolder.c_str());
-      fprintf(stderr, "Try `%s %s %s %s`\n", argv[0], argv[1], argv[2], argv[3]);
-      exit(1);
+      // Try again with `fusermount`
+      argv[0] = "fusermount";
+      if (execvp(argv[0], (char* const*)argv) == -1) {
+        fprintf(stderr, "fusermount{3,} failed to execute. You may have an mount living at '%s' to clean up now\n", MountFolder.c_str());
+        fprintf(stderr, "Try `%s %s %s %s`\n", argv[0], argv[1], argv[2], argv[3]);
+        exit(1);
+      }
     }
   } else {
     // Wait for fusermount to leave


### PR DESCRIPTION
Apparently some distros don't symlink these, so try both with the newer fusermount3 going first as its the common path now.

Fixes #5375