### PR TITLE
use <signal.h> instead of glibc header to enhance portability (musl)

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h
@@ -30,7 +30,7 @@ $end_info$
 #include <optional>
 #include <sys/stat.h>
 
-#include <bits/types/sigset_t.h>
+#include <signal.h>
 #include <linux/seccomp.h>
 
 namespace FEX::HLE {


### PR DESCRIPTION
building using musl fails with:

```
FEX/Source/Tools/LinuxEmulation/LinuxSyscalls/ThreadManager.h:33:10: fatal error: 'bits/types/sigset_t.h' file not found
   33 | #include <bits/types/sigset_t.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

`<bits/types/sigset_t.h>` is a glibc internal header, use `<signal.h>` instead.

fixes: #5459