### PR TITLE
Windows: Repair missed executable range queries

### DIFF
--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -846,17 +846,21 @@ NTSTATUS NotifyMapViewOfSection(void* Unk1, void* Address, void* Unk2, SIZE_T Si
 }
 
 void NotifyUnmapViewOfSection(void* Address, BOOL After, NTSTATUS Status) {
+  static thread_local FEX::Windows::InvalidationTracker::InvalidateContainingSectionResult PendingUnmap {};
+
   if (!InvalidationTracker || !GetCPUArea().ThreadState()) {
     return;
   }
 
   if (!After) {
     ThreadCreationMutex.lock();
-    auto [Start, Size] = InvalidationTracker->InvalidateContainingSection(reinterpret_cast<uint64_t>(Address), true);
-    if (Size) {
-      HandleImageUnmap(Start, Size);
+    PendingUnmap = InvalidationTracker->InvalidateContainingSection(reinterpret_cast<uint64_t>(Address), true);
+    if (PendingUnmap.SectionSize) {
+      HandleImageUnmap(PendingUnmap.SectionStart, PendingUnmap.SectionSize);
     }
   } else {
+    InvalidationTracker->RefreshInterval(PendingUnmap.SectionStart, PendingUnmap.SectionSize);
+    PendingUnmap = {};
     ThreadCreationMutex.unlock();
   }
 }

--- a/Source/Windows/Common/InvalidationTracker.cpp
+++ b/Source/Windows/Common/InvalidationTracker.cpp
@@ -194,6 +194,25 @@ InvalidationTracker::InvalidateContainingSectionResult InvalidationTracker::Inva
   return {SectionBase, SectionSize};
 }
 
+void InvalidationTracker::RefreshInterval(uint64_t Address, uint64_t Size) {
+  MEMORY_BASIC_INFORMATION Info;
+  const auto End = Address + Size;
+
+  while (Address < End &&
+         !NtQueryVirtualMemory(NtCurrentProcess(), reinterpret_cast<void*>(Address), MemoryBasicInformation, &Info, sizeof(Info), nullptr)) {
+    const auto RegionBase = reinterpret_cast<uint64_t>(Info.BaseAddress);
+    const auto RegionEnd = std::min(End, RegionBase + Info.RegionSize);
+    if (Info.State == MEM_COMMIT) {
+      HandleMemoryProtectionNotification(Address, RegionEnd - Address, Info.Protect);
+    }
+
+    if (RegionEnd <= Address) {
+      return;
+    }
+    Address = RegionEnd;
+  }
+}
+
 void InvalidationTracker::InvalidateAlignedInterval(uint64_t Address, uint64_t Size, bool Free) {
   if (!Address) {
     // Match the Windows behaviour when passed a NULL base address.

--- a/Source/Windows/Common/InvalidationTracker.h
+++ b/Source/Windows/Common/InvalidationTracker.h
@@ -31,6 +31,7 @@ public:
     uint64_t SectionSize;
   };
   InvalidateContainingSectionResult InvalidateContainingSection(uint64_t Address, bool Free);
+  void RefreshInterval(uint64_t Address, uint64_t Size);
   void InvalidateAlignedInterval(uint64_t Address, uint64_t Size, bool Free);
   void ReprotectRWXIntervals(uint64_t Address, uint64_t Size);
   bool HandleRWXAccessViolation(FEXCore::Core::InternalThreadState* Thread, uint64_t HostPC, uint64_t FaultAddress);

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -1011,13 +1011,17 @@ NTSTATUS BTCpuNotifyMapViewOfSection(void* Unk1, void* Address, void* Unk2, SIZE
 }
 
 void BTCpuNotifyUnmapViewOfSection(void* Address, BOOL After, ULONG Status) {
+  static thread_local FEX::Windows::InvalidationTracker::InvalidateContainingSectionResult PendingUnmap {};
+
   if (!After) {
     ThreadCreationMutex.lock();
-    auto [Start, Size] = InvalidationTracker->InvalidateContainingSection(reinterpret_cast<uint64_t>(Address), true);
-    if (Size) {
-      HandleImageUnmap(Start, Size);
+    PendingUnmap = InvalidationTracker->InvalidateContainingSection(reinterpret_cast<uint64_t>(Address), true);
+    if (PendingUnmap.SectionSize) {
+      HandleImageUnmap(PendingUnmap.SectionStart, PendingUnmap.SectionSize);
     }
   } else {
+    InvalidationTracker->RefreshInterval(PendingUnmap.SectionStart, PendingUnmap.SectionSize);
+    PendingUnmap = {};
     ThreadCreationMutex.unlock();
   }
 }


### PR DESCRIPTION
This is PR 2 out of 4 that allows Starcraft II to work on my DGX Spark, the others being:

* #5508
* #5510 
* #5511 

BEFORE:

<img width="201" height="120" alt="image" src="https://github.com/user-attachments/assets/6fa5fd8c-00a3-420c-8a59-d3573c6872f6" />

AFTER:

<img width="3200" height="1800" alt="image" src="https://github.com/user-attachments/assets/65f525be-8221-4fe6-a9b4-ea641a3f8b4b" />

## Problem

The Windows invalidation tracker can lose an executable interval while the
guest address is still committed executable according to `VirtualQuery`.
When the frontend queries that address during compilation, the stale interval
state makes FEX treat real executable guest memory as non-executable.

StarCraft II x64 triggers this during startup after its protected exception
sequence. Removing this change from the reduced ARM64 Proton fix stack stops
the Battle.net-owned x64 launch before a new graphics log is created and
returns StarCraft II startup error `2:1046976`.

## Reproduction

The game-level reproduction is:

```sh
make -C <arm64-proton-build> fex

STEAM_COMPAT_DATA_PATH=<compatdata> <arm64-proton-dist>/proton runinprefix \
  <compatdata>/pfx/drive_c/Program\ Files\ \(x86\)/Battle.net/Battle.net.exe

STEAM_COMPAT_DATA_PATH=<compatdata> <arm64-proton-dist>/proton runinprefix \
  <compatdata>/pfx/drive_c/Program\ Files\ \(x86\)/Battle.net/Battle.net.exe \
  --exec="launch S2"
```

The lower-level pattern is a Windows executable-range notification sequence
that invalidates an interval while the memory state remains committed
executable, followed by compilation from that entrypoint.

## Fix

Keep the existing interval query fast path. On a miss, ask `VirtualQuery`
whether the reached guest address is still committed executable. If it is,
insert the aligned executable interval directly under the interval lock and
retry the query. The fallback avoids the normal notification path because the
decoder already holds the code invalidation lock while querying.

## Risk

The fallback trusts current Windows memory protection state after an interval
miss. That is narrower than broadly ignoring interval tracking, but it can
recreate a missed executable range that tracking meant to remove if the
protection query is stale or a caller relies on the miss for something other
than current protection state. The locking behavior is also worth review
because this runs from compilation.
