### PR TITLE
Allocators: Remove legacy NOREPLACE handling

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/LinuxAllocator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/LinuxAllocator.cpp
@@ -196,14 +196,7 @@ restart: {
 
     if (MappedPtr == MAP_FAILED && errno != EEXIST) {
       return reinterpret_cast<void*>(-errno);
-    } else if (MappedPtr == MAP_FAILED || MappedPtr >= reinterpret_cast<void*>(TOP_KEY << FEXCore::Utils::FEX_PAGE_SHIFT)) {
-      // Handles the case where MAP_FIXED_NOREPLACE failed with MAP_FAILED
-      // or if the host system's kernel isn't new enough then it returns the wrong pointer
-      if (MappedPtr != MAP_FAILED && MappedPtr >= reinterpret_cast<void*>(TOP_KEY << FEXCore::Utils::FEX_PAGE_SHIFT)) {
-        // Make sure to munmap this so we don't leak memory
-        ::munmap(MappedPtr, length);
-      }
-
+    } else if (MappedPtr == MAP_FAILED) {
       if (UpperPage == TOP_KEY) {
         BottomPage = BASE_KEY;
         Wrapped = true;
@@ -240,13 +233,7 @@ restart: {
     void* MappedPtr = ::mmap(reinterpret_cast<void*>(PageAddr << FEXCore::Utils::FEX_PAGE_SHIFT),
                              PagesLength << FEXCore::Utils::FEX_PAGE_SHIFT, prot, flags, fd, offset);
 
-    if (MappedPtr >= reinterpret_cast<void*>(TOP_KEY << FEXCore::Utils::FEX_PAGE_SHIFT) && (flags & FEX_MAP_FIXED_NOREPLACE)) {
-      // Handles the case where MAP_FIXED_NOREPLACE isn't handled by the host system's
-      // kernel and returns the wrong pointer
-      // Make sure to munmap this so we don't leak memory
-      ::munmap(MappedPtr, length);
-      return reinterpret_cast<void*>(-EEXIST);
-    } else if (MappedPtr != MAP_FAILED) {
+    if (MappedPtr != MAP_FAILED) {
       SetUsedPages(PageAddr, PagesLength);
       return MappedPtr;
     } else {

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
@@ -703,22 +703,11 @@ void LoadFEXGeneratedCode(FEXCore::Core::InternalThreadState* Thread, bool Is64B
       Mapping->X86GeneratedCodePtr = Result;
     }
   } else {
-    // First 64bit page
-    constexpr uintptr_t LOCATION_MAX = 0x1'0000'0000;
-
     // We need to have the sigret handler in the lower 32bits of memory space
     // Scan top down and try to allocate a location
     for (size_t Location = 0xFFFF'E000; Location != 0x0; Location -= PageSize) {
       auto Ptr = Handler->GuestMmap(Is64Bit, Thread, reinterpret_cast<void*>(Location), PageSize, PROT_READ | PROT_WRITE,
                                     MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-
-      if (!FEX::HLE::HasSyscallError(Ptr) && reinterpret_cast<uintptr_t>(Ptr) >= LOCATION_MAX) {
-        // Failed to map in the lower 32bits
-        // Try again
-        // Can happen in the case that host kernel ignores MAP_FIXED_NOREPLACE
-        Handler->GuestMunmap(Thread, Ptr, PageSize);
-        continue;
-      }
 
       if (!FEX::HLE::HasSyscallError(Ptr)) {
         Mapping->X86GeneratedCodePtr = Ptr;


### PR DESCRIPTION
We needed this handling on old kernels that didn't understand the NOREPLACE flag. We no longer support kernels this old, so remove some of this vestigial code.