### PR TITLE
Frontend: Fix vsyscall page tracking. 

### DIFF
--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -124,9 +124,9 @@ uint8_t Decoder::ReadByte() {
 }
 
 std::optional<uint8_t> Decoder::PeekByte(uint8_t Offset) {
-  uint64_t ByteAddress = reinterpret_cast<uint64_t>(InstStream + InstructionSize + Offset);
+  uint64_t ByteAddress = reinterpret_cast<uint64_t>(InstStream.InstStream + InstructionSize + Offset);
   if (CheckRangeExecutable(ByteAddress, 1)) {
-    return InstStream[InstructionSize + Offset];
+    return InstStream.AdjustedInstStream[InstructionSize + Offset];
   } else {
     return std::nullopt;
   }
@@ -136,9 +136,9 @@ std::pair<uint64_t, bool> Decoder::ReadData(uint8_t Size) {
   LOGMAN_THROW_A_FMT(Size != 0 && Size <= sizeof(uint64_t), "Unknown data size to read");
 
   uint64_t Res = 0;
-  uint64_t Address = reinterpret_cast<uint64_t>(InstStream + InstructionSize);
+  uint64_t Address = reinterpret_cast<uint64_t>(InstStream.InstStream + InstructionSize);
   if (CheckRangeExecutable(Address, Size)) {
-    std::memcpy(&Res, &InstStream[InstructionSize], Size);
+    std::memcpy(&Res, &InstStream.AdjustedInstStream[InstructionSize], Size);
   } else {
     HitNonExecutableRange = true;
     // See PeekByte, this specific case may cause some executable memory to read as 0 but it doesn't matter as the entire instruction will be rolled back anyway.
@@ -1341,7 +1341,7 @@ void Decoder::AddBranchTarget(uint64_t Target) {
   }
 }
 
-const uint8_t* Decoder::AdjustAddrForSpecialRegion(const uint8_t* _InstStream, uint64_t EntryPoint, uint64_t RIP) {
+const Decoder::DecodeStream Decoder::AdjustAddrForSpecialRegion(const uint8_t* _InstStream, uint64_t EntryPoint, uint64_t RIP) {
   constexpr uint64_t VSyscall_Base = 0xFFFF'FFFF'FF60'0000ULL;
   constexpr uint64_t VSyscall_End = VSyscall_Base + 0x1000;
 
@@ -1352,10 +1352,16 @@ const uint8_t* Decoder::AdjustAddrForSpecialRegion(const uint8_t* _InstStream, u
     // Offset 0x400: vtime
     // Offset 0x800: vgetcpu
     uint64_t Offset = RIP - VSyscall_Base;
-    return VSyscallData + Offset;
+    return DecodeStream {
+      .InstStream = _InstStream - EntryPoint + RIP,
+      .AdjustedInstStream = VSyscallData + Offset,
+    };
   }
 
-  return _InstStream - EntryPoint + RIP;
+  return DecodeStream {
+    .InstStream = _InstStream - EntryPoint + RIP,
+    .AdjustedInstStream = _InstStream - EntryPoint + RIP,
+  };
 }
 
 bool Decoder::CheckIfCacheable(FEXCore::Core::InternalThreadState& Thread, const uint8_t* InstStream, uint64_t PC, uint64_t MaxInst) {
@@ -1383,7 +1389,6 @@ void Decoder::DecodeInstructionsAtEntry(FEXCore::Core::InternalThreadState* Thre
 
   EntryPoint = PC;
   BlockInfo.EntryPoints = {PC};
-  InstStream = _InstStream;
 
   uint64_t TotalInstructions {};
 

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -56,6 +56,7 @@ public:
 
   Decoder(FEXCore::Core::InternalThreadState* Thread);
   bool CheckIfCacheable(FEXCore::Core::InternalThreadState&, const uint8_t* InstStream, uint64_t PC, uint64_t MaxInst);
+
   void DecodeInstructionsAtEntry(FEXCore::Core::InternalThreadState* Thread, const uint8_t* InstStream, uint64_t PC, uint64_t MaxInst);
 
   const DecodedBlockInformation* GetDecodedBlockInfo() const {
@@ -127,7 +128,27 @@ private:
   bool HitNonExecutableRange {};
   bool HitBadRelocation {};
 
-  const uint8_t* InstStream {};
+  struct DecodeStream {
+    // Original instruction stream RIP location.
+    const uint8_t* InstStream;
+
+    // Adjusted location for FEX actually decodes from.
+    const uint8_t* AdjustedInstStream;
+
+    DecodeStream& operator-=(size_t offset) noexcept {
+      InstStream -= offset;
+      AdjustedInstStream -= offset;
+      return *this;
+    }
+
+    DecodeStream& operator+=(size_t offset) noexcept {
+      InstStream += offset;
+      AdjustedInstStream += offset;
+      return *this;
+    }
+  };
+
+  DecodeStream InstStream;
   IR::OpSize GetGPROpSize() const {
     return BlockInfo.Is64BitMode ? IR::OpSize::i64Bit : IR::OpSize::i32Bit;
   }
@@ -169,6 +190,6 @@ private:
   const std::array<X86Tables::X86InstInfo, X86Tables::MAX_VEX_TABLE_SIZE>* VEXTable {};
   const std::array<X86Tables::X86InstInfo, X86Tables::MAX_VEX_GROUP_TABLE_SIZE>* VEXTableGroup {};
 
-  const uint8_t* AdjustAddrForSpecialRegion(const uint8_t* _InstStream, uint64_t EntryPoint, uint64_t RIP);
+  const DecodeStream AdjustAddrForSpecialRegion(const uint8_t* _InstStream, uint64_t EntryPoint, uint64_t RIP);
 };
 } // namespace FEXCore::Frontend

--- a/Source/Tools/FEXInterpreter/ELFCodeLoader.h
+++ b/Source/Tools/FEXInterpreter/ELFCodeLoader.h
@@ -645,6 +645,11 @@ public:
 
     if (Is64BitMode()) {
       AuxVariables.emplace_back(auxv_t {4, 0x38}); // AT_PHENT
+
+      // 64-bit vsyscall entry points are hardcoded to a single page at 0xffffffffff600000.
+      // FEX can't actually map anything there so it is a hardcoded quirk, similar to how the kernel traps these executions.
+      // Just track it as a mapped anonymous executable page.
+      Handler->AddVirtualPage(Thread, 0xFFFFFFFFFF600000ULL, FEXCore::Utils::FEX_PAGE_SIZE, PROT_READ | PROT_EXEC);
     } else {
       AuxVariables.emplace_back(auxv_t {4, 0x20}); // AT_PHENT
 

--- a/Source/Tools/FEXOfflineCompiler/Main.cpp
+++ b/Source/Tools/FEXOfflineCompiler/Main.cpp
@@ -64,6 +64,11 @@ public:
   uint64_t GuestMunmap(FEXCore::Core::InternalThreadState*, void* addr, uint64_t length) override {
     return munmap(addr, length);
   }
+
+  void AddVirtualPage(FEXCore::Core::InternalThreadState* Thread, uint64_t addr, size_t length, int prot) override {
+    LogMan::Msg::AFmt("Can't Track mmap through here");
+    FEX_UNREACHABLE;
+  }
 };
 
 static void MsgHandler(LogMan::DebugLevels Level, const char* Message) {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -108,6 +108,8 @@ public:
 
   // does a guest munmap as if done via a guest syscall
   virtual uint64_t GuestMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, uint64_t length) = 0;
+
+  virtual void AddVirtualPage(FEXCore::Core::InternalThreadState* Thread, uint64_t addr, size_t length, int prot) = 0;
 };
 
 class SyscallHandler : public FEXCore::HLE::SyscallHandler,
@@ -254,6 +256,10 @@ public:
   std::optional<LateApplyExtendedVolatileMetadata> TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t addr, size_t length,
                                                              int prot, int flags, int fd, off_t offset,
                                                              std::optional<FEXCore::ExecutableFileSectionInfo>& CachedSection);
+
+  void AddVirtualPage(FEXCore::Core::InternalThreadState* Thread, uint64_t addr, size_t length, int prot) override;
+  using SyscallMmapInterface::AddVirtualPage;
+
   void TrackMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length);
   void TrackMremap(FEXCore::Core::InternalThreadState* Thread, uint64_t OldAddress, size_t OldSize, size_t NewSize, int flags, uint64_t NewAddress);
   void TrackShmat(FEXCore::Core::InternalThreadState* Thread, int shmid, uint64_t shmaddr, int shmflg, uint64_t Length);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
@@ -437,7 +437,6 @@ namespace x64 {
     REGISTER_SYSCALL_IMPL_X64(getsockopt, SyscallPassthrough5<SYSCALL_DEF(getsockopt)>);
     REGISTER_SYSCALL_IMPL_X64(wait4, SyscallPassthrough4<SYSCALL_DEF(wait4)>);
     REGISTER_SYSCALL_IMPL_X64(semop, SyscallPassthrough3<SYSCALL_DEF(semop)>);
-    REGISTER_SYSCALL_IMPL_X64(gettimeofday, SyscallPassthrough2<SYSCALL_DEF(gettimeofday)>);
     REGISTER_SYSCALL_IMPL_X64(getrlimit, SyscallPassthrough2<SYSCALL_DEF(getrlimit)>);
     REGISTER_SYSCALL_IMPL_X64(getrusage, SyscallPassthrough2<SYSCALL_DEF(getrusage)>);
     REGISTER_SYSCALL_IMPL_X64(sysinfo, SyscallPassthrough1<SYSCALL_DEF(sysinfo)>);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -721,6 +721,12 @@ SyscallHandler::TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t a
   return VolatileMetadata;
 }
 
+void SyscallHandler::AddVirtualPage(FEXCore::Core::InternalThreadState* Thread, uint64_t addr, size_t length, int prot) {
+  auto lk = FEXCore::GuardSignalDeferringSectionWithFallback(VMATracking.Mutex, Thread);
+  VMATracking.TrackVMARange(CTX, nullptr, addr, 0, length, VMATracking::VMAFlags::fromFlags(MAP_ANONYMOUS | MAP_PRIVATE),
+                            VMATracking::VMAProt::fromProt(prot));
+}
+
 void SyscallHandler::TrackMunmap(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t length) {
   uint64_t Size = FEXCore::AlignUp(length, FEXCore::Utils::FEX_PAGE_SIZE);
   VMATracking.DeleteVMARange(CTX, reinterpret_cast<uintptr_t>(addr), Size);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Time.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Time.cpp
@@ -22,6 +22,16 @@ $end_info$
 namespace FEX::HLE::x64 {
 void RegisterTime(FEX::HLE::SyscallHandler* Handler) {
   using namespace FEXCore::IR;
+
+  REGISTER_SYSCALL_IMPL_X64(gettimeofday, [](FEXCore::Core::CpuStateFrame* Frame, timeval* tv, struct timezone* tz) -> uint64_t {
+    FaultSafeUserMemAccess::VerifyIsWritableOrNull(tv, sizeof(*tv));
+    FaultSafeUserMemAccess::VerifyIsWritableOrNull(tz, sizeof(*tz));
+
+    // Passed through glibc to ensure vdso is used if possible.
+    uint64_t Result = ::gettimeofday(tv, tz);
+    SYSCALL_ERRNO();
+  });
+
   REGISTER_SYSCALL_IMPL_X64(time, [](FEXCore::Core::CpuStateFrame* Frame, time_t* tloc) -> uint64_t {
     FaultSafeUserMemAccess::VerifyIsWritableOrNull(tloc, sizeof(time_t));
     uint64_t Result = ::time(tloc);

--- a/unittests/FEXLinuxTests/tests/syscalls/vsyscall.64.cpp
+++ b/unittests/FEXLinuxTests/tests/syscalls/vsyscall.64.cpp
@@ -1,0 +1,26 @@
+#include <cstdint>
+#include <sys/time.h>
+
+using gettime_type = int (*)(struct timeval* tv, struct timezone* tz);
+gettime_type gettimeofday_vsyscall = (gettime_type)0xFFFF'FFFF'FF60'0000ULL;
+
+using time_type = int (*)(time_t* tloc);
+time_type time_vsyscall = (time_type)0xFFFF'FFFF'FF60'0400ULL;
+
+using getcpu_type = int (*)(uint32_t* cpu, uint32_t* node);
+getcpu_type getcpu_vsyscall = (getcpu_type)0xFFFF'FFFF'FF60'0800ULL;
+
+int main() {
+  // This test just ensures that these vsyscalls execute without crashing.
+  // FEX has broken vsyscalls periodically.
+  timeval tv {};
+  gettimeofday_vsyscall(&tv, nullptr);
+
+  time_t tloc {};
+  time_vsyscall(&tloc);
+
+  uint32_t cpu, node;
+  getcpu_vsyscall(&cpu, &node);
+
+  return 0;
+}


### PR DESCRIPTION
Now that NX is tracked in the frontend, we need to ensure that adjusted
RIP pages are tracked correctly. Keep around both instruction stream
pointers, validate the the original RIP is executable, and read from the
adjusted RIP as appropriate.

Fixes https://github.com/FEX-Emu/FEX/issues/5544