### PR TITLE
include <libgen.h> for basename

### DIFF
--- a/Source/Tools/FEXOfflineCompiler/Main.cpp
+++ b/Source/Tools/FEXOfflineCompiler/Main.cpp
@@ -17,6 +17,7 @@
 #include <OptionParser.h>
 
 #include <fmt/printf.h>
+#include <libgen.h>
 
 #include <fstream>
 #include <optional>


### PR DESCRIPTION
building on clang/musl build fails due to missing symbol:

```
/run/host/home/pepper/dev/ghrepos/FEX/Source/Tools/FEXOfflineCompiler/Main.cpp:321:35: error: use of undeclared identifier 'basename'
  321 |   auto CommandName = std::string {basename(argv[0])} + " " + (argc > 1 ? argv[1] : "");
      |                                   ^~~~~~~~
/run/host/home/pepper/dev/ghrepos/FEX/Source/Tools/FEXOfflineCompiler/Main.cpp:327:43: error: use of undeclared identifier 'basename'
  327 |     fmt::print("Usage: {} <command>\n\n", basename(argv[0]));
      |                                           ^~~~~~~~
```

include missing header.

fixes: #5465