### PR TITLE
Fix incorrect RSP update for 16bit leave

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -502,7 +502,7 @@ void OpDispatchBuilder::LEAVEOp(OpcodeArgs) {
   auto NewGPR = Pop(OperandSize, SP);
 
   // Store the new stack pointer
-  StoreGPRRegister(X86State::REG_RSP, SP, OperandSize);
+  StoreGPRRegister(X86State::REG_RSP, SP, GPRSize);
 
   // Store what we loaded to RBP
   StoreGPRRegister(X86State::REG_RBP, NewGPR, OperandSize);

--- a/unittests/ASM/FEX_bugs/o16_leave.asm
+++ b/unittests/ASM/FEX_bugs/o16_leave.asm
@@ -1,0 +1,22 @@
+BITS 64
+%ifdef CONFIG
+{
+  "RegData": {
+    "RSP": "0x100000002", "RBP": "0x100007788"
+  },
+  "MemoryRegions": {
+    "0x100000000": "4096"
+  },
+  "MemoryData": {
+    "0x100000000": "88 77 66 55 44 33 22 11"
+  }
+}
+%endif
+
+
+mov rsp, 0xdeadbeef
+mov rbp, 0x100000000
+
+o16 leave
+
+hlt


### PR DESCRIPTION
When executing the `leave` instruction with an `o16` prefix, the operand size is correctly reduced to 16 bits. However, the previous implementation erroneously used this 16-bit size to also update the `RSP`. This caused only the lower 16 bits of `RSP` to be updated.
However, instead the native stack address size (`GPRSize`) should be used for the update.