### PR TITLE
Wine: Add support for enabling Mono heuristic earlier

### DIFF
--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -34,6 +34,7 @@ $end_info$
 #include "Common/Exception.h"
 #include "Common/ImageTracker.h"
 #include "Common/InvalidationTracker.h"
+#include "Common/MonoHeuristic.h"
 #include "Common/OvercommitTracker.h"
 #include "Common/TSOHandlerConfig.h"
 #include "Common/CPUFeatures.h"
@@ -583,6 +584,9 @@ NTSTATUS ProcessInit() {
   FEX::Config::LoadConfig(fextl::string {ExecutableName}, _environ, FEX::ReadPortabilityInformation());
   FEXCore::Config::ReloadMetaLayer();
   FEX::Windows::Logging::Init();
+
+  // Handle Mono TSO heuristic early.
+  FEX::Windows::HandleMonoTSOHeuristicConfig(FEX::Windows::BaseName(FEX::Windows::GetExecutableFilePathW()));
 
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, "1");
 

--- a/Source/Windows/Common/CMakeLists.txt
+++ b/Source/Windows/Common/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(CommonWindowsRuntime PRIVATE "${CMAKE_SOURCE_DIR}/Sou
 add_library(CommonWindows STATIC
   Allocator.cpp
   CPUFeatures.cpp
+  MonoHeuristic.cpp
   SHMStats.cpp
   InvalidationTracker.cpp
   ImageTracker.cpp

--- a/Source/Windows/Common/Module.h
+++ b/Source/Windows/Common/Module.h
@@ -22,6 +22,17 @@ inline fextl::string GetExecutableFilePath() {
   return Path;
 }
 
+inline std::wstring GetExecutableFilePathW() {
+  std::array<WCHAR, PATH_MAX> Buf;
+  UNICODE_STRING PathW {.Length = 0, .MaximumLength = Buf.size() * sizeof(WCHAR), .Buffer = Buf.data()};
+
+  if (LdrGetDllFullName(nullptr, &PathW)) {
+    return {};
+  }
+
+  return std::wstring(PathW.Buffer);
+}
+
 inline fextl::string GetSectionFilePath(uint64_t Address) {
   struct {
     MEMORY_SECTION_NAME Info;
@@ -43,4 +54,8 @@ inline fextl::string GetSectionFilePath(uint64_t Address) {
 inline std::string_view BaseName(std::string_view Path) {
   return Path.substr(Path.find_last_of('\\') + 1);
 }
+inline std::wstring_view BaseName(std::wstring_view Path) {
+  return Path.substr(Path.find_last_of(L'\\') + 1);
+}
+
 } // namespace FEX::Windows

--- a/Source/Windows/Common/MonoHeuristic.cpp
+++ b/Source/Windows/Common/MonoHeuristic.cpp
@@ -1,0 +1,100 @@
+#include <FEXCore/Config/Config.h>
+
+#include <cstddef>
+#include <ntstatus.h>
+#include <shlwapi.h>
+#include <windef.h>
+#include <winternl.h>
+
+namespace FEX::Windows {
+std::wstring GetCurrentPath() {
+  std::wstring PathStr(4096, L'\0');
+  DWORD Result {};
+
+  while (true) {
+    Result = GetCurrentDirectoryW(PathStr.size(), PathStr.data());
+
+    // Failure for whatever reason.
+    if (Result == 0) {
+      break;
+    }
+
+    // String fit.
+    if (Result < PathStr.size()) {
+      PathStr.resize(Result);
+      break;
+    }
+
+    // String too large.
+    if (Result >= PathStr.size()) {
+      PathStr.resize(Result);
+    }
+  }
+
+  return PathStr;
+}
+
+void HandleMonoTSOHeuristicConfig(std::wstring_view ExecutableName) {
+  // Only use mono heuristic for Steam games.
+  bool ShouldDoMonoDetect = getenv("SteamAppId") != nullptr;
+
+  const auto SteamCompat = getenv("STEAM_COMPAT_FEX_CONFIG");
+  if (getenv("STEAM_FEX_TSOENABLED")) {
+    // If TSO is explicitly controlled by user, then disable heuristic.
+    ShouldDoMonoDetect = false;
+    LogMan::Msg::DFmt("FEX TSO controlled by user.");
+  }
+
+  if (SteamCompat && strstr(SteamCompat, "TSOEnabled:") != nullptr) {
+    // If TSO is explicitly controlled by compat config, then disable heuristic.
+    ShouldDoMonoDetect = false;
+    LogMan::Msg::DFmt("FEX TSO controlled by compat.");
+  }
+
+  if (ShouldDoMonoDetect) {
+    const auto PathStr = GetCurrentPath();
+
+    // Paths to find mono relative to the current working directory.
+    // If the file exists, then this will be a mono+unity game.
+    // TODO: This could be extended to Linux native games if the Linux side could detect the file mapping.
+    const std::array<const wchar_t*, 2> PathAdders = {
+      L"\\Mono\\EmbedRuntime\\mono.dll",
+      L"\\MonoBleedingEdge\\EmbedRuntime\\mono-2.0-bdwgc.dll",
+    };
+
+    bool IsMono {};
+    if (!PathStr.empty()) {
+      for (auto adder : PathAdders) {
+        auto NewPath = PathStr + adder;
+        if (PathFileExistsW(NewPath.c_str())) {
+          IsMono = true;
+          break;
+        }
+      }
+    }
+
+    if (!IsMono && !ExecutableName.empty()) {
+      ExecutableName.remove_suffix(ExecutableName.ends_with(L".exe") ? strlen(".exe") : 0);
+      // Older Unity titles stuck the mono.dll in to a sub-directory.
+      auto NewPath = PathStr;
+      NewPath += L"\\";
+      NewPath += ExecutableName;
+      NewPath += L"\\";
+      NewPath += ExecutableName;
+      NewPath += L"_Data\\Mono\\mono.dll";
+      if (PathFileExistsW(NewPath.c_str())) {
+        LogMan::Msg::DFmt("Found Mono in legacy path.");
+        IsMono = true;
+      }
+    }
+
+    FEX_CONFIG_OPT(MaxInst, MAXINST);
+    FEX_CONFIG_OPT(Multiblock, MULTIBLOCK);
+    if (IsMono && Multiblock && MaxInst() >= 500) {
+      LogMan::Msg::DFmt("Mono has been detected in expected game directory. Turning on Mono TSO heuristic.");
+      FEXCore::Config::Set(FEXCore::Config::CONFIG_MONOHACKS, "1");
+      FEXCore::Config::Set(FEXCore::Config::CONFIG_TSOENABLED, "0");
+    }
+  }
+}
+} // namespace FEX::Windows

--- a/Source/Windows/Common/MonoHeuristic.h
+++ b/Source/Windows/Common/MonoHeuristic.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include <string_view>
+
+namespace FEX::Windows {
+void HandleMonoTSOHeuristicConfig(std::wstring_view ExecutableName);
+}

--- a/Source/Windows/Common/WinAPI/IO.cpp
+++ b/Source/Windows/Common/WinAPI/IO.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstdint>
 #include <cerrno>
+#include <ntstatus.h>
 #include <winternl.h>
 #include <windows.h>
 #include <processenv.h>
@@ -256,7 +257,22 @@ DLLEXPORT_FUNC(DWORD, GetFileAttributesA, (LPCSTR lpFileName)) {
 }
 
 DLLEXPORT_FUNC(DWORD, GetFileAttributesW, (LPCWSTR lpFileName)) {
-  UNIMPLEMENTED();
+  FILE_BASIC_INFORMATION Info;
+  ScopedUnicodeString NTPath;
+  if (!RtlDosPathNameToNtPathName_U(lpFileName, &*NTPath, nullptr, nullptr)) {
+    SetLastError(ERROR_PATH_NOT_FOUND);
+    return INVALID_FILE_ATTRIBUTES;
+  }
+
+  OBJECT_ATTRIBUTES ObjAttributes;
+  InitializeObjectAttributes(&ObjAttributes, &*NTPath, OBJ_CASE_INSENSITIVE, nullptr, nullptr);
+  NTSTATUS Status = NtQueryAttributesFile(&ObjAttributes, &Info);
+
+  if (Status == STATUS_SUCCESS) {
+    return Info.FileAttributes;
+  }
+
+  return INVALID_FILE_ATTRIBUTES;
 }
 
 DLLEXPORT_FUNC(WINBOOL, SetFileAttributesA, (LPCSTR lpFileName, DWORD dwFileAttributes)) {
@@ -369,4 +385,18 @@ DLLEXPORT_FUNC(DWORD, GetCurrentDirectoryA, (DWORD nBufferLength, LPSTR lpBuffer
 
 DLLEXPORT_FUNC(DWORD, GetCurrentDirectoryW, (DWORD nBufferLength, LPWSTR lpBuffer)) {
   return RtlGetCurrentDirectory_U(nBufferLength * sizeof(wchar_t), lpBuffer) / sizeof(wchar_t);
+}
+
+DLLEXPORT_FUNC(BOOL, PathFileExistsA, (LPCSTR Path)) {
+  if (!Path) {
+    return false;
+  }
+  return GetFileAttributesA(Path) != INVALID_FILE_ATTRIBUTES;
+}
+
+DLLEXPORT_FUNC(BOOL, PathFileExistsW, (LPWSTR Path)) {
+  if (!Path) {
+    return false;
+  }
+  return GetFileAttributesW(Path) != INVALID_FILE_ATTRIBUTES;
 }

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -36,6 +36,7 @@ $end_info$
 #include "Common/TSOHandlerConfig.h"
 #include "Common/ImageTracker.h"
 #include "Common/InvalidationTracker.h"
+#include "Common/MonoHeuristic.h"
 #include "Common/OvercommitTracker.h"
 #include "Common/CPUFeatures.h"
 #include "Common/Logging.h"
@@ -513,6 +514,9 @@ void BTCpuProcessInit() {
   FEX::Config::LoadConfig(fextl::string {ExecutableName}, _environ, FEX::ReadPortabilityInformation());
   FEXCore::Config::ReloadMetaLayer();
   FEX::Windows::Logging::Init();
+
+  // Handle Mono TSO heuristic early.
+  FEX::Windows::HandleMonoTSOHeuristicConfig(FEX::Windows::BaseName(FEX::Windows::GetExecutableFilePathW()));
 
   FEXCore::Config::Set(FEXCore::Config::CONFIG_INTERPRETER_INSTALLED, "0");
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, "0");


### PR DESCRIPTION
The Mono TSO heuristic by default doesn't really do anything when TSO is
enabled. So add a detection during wow64/arm64ec initialization that
runs through a handful of checks to see if the Mono TSO heuristic should
be enabled.

This ensures that we don't need to do any code cache clearing or
anything partway through the game loading mono, while still allowing
overrides if it has explicitly been set.

Specifically:
- If `SteamAppId` isn't set then skip heuristic entirely.
- Treat `STEAM_FEX_TSOENABLED` as a tristate.
  - If it exists, skip the heuristic detection even if it is 0.
- Treat `STEAM_COMPAT_FEX_CONFIG` as a tristate.
  - Same as above

It explicitly checks with the current executing path with the common
path to the mono runtime. Might need to add more in the future.