### PR TITLE
Library Forwarding: Various build system improvements

### DIFF
--- a/ThunkLibs/Generator/CMakeLists.txt
+++ b/ThunkLibs/Generator/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Clang REQUIRED CONFIG)
+find_package(LLVM REQUIRED CONFIG)
 find_package(OpenSSL REQUIRED COMPONENTS Crypto)
 
 # Query clang's global resource directory for system include directories
@@ -12,7 +13,7 @@ endif()
 
 add_library(thunkgenlib STATIC analysis.cpp data_layout.cpp gen.cpp)
 target_include_directories(thunkgenlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(thunkgenlib SYSTEM PUBLIC ${CLANG_INCLUDE_DIRS})
+target_include_directories(thunkgenlib SYSTEM PUBLIC ${CLANG_INCLUDE_DIRS} ${LLVM_INCLUDE_DIRS})
 target_link_libraries(thunkgenlib PUBLIC clang-cpp LLVM)
 target_link_libraries(thunkgenlib PRIVATE OpenSSL::Crypto)
 target_link_libraries(thunkgenlib PRIVATE fmt::fmt)

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -4,6 +4,20 @@ include(${FEX_PROJECT_SOURCE_DIR}/Data/CMake/version_to_variables.cmake)
 
 option(ENABLE_CLANG_THUNKS "Enable building thunks with clang" FALSE)
 
+find_package(PkgConfig REQUIRED)
+
+# Use include directories from pkg-config and fall back to global defaults if not available.
+# /usr/include is dropped to avoid mixing foreign-architecture standard library headers.
+function(target_include_directories_from_pkgconfig target pkg)
+  pkg_check_modules(PKG QUIET ${pkg})
+  if (PKG_FOUND)
+    list(REMOVE_ITEM PKG_INCLUDE_DIRS /usr/include)
+    target_include_directories(${target} INTERFACE ${PKG_INCLUDE_DIRS})
+  elseif (ARGN)
+    target_include_directories(${target} INTERFACE ${ARGN})
+  endif()
+endfunction()
+
 if (ENABLE_CLANG_THUNKS)
   set(LD_OVERRIDE "-fuse-ld=lld")
   add_link_options(${LD_OVERRIDE})
@@ -14,7 +28,7 @@ if (NOT X86_DEV_ROOTFS)
 endif()
 
 find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
+if (CCACHE_PROGRAM)
   message(STATUS "CCache enabled for guest thunks")
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif()
@@ -178,6 +192,7 @@ if (BITNESS EQUAL 64)
   #add_guest_lib(fex_malloc)
 
   generate(libasound ${CMAKE_CURRENT_SOURCE_DIR}/../libasound/libasound_interface.cpp)
+  target_include_directories_from_pkgconfig(libasound-guest-deps alsa)
   add_guest_lib(asound "libasound.so.2")
 
   # disabled for now, headers are platform specific
@@ -190,17 +205,17 @@ if (BITNESS EQUAL 64)
 
   generate(libvulkan ${CMAKE_CURRENT_SOURCE_DIR}/../libvulkan/libvulkan_interface.cpp)
   target_include_directories(libvulkan-guest-deps INTERFACE ${FEX_PROJECT_SOURCE_DIR}/External/Vulkan-Headers/include/)
+  target_include_directories_from_pkgconfig(libvulkan-guest-deps "xcb;x11;xrandr;xrender")
   add_guest_lib(vulkan "libvulkan.so.1")
 
   generate(libdrm ${CMAKE_CURRENT_SOURCE_DIR}/../libdrm/libdrm_interface.cpp)
-  target_include_directories(libdrm-guest-deps INTERFACE /usr/include/drm/)
-  target_include_directories(libdrm-guest-deps INTERFACE /usr/include/libdrm/)
+  target_include_directories_from_pkgconfig(libdrm-guest-deps libdrm /usr/include/drm /usr/include/libdrm)
   add_guest_lib(drm "libdrm.so.2")
 endif()
 
 generate(libwayland-client ${CMAKE_CURRENT_SOURCE_DIR}/../libwayland-client/libwayland-client_interface.cpp)
 add_guest_lib(wayland-client "libwayland-client.so.0.20.0")
-target_include_directories(libwayland-client-guest-deps INTERFACE /usr/include/wayland)
+target_include_directories_from_pkgconfig(libwayland-client-guest-deps wayland-client /usr/include/wayland)
 
 generate(libVDSO ${CMAKE_CURRENT_SOURCE_DIR}/../libVDSO/libVDSO_interface.cpp)
 add_guest_lib(VDSO "linux-vdso.so.1")
@@ -236,9 +251,12 @@ if (BUILD_FEX_LINUX_TESTS)
 endif()
 
 generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp)
+target_include_directories_from_pkgconfig(libGL-guest-deps gl)
+target_include_directories_from_pkgconfig(libGL-guest-deps "xcb;x11;xrandr;xrender")
 add_guest_lib(GL "libGL.so.1")
 
 generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp)
+target_include_directories_from_pkgconfig(libEGL-guest-deps egl)
 add_guest_lib(EGL "libEGL.so.1")
 target_link_libraries(EGL-guest PRIVATE GL-guest)
 

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -5,6 +5,20 @@ include(${FEX_PROJECT_SOURCE_DIR}/Data/CMake/version_to_variables.cmake)
 set(CMAKE_CXX_STANDARD 20)
 option(ENABLE_CLANG_THUNKS "Enable building thunks with clang" FALSE)
 
+find_package(PkgConfig REQUIRED)
+
+# Helper to add include directories from pkg-config, falling back to global defaults if not available.
+# /usr/include is dropped to avoid mixing foreign-architecture standard library headers.
+function(target_include_directories_from_pkgconfig target pkg)
+  pkg_check_modules(PKG QUIET ${pkg})
+  if (PKG_FOUND)
+    list(REMOVE_ITEM PKG_INCLUDE_DIRS /usr/include)
+    target_include_directories(${target} INTERFACE ${PKG_INCLUDE_DIRS})
+  elseif (ARGN)
+    target_include_directories(${target} INTERFACE ${ARGN})
+  endif()
+endfunction()
+
 # Extra flags for thunkgen's libclang invocation.
 # On non-standard layouts (e.g. NixOS), libclang can't discover system C/C++
 # include directories automatically. Set THUNKGEN_EXTRA_FLAGS in the environment
@@ -72,7 +86,7 @@ endfunction()
 
 function(add_host_lib NAME GUEST_BITNESS)
   set(SOURCE_FILE ../lib${NAME}/lib${NAME}_Host.cpp)
-    get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
+  get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
   if (NOT EXISTS "${SOURCE_FILE_ABS}")
     set(SOURCE_FILE ../lib${NAME}/Host.cpp)
     get_filename_component(SOURCE_FILE_ABS "${SOURCE_FILE}" ABSOLUTE)
@@ -112,6 +126,7 @@ foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
   #add_host_lib(fex_malloc ${GUEST_BITNESS})
 
   generate(libasound ${CMAKE_CURRENT_SOURCE_DIR}/../libasound/libasound_interface.cpp ${GUEST_BITNESS})
+  target_include_directories_from_pkgconfig(libasound-${GUEST_BITNESS}-deps alsa)
   add_host_lib(asound ${GUEST_BITNESS})
 
   # disabled for now, headers are platform specific
@@ -121,8 +136,7 @@ foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
   # target_include_directories(SDL2-host PRIVATE ${SDL2_INCLUDE_DIRS})
 
   generate(libdrm ${CMAKE_CURRENT_SOURCE_DIR}/../libdrm/libdrm_interface.cpp ${GUEST_BITNESS})
-  target_include_directories(libdrm-${GUEST_BITNESS}-deps INTERFACE /usr/include/drm/)
-  target_include_directories(libdrm-${GUEST_BITNESS}-deps INTERFACE /usr/include/libdrm/)
+  target_include_directories_from_pkgconfig(libdrm-${GUEST_BITNESS}-deps libdrm /usr/include/drm /usr/include/libdrm)
   add_host_lib(drm ${GUEST_BITNESS})
 endforeach()
 
@@ -135,16 +149,20 @@ foreach(GUEST_BITNESS IN LISTS BITNESS_LIST)
 
   generate(libvulkan ${CMAKE_CURRENT_SOURCE_DIR}/../libvulkan/libvulkan_interface.cpp ${GUEST_BITNESS})
   target_include_directories(libvulkan-${GUEST_BITNESS}-deps INTERFACE ${FEX_PROJECT_SOURCE_DIR}/External/Vulkan-Headers/include/)
+  target_include_directories_from_pkgconfig(libvulkan-${GUEST_BITNESS}-deps "xcb;x11;xrandr;xrender")
   add_host_lib(vulkan ${GUEST_BITNESS})
 
   generate(libwayland-client ${CMAKE_CURRENT_SOURCE_DIR}/../libwayland-client/libwayland-client_interface.cpp ${GUEST_BITNESS})
   add_host_lib(wayland-client ${GUEST_BITNESS})
-  target_include_directories(libwayland-client-${GUEST_BITNESS}-deps INTERFACE /usr/include/wayland)
+  target_include_directories_from_pkgconfig(libwayland-client-${GUEST_BITNESS}-deps wayland-client /usr/include/wayland)
 
   generate(libEGL ${CMAKE_CURRENT_SOURCE_DIR}/../libEGL/libEGL_interface.cpp ${GUEST_BITNESS})
+  target_include_directories_from_pkgconfig(libEGL-${GUEST_BITNESS}-deps egl)
   add_host_lib(EGL ${GUEST_BITNESS})
 
   generate(libGL ${CMAKE_CURRENT_SOURCE_DIR}/../libGL/libGL_interface.cpp ${GUEST_BITNESS})
+  target_include_directories_from_pkgconfig(libGL-${GUEST_BITNESS}-deps gl)
+  target_include_directories_from_pkgconfig(libGL-${GUEST_BITNESS}-deps "xcb;x11;xrandr;xrender")
   add_host_lib(GL ${GUEST_BITNESS})
 
   find_package(OpenGL REQUIRED)

--- a/ThunkLibs/HostLibs/CMakeLists.txt
+++ b/ThunkLibs/HostLibs/CMakeLists.txt
@@ -5,6 +5,12 @@ include(${FEX_PROJECT_SOURCE_DIR}/Data/CMake/version_to_variables.cmake)
 set(CMAKE_CXX_STANDARD 20)
 option(ENABLE_CLANG_THUNKS "Enable building thunks with clang" FALSE)
 
+# Extra flags for thunkgen's libclang invocation.
+# On non-standard layouts (e.g. NixOS), libclang can't discover system C/C++
+# include directories automatically. Set THUNKGEN_EXTRA_FLAGS in the environment
+# to provide them (e.g. "-idirafter;/path/to/glibc/include").
+separate_arguments(THUNKGEN_SYSTEM_INCLUDES UNIX_COMMAND "$ENV{THUNKGEN_EXTRA_FLAGS}")
+
 if (ENABLE_CLANG_THUNKS)
   set(LD_OVERRIDE "-fuse-ld=lld")
   add_link_options(${LD_OVERRIDE})
@@ -52,6 +58,7 @@ function(generate NAME SOURCE_FILE GUEST_BITNESS)
     DEPENDS "${SOURCE_FILE}"
     DEPENDS thunkgen
     COMMAND thunkgen "${SOURCE_FILE}" "${NAME}" "-host" "${OUTFILE}" "${X86_DEV_ROOTFS}" ${BITNESS_FLAGS} -- -std=c++20
+      ${THUNKGEN_SYSTEM_INCLUDES}
       # Expand compile definitions to space-separated list of -D parameters
       "$<$<BOOL:${compile_prop}>:;-D$<JOIN:${compile_prop},;-D>>"
       # Expand include directories to space-separated list of -isystem parameters


### PR DESCRIPTION
Makes it play nicer with cross-compilation setups that actually bundle x86 variants of our forwarded libraries.

Notably, this will considerably clean up the nixpkgs packaging for FEX.