### PR TITLE
[SVE256] Handle SSE insertions for CVTPI2PD

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2755,7 +2755,7 @@ void OpDispatchBuilder::MMX_To_XMM_Vector_CVT_Int_To_Float(OpcodeArgs) {
   // Always signed
   Src = _Vector_SToF(DstSize, ElementSize, Src);
 
-  StoreResultFPR(Op, Src);
+  StoreResult_WithAVXInsert(VectorOpType::SSE, RegClass::FPR, Op, Src);
 }
 
 void OpDispatchBuilder::XMM_To_MMX_Vector_CVT_Float_To_Int(OpcodeArgs, IR::OpSize SrcElementSize, bool HostRoundingMode) {

--- a/unittests/ASM/SSELanePreservation/cvtpi2pd.asm
+++ b/unittests/ASM/SSELanePreservation/cvtpi2pd.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xc1d53016d6c00000", "0xc180996b88000000", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc1d53016d6c00000", "0xc180996b88000000", "0xef673dac6e4cbb7b", "0x5b3d85d342718be9"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+movq mm0, [rel .data]
+
+cvtpi2pd xmm0, [rel .data]
+cvtpi2pd xmm1, mm0
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/cvtpi2ps.asm
+++ b/unittests/ASM/SSELanePreservation/cvtpi2ps.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xcc04cb5ccea980b7", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xcc04cb5ccea980b7", "0xbd7eb46a1278f793", "0xef673dac6e4cbb7b", "0x5b3d85d342718be9"]
+  }
+}
+%endif
+
+vmovapd ymm0, [rel .data]
+vmovapd ymm1, [rel .data + (1 * 32)]
+movq mm0, [rel .data]
+
+cvtpi2ps xmm0, [rel .data]
+cvtpi2ps xmm1, mm0
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271


### PR DESCRIPTION
See #3799

CVTPI2PS is technically already handled, but we can add a test for it as well, just to cover our bases.