### PR TITLE
OpcodeDispatcher: Fix FIST 16-bit IE for denormal inputs 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -163,7 +163,7 @@ void OpDispatchBuilder::FIST(OpcodeArgs, bool Truncate) {
 
     // Check for NaN/Infinity: exponent = 0x7fff
     SaveNZCV();
-    _TestNZ(OpSize::i64Bit, Exponent, Constant(0x7fff));
+    SubWithFlags(OpSize::i64Bit, Exponent, 0x7fff);
     Ref IsSpecial = _NZCVSelect01(CondClass::EQ);
 
     // For overflow detection, check if exponent indicates a value >= 2^15

--- a/unittests/ASM/FEX_bugs/FIST16_denormal_IE.asm
+++ b/unittests/ASM/FEX_bugs/FIST16_denormal_IE.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX":  "0",
+    "RBX":  "0"
+  }
+}
+%endif
+
+; FIST/FISTP to a 16-bit destination must not set IE when the input is a
+; denormal that rounds into range. The overflow/NaN-Inf detection should
+; only raise IE for exponent == 0x7fff or exponent >= 0x400e.
+
+mov r15, 0xe0000000
+fninit
+
+mov dword [r15 + 0], 0x00000001
+mov dword [r15 + 4], 0x00000000
+mov word  [r15 + 8], 0x0000
+
+fld tword [r15 + 0]
+
+fistp word [r15 + 16]
+
+movzx rax, word [r15 + 16]
+
+fnstsw ax
+movzx rbx, ax
+and rbx, 1
+
+xor rax, rax
+
+hlt

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -9959,7 +9959,7 @@
       ]
     },
     "fisttp word [rax]": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdf !11b /1"
       ],
@@ -9968,14 +9968,15 @@
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
         "mov x21, v2.d[1]",
+        "mov w22, #0x7fff",
         "and x21, x21, #0x7fff",
-        "mrs x22, nzcv",
-        "tst x21, #0x7fff",
-        "cset x23, eq",
+        "mrs x23, nzcv",
+        "cmp x21, x22",
+        "cset x22, eq",
         "mov w24, #0x400e",
         "cmp x21, x24",
         "cset x21, hs",
-        "orr x21, x23, x21",
+        "orr x21, x22, x21",
         "strb w21, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -9987,7 +9988,7 @@
         "strh w21, [x4]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
-        "msr nzcv, x22",
+        "msr nzcv, x23",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
         "mov w22, #0x1",
@@ -9997,7 +9998,7 @@
       ]
     },
     "fist word [rax]": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 23,
       "Comment": [
         "0xdf !11b /2"
       ],
@@ -10006,14 +10007,15 @@
         "add x20, x28, x20, lsl #4",
         "ldr q2, [x20, #1056]",
         "mov x20, v2.d[1]",
+        "mov w21, #0x7fff",
         "and x20, x20, #0x7fff",
-        "mrs x21, nzcv",
-        "tst x20, #0x7fff",
-        "cset x22, eq",
+        "mrs x22, nzcv",
+        "cmp x20, x21",
+        "cset x21, eq",
         "mov w23, #0x400e",
         "cmp x20, x23",
         "cset x20, hs",
-        "orr x20, x22, x20",
+        "orr x20, x21, x20",
         "strb w20, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -10023,11 +10025,11 @@
         "ldr x30, [sp], #16",
         "mov w20, w0",
         "strh w20, [x4]",
-        "msr nzcv, x21"
+        "msr nzcv, x22"
       ]
     },
     "fistp word [rax]": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdf !11b /3"
       ],
@@ -10036,14 +10038,15 @@
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
         "mov x21, v2.d[1]",
+        "mov w22, #0x7fff",
         "and x21, x21, #0x7fff",
-        "mrs x22, nzcv",
-        "tst x21, #0x7fff",
-        "cset x23, eq",
+        "mrs x23, nzcv",
+        "cmp x21, x22",
+        "cset x22, eq",
         "mov w24, #0x400e",
         "cmp x21, x24",
         "cset x21, hs",
-        "orr x21, x23, x21",
+        "orr x21, x22, x21",
         "strb w21, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -10055,7 +10058,7 @@
         "strh w21, [x4]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
-        "msr nzcv, x22",
+        "msr nzcv, x23",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
         "mov w22, #0x1",

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -9894,7 +9894,7 @@
       ]
     },
     "fisttp word [rax]": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdf !11b /1"
       ],
@@ -9903,14 +9903,15 @@
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
         "mov x21, v2.d[1]",
+        "mov w22, #0x7fff",
         "and x21, x21, #0x7fff",
-        "mrs x22, nzcv",
-        "tst x21, #0x7fff",
-        "cset x23, eq",
+        "mrs x23, nzcv",
+        "cmp x21, x22",
+        "cset x22, eq",
         "mov w24, #0x400e",
         "cmp x21, x24",
         "cset x21, hs",
-        "orr x21, x23, x21",
+        "orr x21, x22, x21",
         "strb w21, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -9922,7 +9923,7 @@
         "strh w21, [x4]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
-        "msr nzcv, x22",
+        "msr nzcv, x23",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
         "mov w22, #0x1",
@@ -9932,7 +9933,7 @@
       ]
     },
     "fist word [rax]": {
-      "ExpectedInstructionCount": 22,
+      "ExpectedInstructionCount": 23,
       "Comment": [
         "0xdf !11b /2"
       ],
@@ -9941,14 +9942,15 @@
         "add x20, x28, x20, lsl #4",
         "ldr q2, [x20, #1056]",
         "mov x20, v2.d[1]",
+        "mov w21, #0x7fff",
         "and x20, x20, #0x7fff",
-        "mrs x21, nzcv",
-        "tst x20, #0x7fff",
-        "cset x22, eq",
+        "mrs x22, nzcv",
+        "cmp x20, x21",
+        "cset x21, eq",
         "mov w23, #0x400e",
         "cmp x20, x23",
         "cset x20, hs",
-        "orr x20, x22, x20",
+        "orr x20, x21, x20",
         "strb w20, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -9958,11 +9960,11 @@
         "ldr x30, [sp], #16",
         "mov w20, w0",
         "strh w20, [x4]",
-        "msr nzcv, x21"
+        "msr nzcv, x22"
       ]
     },
     "fistp word [rax]": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdf !11b /3"
       ],
@@ -9971,14 +9973,15 @@
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
         "mov x21, v2.d[1]",
+        "mov w22, #0x7fff",
         "and x21, x21, #0x7fff",
-        "mrs x22, nzcv",
-        "tst x21, #0x7fff",
-        "cset x23, eq",
+        "mrs x23, nzcv",
+        "cmp x21, x22",
+        "cset x22, eq",
         "mov w24, #0x400e",
         "cmp x21, x24",
         "cset x21, hs",
-        "orr x21, x23, x21",
+        "orr x21, x22, x21",
         "strb w21, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -9990,7 +9993,7 @@
         "strh w21, [x4]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
-        "msr nzcv, x22",
+        "msr nzcv, x23",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
         "mov w22, #0x1",


### PR DESCRIPTION
The special-value check masked the biased exponent with 0x7fff and
then used TestNZ, so it triggered on Exp==0 (denormals) instead of
Exp==0x7fff (NaN/Inf). Replace the TestNZ with SubWithFlags against
0x7fff so EQ only fires for genuine NaN/Inf.