### PR TITLE
CodeCache: Slightly optimize cache file writing

### DIFF
--- a/FEXCore/Source/Interface/Core/CodeCache.cpp
+++ b/FEXCore/Source/Interface/Core/CodeCache.cpp
@@ -300,12 +300,10 @@ bool CodeCache::SaveData(Core::InternalThreadState& Thread, int fd, const Execut
   ::write(fd, Relocations.data(), Relocations.size() * sizeof(Relocations[0]));
 
   // Pad to next page in file so that the CodeBuffer can be mmap'ed into process on load
-  char Zero[64] {};
-  auto Off = lseek(fd, 0, SEEK_CUR);
-  while (Off != AlignUp(Off, Utils::FEX_PAGE_SIZE)) {
-    auto BytesToWrite = std::min(AlignUp(Off, Utils::FEX_PAGE_SIZE) - Off, sizeof(Zero));
-    ::write(fd, Zero, BytesToWrite);
-    Off += BytesToWrite;
+  {
+    auto AlignedSize = AlignUp(lseek(fd, 0, SEEK_CUR), Utils::FEX_PAGE_SIZE);
+    ::ftruncate(fd, AlignedSize);
+    lseek(fd, AlignedSize, SEEK_SET);
   }
 
   // Dump the host code (relocated for position-independent serialization)

--- a/Source/Windows/Common/CRT/IO.cpp
+++ b/Source/Windows/Common/CRT/IO.cpp
@@ -272,6 +272,18 @@ int write(int FileHandle, const void* Buf, unsigned int MaxCharCount) {
   return _write(FileHandle, Buf, MaxCharCount);
 }
 
+DLLEXPORT_FUNC(int, ftruncate, (int FileHandle, off_t Length)) {
+  FILE_END_OF_FILE_INFO Info {.EndOfFile = {.QuadPart = Length}};
+  if (!SetFileInformationByHandle(GetFile(FileHandle)->Handle, FileEndOfFileInfo, &Info, sizeof(Info))) {
+    return ErrnoReturn(EINVAL);
+  }
+  return 0;
+}
+
+int _chsize(int FileHandle, long Length) {
+  return ftruncate(FileHandle, Length);
+}
+
 DLLEXPORT_FUNC(int, _isatty, (int _FileHandle)) {
   return 0;
 }


### PR DESCRIPTION
ftruncate only requires one call (and one extra seek) instead up to 64 manual zero writes.