### PR TITLE
Snapdragon X2 Elite fixes

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -92,6 +92,7 @@ namespace ProductNames {
   static const char ARM_AppleSilicon[] = "Apple Silicon";
 
   static const char ARM_ORYON_1[] = "Oryon-1";
+  static const char ARM_ORYON_3[] = "Oryon-3";
   static const char ARM_Ampere_1[] = "AmpereOne";
   static const char ARM_Ampere_1A[] = "AmpereOneA";
   static const char ARM_Ampere_1B[] = "AmpereOneB";
@@ -186,8 +187,9 @@ void CPUIDEmu::SetupHostHybridFlag() {
   // CPU priority order
   // This is mostly arbitrary but will sort by some sort of CPU priority by performance
   // Relative list so things they will commonly end up in big.little configurations sort of relate
-  static constexpr std::array<CPUMIDR, 67> CPUMIDRs = {{
+  static constexpr std::array<CPUMIDR, 68> CPUMIDRs = {{
     // Typically big CPU cores
+    {0x51, 0x002, 1, ProductNames::ARM_ORYON_3}, // Qualcomm Oryon-3
     {0x51, 0x001, 1, ProductNames::ARM_ORYON_1}, // Qualcomm Oryon-1
 
     {0x61, 0x039, 1, ProductNames::ARM_Avalanche_M2Max}, // Apple Avalanche (M2 Max)

--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -539,6 +539,7 @@ static void HandleErrata(FEXCore::HostFeatures* HostFeatures, uint64_t MIDR) {
 
   constexpr uint32_t Implementer_QCOM = 0x51;
   constexpr uint32_t PartNum_Oryon1 = 0x001;
+  constexpr uint32_t PartNum_Oryon3 = 0x002;
 
   auto GetMIDRImplementer = [](uint32_t MIDR) -> uint32_t {
     return (MIDR >> 24) & 0xFF;
@@ -552,7 +553,7 @@ static void HandleErrata(FEXCore::HostFeatures* HostFeatures, uint64_t MIDR) {
   const uint32_t MIDR_PartNum = GetMIDRPartNum(MIDR);
 
 #ifdef ARCHITECTURE_arm64
-  if (MIDR_Implementer == Implementer_QCOM && MIDR_PartNum == PartNum_Oryon1) {
+  if (MIDR_Implementer == Implementer_QCOM && (MIDR_PartNum == PartNum_Oryon1 || MIDR_PartNum == PartNum_Oryon3)) {
     // Work around an errata in Qualcomm's Oryon.
     // While this CPU implements the RAND extension:
     // - The RNDR register works.

--- a/Source/Tools/FEXGetConfig/CMakeLists.txt
+++ b/Source/Tools/FEXGetConfig/CMakeLists.txt
@@ -11,3 +11,4 @@ install(TARGETS FEXGetConfig RUNTIME
 target_link_libraries(FEXGetConfig PRIVATE ${LIBS})
 
 target_include_directories(FEXGetConfig PRIVATE ${CMAKE_BINARY_DIR}/generated)
+target_compile_options(FEXGetConfig PRIVATE ${FEX_TUNE_COMPILE_FLAGS})

--- a/Source/Tools/FEXGetConfig/Main.cpp
+++ b/Source/Tools/FEXGetConfig/Main.cpp
@@ -100,35 +100,35 @@ TSOEmulationFacts GetTSOEmulationFacts() {
 namespace SIGBUSTest {
 static bool* FaultArray {};
 
-__attribute__((naked)) void atomic_store_u16(std::byte* Data, uint16_t Value) {
+__attribute__((naked)) void atomic_load_u16(std::byte* Data) {
   asm volatile(R"(
-    stlrh w1, [x0];
+    ldarh w1, [x0];
     ret;
     )" ::
-                 : "memory");
+                 : "x1", "memory");
 }
 
-__attribute__((naked)) void atomic_store_u32(std::byte* Data, uint32_t Value) {
+__attribute__((naked)) void atomic_load_u32(std::byte* Data) {
   asm volatile(R"(
-    stlr w1, [x0];
+    ldar w1, [x0];
     ret;
     )" ::
-                 : "memory");
+                 : "x1", "memory");
 }
 
-__attribute__((naked)) void atomic_store_u64(std::byte* Data, uint64_t Value) {
+__attribute__((naked)) void atomic_load_u64(std::byte* Data) {
   asm volatile(R"(
-    stlr x1, [x0];
+    ldar x1, [x0];
     ret;
     )" ::
-                 : "memory");
+                 : "x1", "memory");
 }
-__attribute__((naked)) void atomic_store_u128(std::byte* Data, uint64_t Value) {
+__attribute__((naked)) void atomic_load_u128(std::byte* Data) {
   asm volatile(R"(
-    stlxp w3, x1, x1, [x0];
+    ldaxp x1, x2, [x0];
     ret;
     )" ::
-                 : "memory");
+                 : "x1", "x2", "x3", "memory");
 }
 
 static void HandleSIGBUS(int, siginfo_t* info, void* context) {
@@ -150,7 +150,7 @@ void TestSIGBUS() {
   auto test_fault = [](bool* FaultOffsets, auto AccessFunction, std::byte* AccessArray) {
     FaultArray = FaultOffsets;
     for (size_t i = 0; i < 64; ++i) {
-      AccessFunction(AccessArray + i, 1);
+      AccessFunction(AccessArray + i);
     }
   };
 
@@ -176,10 +176,10 @@ void TestSIGBUS() {
   bool FaultOffset_64bit[64] {};
   bool FaultOffset_128bit[64] {};
 
-  test_fault(FaultOffset_16bit, atomic_store_u16, ptr);
-  test_fault(FaultOffset_32bit, atomic_store_u32, ptr);
-  test_fault(FaultOffset_64bit, atomic_store_u64, ptr);
-  test_fault(FaultOffset_128bit, atomic_store_u128, ptr);
+  test_fault(FaultOffset_16bit, atomic_load_u16, ptr);
+  test_fault(FaultOffset_32bit, atomic_load_u32, ptr);
+  test_fault(FaultOffset_64bit, atomic_load_u64, ptr);
+  test_fault(FaultOffset_128bit, atomic_load_u128, ptr);
 
   munmap(ptr, 4096);
   sigaction(SIGBUS, &act, nullptr);


### PR DESCRIPTION
- RNDRRS is still broken on this CPU
- Fault granularity checking needs to use loads
  - stlxp does monitor check before alignment check, use loads for all for consistency
  - Fault granularity is still 16B which matches LSE2 requirements.
- X2E still only ships a 19.2Mhz cycle counter, so still only ARMv9.0-a hardware
- Adds product name to CPUID
  - Oryon-3 being CPU PartID 2 isn't a mistake.
  - No distinction between Oryon-1 and Oryon-2, both are partid 1.

cpuinfo:
```
processor   : 0
BogoMIPS    : 38.40
Features    : fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bf16 rng ecv afp rpres
CPU implementer   : 0x51
CPU architecture: 8
CPU variant : 0x1
CPU part    : 0x002
CPU revision      : 1
```