### PR TITLE
IntrusiveIRList: Amend signature for PostRA()

### DIFF
--- a/FEXCore/Source/Interface/IR/IntrusiveIRList.h
+++ b/FEXCore/Source/Interface/IR/IntrusiveIRList.h
@@ -186,12 +186,12 @@ public:
   }
 
   [[nodiscard]]
-  unsigned PostRA() const {
+  bool PostRA() const {
     return GetHeader()->PostRA;
   }
 
   [[nodiscard]]
-  unsigned SpillSlots() const {
+  uint32_t SpillSlots() const {
     return GetHeader()->SpillSlots;
   }
 


### PR DESCRIPTION
PostRA is a bool, not an unsigned value. We can also adjust SpillSlots() to use uint32_t like its returned data member.