### PR TITLE
Config: Use more sensible default for portable config location

### DIFF
--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -656,7 +656,7 @@ fextl::string GetDataDirectory(bool Global, const PortableInformation& PortableI
 fextl::string GetConfigDirectory(bool Global, const PortableInformation& PortableInfo) {
   const char* ConfigOverride = getenv("FEX_APP_CONFIG_LOCATION");
   if (PortableInfo.IsPortable && Global) {
-    return fextl::fmt::format("{}/fex-emu/", PortableInfo.InterpreterPath);
+    return fextl::fmt::format("{}/../share/fex-emu/", PortableInfo.InterpreterPath);
   } else if (ConfigOverride && !Global) {
     fextl::string AppConfigStr = ConfigOverride;
     if (FHU::Filesystem::IsRelative(AppConfigStr)) {


### PR DESCRIPTION
The previous code would look for `Config.json` in `<path-to-FEX>/fex-emu/Config.json`, which after CMake installation is typically `<portable-folder>/bin/fex-emu/Config.json`. This deviates unnecessarily from the global default `/usr/share/fex-emu/Config.json`, so instead use `<path-to-fex>/../fex-emu/Config.json`.
