### PR TITLE
SoftFloat: Fix FSCALE(0, +Inf) to raise IE and return a quiet NaN

### DIFF
--- a/FEXCore/Source/Common/SoftFloat.h
+++ b/FEXCore/Source/Common/SoftFloat.h
@@ -324,6 +324,13 @@ struct FEX_PACKED X80SoftFloat {
 #else
     extFloat80_t Zero {0, 0};
     if (extF80_eq(state, lhs, Zero)) {
+      // FSCALE(0, +Inf) is 0 * Inf, which is invalid. FSCALE(0, anything
+      // else) is still 0.
+      if (rhs.Top.Exponent == 0x7FFF && rhs.Top.Sign == 0 && (rhs.Significand & 0x7FFFFFFFFFFFFFFFULL) == 0) {
+        state->exceptionFlags |= softfloat_flag_invalid;
+        X80SoftFloat QNaN(0, 0x7FFFUL, 0xC000000000000000ULL);
+        return QNaN;
+      }
       return lhs;
     }
     X80SoftFloat Int = FRNDINT(state, rhs, softfloat_round_minMag);

--- a/unittests/ASM/FEX_bugs/FSCALE_zero_inf.asm
+++ b/unittests/ASM/FEX_bugs/FSCALE_zero_inf.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RBX":  "0x0001"
+  }
+}
+%endif
+
+; FSCALE(+0, +Inf) is 0 * 2^(+Inf) = 0 * Inf, which must raise the invalid
+; operation exception (IE=1).
+
+mov r15, 0xe0000000
+fninit
+
+mov dword [r15 + 0], 0x00000000
+mov dword [r15 + 4], 0x7ff00000
+
+fld qword [r15 + 0]
+fldz
+
+fscale
+
+fstp qword [r15 + 16]
+fstp st0
+
+fnstsw ax
+movzx rbx, ax
+and rbx, 1
+
+hlt


### PR DESCRIPTION
The lhs==0 short-circuit in X80SoftFloat::FSCALE returned lhs
unchanged without calling extF80_mul, so the 0*Inf invalid-operation
case wasn't fully handled. Detect +Inf rhs explicitly
in the zero-lhs path and raise the flag, returning QNaN.