### PR TITLE
Allocator: Mark large unmapped regions as DONTDUMP

### DIFF
--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -262,8 +262,18 @@ fextl::vector<MemoryRegion> StealMemoryRegion(uintptr_t Begin, uintptr_t End) {
   }
 
   // Block remaining memory gaps
+  bool SupportsDontDump = true;
   for (auto RegionIt = Regions.begin(); RegionIt != Regions.end(); ++RegionIt) {
     auto Alloc = ::mmap(RegionIt->Ptr, RegionIt->Size, PROT_NONE, MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED_NOREPLACE, -1, 0);
+
+    if (SupportsDontDump) {
+      // Mark these regions as don't dump so that coredump doesn't try dumping large unmapped regions.
+      // Ideally coredump would be smart enough to only dump resident pages, but here we are.
+      auto Result = madvise(RegionIt->Ptr, RegionIt->Size, MADV_DONTDUMP);
+      if (Result == -1) {
+        SupportsDontDump = false;
+      }
+    }
 
     LogMan::Throw::AFmt(Alloc != MAP_FAILED, "StealMemoryRegion: mmap({}, {:x}) failed: {}", fmt::ptr(RegionIt->Ptr), RegionIt->Size, errno);
     LogMan::Throw::AFmt(Alloc == RegionIt->Ptr, "mmap returned {} instead of {}", Alloc, fmt::ptr(RegionIt->Ptr));


### PR DESCRIPTION
coredump applications aren't smart enough to only dump resident pages, so explicitly mark our 128TB and other mapped VA ranges as DONTDUMP.

This will speed up coredumps.