### PR TITLE
CodeCache: Delay cache loading for guest library wrappers until after LoadLib

### DIFF
--- a/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
+++ b/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
@@ -597,9 +597,12 @@ int main(int argc, char** argv, char** const envp) {
 
   SyscallHandler->DefaultProgramBreak(BRKInfo.Base, BRKInfo.Size);
 
-  // Request code cache generation
   if (FEXCore::Config::Get_ENABLECODECACHINGWIP()) {
+    // Request code cache generation
     FEXServerClient::PopulateCodeCache(FEXServerClient::GetServerFD(), Loader.GetMainElfFD(), FEXCore::Config::Get_MULTIBLOCK());
+
+    // Finalize code cache for libVDSO-guest.so. This needs to be done explicitly since VDSO doesn't use LoadLib.
+    SyscallHandler->TriggerGuestLibWrapperCodeCacheLoad(*ParentThread->Thread, reinterpret_cast<uintptr_t>(VDSOMapping.VDSOBase));
   }
 
   // Pull RIP and stack pointer from loader and set the thread data to it.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -292,6 +292,7 @@ public:
   std::optional<FEXCore::ExecutableFileSectionInfo>
   LookupExecutableFileSection(FEXCore::Core::InternalThreadState* Thread, uint64_t GuestAddr) final override;
 
+  void TriggerGuestLibWrapperCodeCacheLoad(FEXCore::Core::InternalThreadState&, uint64_t AnyAddr);
   int OpenCodeMapFile() override;
 
   FEXCore::HLE::ExecutableRangeInfo QueryGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Address) override;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -366,6 +366,26 @@ uint64_t SyscallHandler::GuestMremap(bool Is64Bit, FEXCore::Core::InternalThread
   return Result;
 }
 
+void SyscallHandler::TriggerGuestLibWrapperCodeCacheLoad(FEXCore::Core::InternalThreadState& Thread, uint64_t AnyAddr) {
+  if (!EnableCodeCaching) {
+    return;
+  }
+
+  // TODO: Instead of deferring the entire cache load, only delay applicance of sha256 relocations!
+
+  auto lk = FEXCore::GuardSignalDeferringSection<std::shared_lock>(VMATracking.Mutex, &Thread);
+  auto VMAEntry = VMATracking.FindVMAEntry(reinterpret_cast<uint64_t>(AnyAddr));
+
+  for (auto* VMA = VMAEntry->second.Resource->FirstVMA; VMA; VMA = VMA->ResourceNextVMA) {
+    if (!VMA->Prot.Executable) {
+      continue;
+    }
+
+    auto SectionInfo = BuildSectionInfo(*VMAEntry->second.Resource, VMA->Base, VMA->Length);
+    LoadCodeCache(Thread, SectionInfo, CodeCacheConfigId);
+  }
+}
+
 int SyscallHandler::OpenCodeMapFile() {
   // Query from FEXServer whether this is the first instance of this executable; if it is, also enable code dumping!
   FEX_CONFIG_OPT(RootFSPath, ROOTFS);
@@ -623,7 +643,11 @@ SyscallHandler::TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t a
   // Load code cache if present.
   // FEXServer was requested to generate library caches on program launch.
   if (EnableCodeCaching && Resource && Resource->MappedFile && VMATracking::VMAProt::fromProt(prot).Executable) {
-    if (Thread) {
+    if (Resource->MappedFile->Filename.ends_with("-guest.so")) {
+      // For guest library wrappers, cache loading must be delayed until LoadLib is called.
+      // Before that, we can't patch up the SHA256 function identifiers.
+      LogMan::Msg::IFmt("Delaying code cache load for {}", Resource->MappedFile->Filename);
+    } else if (Thread) {
       if (!Resource->RequiresDelayedCacheLoad) {
         CachedSection.emplace(BuildSectionInfo(*Resource, addr, Size));
       } else {

--- a/Source/Tools/LinuxEmulation/Thunks.cpp
+++ b/Source/Tools/LinuxEmulation/Thunks.cpp
@@ -259,6 +259,8 @@ void ThunkHandler_impl::LoadLib(std::string_view Name) {
 
     LogMan::Msg::DFmt("Loaded {} syms", i);
   }
+
+  _SyscallHandler->TriggerGuestLibWrapperCodeCacheLoad(*ThreadObject->Thread, ThreadObject->Thread->CurrentFrame->State.rip);
 }
 
 /**


### PR DESCRIPTION
These libraries need to be initialized before relocating their caches, since the guest function hashes won't be registered before.

#5441 will let us handle this more cleanly, since we can then resolve FEX relocations in two phases instead. For now, this PR addresses crashes that would happen when enabling code caching with libVDSO-guest.so installed.
