### PR TITLE
set sysroot to X86_DEV_ROOTFS for guest toolchain

### DIFF
--- a/ThunkLibs/Generator/main.cpp
+++ b/ThunkLibs/Generator/main.cpp
@@ -92,8 +92,6 @@ int main(int argc, char* const argv[]) {
     }
     AdjustedArgs.push_back("-DGUEST_THUNK_LIBRARY");
     AdjustedArgs.push_back(std::string {"--target="} + platform);
-    AdjustedArgs.push_back("-isystem");
-    AdjustedArgs.push_back(std::string {"/usr/"} + platform + "/include/");
 
     append_x86_rootfs_includes(AdjustedArgs, platform);
 

--- a/ThunkLibs/GuestLibs/CMakeLists.txt
+++ b/ThunkLibs/GuestLibs/CMakeLists.txt
@@ -87,11 +87,12 @@ function(generate NAME SOURCE_FILE)
 
   if (BITNESS EQUAL 32)
     set(BITNESS_FLAGS "-for-32bit-guest")
-    set(BITNESS_FLAGS2 "-m32" "--target=i686-linux-gnu" "-isystem" "/usr/i686-linux-gnu/include/")
+    set(BITNESS_FLAGS2 "-m32" "--target=i686-linux-gnu")
   else()
     set(BITNESS_FLAGS "")
-    set(BITNESS_FLAGS2 "--target=x86_64-linux-gnu" "-isystem" "/usr/x86_64-linux-gnu/include/")
+    set(BITNESS_FLAGS2 "--target=x86_64-linux-gnu")
   endif()
+  list(APPEND BITNESS_FLAGS2 "--sysroot" "${X86_DEV_ROOTFS}")
 
   add_custom_command(
     OUTPUT "${OUTFILE}"

--- a/unittests/ThunkLibs/CMakeLists.txt
+++ b/unittests/ThunkLibs/CMakeLists.txt
@@ -4,6 +4,10 @@ target_link_libraries(thunkgentest PRIVATE fmt::fmt)
 target_link_libraries(thunkgentest PRIVATE thunkgenlib)
 catch_discover_tests(thunkgentest TEST_SUFFIX ".ThunkGen")
 
+target_compile_definitions(thunkgentest PRIVATE
+  "X86_DEV_ROOTFS=\"${X86_DEV_ROOTFS}\""
+)
+
 add_custom_target(thunkgen_tests
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   USES_TERMINAL

--- a/unittests/ThunkLibs/common.h
+++ b/unittests/ThunkLibs/common.h
@@ -75,16 +75,17 @@ run_tool(clang::tooling::ToolAction& action, std::string_view code, bool silent 
     args.push_back("-resource-dir");
     args.push_back(CLANG_RESOURCE_DIR);
   }
-  if (guest_abi == GuestABI::X86_64) {
-    args.push_back("-target");
-    args.push_back("x86_64-linux-gnu");
-    args.push_back("-isystem");
-    args.push_back("/usr/x86_64-linux-gnu/include/");
-  } else if (guest_abi == GuestABI::X86_32) {
-    args.push_back("-target");
-    args.push_back("i686-linux-gnu");
-    args.push_back("-isystem");
-    args.push_back("/usr/i686-linux-gnu/include/");
+  if (guest_abi) {
+    args.push_back("--sysroot");
+    args.push_back(X86_DEV_ROOTFS);
+    if (guest_abi == GuestABI::X86_64) {
+      args.push_back("-target");
+      args.push_back("x86_64-linux-gnu");
+    } else if (guest_abi == GuestABI::X86_32) {
+      args.push_back("-m32");
+      args.push_back("-target");
+      args.push_back("i686-linux-gnu");
+    }
   } else {
     args.push_back("-DHOST");
   }


### PR DESCRIPTION
**Faulty Behaviour:**
When not building on Ubuntu `unittests/ThunkLibs` fails to find c++ header and fails:

```
gen_input.cpp:2:10: fatal error: 'cstddef' file not found
    2 | #include <cstddef>
      |          ^~~~~~~~~
1 error generated.
```

This also includes building with nix-shell:
```
nix-shell ../Data/nix/LibraryForwarding/shell.nix --run "cmake --build . --target thunkgen_tests"
```

**Root Cause**:
`X86_DEV_ROOTFS` is not used, but  header paths are hard coded to Ubuntu's multilib layout (`/usr/i686-linux-gnu/include/`, `/usr/x86_64-linux-gnu/include/`). It works on Ubuntu but the mechanism to use to another directory is broken and the include paths always point to the host.

**Solution**:
set `--sysroot ${X86_DEV_ROOTFS}` for guest builds and remove hard coded include paths.

Fix: #5515