### PR TITLE
Passes: Trim unnecessary forward declarations

### DIFF
--- a/FEXCore/Source/Interface/IR/Passes.h
+++ b/FEXCore/Source/Interface/IR/Passes.h
@@ -8,23 +8,18 @@ class CPUIDEmu;
 struct HostFeatures;
 } // namespace FEXCore
 
-namespace FEXCore::Utils {
-class IntrusivePooledAllocator;
-}
-
 namespace FEXCore::IR {
 class Pass;
-class RegisterAllocationPass;
 
-fextl::unique_ptr<FEXCore::IR::Pass> CreateDeadFlagCalculationEliminination();
-fextl::unique_ptr<FEXCore::IR::RegisterAllocationPass> CreateRegisterAllocationPass(const FEXCore::CPUIDEmu* CPUID);
-fextl::unique_ptr<FEXCore::IR::Pass> CreateX87StackOptimizationPass(const FEXCore::HostFeatures&, OpSize GPROpSize);
+fextl::unique_ptr<Pass> CreateDeadFlagCalculationEliminination();
+fextl::unique_ptr<Pass> CreateRegisterAllocationPass(const CPUIDEmu* CPUID);
+fextl::unique_ptr<Pass> CreateX87StackOptimizationPass(const HostFeatures&, OpSize GPROpSize);
 
 namespace Validation {
-  fextl::unique_ptr<FEXCore::IR::Pass> CreateIRValidation();
+  fextl::unique_ptr<Pass> CreateIRValidation();
 } // namespace Validation
 
 namespace Debug {
-  fextl::unique_ptr<FEXCore::IR::Pass> CreateIRDumper();
+  fextl::unique_ptr<Pass> CreateIRDumper();
 }
 } // namespace FEXCore::IR

--- a/FEXCore/Source/Interface/IR/Passes/IRDumperPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/IRDumperPass.cpp
@@ -67,7 +67,7 @@ void IRDumper::Run(IREmitter* IREmit) {
   }
 }
 
-fextl::unique_ptr<FEXCore::IR::Pass> CreateIRDumper() {
+fextl::unique_ptr<Pass> CreateIRDumper() {
   return fextl::make_unique<IRDumper>();
 }
 } // namespace FEXCore::IR::Debug

--- a/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -271,7 +271,7 @@ void IRValidation::Run(IREmitter* IREmit) {
   }
 }
 
-fextl::unique_ptr<FEXCore::IR::Pass> CreateIRValidation() {
+fextl::unique_ptr<Pass> CreateIRValidation() {
   return fextl::make_unique<IRValidation>();
 }
 } // namespace FEXCore::IR::Validation

--- a/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
@@ -747,7 +747,7 @@ void DeadFlagCalculationEliminination::Run(IREmitter* IREmit) {
   }
 }
 
-fextl::unique_ptr<FEXCore::IR::Pass> CreateDeadFlagCalculationEliminination() {
+fextl::unique_ptr<Pass> CreateDeadFlagCalculationEliminination() {
   return fextl::make_unique<DeadFlagCalculationEliminination>();
 }
 

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -781,7 +781,7 @@ void ConstrainedRAPass::Run(IREmitter* IREmit_) {
   IR->GetHeader()->PostRA = true;
 }
 
-fextl::unique_ptr<IR::RegisterAllocationPass> CreateRegisterAllocationPass(const FEXCore::CPUIDEmu* CPUID) {
+fextl::unique_ptr<IR::Pass> CreateRegisterAllocationPass(const CPUIDEmu* CPUID) {
   return fextl::make_unique<ConstrainedRAPass>(CPUID);
 }
 } // namespace FEXCore::IR

--- a/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
@@ -1225,7 +1225,7 @@ void X87StackOptimization::Run(IREmitter* Emit) {
   return;
 }
 
-fextl::unique_ptr<Pass> CreateX87StackOptimizationPass(const FEXCore::HostFeatures& Features, OpSize GPROpSize) {
+fextl::unique_ptr<Pass> CreateX87StackOptimizationPass(const HostFeatures& Features, OpSize GPROpSize) {
   return fextl::make_unique<X87StackOptimization>(Features, GPROpSize);
 }
 } // namespace FEXCore::IR


### PR DESCRIPTION
Less visual noise and lingering types left in the header.