### PR TITLE
win32: Query DCZID_EL0 so clzero works

### DIFF
--- a/Source/Windows/Common/CPUFeatures.cpp
+++ b/Source/Windows/Common/CPUFeatures.cpp
@@ -31,6 +31,14 @@ uint64_t ReadRegU64(HKEY Key, const char* Name) {
 } // namespace
 
 namespace FEX::Windows {
+#define GetSysReg(name, reg)                         \
+  static uint64_t Get_##name() {                     \
+    uint64_t Result {};                              \
+    __asm("mrs %[Res], " #reg : [Res] "=r"(Result)); \
+    return Result;                                   \
+  }
+GetSysReg(DCZID_EL0, DCZID_EL0);
+
 class CPUFeaturesFromRegistry final : public FEX::CPUFeatures {
 public:
   explicit CPUFeaturesFromRegistry(HKEY Key) {
@@ -43,6 +51,7 @@ public:
     ZFR0.SetReg(ReadRegU64(Key, "CP 4024"));
     MMFR1.SetReg(ReadRegU64(Key, "CP 4039"));
     ISAR2.SetReg(ReadRegU64(Key, "CP 4032"));
+    DCZID.SetReg(Get_DCZID_EL0());
     FillFeatureFlags();
   }
 };


### PR DESCRIPTION
EL0 registers are readable without going through the registry, but we were failing to populate this register, which was causing clzero to not be supported.