### PR TITLE
remove dead code (ObjectCacheRefCounter)

### DIFF
--- a/FEXCore/include/FEXCore/Debug/InternalThreadState.h
+++ b/FEXCore/include/FEXCore/Debug/InternalThreadState.h
@@ -104,8 +104,6 @@ struct alignas(FEXCore::Utils::FEX_PAGE_SIZE) InternalThreadState : public FEXCo
 
   std::shared_ptr<FEXCore::CompileService> CompileService;
 
-  std::shared_mutex ObjectCacheRefCounter {};
-
   // This pointer is owned by the frontend.
   FEXCore::SHMStats::ThreadStats* ThreadStats {};
 


### PR DESCRIPTION
building using libc++ failes due to shared_mutex ObjectCacheRefCounter inflating InternalThreadState beyond FEX_PAGE_SIZE, thus triggering the static assert:

```
FEXCore/Debug/InternalThreadState.h:133:15: error: static assertion failed
FEX/FEXCore/include/FEXCore/Debug/InternalThreadState.h:133:145: note: expression evaluates to '7680 < 4096'
FEX/FEXCore/include/FEXCore/Debug/InternalThreadState.h:136:58: note: expression evaluates to '12288 == 8192'
```

remove `ObjectCacheRefCounter` as it is not used anywhere.

fix: #5456