### PR TITLE
FEXCore: Add support for developer single stepping, read/write watching.

### DIFF
--- a/FEXCore/Source/Interface/Context/Context.h
+++ b/FEXCore/Source/Interface/Context/Context.h
@@ -64,6 +64,8 @@ struct CustomIRResult {
 using BlockDelinkerFunc = void (*)(FEXCore::Context::ExitFunctionLinkData* Record);
 constexpr uint32_t TSC_SCALE_MAXIMUM = 1'000'000'000; ///< 1Ghz
 
+constexpr static bool BLOCK_DEBUGGING = false;
+
 class CodeCache : public AbstractCodeCache {
 public:
   CodeCache(ContextImpl&);
@@ -233,6 +235,83 @@ public:
 
   void MarkMonoBackpatcherBlock(uint64_t BlockEntry) override;
 
+  // Manual debugging tooling which is useful for developers.
+  struct TrackingEmpty {
+    // RIP stepping handling
+    virtual void AddSingleStepTarget(uint64_t GuestRIP) {}
+    virtual void AllTargetSingleStep() {}
+    virtual void RemoveSingleStepTarget(uint64_t GuestRIP) {}
+    virtual bool IsSingleStepTarget(uint64_t GuestRIP) {
+      return false;
+    }
+
+    // Watchpoints
+    virtual void AddWriteWatchPoint(uint64_t Ptr) {}
+    virtual void AddReadWatchPoint(uint64_t Ptr) {}
+    virtual bool ContainsWriteWatchPoint(uint64_t Ptr, size_t Size) {
+      return false;
+    }
+    virtual bool ContainsReadWatchPoint(uint64_t Ptr, size_t Size) {
+      return false;
+    }
+  };
+
+  struct TrackingPossible final : public TrackingEmpty {
+    void AddSingleStepTarget(uint64_t GuestRIP) override {
+      SingleStepTargets.emplace(GuestRIP);
+    }
+
+    void RemoveSingleStepTarget(uint64_t GuestRIP) override {
+      SingleStepTargets.erase(GuestRIP);
+    }
+
+    void AllTargetSingleStep() override {
+      SingleStepEverything = true;
+    }
+
+    bool IsSingleStepTarget(uint64_t GuestRIP) override {
+      return SingleStepEverything || SingleStepTargets.contains(GuestRIP);
+    }
+
+    void AddWriteWatchPoint(uint64_t Ptr) override {
+      WatchWriteTargets.emplace(Ptr);
+    }
+
+    void AddReadWatchPoint(uint64_t Ptr) override {
+      WatchReadTargets.emplace(Ptr);
+    }
+
+    bool ContainsWriteWatchPoint(uint64_t Ptr, size_t Size) override {
+      return ContainsRange(WatchWriteTargets, Ptr, Size);
+    }
+
+    bool ContainsReadWatchPoint(uint64_t Ptr, size_t Size) override {
+      return ContainsRange(WatchReadTargets, Ptr, Size);
+    }
+
+  private:
+    bool SingleStepEverything {};
+    fextl::set<uint64_t> SingleStepTargets {};
+    fextl::set<uint64_t> WatchWriteTargets {};
+    fextl::set<uint64_t> WatchReadTargets {};
+
+    static bool ContainsRange(const fextl::set<uint64_t>& Set, uint64_t Ptr, size_t Size) {
+      for (auto it = Set.lower_bound(Ptr); it != Set.end(); --it) {
+        auto Watch = *it;
+        if (Watch < Ptr) {
+          break;
+        }
+        if (Watch >= Ptr && Watch < (Ptr + Size)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  };
+  using TrackingStructure = std::conditional<BLOCK_DEBUGGING, TrackingPossible, TrackingEmpty>::type;
+
+  TrackingStructure BlockDebuggerTracker {};
 public:
   struct {
     uint64_t VirtualMemSize {1ULL << 36};

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -358,6 +358,16 @@ bool ContextImpl::InitCore() {
     Config.NeedsPendingInterruptFaultCheck = true;
   }
 
+  if constexpr (BLOCK_DEBUGGING) {
+    // If the developer wants to do any single-stepping points or watch points.
+    // Add them here.
+    //
+    // eg:
+    // BlockDebuggerTracker.AllTargetSingleStep();
+    // BlockDebuggerTracker.AddSingleStepTarget(0x14000'0000ULL);
+    // BlockDebuggerTracker.AddWriteWatchPoint(0x420BA5ED);
+  }
+
   return true;
 }
 
@@ -376,7 +386,7 @@ void ContextImpl::ExecuteThread(FEXCore::Core::InternalThreadState* Thread) {
 }
 
 void ContextImpl::InitializeCompiler(FEXCore::Core::InternalThreadState* Thread) {
-  Thread->OpDispatcher = fextl::make_unique<FEXCore::IR::OpDispatchBuilder>(this);
+  Thread->OpDispatcher = fextl::make_unique<FEXCore::IR::OpDispatchBuilder>(this, Thread);
   Thread->OpDispatcher->SetMultiblock(Config.Multiblock);
   Thread->LookupCache = fextl::make_unique<FEXCore::LookupCache>(this);
   Thread->FrontendDecoder = fextl::make_unique<FEXCore::Frontend::Decoder>(Thread);
@@ -818,6 +828,17 @@ ContextImpl::CompileCodeResult ContextImpl::CompileCode(FEXCore::Core::InternalT
 }
 
 uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_t GuestRIP, uint64_t MaxInst) {
+  if constexpr (BLOCK_DEBUGGING) {
+    // Block debugging logic is hand-written and needs to be handled with care.
+    // Force MaxInst to only be one in this case.
+    MaxInst = 1;
+
+    // If the entrypoint is part of the single step targets then single step it.
+    if (BlockDebuggerTracker.IsSingleStepTarget(GuestRIP)) {
+      return CompileSingleStep(Frame, GuestRIP);
+    }
+  }
+
   auto Thread = Frame->Thread;
   FEXCORE_PROFILE_SCOPED("CompileBlock");
   FEXCORE_PROFILE_ACCUMULATION(Thread, AccumulatedJITTime);

--- a/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
@@ -55,6 +55,29 @@ DEF_OP(ExitFunction) {
 
   uint64_t NewRIP;
 
+  if constexpr (Context::BLOCK_DEBUGGING) {
+    // Skip block linking when BLOCK_DEBUGGING as it adds overhead and is unncessary.
+    // This is a debug only feature and doesn't need caching help.
+    bool IsInlineRIP = IsInlineConstant(Op->NewRIP, &NewRIP) || IsInlineEntrypointOffset(Op->NewRIP, &NewRIP);
+    ARMEmitter::ForwardLabel l_ExitLink;
+    if (IsInlineRIP) {
+      ldr(TMP1, &l_ExitLink);
+      str(TMP1, STATE, offsetof(FEXCore::Core::CpuStateFrame, State.rip));
+    } else {
+      auto RipReg = GetReg(Op->NewRIP);
+      str(RipReg.X(), STATE, offsetof(FEXCore::Core::CpuStateFrame, State.rip));
+    }
+    ldr(TMP2, STATE, offsetof(FEXCore::Core::CpuStateFrame, Pointers.DispatcherLoopTop));
+    br(TMP2);
+
+    if (IsInlineRIP) {
+      BindOrRestart(&l_ExitLink);
+      dc64(NewRIP);
+    }
+
+    return;
+  }
+
   if (IsInlineConstant(Op->NewRIP, &NewRIP) || IsInlineEntrypointOffset(Op->NewRIP, &NewRIP)) {
 #ifdef ARCHITECTURE_arm64ec
     if (NewRIP < EC_CODE_BITMAP_MAX_ADDRESS && RtlIsEcCode(NewRIP)) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4216,6 +4216,94 @@ void OpDispatchBuilder::UpdatePrefixFromSegment(Ref Segment, uint32_t SegmentReg
   }
 }
 
+uint64_t OpDispatchBuilder::CalcAddress(const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, bool IsLoad) {
+  if constexpr (!Context::BLOCK_DEBUGGING) {
+    LOGMAN_MSG_A_FMT("Tried to calculate address without block debugging enabled!");
+    FEX_UNREACHABLE;
+  }
+
+  const auto GPRSize = GetGPROpSize();
+  const auto GPRMask = GPRSize == OpSize::i64Bit ? ~0ULL : ~0U;
+
+  // This makes the assumption that InternalThreadState is synchronized at the point of call!
+  uint64_t Ptr {};
+  if (Operand.IsLiteral()) {
+    Ptr = Operand.Literal();
+
+    if (Operand.Data.Literal.Size != 8 && IsLoad) {
+      // zero extend
+      uint64_t width = Operand.Data.Literal.Size * 8;
+      Ptr &= ((1ULL << width) - 1);
+    }
+  } else if (Operand.IsGPR()) {
+    // Not a memory source.
+    return ~0ULL;
+  } else if (Operand.IsGPRDirect()) {
+    Ptr = Thread->CurrentFrame->State.gregs[Operand.Data.GPR.GPR] & GPRMask;
+  } else if (Operand.IsGPRIndirect() || Operand.IsGPRIndirectRelocation()) {
+    Ptr = Thread->CurrentFrame->State.gregs[Operand.Data.GPR.GPR] & GPRMask;
+    Ptr += static_cast<int32_t>(Operand.Data.GPRIndirect.Displacement);
+  } else if (Operand.IsRIPRelative() || Operand.IsRIPRelativeRelocation()) {
+    // 64-bit is RIP relative, while 32-bit is absolute.
+    if (Is64BitMode) {
+      Ptr = Op->PC + Op->InstSize + static_cast<int32_t>(Operand.Data.RIPLiteral.Value) - Entry;
+    } else {
+      Ptr = Operand.Data.RIPLiteral.Value;
+    }
+  } else if (Operand.IsSIB() || Operand.IsSIBRelocation()) {
+    const bool IsVSIB = IsLoad && ((Op->Flags & X86Tables::DecodeFlags::FLAG_VSIB_BYTE) != 0);
+    if (IsVSIB) {
+      // TODO: Unhandled.
+      return ~0ULL;
+    }
+    if (Operand.Data.SIB.Base != FEXCore::X86State::REG_INVALID) {
+      Ptr = Thread->CurrentFrame->State.gregs[Operand.Data.SIB.Base] & GPRMask;
+    }
+
+    if (Operand.Data.SIB.Index != FEXCore::X86State::REG_INVALID) {
+      Ptr += (Thread->CurrentFrame->State.gregs[Operand.Data.SIB.Index] * Operand.Data.SIB.Scale) & GPRMask;
+    }
+
+    Ptr += static_cast<int32_t>(Operand.Data.SIB.Offset);
+  }
+
+  auto AppendSegment = [&](uint64_t Ptr, uint32_t Flags, uint32_t DefaultPrefix = FEXCore::X86Tables::DecodeFlags::FLAG_NO_PREFIX,
+                           bool Override = false) -> uint64_t {
+    uint32_t Prefix = Flags & FEXCore::X86Tables::DecodeFlags::FLAG_SEGMENTS;
+
+    if (Is64BitMode) {
+      if (Prefix == FEXCore::X86Tables::DecodeFlags::FLAG_FS_PREFIX) {
+        return Ptr + Thread->CurrentFrame->State.fs_cached;
+      } else if (Prefix == FEXCore::X86Tables::DecodeFlags::FLAG_GS_PREFIX) {
+        return Ptr + Thread->CurrentFrame->State.gs_cached;
+      }
+      // If there was any other segment in 64bit then it is ignored
+    } else {
+      if (Prefix == FEXCore::X86Tables::DecodeFlags::FLAG_NO_PREFIX || Override) {
+        // If there was no prefix then use the default one if available
+        // Or the argument only uses a specific prefix (with override set)
+        Prefix = DefaultPrefix;
+      }
+      // With the segment register optimization we store the GDT bases directly in the segment register to remove indexed loads
+      switch (Prefix) {
+      [[likely]] case FEXCore::X86Tables::DecodeFlags::FLAG_NO_PREFIX:
+        return Ptr;
+      case FEXCore::X86Tables::DecodeFlags::FLAG_ES_PREFIX: return Ptr + Thread->CurrentFrame->State.es_cached;
+      case FEXCore::X86Tables::DecodeFlags::FLAG_CS_PREFIX: return Ptr + Thread->CurrentFrame->State.cs_cached;
+      case FEXCore::X86Tables::DecodeFlags::FLAG_SS_PREFIX: return Ptr + Thread->CurrentFrame->State.ss_cached;
+      case FEXCore::X86Tables::DecodeFlags::FLAG_DS_PREFIX: return Ptr + Thread->CurrentFrame->State.ds_cached;
+      case FEXCore::X86Tables::DecodeFlags::FLAG_FS_PREFIX: return Ptr + Thread->CurrentFrame->State.fs_cached;
+      case FEXCore::X86Tables::DecodeFlags::FLAG_GS_PREFIX: return Ptr + Thread->CurrentFrame->State.gs_cached;
+      default: FEX_UNREACHABLE;
+      }
+    }
+
+    return Ptr;
+  };
+
+  return AppendSegment(Ptr, Op->Flags);
+};
+
 AddressMode OpDispatchBuilder::DecodeAddress(const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand,
                                              MemoryAccessType AccessType, bool IsLoad) {
   const auto GPRSize = GetGPROpSize();
@@ -4306,6 +4394,7 @@ Ref OpDispatchBuilder::LoadSource_WithOpSize(RegClass Class, const X86Tables::De
   auto [Align, LoadData, ForceLoad, AccessType, AllowUpperGarbage] = Options;
   AddressMode A = DecodeAddress(Op, Operand, AccessType, true /* IsLoad */);
 
+  Ref Result {};
   if (Operand.IsGPR()) {
     const auto gpr = Operand.Data.GPR.GPR;
     const auto highIndex = Operand.Data.GPR.HighBits ? 1 : 0;
@@ -4335,22 +4424,35 @@ Ref OpDispatchBuilder::LoadSource_WithOpSize(RegClass Class, const X86Tables::De
     }
   }
 
-  if ((IsOperandMem(Operand, true) && LoadData) || ForceLoad) {
+  const bool ShouldLoad = (IsOperandMem(Operand, true) && LoadData) || ForceLoad;
+  if (ShouldLoad) {
     if (OpSize == OpSize::f80Bit) {
       Ref MemSrc = LoadEffectiveAddress(this, A, GetGPROpSize(), true);
       if (CTX->HostFeatures.SupportsSVE128 || CTX->HostFeatures.SupportsSVE256) {
-        return _LoadMemX87SVEOptPredicate(OpSize::i128Bit, OpSize::i16Bit, MemSrc);
+        Result = _LoadMemX87SVEOptPredicate(OpSize::i128Bit, OpSize::i16Bit, MemSrc);
       } else {
         // For X87 extended doubles, Split the load.
         auto Res = _LoadMem(Class, OpSize::i64Bit, MemSrc, Align == OpSize::iInvalid ? OpSize : Align);
-        return _VLoadVectorElement(OpSize::i128Bit, OpSize::i16Bit, Res, 4, Add(OpSize::i64Bit, MemSrc, 8));
+        Result = _VLoadVectorElement(OpSize::i128Bit, OpSize::i16Bit, Res, 4, Add(OpSize::i64Bit, MemSrc, 8));
+      }
+    } else {
+      Result = _LoadMemAutoTSO(Class, OpSize, A, Align == OpSize::iInvalid ? OpSize : Align);
+    }
+  } else {
+    Result = LoadEffectiveAddress(this, A, GetGPROpSize(), false, AllowUpperGarbage);
+  }
+
+  if constexpr (Context::BLOCK_DEBUGGING) {
+    if (ShouldLoad && CTX->BlockDebuggerTracker.IsSingleStepTarget(Entry)) {
+      uint64_t Ptr = CalcAddress(Op, Operand, true);
+      if (CTX->BlockDebuggerTracker.ContainsReadWatchPoint(Ptr, OpSizeToSize(OpSize))) {
+        // It's up to the developer if they want more advanced debugging logic here.
+        LogMan::Msg::IFmt("Entrypoint 0x{:x} will hit read watch: [0x{:x}, 0x{:x})", Entry, Ptr, Ptr + OpSizeToSize(OpSize));
       }
     }
-
-    return _LoadMemAutoTSO(Class, OpSize, A, Align == OpSize::iInvalid ? OpSize : Align);
-  } else {
-    return LoadEffectiveAddress(this, A, GetGPROpSize(), false, AllowUpperGarbage);
   }
+
+  return Result;
 }
 
 Ref OpDispatchBuilder::LoadGPRRegister(uint32_t GPR, IR::OpSize Size, uint8_t Offset, bool AllowUpperGarbage) {
@@ -4476,6 +4578,16 @@ void OpDispatchBuilder::StoreResult_WithOpSize(RegClass Class, FEXCore::X86Table
   } else {
     _StoreMemAutoTSO(Class, OpSize, A, Src, Align == OpSize::iInvalid ? OpSize : Align);
   }
+
+  if constexpr (Context::BLOCK_DEBUGGING) {
+    if (CTX->BlockDebuggerTracker.IsSingleStepTarget(Entry)) {
+      uint64_t Ptr = CalcAddress(Op, Operand, false);
+      if (CTX->BlockDebuggerTracker.ContainsWriteWatchPoint(Ptr, OpSizeToSize(OpSize))) {
+        // It's up to the developer if they want more advanced debugging logic here.
+        LogMan::Msg::IFmt("Entrypoint 0x{:x} will hit write watch: [0x{:x}, 0x{:x})", Entry, Ptr, Ptr + OpSizeToSize(OpSize));
+      }
+    }
+  }
 }
 
 void OpDispatchBuilder::StoreResult(RegClass Class, X86Tables::DecodedOp Op, const X86Tables::DecodedOperand& Operand, Ref Src,
@@ -4487,9 +4599,10 @@ void OpDispatchBuilder::StoreResult(RegClass Class, X86Tables::DecodedOp Op, Ref
   StoreResult(Class, Op, Op->Dest, Src, Align, AccessType);
 }
 
-OpDispatchBuilder::OpDispatchBuilder(FEXCore::Context::ContextImpl* ctx)
+OpDispatchBuilder::OpDispatchBuilder(FEXCore::Context::ContextImpl* ctx, FEXCore::Core::InternalThreadState* Thread)
   : IREmitter {ctx->OpDispatcherAllocator, ctx->HostFeatures.SupportsTSOImm9}
-  , CTX {ctx} {
+  , CTX {ctx}
+  , Thread {Thread} {
   if (CTX->HostFeatures.SupportsAVX && CTX->HostFeatures.SupportsSVE256) {
     SaveAVXStateFunc = &OpDispatchBuilder::SaveAVXState;
     RestoreAVXStateFunc = &OpDispatchBuilder::RestoreAVXState;

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -303,7 +303,7 @@ public:
     StartNewBlock();
   }
 
-  OpDispatchBuilder(FEXCore::Context::ContextImpl* ctx);
+  OpDispatchBuilder(FEXCore::Context::ContextImpl* ctx, FEXCore::Core::InternalThreadState* Thread);
 
   // Should only be called at the start of IR Emission.
   void ResetWorkingList();
@@ -1376,6 +1376,7 @@ private:
   };
 
   FEXCore::Context::ContextImpl* CTX {};
+  FEXCore::Core::InternalThreadState* Thread;
 
   constexpr static unsigned FullNZCVMask = (1U << FEXCore::X86State::RFLAG_CF_RAW_LOC) | (1U << FEXCore::X86State::RFLAG_ZF_RAW_LOC) |
                                            (1U << FEXCore::X86State::RFLAG_SF_RAW_LOC) | (1U << FEXCore::X86State::RFLAG_OF_RAW_LOC);
@@ -1591,6 +1592,7 @@ private:
   }
 
   AddressMode DecodeAddress(const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, MemoryAccessType AccessType, bool IsLoad);
+  uint64_t CalcAddress(const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, bool IsLoad);
 
   Ref LoadSource(RegClass Class, const X86Tables::DecodedOp& Op, const X86Tables::DecodedOperand& Operand, uint32_t Flags,
                  const LoadSourceOptions& Options = {});


### PR DESCRIPTION
This is a fairly heavy handed approach to debugging but is super handy when dissecting a problem.  Basically toggle the constexpr `BLOCK_DEBUGGING` option, and you get watchpoints and single-stepping support. The watchpoints trigger /before/ the read/write because of how the implementation works.