### PR TITLE
use <sys/prctl.h> to enhance portability (clang)

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -12,7 +12,6 @@
 #include <cstdint>
 
 #ifndef _WIN32
-#include <linux/prctl.h>
 #include <sys/prctl.h>
 #endif
 

--- a/FEXCore/Source/Utils/AllocatorHooks.cpp
+++ b/FEXCore/Source/Utils/AllocatorHooks.cpp
@@ -2,7 +2,6 @@
 #ifdef ENABLE_FEX_ALLOCATOR
 #include <rpmalloc/rpmalloc.h>
 #ifndef _WIN32
-#include <linux/prctl.h>
 #include <sys/prctl.h>
 #include <sys/mman.h>
 #else

--- a/FEXCore/include/FEXCore/Utils/PrctlUtils.h
+++ b/FEXCore/include/FEXCore/Utils/PrctlUtils.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #ifndef _WIN32
-#include <linux/prctl.h>
 #include <sys/mman.h>
 #include <sys/user.h>
 #include <sys/prctl.h>

--- a/Source/Tools/FEXInterpreter/ELFCodeLoader.h
+++ b/Source/Tools/FEXInterpreter/ELFCodeLoader.h
@@ -32,7 +32,6 @@
 #include <sys/personality.h>
 #include <sys/prctl.h>
 #include <sys/random.h>
-#include <linux/prctl.h>
 
 #define PAGE_START(x) ((x) & ~(uintptr_t)(4095))
 #define PAGE_OFFSET(x) ((x) & 4095)


### PR DESCRIPTION
using `<sys/prctl.h>` and `<linux/prctl.h>` simultaneously causes clang to fail:

```
In file included from FEX/FEXCore/Source/Utils/AllocatorHooks.cpp:6:
/usr/include/sys/prctl.h:88:8: error: redefinition of 'prctl_mm_map'
   88 | struct prctl_mm_map {
      |        ^
/usr/include/linux/prctl.h:134:8: note: previous definition is here
  134 | struct prctl_mm_map {
      |        ^
1 error generated.
```

prefer `<sys/prctl.h>` and do not include `<linux/prctl.h>`

fix: #5454