### PR TITLE
Steam/CompatTool: Fixes Graphics Provider path handling

### DIFF
--- a/Source/Steam/CompatTool.cpp
+++ b/Source/Steam/CompatTool.cpp
@@ -35,7 +35,7 @@ fextl::string GenerateSteamConfigTemplate(const FEX::Config::PortableInformation
   const char* CacheDir = getenv("XDG_CACHE_HOME");
   const auto UserDirectory = fextl::fmt::format("/run/user/{}", geteuid());
   if (GraphicsProvider) {
-    MountPoint = GraphicsProvider;
+    MountPoint = FHU::Filesystem::ParentPath(GraphicsProvider);
   } else if (RuntimeDir) {
     MountPoint = fextl::fmt::format("{}/fexrootfs/", RuntimeDir);
   } else if (FHU::Filesystem::Exists(UserDirectory)) {


### PR DESCRIPTION
Graphics provider needs to be a path to a json file in the root of the rootfs. Make sure to strip the filepath off to get the directory.

Misunderstood the assignment before.