### PR TITLE
Arm64Emitter: Disable 32-bit constant optimization when NOP-padding is requested

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -448,8 +448,10 @@ void Arm64Emitter::LoadConstant(ARMEmitter::Size s, ARMEmitter::Register Reg, ui
     return;
   }
 
-  if ((Constant >> 32) == 0) {
+  if ((Constant >> 32) == 0 && !NOPPad) {
     // If the upper 32-bits is all zero, we can now switch to a 32-bit move.
+    // NOTE: The NOP padding code does not appropriately adjust to this yet,
+    //       so we skip this optimization in that case
     s = ARMEmitter::Size::i32Bit;
     Is64Bit = false;
     Segments = std::min(Segments, 2);


### PR DESCRIPTION
Code caching requires this even for simple libraries like libdl.so (as observed in the 32-bit build of Super Meat Boy).

Example assembly from cache versus runtime-generated, where the former packs the constant in 16 bytes but the latter uses only 8:
```
I  OFFSET               FROM CACHE                        FROM JIT            
I +0x001c: mov w20, #0x3009                 mov w20, #0x3009                 (start of relocated constant)
I +0x0020: movk w20, #0xffd3, lsl #16       movk w20, #0xffd3, lsl #16      
I +0x0024: nop                             |str w20, [x8, #-4]!             
I +0x0028: nop                             |stp xzr, xzr, [x25, #-16]!      
I +0x002c: str w20, [x8, #-4]!             |...
I +0x0030: stp xzr, xzr, [x25, #-16]!      |...
```
There seem to be multiple issues in the NOP padding code later in that file. I can't look into and validate each of these at the moment, but if anyone wants to give it a stab, this trivially reproduces by running the 32-bit Linux build of Super Meat Boy with code cache validation enabled.
