### PR TITLE
Windows/ImageTracker: Wire up LoadCache and EnableLoadedSection 

### DIFF
--- a/Source/Windows/Common/ImageTracker.cpp
+++ b/Source/Windows/Common/ImageTracker.cpp
@@ -171,8 +171,8 @@ FEXCore::ExecutableFileSectionInfo ImageTracker::HandleImageMap(std::string_view
     }
 
     auto AOTImage = AOTImages.find(ID);
-    if (AOTImage != AOTImages.end()) {
-      // TODO: CodeCache::EnableLoadedSection
+    if (AOTImage != AOTImages.end() && AOTImage->second.CacheFile) {
+      CTX.GetCodeCache().EnableLoadedSection(nullptr, *AOTImage->second.CacheFile, ImageInfo->SectionInfo);
     }
   }
 
@@ -279,9 +279,16 @@ void ImageTracker::LoadAOTImages(MappedImageInfo& ImageInfo) {
               UniqueId.resize(AnsiLength);
               RtlUnicodeToMultiByteN(UniqueId.data(), AnsiLength, NULL, Info->FileName, Info->FileNameLength);
 
-              AOTImages[UniqueId] = {.Data = static_cast<std::byte*>(LoadAddress)};
-              // TODO: CodeCache::LoadCache, CodeCache::RegisterMappedCodeBuffer
-              LogMan::Msg::IFmt("Loaded cache: {}", UniqueId);
+              auto CacheSpan = std::span {static_cast<std::byte*>(LoadAddress), MappedSize};
+              auto MappedCache = CTX.GetCodeCache().LoadCache(CacheSpan, ImageInfo.Info, ImageInfo.SectionInfo.FileStartVA);
+              if (MappedCache) {
+                CTX.GetCodeCache().RegisterMappedCodeBuffer(*MappedCache);
+                AOTImages[UniqueId] = {.CacheFile = std::move(MappedCache)};
+                LogMan::Msg::IFmt("Loaded cache: {}", UniqueId);
+              } else {
+                NtUnmapViewOfSection(NtCurrentProcess(), LoadAddress);
+                LogMan::Msg::EFmt("Failed to load cache: {}", UniqueId);
+              }
             }
           }
         }

--- a/Source/Windows/Common/ImageTracker.h
+++ b/Source/Windows/Common/ImageTracker.h
@@ -56,7 +56,7 @@ private:
   };
 
   struct AOTImageInfo {
-    std::byte* Data;
+    fextl::unique_ptr<FEXCore::MappedCodeCacheFile> CacheFile;
   };
 
   void LoadAOTImages(MappedImageInfo& Info);


### PR DESCRIPTION
The lazy code loading refactor replaced LoadData with the new LoadCache/EnableLoadedSection API but left the Windows path as TODOs.
Implement the wiring: LoadAOTImages now calls LoadCache + RegisterMappedCodeBuffer for each mapped cache file, and HandleImageMap calls EnableLoadedSection (with nullptr thread since lazy mapping is not yet implemented on Windows).