### PR TITLE
[SVE256] Vector: Handle SSE insertion properly for various ALU operations

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -250,7 +250,7 @@ void OpDispatchBuilder::VectorALUOp(OpcodeArgs, IROps IROp, IR::OpSize ElementSi
 
   DeriveOp(ALUOp, IROp, _VAdd(Size, ElementSize, Dest, Src));
 
-  StoreResultFPR(Op, ALUOp);
+  StoreResult_WithAVXInsert(VectorOpType::SSE, RegClass::FPR, Op, ALUOp);
 }
 
 void OpDispatchBuilder::VectorXOROp(OpcodeArgs) {
@@ -298,7 +298,7 @@ void OpDispatchBuilder::VectorALUROp(OpcodeArgs, IROps IROp, IR::OpSize ElementS
 
   DeriveOp(ALUOp, IROp, _VAdd(Size, ElementSize, Src, Dest));
 
-  StoreResultFPR(Op, ALUOp);
+  StoreResult_WithAVXInsert(VectorOpType::SSE, RegClass::FPR, Op, ALUOp);
 }
 
 Ref OpDispatchBuilder::VectorScalarInsertALUOpImpl(OpcodeArgs, IROps IROp, IR::OpSize DstSize, IR::OpSize ElementSize,

--- a/unittests/ASM/SSELanePreservation/README.md
+++ b/unittests/ASM/SSELanePreservation/README.md
@@ -1,0 +1,10 @@
+These unit-tests aim to ensure that SSE operations won't accidentally overwrite the upper 128-bit lane
+on a system where SVE-256 is available. The underlying problem when handling SSE and AVX on an ARM system,
+is that Adv. SIMD on ARM will always zero-extend registers that are participating in an arithmetic operation
+(and others as well in some cases), whereas SSE on x86 does *not* perform this behavior. SSE leaves the upper
+half (or upper three quadwords, if using AVX-512) untouched.
+
+Therefore, to avoid the issue of the upper vector lanes being trounced, what we do is perform an insert
+if an SSE operation happens to execute on a system that has SVE-256, preserving data in the upper lanes.
+
+All of the tests in this folder aim to prevent changes where that guarantee is violated from slipping through.

--- a/unittests/ASM/SSELanePreservation/addpd.asm
+++ b/unittests/ASM/SSELanePreservation/addpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28fab3fa4a5", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4559bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+addpd xmm0, xmm1
+vaddpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/addps.asm
+++ b/unittests/ASM/SSELanePreservation/addps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28fab3fa4a5", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1b56970b", "0x45c9bd7eb4ea1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+addps xmm0, xmm1
+vaddps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/andnpd.asm
+++ b/unittests/ASM/SSELanePreservation/andnpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x0200085014004148", "0x8002306200286011", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+andnpd xmm0, xmm1
+vandnpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/andnps.asm
+++ b/unittests/ASM/SSELanePreservation/andnps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x0200085014004148", "0x8002306200286011", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+andnps xmm0, xmm1
+vandnps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/andpd.asm
+++ b/unittests/ASM/SSELanePreservation/andpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x41cc1286830b0401", "0x3d7c840812509782", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+andpd xmm0, xmm1
+vandpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/andps.asm
+++ b/unittests/ASM/SSELanePreservation/andps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x41cc1286830b0401", "0x3d7c840812509782", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+andps xmm0, xmm1
+vandps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/divpd.asm
+++ b/unittests/ASM/SSELanePreservation/divpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfa106897cab7a1f1", "0xffee049438178d88", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xfff0000000000000", "0x3ff0000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+divpd xmm0, xmm1
+vdivpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/divps.asm
+++ b/unittests/ASM/SSELanePreservation/divps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xf99484a853b0225a", "0xff7e16a463d68471", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xff8000003f800000", "0x3f8000003f800000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+divps xmm0, xmm1
+vdivps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/haddpd.asm
+++ b/unittests/ASM/SSELanePreservation/haddpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdec98f49ad20365", "0x43cc1ad6970b4549", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x4549ae5cce5ca72c", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+haddpd xmm0, xmm1
+vhaddpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/haddps.asm
+++ b/unittests/ASM/SSELanePreservation/haddps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x7d7ccd88fdecd28f", "0xbd7eb46a43cc1ad6", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x4549bd7ec4be43cc", "0x4549bd7e1ad6970b", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+haddps xmm0, xmm1
+vhaddps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/maxpd.asm
+++ b/unittests/ASM/SSELanePreservation/maxpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x43cc1ad6970b4549", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+maxpd xmm0, xmm1
+vmaxpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/maxps.asm
+++ b/unittests/ASM/SSELanePreservation/maxps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x43cc1ad6970b4549", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+maxps xmm0, xmm1
+vmaxps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/minpd.asm
+++ b/unittests/ASM/SSELanePreservation/minpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28fab3fa4a5", "0xbd7eb46a1278f793", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+minpd xmm0, xmm1
+vminpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/minps.asm
+++ b/unittests/ASM/SSELanePreservation/minps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28fab3fa4a5", "0xbd7eb46a1278f793", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+minps xmm0, xmm1
+vminps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/mulpd.asm
+++ b/unittests/ASM/SSELanePreservation/mulpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfff0000000000000", "0xfb0ba3134b0b9f10", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x848007bf3bd99e56", "0x4aa4b4781c8e9292", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+mulpd xmm0, xmm1
+vmulpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/mulps.asm
+++ b/unittests/ASM/SSELanePreservation/mulps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xff80000002d08487", "0xfb7b861609cae486", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x81498d7200000006", "0x4b1efb1c295605c5", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+mulps xmm0, xmm1
+vmulps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/orpd.asm
+++ b/unittests/ASM/SSELanePreservation/orpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xffecdadfbf3fe5ed", "0xfd7efdea36f8ffd3", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+orpd xmm0, xmm1
+vorpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/orps.asm
+++ b/unittests/ASM/SSELanePreservation/orps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xffecdadfbf3fe5ed", "0xfd7efdea36f8ffd3", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+orps xmm0, xmm1
+vorps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/paddb.asm
+++ b/unittests/ASM/SSELanePreservation/paddb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x40b8ec65424ae9ee", "0x3afa81f248489655", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be869834ac2e16", "0x8a927afc68d424f0", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+paddb xmm0, xmm1
+vpaddb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/paddd.asm
+++ b/unittests/ASM/SSELanePreservation/paddd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x41b8ed65424ae9ee", "0x3afb81f249499755", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be879835ad2e16", "0x8a937afc68d424f0", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+paddd xmm0, xmm1
+vpaddd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/paddq.asm
+++ b/unittests/ASM/SSELanePreservation/paddq.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x41b8ed66424ae9ee", "0x3afb81f249499755", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be879835ad2e16", "0x8a937afd68d424f0", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+paddq xmm0, xmm1
+vpaddq xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/paddsb.asm
+++ b/unittests/ASM/SSELanePreservation/paddsb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x40b8ec80804ae9ee", "0x3a7f81f248489680", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be7f9834ac8016", "0x7f7f807f807f247f", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+paddsb xmm0, xmm1
+vpaddsb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/paddsw.asm
+++ b/unittests/ASM/SSELanePreservation/paddsw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x41b8ed658000e9ee", "0x3afa81f249489755", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be7fff35ac8000", "0x7fff8000800024f0", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+paddsw xmm0, xmm1
+vpaddsw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/paddusb.asm
+++ b/unittests/ASM/SSELanePreservation/paddusb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xffffecffff4ae9ee", "0xfffafff248ffffff", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be86ff34ffff16", "0x8a92fffcffd424f0", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+paddusb xmm0, xmm1
+vpaddusb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/paddusw.asm
+++ b/unittests/ASM/SSELanePreservation/paddusw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xffffed65ffffe9ee", "0xffffffff4948ffff", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be879835acffff", "0x8a92ffffffff24f0", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+paddusw xmm0, xmm1
+vpaddusw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/paddw.asm
+++ b/unittests/ASM/SSELanePreservation/paddw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x41b8ed65424ae9ee", "0x3afa81f249489755", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be879835ac2e16", "0x8a927afc68d424f0", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+paddw xmm0, xmm1
+vpaddw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pand.asm
+++ b/unittests/ASM/SSELanePreservation/pand.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x41cc1286830b0401", "0x3d7c840812509782", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+pand xmm0, xmm1
+vpand xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pandn.asm
+++ b/unittests/ASM/SSELanePreservation/pandn.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x0200085014004148", "0x8002306200286011", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+pandn xmm0, xmm1
+vpandn xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pavgb.asm
+++ b/unittests/ASM/SSELanePreservation/pavgb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xa0dc76b3a1257577", "0x9d7dc17924a4cbab", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x625f43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pavgb xmm0, xmm1
+vpavgb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pavgw.asm
+++ b/unittests/ASM/SSELanePreservation/pavgw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xa0dc76b3a12574f7", "0x9d7dc0f924a4cbab", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x625f43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pavgw xmm0, xmm1
+vpavgw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pcmpeqb.asm
+++ b/unittests/ASM/SSELanePreservation/pcmpeqb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x0000000000000000", "0x0000000000000000", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000ffffffffffff", "0xffffffffffffffff", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pcmpeqb xmm0, xmm1
+vpcmpeqb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pcmpeqd.asm
+++ b/unittests/ASM/SSELanePreservation/pcmpeqd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x0000000000000000", "0x0000000000000000", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x00000000ffffffff", "0xffffffffffffffff", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pcmpeqd xmm0, xmm1
+vpcmpeqd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pcmpeqq.asm
+++ b/unittests/ASM/SSELanePreservation/pcmpeqq.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x0000000000000000", "0x0000000000000000", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000000000000000", "0xffffffffffffffff", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pcmpeqq xmm0, xmm1
+vpcmpeqq xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pcmpeqw.asm
+++ b/unittests/ASM/SSELanePreservation/pcmpeqw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x0000000000000000", "0x0000000000000000", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000ffffffffffff", "0xffffffffffffffff", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pcmpeqw xmm0, xmm1
+vpcmpeqw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pcmpgtb.asm
+++ b/unittests/ASM/SSELanePreservation/pcmpgtb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x00ff0000ffff0000", "0xff00ff00ff0000ff", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pcmpgtb xmm0, xmm1
+vpcmpgtb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pcmpgtd.asm
+++ b/unittests/ASM/SSELanePreservation/pcmpgtd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x00000000ffffffff", "0xffffffffffffffff", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pcmpgtd xmm0, xmm1
+vpcmpgtd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pcmpgtq.asm
+++ b/unittests/ASM/SSELanePreservation/pcmpgtq.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x0000000000000000", "0xffffffffffffffff", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pcmpgtq xmm0, xmm1
+vpcmpgtq xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pcmpgtw.asm
+++ b/unittests/ASM/SSELanePreservation/pcmpgtw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x00000000ffff0000", "0xffffffffffff0000", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pcmpgtw xmm0, xmm1
+vpcmpgtw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/phaddd.asm
+++ b/unittests/ASM/SSELanePreservation/phaddd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xb44d6d4aa92c7734", "0xcff7abfddad7601f", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xf9b3cff6df94dad7", "0xf9b3cff61ad6dad7", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+phaddd xmm0, xmm1
+vphaddd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/phaddw.asm
+++ b/unittests/ASM/SSELanePreservation/phaddw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x4b04d692d07b4fe4", "0x71e80a0b5ea2dc54", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x02c7c6e2088ab1e1", "0x02c7c6e243ccb1e1", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+phaddw xmm0, xmm1
+vphaddw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pmaxsb.asm
+++ b/unittests/ASM/SSELanePreservation/pmaxsb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x43ec1ad6ab3f4549", "0x7d7ecd6a3678f7c2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pmaxsb xmm0, xmm1
+vpmaxsb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pmaxsd.asm
+++ b/unittests/ASM/SSELanePreservation/pmaxsd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x43cc1ad6ab3fa4a5", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pmaxsd xmm0, xmm1
+vpmaxsd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pmaxsw.asm
+++ b/unittests/ASM/SSELanePreservation/pmaxsw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x43cc1ad6ab3f4549", "0x7d7ccd8836d0f793", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pmaxsw xmm0, xmm1
+vpmaxsw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pmaxub.asm
+++ b/unittests/ASM/SSELanePreservation/pmaxub.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd2d6ab3fa4a5", "0xbd7ecd8836d0f7c2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pmaxub xmm0, xmm1
+vpmaxub xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pmaxud.asm
+++ b/unittests/ASM/SSELanePreservation/pmaxud.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28fab3fa4a5", "0xbd7eb46a36d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pmaxud xmm0, xmm1
+vpmaxud xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pmaxuw.asm
+++ b/unittests/ASM/SSELanePreservation/pmaxuw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28fab3fa4a5", "0xbd7ecd8836d0f793", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pmaxuw xmm0, xmm1
+vpmaxuw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pminsb.asm
+++ b/unittests/ASM/SSELanePreservation/pminsb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdccd28f970ba4a5", "0xbd7cb48812d09f93", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pminsb xmm0, xmm1
+vpminsb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pminsd.asm
+++ b/unittests/ASM/SSELanePreservation/pminsd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28f970b4549", "0xbd7eb46a1278f793", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pminsd xmm0, xmm1
+vpminsd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pminsw.asm
+++ b/unittests/ASM/SSELanePreservation/pminsw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28f970ba4a5", "0xbd7eb46a12789fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pminsw xmm0, xmm1
+vpminsw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pminub.asm
+++ b/unittests/ASM/SSELanePreservation/pminub.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x43cc1a8f970b4549", "0x7d7cb46a12789f93", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pminub xmm0, xmm1
+vpminub xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pminud.asm
+++ b/unittests/ASM/SSELanePreservation/pminud.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x43cc1ad6970b4549", "0x7d7ccd881278f793", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pminud xmm0, xmm1
+vpminud xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pminuw.asm
+++ b/unittests/ASM/SSELanePreservation/pminuw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x43cc1ad6970b4549", "0x7d7cb46a12789fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pminuw xmm0, xmm1
+vpminuw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pmulhuw.asm
+++ b/unittests/ASM/SSELanePreservation/pmulhuw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x433f161265092c8f", "0x5ce290d803f49a7f", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x000011f402d0591d", "0x12c08c437f250155", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pmulhuw xmm0, xmm1
+vpmulhuw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pmulld.asm
+++ b/unittests/ASM/SSELanePreservation/pmulld.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x884e898a629d6c0d", "0x4720ba504adfea66", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x935c6a901b81fa79", "0x8a1f4a040cb51840", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pmulld xmm0, xmm1
+vpmulld xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pmullw.asm
+++ b/unittests/ASM/SSELanePreservation/pmullw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x1c10898a84b56c0d", "0x4f08ba505180ea66", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x00006a902ae4fa79", "0x6ed14a043be41840", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+pmullw xmm0, xmm1
+vpmullw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/por.asm
+++ b/unittests/ASM/SSELanePreservation/por.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xffecdadfbf3fe5ed", "0xfd7efdea36f8ffd3", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+por xmm0, xmm1
+vpor xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/psubb.asm
+++ b/unittests/ASM/SSELanePreservation/psubb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xba20b8b914345f5c", "0xc0fe191e2458a82f", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+psubb xmm0, xmm1
+vpsubb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/psubd.asm
+++ b/unittests/ASM/SSELanePreservation/psubd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xba20b7b914345f5c", "0xbffe191e2457a82f", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+psubd xmm0, xmm1
+vpsubd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/psubq.asm
+++ b/unittests/ASM/SSELanePreservation/psubq.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xba20b7b914345f5c", "0xbffe191e2457a82f", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+psubq xmm0, xmm1
+vpsubq xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/psubsb.asm
+++ b/unittests/ASM/SSELanePreservation/psubsb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xba20b8b914348080", "0x7ffe19802480a82f", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+psubsb xmm0, xmm1
+vpsubsb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/psubsw.asm
+++ b/unittests/ASM/SSELanePreservation/psubsw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xba20b7b914348000", "0x7fff191e2458a82f", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+psubsw xmm0, xmm1
+vpsubsw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/psubusb.asm
+++ b/unittests/ASM/SSELanePreservation/psubusb.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xba20b80014345f5c", "0x0000191e2458002f", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+psubusb xmm0, xmm1
+vpsubusb xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/psubusw.asm
+++ b/unittests/ASM/SSELanePreservation/psubusw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xba20b7b914345f5c", "0x0000191e24580000", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+psubusw xmm0, xmm1
+vpsubusw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/psubw.asm
+++ b/unittests/ASM/SSELanePreservation/psubw.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xba20b7b914345f5c", "0xbffe191e2458a82f", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+psubw xmm0, xmm1
+vpsubw xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/pxor.asm
+++ b/unittests/ASM/SSELanePreservation/pxor.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xbe20c8593c34e1ec", "0xc00279e224a86851", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+pxor xmm0, xmm1
+vpxor xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/subpd.asm
+++ b/unittests/ASM/SSELanePreservation/subpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28fab3fa4a5", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc1ad6970b", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+subpd xmm0, xmm1
+vsubpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/subps.asm
+++ b/unittests/ASM/SSELanePreservation/subps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28fab3fa4a5", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc00000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+subps xmm0, xmm1
+vsubps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/xorpd.asm
+++ b/unittests/ASM/SSELanePreservation/xorpd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xbe20c8593c34e1ec", "0xc00279e224a86851", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+xorpd xmm0, xmm1
+vxorpd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/xorps.asm
+++ b/unittests/ASM/SSELanePreservation/xorps.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xbe20c8593c34e1ec", "0xc00279e224a86851", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be000000000000", "0x0000000000000000", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+vmovapd ymm2, [rel .data + (2 * 32)]
+vmovapd ymm3, [rel .data + (3 * 32)]
+
+xorps xmm0, xmm1
+vxorps xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271


### PR DESCRIPTION
See #3799 for the bulk of the issue explanation. Ensures that emulated SSE operation on aarch64 don't end up obliterating the upper 128-bit lane when SVE-256 is present (Adv. SIMD operations zero-extend)

Knocks out quite a few SSE instructions right off the jump.