### PR TITLE
HostFeatures: Don't capture CTR/MIDR under simulator

### DIFF
--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -754,7 +754,7 @@ FEXCore::HostFeatures FetchHostFeatures() {
 
   uint64_t CTR = 0;
   uint64_t MIDR = 0;
-#ifdef ARCHITECTURE_arm64
+#if defined(ARCHITECTURE_arm64) && !defined(VIXL_SIMULATOR)
   // We need to get the CPU's cache line size
   // We expect sane targets that have correct cacheline sizes across clusters
   __asm volatile("mrs %[ctr], ctr_el0" : [ctr] "=r"(CTR));


### PR DESCRIPTION
If the simulator was selected, we would still capture CTR and MIDR on the host AArch64 system. Potentially modifying codegen in unexpected ways.

Ensure we return 0/0 like under x86 with simulator to simulate "unknown".