### PR TITLE
LinuxSyscalls: Re-open file descriptors for parsing ELF headers

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -219,8 +219,12 @@ static ReadELFHeadersResult ReadELFHeaders(int FD, std::span<std::byte> HeaderDa
     // Read from FD in case the caller didn't have a mapped header available
   }
 
+  // Re-open the file with a fresh file descriptor (and let ELFParser close it on return).
+  // NOTE: FDs returned by dup() share the same cursor state, so reading from them would have observable side effects.
+  auto NewFD = open(fextl::fmt::format("/proc/self/fd/{}", FD).c_str(), O_RDONLY);
+
   ELFParser Parser;
-  Parser.ReadElf(dup(FD));
+  Parser.ReadElf(NewFD);
 
   auto Relocations = Parser.PopulateRelocations();
   if (!Relocations.empty()) {


### PR DESCRIPTION
File descriptors returned by dup() share state with the original FD, so we need to use open() to create a fully independent object.

Fixes #5379