### PR TITLE
include missing header unistd.h

### DIFF
--- a/unittests/APITests/Allocator.cpp
+++ b/unittests/APITests/Allocator.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_all.hpp>
 #include <FEXCore/Utils/Allocator.h>
 
+#include <unistd.h>
+
 namespace {
 
 using FEXCore::Allocator::MemoryRegion;


### PR DESCRIPTION
build on clang/musl fails with:

```
FEX/unittests/APITests/Allocator.cpp:17:5: error: use of undeclared identifier 'close'
FEX/unittests/APITests/Allocator.cpp:23:5: error: use of undeclared identifier 'lseek'; did you mean 'fseek'?
FEX/unittests/APITests/Allocator.cpp:23:11: error: cannot initialize a parameter of type 'FILE *' (aka 'struct _IO_FILE *') with an lvalue of type 'int'
FEX/unittests/APITests/Allocator.cpp:24:5: error: use of undeclared identifier 'write'; did you mean '_IO_cookie_io_functions_t::write'?
FEX/unittests/APITests/Allocator.cpp:24:5: error: invalid use of non-static data member 'write'
```

include header to provide defintions

fix: #5476