### PR TITLE
HostFeatures: Only enable `dc zva` optimization on Ampere CPUs

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
@@ -568,7 +568,7 @@ DEF_OP(LoadDF) {
 
 DEF_OP(ContextClear) {
   auto Op = IROp->C<IR::IROp_ContextClear>();
-  if (CTX->HostFeatures.SupportsCLZERO) {
+  if (CTX->HostFeatures.PreferZVAForVZero) {
     // We can use CLZero directly when hardware supports it.
     // Provides a fairly generous speed-up on Ampere1A hardware.
     // TODO: When FEAT_MOPS hardware ships, test memset using MOPS.

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -42,6 +42,7 @@ struct HostFeatures {
   bool Supports3DNow {};
   bool SupportsSSE4a {};
   bool SupportsMOPS {};
+  bool PreferZVAForVZero {};
 
   // Float exception behaviour
   bool SupportsAFP {};

--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -541,6 +541,8 @@ static void HandleErrata(FEXCore::HostFeatures* HostFeatures, uint64_t MIDR) {
   constexpr uint32_t PartNum_Oryon1 = 0x001;
   constexpr uint32_t PartNum_Oryon3 = 0x002;
 
+  constexpr uint32_t Implementer_Ampere = 0xc0;
+
   auto GetMIDRImplementer = [](uint32_t MIDR) -> uint32_t {
     return (MIDR >> 24) & 0xFF;
   };
@@ -592,6 +594,15 @@ static void HandleErrata(FEXCore::HostFeatures* HostFeatures, uint64_t MIDR) {
       HostFeatures->SupportsTSOImm9 = false;
       break;
     }
+  }
+
+  if (MIDR_Implementer == Implementer_Ampere) {
+    // Ampere Computing CPUs that support CLZero should prefer using `dc zva` for vzero{upper,all} as its faster there.
+    // For Cortex CPUs it doesn't matter one way or the other.
+    // For Oryon CPUs, it is dramatically faster to avoid `dc zva` as it has dramatic stalls around barriers and overlapping `dc zva`.
+    //
+    // Because the `dc zva` optimization was implemented for Ampere, only use that path on the hardware.
+    HostFeatures->PreferZVAForVZero = HostFeatures->SupportsCLZERO;
   }
 }
 
@@ -658,6 +669,7 @@ void FetchHostFeatures(FEX::CPUFeatures& Features, FEXCore::HostFeatures& HostFe
   HostFeatures.SupportsAVX = true;
   HostFeatures.SupportsAES256 = HostFeatures.SupportsAVX && HostFeatures.SupportsAES;
   HostFeatures.SupportsPreserveAllABI = FEX_HAS_PRESERVE_ALL_ATTR;
+  HostFeatures.PreferZVAForVZero = false;
 
   if (CTR) {
     HostFeatures.DCacheLineSize = 4 << ((CTR >> 16) & 0xF);

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -1482,24 +1482,25 @@
       ]
     },
     "vzeroupper": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "Might be able to use DZ ZVA",
         "Map 1 0b01 0x77 L=0"
       ],
       "ExpectedArm64ASM": [
-        "add x0, x28, #0xc0 (192)",
-        "dc zva, x0",
-        "add x0, x28, #0x100 (256)",
-        "dc zva, x0",
-        "add x0, x28, #0x140 (320)",
-        "dc zva, x0",
-        "add x0, x28, #0x180 (384)",
-        "dc zva, x0"
+        "movi v0.2d, #0x0",
+        "stp q0, q0, [x28, #192]",
+        "stp q0, q0, [x28, #224]",
+        "stp q0, q0, [x28, #256]",
+        "stp q0, q0, [x28, #288]",
+        "stp q0, q0, [x28, #320]",
+        "stp q0, q0, [x28, #352]",
+        "stp q0, q0, [x28, #384]",
+        "stp q0, q0, [x28, #416]"
       ]
     },
     "vzeroall": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 25,
       "Comment": [
         "Might be able to use DZ ZVA",
         "Map 1 0b01 0x77 L=1"
@@ -1521,14 +1522,15 @@
         "movi v29.2d, #0x0",
         "movi v30.2d, #0x0",
         "movi v31.2d, #0x0",
-        "add x0, x28, #0xc0 (192)",
-        "dc zva, x0",
-        "add x0, x28, #0x100 (256)",
-        "dc zva, x0",
-        "add x0, x28, #0x140 (320)",
-        "dc zva, x0",
-        "add x0, x28, #0x180 (384)",
-        "dc zva, x0"
+        "movi v0.2d, #0x0",
+        "stp q0, q0, [x28, #192]",
+        "stp q0, q0, [x28, #224]",
+        "stp q0, q0, [x28, #256]",
+        "stp q0, q0, [x28, #288]",
+        "stp q0, q0, [x28, #320]",
+        "stp q0, q0, [x28, #352]",
+        "stp q0, q0, [x28, #384]",
+        "stp q0, q0, [x28, #416]"
       ]
     },
     "vcmpps xmm0, xmm1, xmm2, 0x00": {


### PR DESCRIPTION
This optimization was only written for Ampere1A where it showed a noticable performance improvement in #5321. On Cortex it didn't matter. Turns out this actually hits a bad case on Oryon CPUs where `dc zva` is actually dramatically slower in the face of memory barriers and overlapping stores in flight.

So now just detect Ampere and only use the optimization on that hardware and send everyone else down the regular path.

microbench A1A:
```
Cycle counter frequency: 1000000000
Cycle counter granularity: 20
ns in cycle: 1
suite: memory
Test, Total Cycles, Iterations, Cycles Average, Iter Time Average, iterations/Second
dc zva - vzeroupper, 723390880, 363855872, 1.99, 1.99 nanosecond, 502986534.75
dc zva - vzeroall, 571708060, 161742848, 3.53, 3.53 nanosecond, 282911610.52
dc zva (stp emu) - vzeroupper, 541543980, 107872256, 5.02, 5.02 nanosecond, 199193897.42
dc zva (stp emu) - vzeroall, 722548940, 71958528, 10.04, 10.04 nanosecond, 99589832.63
```

microbench X2E:
```
Cycle counter frequency: 19200000
Cycle counter granularity: 1
ns in cycle: 52.083333333333336
suite: memory
Test, Total Cycles, Iterations, Cycles Average, Iter Time Average, iterations/Second
dc zva - memset 0, 12065162, 49, 246227.80, 12.82 millisecond, 77.98
dc zva - vzeroupper, 12098598, 4325376, 2.80, 145.68 nanosecond, 6864201.89
dc zva - vzeroall, 12031459, 4325376, 2.78, 144.87 nanosecond, 6902506.11
dc zva (stp emu) - vzeroupper, 13899441, 363855872, 0.04, 1.99 nanosecond, 502612496.60
dc zva (stp emu) - vzeroall, 12389283, 161742848, 0.08, 3.99 nanosecond, 250657175.37
```