### PR TITLE
LinuxSyscalls: Skip reading ELF files when code caching is disabled

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -541,9 +541,9 @@ SyscallHandler::TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t a
         Resource->MappedFile->Filename = fextl::string(Tmp, PathLength);
         Resource->MappedFile->FileId = CTX->GetCodeCache().ComputeCodeMapId(Resource->MappedFile->Filename, fd);
 
-        // Read ELF headers if applicable.
+        // Read ELF headers if applicable and needed for code caching.
         // For performance, skip ELF checks if we're not mapping the file header
-        bool CheckForElfFile = (offset == 0);
+        bool CheckForElfFile = (offset == 0) && EnableCodeCaching;
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
         CheckForElfFile = true;
 #endif


### PR DESCRIPTION
ELF headers were read unconditionally because doing so was assumed to be cheap (as the guest app would read them anyway shortly after). However, relocation parsing was added since then, which has less predictable performance due to crossing page boundaries and reading larger amounts of memory. It might be possible to make the underlying code more efficient, but until that's done it's better to skip this logic unless needed.

Closes #5390