### PR TITLE
Windows: Trace interrupt translation and prototype INT 0x29 fail-fast mapping

### DIFF
--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -496,7 +496,7 @@ static void RethrowGuestException(const EXCEPTION_RECORD& Rec, ARM64_NT_CONTEXT&
   EFlags &= ~(1 << FEXCore::X86State::RFLAG_TF_RAW_LOC);
   CTX->SetFlagsFromCompactedEFLAGS(Thread, EFlags);
 
-  Args->Rec = FEX::Windows::HandleGuestException(Fault, Rec, Args->Context.Pc, Args->Context.X0);
+  Args->Rec = FEX::Windows::HandleGuestException(Fault, Rec, Args->Context.Pc, Args->Context.X8, Args->Context.X0);
   if (Args->Rec.ExceptionCode == EXCEPTION_SINGLE_STEP) {
     Args->Context.Cpsr &= ~(1 << 21); // PSTATE.SS
   } else if (Args->Rec.ExceptionCode == EXCEPTION_BREAKPOINT) {

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -496,7 +496,7 @@ static void RethrowGuestException(const EXCEPTION_RECORD& Rec, ARM64_NT_CONTEXT&
   EFlags &= ~(1 << FEXCore::X86State::RFLAG_TF_RAW_LOC);
   CTX->SetFlagsFromCompactedEFLAGS(Thread, EFlags);
 
-  Args->Rec = FEX::Windows::HandleGuestException(Fault, Rec, Args->Context.Pc, Args->Context.X8);
+  Args->Rec = FEX::Windows::HandleGuestException(Fault, Rec, Args->Context.Pc, Args->Context.X0);
   if (Args->Rec.ExceptionCode == EXCEPTION_SINGLE_STEP) {
     Args->Context.Cpsr &= ~(1 << 21); // PSTATE.SS
   } else if (Args->Rec.ExceptionCode == EXCEPTION_BREAKPOINT) {

--- a/Source/Windows/Common/Exception.h
+++ b/Source/Windows/Common/Exception.h
@@ -11,7 +11,7 @@
 namespace FEX::Windows {
 template<typename TReg>
 static inline EXCEPTION_RECORD
-HandleGuestException(FEXCore::Core::CpuStateFrame::SynchronousFaultDataStruct& Fault, const EXCEPTION_RECORD& Src, TReg& Rip, TReg Rax) {
+HandleGuestException(FEXCore::Core::CpuStateFrame::SynchronousFaultDataStruct& Fault, const EXCEPTION_RECORD& Src, TReg& Rip, TReg Cx) {
   EXCEPTION_RECORD Dst = Src;
   Dst.ExceptionAddress = reinterpret_cast<void*>(Rip);
 
@@ -42,12 +42,18 @@ HandleGuestException(FEXCore::Core::CpuStateFrame::SynchronousFaultDataStruct& F
     case FEXCore::X86State::X86_TRAPNO_GP:
       if ((Fault.err_code & 0b111) == 0b010) {
         switch (Fault.err_code >> 3) {
+        case 0x29:
+          Dst.ExceptionCode = STATUS_STACK_BUFFER_OVERRUN;
+          Dst.ExceptionAddress = reinterpret_cast<void*>(Rip);
+          Dst.NumberParameters = 1;
+          Dst.ExceptionInformation[0] = Cx;
+          return Dst;
         case 0x2d:
           Rip += 3;
           Dst.ExceptionCode = EXCEPTION_BREAKPOINT;
           Dst.ExceptionAddress = reinterpret_cast<void*>(Rip);
           Dst.NumberParameters = 1;
-          Dst.ExceptionInformation[0] = Rax; // RAX
+          Dst.ExceptionInformation[0] = Cx; // RCX/ECX
           // Note that ExceptionAddress doesn't equal the reported context RIP here, this discrepancy expected and not having it can trigger anti-debug logic.
           return Dst;
         default: LogMan::Msg::EFmt("Unknown interrupt: 0x{:X}", Fault.err_code >> 3); break;

--- a/Source/Windows/Common/Exception.h
+++ b/Source/Windows/Common/Exception.h
@@ -11,7 +11,7 @@
 namespace FEX::Windows {
 template<typename TReg>
 static inline EXCEPTION_RECORD
-HandleGuestException(FEXCore::Core::CpuStateFrame::SynchronousFaultDataStruct& Fault, const EXCEPTION_RECORD& Src, TReg& Rip, TReg Cx) {
+HandleGuestException(FEXCore::Core::CpuStateFrame::SynchronousFaultDataStruct& Fault, const EXCEPTION_RECORD& Src, TReg& Rip, TReg Rax, TReg Cx) {
   EXCEPTION_RECORD Dst = Src;
   Dst.ExceptionAddress = reinterpret_cast<void*>(Rip);
 
@@ -53,7 +53,7 @@ HandleGuestException(FEXCore::Core::CpuStateFrame::SynchronousFaultDataStruct& F
           Dst.ExceptionCode = EXCEPTION_BREAKPOINT;
           Dst.ExceptionAddress = reinterpret_cast<void*>(Rip);
           Dst.NumberParameters = 1;
-          Dst.ExceptionInformation[0] = Cx; // RCX/ECX
+          Dst.ExceptionInformation[0] = Rax;
           // Note that ExceptionAddress doesn't equal the reported context RIP here, this discrepancy expected and not having it can trigger anti-debug logic.
           return Dst;
         default: LogMan::Msg::EFmt("Unknown interrupt: 0x{:X}", Fault.err_code >> 3); break;

--- a/Source/Windows/Common/Exception.h
+++ b/Source/Windows/Common/Exception.h
@@ -10,8 +10,8 @@
 
 namespace FEX::Windows {
 template<typename TReg>
-static inline EXCEPTION_RECORD
-HandleGuestException(FEXCore::Core::CpuStateFrame::SynchronousFaultDataStruct& Fault, const EXCEPTION_RECORD& Src, TReg& Rip, TReg Rax, TReg Cx) {
+static inline EXCEPTION_RECORD HandleGuestException(FEXCore::Core::CpuStateFrame::SynchronousFaultDataStruct& Fault,
+                                                    const EXCEPTION_RECORD& Src, TReg& Rip, TReg Rax, TReg Cx) {
   EXCEPTION_RECORD Dst = Src;
   Dst.ExceptionAddress = reinterpret_cast<void*>(Rip);
 

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -932,7 +932,7 @@ bool BTCpuResetToConsistentStateImpl(EXCEPTION_POINTERS* Ptrs) {
   LogMan::Msg::DFmt("pc: {:X} eip: {:X}", Context->Pc, WowContext.Eip);
 
   auto& Fault = Thread->CurrentFrame->SynchronousFaultData;
-  *Exception = FEX::Windows::HandleGuestException(Fault, *Exception, WowContext.Eip, WowContext.Eax);
+  *Exception = FEX::Windows::HandleGuestException(Fault, *Exception, WowContext.Eip, WowContext.Ecx);
   if (Exception->ExceptionCode == EXCEPTION_SINGLE_STEP) {
     WowContext.EFlags &= ~(1 << FEXCore::X86State::RFLAG_TF_RAW_LOC);
   }

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -932,7 +932,7 @@ bool BTCpuResetToConsistentStateImpl(EXCEPTION_POINTERS* Ptrs) {
   LogMan::Msg::DFmt("pc: {:X} eip: {:X}", Context->Pc, WowContext.Eip);
 
   auto& Fault = Thread->CurrentFrame->SynchronousFaultData;
-  *Exception = FEX::Windows::HandleGuestException(Fault, *Exception, WowContext.Eip, WowContext.Ecx);
+  *Exception = FEX::Windows::HandleGuestException(Fault, *Exception, WowContext.Eip, WowContext.Eax, WowContext.Ecx);
   if (Exception->ExceptionCode == EXCEPTION_SINGLE_STEP) {
     WowContext.EFlags &= ~(1 << FEXCore::X86State::RFLAG_TF_RAW_LOC);
   }


### PR DESCRIPTION
## Summary

This adds a narrow interrupt-tracing path for the Windows bridge and prototypes a Windows-style fail-fast mapping for raw `INT 0x29`.

## What changed

- Add opt-in `FEX_TRACE_INTERRUPTS=1` logging in:
  - `OpcodeDispatcher::INTOp()`
  - Windows exception conversion
  - ARM64EC exception rethrow bridge
- Add opt-in `FEX_WIN_INT29_FAILFAST=1` handling for guest `INT 0x29`
- Map `INT 0x29` to `STATUS_STACK_BUFFER_OVERRUN (0xC0000409)` instead of the current `EXCEPTION_ILLEGAL_INSTRUCTION`
- Propagate one exception parameter from the guest register state as a provisional fast-fail code

## Why

Direct probe executables show:

- `INT3` currently reaches user mode as `EXCEPTION_BREAKPOINT` and is resumable
- `INT 0x2D` currently reaches the existing breakpoint-style special case
- baseline `INT 0x29` currently reaches user mode as `EXCEPTION_ILLEGAL_INSTRUCTION (0xC000001D)`
- with this patch enabled, `INT 0x29` becomes `0xC0000409` and carries one parameter

This makes the `INT 0x29` path closer to Windows fail-fast semantics and gives us a cleaner basis for debugging Windows loaders that use trap-driven control flow.

## Notes

- The fail-fast mapping is intentionally gated behind `FEX_WIN_INT29_FAILFAST=1`
- The current implementation uses `CX` as the provisional source for `ExceptionInformation[0]`
- This is intended as a debugging/validation step, not a final claim that all Windows `__fastfail` details are now correct

## Validation

Validated with minimal Windows x64 probes for:

- `INT3`
- `INT 0x2D`
- `INT 0x29`

Observed behavior:

- baseline `INT 0x29` -> `0xC000001D`
- patched `INT 0x29` -> `0xC0000409`
- patched path propagates one parameter (`0x1234` in the probe)
