### PR TITLE
Windows: handle generic executable map-view notifications

### DIFF
--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -280,11 +280,21 @@ void InitSyscalls() {
   PatchCallChecker();
 }
 
-void HandleImageMap(uint64_t Address, bool MainImage = false) {
+bool HandleImageMap(uint64_t Address, bool MainImage = false) {
+  auto* Nt = RtlImageNtHeader(reinterpret_cast<HMODULE>(Address));
+  if (!Nt || Nt->Signature != IMAGE_NT_SIGNATURE) {
+    return false;
+  }
+
   fextl::string ModulePath = FEX::Windows::GetSectionFilePath(Address);
   fextl::string ModuleName = fextl::string {FEX::Windows::BaseName(ModulePath)};
   InvalidationTracker->HandleImageMap(ModuleName, Address);
   ImageTracker->HandleImageMap(ModulePath, Address, MainImage);
+  return true;
+}
+
+bool IsLikelyMapViewNotification(uint64_t Address, uint64_t Size, ULONG Prot) {
+  return Address && Size && !(Address + Size < Address) && Prot;
 }
 
 void HandleImageUnmap(uint64_t Address, uint64_t Size) {
@@ -838,7 +848,14 @@ NTSTATUS NotifyMapViewOfSection(void* Unk1, void* Address, void* Unk2, SIZE_T Si
 
   {
     std::scoped_lock Lock(ThreadCreationMutex);
-    HandleImageMap(reinterpret_cast<uint64_t>(Address));
+    const uint64_t GuestAddress = reinterpret_cast<uint64_t>(Address);
+    const uint64_t GuestSize = static_cast<uint64_t>(Size);
+
+    if (!HandleImageMap(GuestAddress) && IsLikelyMapViewNotification(GuestAddress, GuestSize, Prot)) {
+      LogMan::Msg::DFmt("[WOWNT] arm64ec.mapview.generic addr=0x{:X} size=0x{:X} prot=0x{:X} alloc=0x{:X}",
+                        GuestAddress, GuestSize, Prot, AllocType);
+      InvalidationTracker->HandleMemoryProtectionNotification(GuestAddress, GuestSize, Prot);
+    }
   }
 
 

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -172,11 +172,21 @@ bool IsAddressInJit(uint64_t Address) {
   return Thread->CTX->IsAddressInCodeBuffer(Thread, Address);
 }
 
-void HandleImageMap(uint64_t Address, bool MainImage = false) {
+bool HandleImageMap(uint64_t Address, bool MainImage = false) {
+  auto* Nt = RtlImageNtHeader(reinterpret_cast<HMODULE>(Address));
+  if (!Nt || Nt->Signature != IMAGE_NT_SIGNATURE) {
+    return false;
+  }
+
   fextl::string ModulePath = FEX::Windows::GetSectionFilePath(Address);
   fextl::string ModuleName = fextl::string {FEX::Windows::BaseName(ModulePath)};
   InvalidationTracker->HandleImageMap(ModuleName, Address);
   ImageTracker->HandleImageMap(ModulePath, Address, MainImage);
+  return true;
+}
+
+bool IsLikelyMapViewNotification(uint64_t Address, uint64_t Size, ULONG Prot) {
+  return Address && Size && !(Address + Size < Address) && Prot;
 }
 
 void HandleImageUnmap(uint64_t Address, uint64_t Size) {
@@ -1006,7 +1016,14 @@ void BTCpuNotifyMemoryFree(void* Address, SIZE_T Size, ULONG FreeType, BOOL Afte
 
 NTSTATUS BTCpuNotifyMapViewOfSection(void* Unk1, void* Address, void* Unk2, SIZE_T Size, ULONG AllocType, ULONG Prot) {
   std::scoped_lock Lock(ThreadCreationMutex);
-  HandleImageMap(reinterpret_cast<uint64_t>(Address));
+  const uint64_t GuestAddress = reinterpret_cast<uint64_t>(Address);
+  const uint64_t GuestSize = static_cast<uint64_t>(Size);
+
+  if (!HandleImageMap(GuestAddress) && IsLikelyMapViewNotification(GuestAddress, GuestSize, Prot)) {
+    LogMan::Msg::DFmt("[WOWNT] wow64.mapview.generic addr=0x{:X} size=0x{:X} prot=0x{:X} alloc=0x{:X}",
+                      GuestAddress, GuestSize, Prot, AllocType);
+    InvalidationTracker->HandleMemoryProtectionNotification(GuestAddress, GuestSize, Prot);
+  }
   return STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
## Summary

This is a draft/RFC PR from the investigation in #5399. While debugging the WoW NoExec failure path, I found a case where Wine can report a successful executable mapped-section view that is not a PE image mapping. FEX currently routes `NotifyMapViewOfSection` through image-map handling, so this kind of executable `MEM_MAPPED` view can miss the normal executable interval/protection tracking path.

This PR contains only the FEX-side part of the experiment. I am opening it as a draft because the full behavior depends on Wine/FEX cooperation, and I would like guidance on whether this is the expected place to handle these notifications.

## What changed

- Make ARM64EC and WOW64 `HandleImageMap()` reject non-PE mappings instead of treating every map-view notification as an image map.
- For non-image map-view notifications that still look like valid mapped ranges, route the range through `InvalidationTracker->HandleMemoryProtectionNotification(...)`.
- Keep image map handling unchanged for real PE images.

## Why

The failing path observed during #5399 had executable `MEM_MAPPED` guest pages visible to Wine/Windows state, but FEX did not have a matching executable interval for the page. In the local diagnostic build this showed up as NoExec entry-block failures, for example:

```text
E B4 NoExec instruction in entry block: 1A2163D
E B4 NoExec instruction in entry block: 1A20539
```

With the paired Wine-side diagnostic change, Wine reports executable non-image section views through the existing backend memory-protect callback. Example diagnostic evidence from the local run:

```text
notify_map_view_of_section wine.mapview.exec-protect-shim addr=0000000001A60000 size=1048576 protect=0x20 alloc=0 status=0
```

The FEX-side change in this PR makes those generic map-view notifications update the executable/protection interval state instead of being dropped by image-only handling.

## Cross-repo concern

This is the part I would like guidance on. The local fix involved both sides:

- Wine side: reusing the existing memory-protect backend callback for successful executable non-image map views.
- FEX side: accepting non-PE map-view notifications as generic protection updates.

I am not sure whether this is the intended contract for `NotifyMapViewOfSection`, or whether FEX would prefer a different Wine callback/ABI shape, a Wine-only change, or a different FEX-side path. Please treat this PR as a request for review of the approach rather than a final proposal.

## Question

What would be the preferred upstream shape for this fix: keep this FEX-side handling, move more of the responsibility to Wine, split this into coordinated Wine and FEX PRs, or use a different notification path entirely?
