### PR TITLE
JIT: Avoid clobbering guest rdx while raising generated faults

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
@@ -73,8 +73,8 @@ DEF_OP(Break) {
   uint64_t Constant {};
   memcpy(&Constant, &State, sizeof(State));
 
-  LoadConstant(ARMEmitter::Size::i64Bit, ARMEmitter::Reg::r1, Constant);
-  str(ARMEmitter::XReg::x1, STATE, offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData));
+  LoadConstant(ARMEmitter::Size::i64Bit, TMP1, Constant);
+  str(TMP1, STATE, offsetof(FEXCore::Core::CpuStateFrame, SynchronousFaultData));
 
   switch (Op->Reason.Signal) {
   case Core::FAULT_SIGILL:


### PR DESCRIPTION
This is PR 1 out of 4 that allows Starcraft II to work on my DGX Spark, the others being:

* #5509 
* #5510
* #5511 

BEFORE:

Starcraft II does not launch with Proton arm64.

<img width="201" height="120" alt="image" src="https://github.com/user-attachments/assets/accf34ac-75d6-4a8c-8545-1701a4c5a161" />

AFTER (all four PRs):

Starcraft II launches and plays smoothly at max settings.

<img width="3200" height="1800" alt="image" src="https://github.com/user-attachments/assets/febeb6f1-331c-4a6a-baaf-fc1c300ce6f8" />

## Problem

ARM64 JIT `Break` emitted generated-fault metadata through host register `x1`.
On the ARM64EC Windows x64 mapping, guest `RDX` is live in that host register
at the fault boundary. The metadata write therefore corrupts the guest register
state observed after a handled generated fault.

StarCraft II x64 reaches this after its handled privileged `WBINVD` startup
probe. The corrupted value later becomes a call target, producing a bad
non-executable guest entry instead of continuing through the protected startup
path.

## Reproduction

A focused test can keep guest `RDX` live across a generated privileged
instruction fault in an x64 Windows PE, handle the exception, then verify the
register-backed value after continuing.

The game-level ARM64 Proton sequence is:

```sh
make -C <arm64-proton-build> fex

STEAM_COMPAT_DATA_PATH=<compatdata> <arm64-proton-dist>/proton runinprefix \
  <compatdata>/pfx/drive_c/Program\ Files\ \(x86\)/Battle.net/Battle.net.exe

STEAM_COMPAT_DATA_PATH=<compatdata> <arm64-proton-dist>/proton runinprefix \
  <compatdata>/pfx/drive_c/Program\ Files\ \(x86\)/Battle.net/Battle.net.exe \
  --exec="launch S2"
```

On the broken path the post-exception SC2 startup trace shows the generated
fault metadata in the `RDX`-derived call target.

## Fix

Use the JIT scratch register `TMP1` for the synchronous-fault metadata constant
instead of hardcoding host register `x1`.

## Risk

The change is local to `Break` emission on the ARM64 JIT and uses an existing
temporary register that the surrounding block already uses for branch targets.
The focused risk is generated-fault state or branch emission regression on the
ARM64 JIT path.
