### PR TITLE
FEXCore: handle LODS address-size override and invalid LOCK prefixes

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -121,6 +121,54 @@ static GetFrameBlockInfoResult GetFrameBlockInfo(FEXCore::Core::CpuStateFrame* F
   return {InlineHeader, nullptr};
 }
 
+static bool IsInvalidLockPrefix(const X86Tables::DecodedInst* DecodedInfo, const X86Tables::X86InstInfo* TableInfo) {
+  if (!(DecodedInfo->Flags & X86Tables::DecodeFlags::FLAG_LOCK)) {
+    return false;
+  }
+
+  if (!TableInfo || !TableInfo->Name) {
+    return true;
+  }
+
+  const std::string_view Name {TableInfo->Name};
+  if (Name == "MOV") {
+    return true;
+  }
+
+  // These ALU encodings have a register destination and a memory/register source,
+  // so LOCK is invalid even if the ModRM source operand names memory.
+  switch (DecodedInfo->OP) {
+  case 0x02:
+  case 0x03:
+  case 0x0A:
+  case 0x0B:
+  case 0x12:
+  case 0x13:
+  case 0x1A:
+  case 0x1B:
+  case 0x22:
+  case 0x23:
+  case 0x2A:
+  case 0x2B:
+  case 0x32:
+  case 0x33: return true;
+  default: break;
+  }
+
+  return false;
+}
+
+static void LogInvalidLockPrefix(uint64_t InstAddress, const X86Tables::DecodedInst* DecodedInfo, const X86Tables::X86InstInfo* TableInfo) {
+  std::array<uint8_t, 8> Bytes {};
+  const auto ByteCount = std::min<size_t>(DecodedInfo->InstSize, Bytes.size());
+  memcpy(Bytes.data(), reinterpret_cast<const void*>(InstAddress), ByteCount);
+
+  LogMan::Msg::EFmt(
+    "Invalid LOCK prefix at 0x{:x}{{'{}'}} flags=0x{:08x} op=0x{:04x} size={} byte_count={} bytes={:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x}",
+    InstAddress, TableInfo && TableInfo->Name ? TableInfo->Name : "UND", DecodedInfo->Flags, DecodedInfo->OP, DecodedInfo->InstSize, ByteCount,
+    Bytes[0], Bytes[1], Bytes[2], Bytes[3], Bytes[4], Bytes[5], Bytes[6], Bytes[7]);
+}
+
 bool ContextImpl::IsAddressInCurrentBlock(FEXCore::Core::InternalThreadState* Thread, uint64_t Address, uint64_t Size) {
   auto [_, InlineTail] = GetFrameBlockInfo(Thread->CurrentFrame);
   return InlineTail && (Address + Size > InlineTail->RIP && Address < InlineTail->RIP + InlineTail->GuestSize);
@@ -660,7 +708,15 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
           Thread->OpDispatcher->SetCurrentCodeBlock(NextOpBlock);
         }
 
-        if (TableInfo && TableInfo->OpcodeDispatcher.OpDispatch) {
+        if (IsInvalidLockPrefix(DecodedInfo, TableInfo)) {
+          LogInvalidLockPrefix(InstAddress, DecodedInfo, TableInfo);
+
+          if (!BlockInstructionsLength) {
+            Thread->OpDispatcher->InvalidOp(DecodedInfo);
+          }
+
+          HadInvalidInst = true;
+        } else if (TableInfo && TableInfo->OpcodeDispatcher.OpDispatch) {
           auto Fn = TableInfo->OpcodeDispatcher.OpDispatch;
           Thread->OpDispatcher->ResetHandledLock();
           Thread->OpDispatcher->ResetDecodeFailure();

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3449,30 +3449,38 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::LODSOp(OpcodeArgs) {
-  if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE) {
-    LogMan::Msg::EFmt("LODSOp: Can't handle address size override (OP: 0x{:04X}, Flags: 0x{:08X})", Op->OP, Op->Flags);
+  if (!Is64BitMode && (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE)) {
+    LogMan::Msg::EFmt("LODSOp: Address size override (0x67) not supported in 32-bit mode (PC: 0x{:x}, OP: 0x{:04X}, Flags: 0x{:08X})",
+                      Op->PC, Op->OP, Op->Flags);
     DecodeFailure = true;
     return;
   }
 
   const auto Size = OpSizeFromSrc(Op);
+  OpSize AddrSize = GetStringOpSize(Op);
   const bool Repeat = (Op->Flags & (FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX | FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX)) != 0;
 
   if (!Repeat) {
-    Ref Dest_RSI = MakeSegmentAddress(X86State::REG_RSI, Op->Flags, X86Tables::DecodeFlags::FLAG_DS_PREFIX);
+    Ref Src_RSI = LoadGPRRegister(X86State::REG_RSI, AddrSize);
+    Ref Dest_RSI = AppendSegmentOffset(Src_RSI, Op->Flags, X86Tables::DecodeFlags::FLAG_DS_PREFIX);
 
     auto Src = _LoadMemGPRAutoTSO(Size, Dest_RSI, Size);
 
     StoreResultGPR(Op, Src);
 
     // Offset the pointer
-    Ref TailDest_RSI = LoadGPRRegister(X86State::REG_RSI);
-    StoreGPRRegister(X86State::REG_RSI, OffsetByDir(TailDest_RSI, IR::OpSizeToSize(Size)));
+    Ref TailDest_RSI = OffsetByDir(Src_RSI, IR::OpSizeToSize(Size));
+    if (Is64BitMode && AddrSize == OpSize::i32Bit) {
+      TailDest_RSI = _Bfe(OpSize::i64Bit, 32, 0, TailDest_RSI);
+      StoreGPRRegister(X86State::REG_RSI, TailDest_RSI);
+    } else {
+      StoreGPRRegister(X86State::REG_RSI, TailDest_RSI, AddrSize);
+    }
   } else {
     // Calculate flags early. because end of block
     CalculateDeferredFlags();
 
-    ForeachDirection([this, Op, Size](int32_t PtrDir) {
+    ForeachDirection([this, Op, Size, AddrSize](int32_t PtrDir) {
       // XXX: Theoretically LODS could be optimized to
       // RSI += {-}(RCX * Size)
       // RAX = [RSI - Size]
@@ -3500,14 +3508,14 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
 
       // Working loop
       {
-        Ref Dest_RSI = MakeSegmentAddress(X86State::REG_RSI, Op->Flags, X86Tables::DecodeFlags::FLAG_DS_PREFIX);
+        Ref Src_RSI = LoadGPRRegister(X86State::REG_RSI, AddrSize);
+        Ref Dest_RSI = AppendSegmentOffset(Src_RSI, Op->Flags, X86Tables::DecodeFlags::FLAG_DS_PREFIX);
 
         auto Src = _LoadMemGPRAutoTSO(Size, Dest_RSI, Size);
 
         StoreResultGPR(Op, Src);
 
         Ref TailCounter = LoadGPRRegister(X86State::REG_RCX);
-        Ref TailDest_RSI = LoadGPRRegister(X86State::REG_RSI);
 
         // Decrement counter
         TailCounter = Sub(OpSize::i64Bit, TailCounter, 1);
@@ -3516,8 +3524,13 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
         StoreGPRRegister(X86State::REG_RCX, TailCounter);
 
         // Offset the pointer
-        TailDest_RSI = Add(OpSize::i64Bit, TailDest_RSI, PtrDir * static_cast<int32_t>(IR::OpSizeToSize(Size)));
-        StoreGPRRegister(X86State::REG_RSI, TailDest_RSI);
+        Ref TailDest_RSI = Add(AddrSize, Src_RSI, PtrDir * static_cast<int32_t>(IR::OpSizeToSize(Size)));
+        if (Is64BitMode && AddrSize == OpSize::i32Bit) {
+          TailDest_RSI = _Bfe(OpSize::i64Bit, 32, 0, TailDest_RSI);
+          StoreGPRRegister(X86State::REG_RSI, TailDest_RSI);
+        } else {
+          StoreGPRRegister(X86State::REG_RSI, TailDest_RSI, AddrSize);
+        }
 
         // Jump back to the start, we have more work to do
         Jump(LoopStart);

--- a/unittests/ASM/Primary/Primary_AD_addrmod.asm
+++ b/unittests/ASM/Primary/Primary_AD_addrmod.asm
@@ -1,0 +1,23 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000089ABCDEF",
+    "RSI": "0x00000000E8000004"
+  },
+  "MemoryRegions": {
+    "0xE8000000": "4096"
+  }
+}
+%endif
+
+; Check LODSD with 0x67 address-size override in 64-bit mode.
+; The load and post-increment must use ESI, and the RSI writeback must zero-extend.
+
+mov rsi, 0x12345678E8000000
+mov rdx, 0xE8000000
+mov dword [rdx], 0x89ABCDEF
+
+db 0x67
+lodsd
+
+hlt


### PR DESCRIPTION
## Summary

This handles two x86 instruction edge cases that showed up while debugging the Windows loader path:

- `LODS` with an address-size override in 64-bit mode
- clearly invalid `LOCK` prefixes that should raise an invalid-op path instead of being reported as missing lock-handler coverage

This addresses #5399.

## What changed

- Allow `LODS` in 64-bit mode to honor `0x67` address-size override semantics.
- Use 32-bit `ESI` address calculation for overridden `LODS`, then zero-extend the `RSI` writeback.
- Keep 32-bit mode `LODS` address-size override unsupported, matching the existing string-op guard style.
- Detect invalid `LOCK` prefix forms before opcode dispatch for:
  - `LOCK MOV`
  - register-destination ALU encodings such as `LOCK ADD reg, [mem]`
- Add an ASM test for `0x67 lodsd` to verify the load address and `RSI` writeback behavior.

## Why

The loader path hit `0x67 lodsd` while running in 64-bit mode. x86-64 defines the address-size override for string operations, so this should use the 32-bit string address register rather than failing decode.

The same investigation also exposed invalid `LOCK` prefixes. Those should be treated as invalid guest instructions when the form is architecturally invalid, rather than falling through to the generic "Missing LOCK HANDLER" diagnostic.

## Notes

- The `LOCK` handling here is intentionally narrow. It does not try to classify every possible invalid `LOCK` prefix form.
- Valid locked memory forms continue to use the existing opcode-handler paths.
- The new `LOCK` pre-check only handles forms that are clearly invalid before dispatch.

## Validation

- Changed files are limited to:
  - `FEXCore/Source/Interface/Core/Core.cpp`
  - `FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp`
  - `unittests/ASM/Primary/Primary_AD_addrmod.asm`
- The new ASM test assembles under the FEX harness pattern with `BITS 64` prepended and a trailing `ret` appended.
