### PR TITLE
determine sigset_t fieldname to enhance portability (musl)

### DIFF
--- a/Source/Tools/LinuxEmulation/CMakeLists.txt
+++ b/Source/Tools/LinuxEmulation/CMakeLists.txt
@@ -164,3 +164,29 @@ add_custom_target(struct_verifier
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL
   COMMAND "ctest" "--output-on-failure" "--timeout" "302" ${TEST_JOB_FLAG} "-R" "Test_verify*")
+
+include(CheckCSourceCompiles)
+
+check_c_source_compiles("
+#include <signal.h>
+int main(void){
+    sigset_t s;
+    (void)sizeof(s.__val);   // glibc
+    return 0;
+}" SIGSET_HAS___VAL)
+
+check_c_source_compiles("
+#include <signal.h>
+int main(void){
+    sigset_t s;
+    (void)sizeof(s.__bits);  // musl
+    return 0;
+}" SIGSET_HAS___BITS)
+
+if(SIGSET_HAS___VAL)
+  add_compile_definitions("SIGSET_VAL=__val")
+elseif(SIGSET_HAS___BITS)
+  add_compile_definitions("SIGSET_VAL=__bits")
+else()
+  message(FATAL_ERROR "Unknown sigset_t layout!")
+endif()

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -652,7 +652,7 @@ void SignalDelegator::HandleGuestSignal(FEX::HLE::ThreadStateObject* ThreadObjec
     ThreadObject->SignalInfo.DeferredSignalFrames.emplace_back(ThreadStateObject::DeferredSignalState {
       .Info = SigInfo,
       .Signal = Signal,
-      .SigMask = _context->uc_sigmask.__val[0],
+      .SigMask = _context->uc_sigmask.SIGSET_VAL[0],
     });
 
     uint64_t NewMask = GetNewSigMask(Signal);


### PR DESCRIPTION
musl build fails due to access to internal glibc member:

```
FEX/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp:655:39: error: no member named '__val' in '__sigset_t'
  655 |       .SigMask = _context->uc_sigmask.__val[0],
      |                  ~~~~~~~~~~~~~~~~~~~~ ^
1 error generated.
```

add check to determine private glibc or musl member name or throw an error.

fixes: #5461