### PR TITLE
LibraryForwarding: Add annotation for snd_htimestamp_t

### DIFF
--- a/ThunkLibs/libasound/libasound_interface.cpp
+++ b/ThunkLibs/libasound/libasound_interface.cpp
@@ -147,6 +147,10 @@ struct fex_gen_type<snd_timer_t> : fexgen::opaque_type {};
 template<>
 struct fex_gen_type<snd_timestamp_t> : fexgen::opaque_type {};
 
+// has empty padding members on musl
+template<>
+struct fex_gen_type<snd_htimestamp_t> : fexgen::assume_compatible_data_layout {};
+
 template<>
 struct fex_gen_type<FILE> : fexgen::opaque_type {};
 


### PR DESCRIPTION
building on musl fails with:
`error: Unsupported parameter type 'snd_htimestamp_t *' (aka 'timespec *')`

due to empty padding members in `alltypes.h`:
```
STRUCT timespec {
  time_t tv_sec;
  int :8*(sizeof(time_t)-sizeof(long))*(__BYTE_ORDER==4321);
  long tv_nsec;
  int :8*(sizeof(time_t)-sizeof(long))*(__BYTE_ORDER!=4321);
};
```
add (missing) annotation to libasound interface

fix: #5513