### PR TITLE
OpcodeDispatcher: Fixes 64-bit LODs with address size override 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3449,30 +3449,38 @@ void OpDispatchBuilder::CMPSOp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::LODSOp(OpcodeArgs) {
-  if (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE) {
-    LogMan::Msg::EFmt("LODSOp: Can't handle address size override (OP: 0x{:04X}, Flags: 0x{:08X})", Op->OP, Op->Flags);
+  if (!Is64BitMode && (Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_ADDRESS_SIZE)) {
+    LogMan::Msg::EFmt("LODSOp: Address size override (0x67) not supported in 32-bit mode (OP: 0x{:04X}).", Op->OP);
     DecodeFailure = true;
     return;
   }
 
   const auto Size = OpSizeFromSrc(Op);
+  OpSize AddrSize = GetStringOpSize(Op);
+
   const bool Repeat = (Op->Flags & (FEXCore::X86Tables::DecodeFlags::FLAG_REP_PREFIX | FEXCore::X86Tables::DecodeFlags::FLAG_REPNE_PREFIX)) != 0;
 
   if (!Repeat) {
-    Ref Dest_RSI = MakeSegmentAddress(X86State::REG_RSI, Op->Flags, X86Tables::DecodeFlags::FLAG_DS_PREFIX);
+    Ref Src_RSI = LoadGPRRegister(X86State::REG_RSI, AddrSize);
+    Ref Dest_RSI = AppendSegmentOffset(Src_RSI, 0, X86Tables::DecodeFlags::FLAG_DS_PREFIX, true);
 
     auto Src = _LoadMemGPRAutoTSO(Size, Dest_RSI, Size);
 
     StoreResultGPR(Op, Src);
 
     // Offset the pointer
-    Ref TailDest_RSI = LoadGPRRegister(X86State::REG_RSI);
-    StoreGPRRegister(X86State::REG_RSI, OffsetByDir(TailDest_RSI, IR::OpSizeToSize(Size)));
+    Ref TailDest_RSI = OffsetByDir(Src_RSI, IR::OpSizeToSize(Size));
+    if (Is64BitMode && AddrSize == OpSize::i32Bit) {
+      TailDest_RSI = _Bfe(OpSize::i64Bit, 32, 0, TailDest_RSI);
+      StoreGPRRegister(X86State::REG_RSI, TailDest_RSI);
+    } else {
+      StoreGPRRegister(X86State::REG_RSI, TailDest_RSI, AddrSize);
+    }
   } else {
     // Calculate flags early. because end of block
     CalculateDeferredFlags();
 
-    ForeachDirection([this, Op, Size](int32_t PtrDir) {
+    ForeachDirection([this, Op, Size, AddrSize](int32_t PtrDir) {
       // XXX: Theoretically LODS could be optimized to
       // RSI += {-}(RCX * Size)
       // RAX = [RSI - Size]
@@ -3500,7 +3508,8 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
 
       // Working loop
       {
-        Ref Dest_RSI = MakeSegmentAddress(X86State::REG_RSI, Op->Flags, X86Tables::DecodeFlags::FLAG_DS_PREFIX);
+        Ref Src_RSI = LoadGPRRegister(X86State::REG_RSI, AddrSize);
+        Ref Dest_RSI = AppendSegmentOffset(Src_RSI, 0, X86Tables::DecodeFlags::FLAG_DS_PREFIX, true);
 
         auto Src = _LoadMemGPRAutoTSO(Size, Dest_RSI, Size);
 
@@ -3516,8 +3525,13 @@ void OpDispatchBuilder::LODSOp(OpcodeArgs) {
         StoreGPRRegister(X86State::REG_RCX, TailCounter);
 
         // Offset the pointer
-        TailDest_RSI = Add(OpSize::i64Bit, TailDest_RSI, PtrDir * static_cast<int32_t>(IR::OpSizeToSize(Size)));
-        StoreGPRRegister(X86State::REG_RSI, TailDest_RSI);
+        TailDest_RSI = Add(AddrSize, TailDest_RSI, PtrDir * static_cast<int32_t>(IR::OpSizeToSize(Size)));
+        if (Is64BitMode && AddrSize == OpSize::i32Bit) {
+          TailDest_RSI = _Bfe(OpSize::i64Bit, 32, 0, TailDest_RSI);
+          StoreGPRRegister(X86State::REG_RSI, TailDest_RSI);
+        } else {
+          StoreGPRRegister(X86State::REG_RSI, TailDest_RSI, AddrSize);
+        }
 
         // Jump back to the start, we have more work to do
         Jump(LoopStart);

--- a/unittests/ASM/FEX_bugs/a32_lods.asm
+++ b/unittests/ASM/FEX_bugs/a32_lods.asm
@@ -1,0 +1,32 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x4142434445464748",
+    "RSI": "0x0000000000080008"
+  },
+  "MemoryRegions": {
+    "0x000080000": "4096",
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; FEX-Emu had a bug where it wouldn't do address-size override on lods.
+
+; Address that overlaps the two memory regions depending on if you mask the upper bits or not.
+; LODS operation needs to exist in rsi.
+mov rsi, 0x1_0008_0000
+mov rsp, 0x0_0008_0000
+mov rdx, 0x1_0000_0000
+mov rbx, 0x4142434445464748
+mov rcx, 0x5152535455565758
+mov rax, 0
+
+mov [rsp], rbx
+mov [rdx], rcx
+
+; Load with address size override.
+; Should truncate the upper bits of the address.
+a32 lodsq
+
+hlt

--- a/unittests/ASM/FEX_bugs/a32_rep_lods.asm
+++ b/unittests/ASM/FEX_bugs/a32_rep_lods.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x5152535455565758",
+    "RSI": "0x0000000000081000"
+  },
+  "MemoryRegions": {
+    "0x000080000": "4096",
+    "0x100000000": "4096"
+  }
+}
+%endif
+
+; FEX-Emu had a bug where it wouldn't do address-size override on lods.
+
+; Address that overlaps the two memory regions depending on if you mask the upper bits or not.
+; LODS operation needs to exist in rsi.
+mov rsi, 0x1_0008_0000
+mov rsp, 0x0_0008_0000
+mov rdx, 0x1_0000_0000
+mov rbx, 0x4142434445464748
+mov rcx, 0x5152535455565758
+mov rax, 0
+
+; Initialize the data
+.top:
+  mov [rsp + rax], rbx
+  mov [rdx + rax], rcx
+  add rax, 8
+  cmp rax, 4096
+jne .top
+
+; Invert the final store
+mov [rsp + rax - 8], rcx
+mov [rdx + rax - 8], rbx
+
+mov rcx, (4096 / 8)
+
+; REP Load with address size override.
+; Should truncate the upper bits of the address.
+a32 rep lodsq
+
+hlt


### PR DESCRIPTION
Fairly trivial but just need to be careful with address size wraparound
as usual.

Brought to attention by #5535, apparently WoW uses this or something. Adds unittests to ensure the behaviour is correct.