### PR TITLE
OpcodeDispatcher: Eliminate redundant moves in VMOVHPOp

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -122,8 +122,8 @@ void OpDispatchBuilder::MOVHPDOp(OpcodeArgs) {
 
 void OpDispatchBuilder::VMOVHPOp(OpcodeArgs) {
   if (Op->Dest.IsGPR()) {
-    Ref Src1 = LoadSourceFPR(Op, Op->Src[0], Op->Flags, {.Align = OpSize::i128Bit});
-    Ref Src2 = LoadSourceFPR(Op, Op->Src[1], Op->Flags, {.Align = OpSize::i64Bit});
+    Ref Src1 = LoadSourceFPR(Op, Op->Src[0], Op->Flags, {.Align = OpSize::i128Bit, .AllowUpperGarbage = true});
+    Ref Src2 = LoadSourceFPR(Op, Op->Src[1], Op->Flags, {.Align = OpSize::i64Bit, .AllowUpperGarbage = true});
     Ref Result = _VInsElement(OpSize::i128Bit, OpSize::i64Bit, 1, 0, Src1, Src2);
 
     StoreResultFPR(Op, Result);

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -398,39 +398,35 @@
       ]
     },
     "vmovhps xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b00 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.8b, v17.8b",
-        "ldr d3, [x4]",
-        "mov v16.16b, v2.16b",
-        "mov v16.d[1], v3.d[0]"
+        "ldr d2, [x4]",
+        "mov v16.16b, v17.16b",
+        "mov v16.d[1], v2.d[0]"
       ]
     },
     "vmovhpd xmm0, xmm1, [rax]": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 1 0b01 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.8b, v17.8b",
-        "ldr d3, [x4]",
-        "mov v16.16b, v2.16b",
-        "mov v16.d[1], v3.d[0]"
+        "ldr d2, [x4]",
+        "mov v16.16b, v17.16b",
+        "mov v16.d[1], v2.d[0]"
       ]
     },
     "vmovlhps xmm0, xmm1, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0x16 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.8b, v17.8b",
-        "mov v3.8b, v17.8b",
-        "mov v16.16b, v2.16b",
-        "mov v16.d[1], v3.d[0]"
+        "mov v16.16b, v17.16b",
+        "mov v16.d[1], v17.d[0]"
       ]
     },
     "vmovshdup xmm0, [rax]": {


### PR DESCRIPTION
Will make removing the TODO in LoadSource regarding partial loads a little easier.