### PR TITLE
fix include redirect for <poll.h> and <signal.h>

### DIFF
--- a/Source/Common/FEXServerClient.cpp
+++ b/Source/Common/FEXServerClient.cpp
@@ -17,9 +17,9 @@
 #include <fcntl.h>
 #include <linux/limits.h>
 #include <unistd.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/prctl.h>
-#include <sys/signal.h>
+#include <signal.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/Source/Tools/FEXGetConfig/Main.cpp
+++ b/Source/Tools/FEXGetConfig/Main.cpp
@@ -14,7 +14,7 @@
 #include <filesystem>
 #include <string>
 #include <sys/prctl.h>
-#include <sys/signal.h>
+#include <signal.h>
 #include <ucontext.h>
 
 namespace {

--- a/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
+++ b/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
@@ -63,7 +63,7 @@ $end_info$
 #include <utility>
 
 #include <sys/sysinfo.h>
-#include <sys/signal.h>
+#include <signal.h>
 
 namespace FEX::Logging {
 static bool SilentLog {};

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -21,7 +21,7 @@
 #include <optional>
 #include <poll.h>
 #include <sys/prctl.h>
-#include <sys/signal.h>
+#include <signal.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/Source/Tools/FEXServer/SquashFS.cpp
+++ b/Source/Tools/FEXServer/SquashFS.cpp
@@ -9,7 +9,7 @@
 
 #include <fcntl.h>
 #include <filesystem>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <thread>

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -33,7 +33,7 @@ $end_info$
 #include <stdint.h>
 #include <sched.h>
 #include <sys/personality.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/prctl.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>


### PR DESCRIPTION
building on musl/clang causes redirecting incorrect #includes warnings:

```
warning: redirecting incorrect #include <sys/poll.h> to <poll.h> [-W#warnings]
warning: redirecting incorrect #include <sys/signal.h> to <signal.h> [-W#warnings]
```

include headers instead of sys/headers.

fix: #5469