### PR TITLE
JIT: Amend op typos in implementations

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
@@ -523,7 +523,7 @@ DEF_OP(AndWithFlags) {
 }
 
 DEF_OP(AndShift) {
-  auto Op = IROp->C<IR::IROp_XorShift>();
+  auto Op = IROp->C<IR::IROp_AndShift>();
 
   and_(ConvertSize48(IROp), GetReg(Node), GetReg(Op->Src1), GetReg(Op->Src2), ConvertIRShiftType(Op->Shift), Op->ShiftAmount);
 }
@@ -721,7 +721,7 @@ DEF_OP(Extr) {
 }
 
 DEF_OP(PDep) {
-  auto Op = IROp->C<IR::IROp_PExt>();
+  auto Op = IROp->C<IR::IROp_PDep>();
   const auto EmitSize = ConvertSize48(IROp);
 
   const auto Dest = GetReg(Node);

--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -4435,7 +4435,7 @@ DEF_OP(VFNMLA) {
   // - SVE    - FMLS
   // - ASIMD  - FMLS
   // - Scalar - FMSUB
-  const auto Op = IROp->C<IR::IROp_VFMLA>();
+  const auto Op = IROp->C<IR::IROp_VFNMLA>();
   const auto OpSize = IROp->Size;
 
   const auto SubRegSize = ConvertSubRegSize248(IROp);
@@ -4503,7 +4503,7 @@ DEF_OP(VFNMLS) {
   // - ASIMD  - FMLS (With Negated addend)
   // - Scalar - FNMADD
 
-  const auto Op = IROp->C<IR::IROp_VFMLS>();
+  const auto Op = IROp->C<IR::IROp_VFNMLS>();
   const auto OpSize = IROp->Size;
 
   const auto SubRegSize = ConvertSubRegSize248(IROp);


### PR DESCRIPTION
Benign, but ensures that they're correct in the event any of their IR definitions change.