### PR TITLE
[SVE256] Add more SSE scalar variant unit tests

### DIFF
--- a/unittests/ASM/SSELanePreservation/addsd.asm
+++ b/unittests/ASM/SSELanePreservation/addsd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x4000000000000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x4000000000000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0x3ff0000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x3ff0000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+addsd xmm0, xmm1
+vaddsd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0x3ff0000000000000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x3ff0000000000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0x3ff0000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x3ff0000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/addss.asm
+++ b/unittests/ASM/SSELanePreservation/addss.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28f40000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc40000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc3f800000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc3f800000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+addss xmm0, xmm1
+vaddss xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28f3f800000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad63f800000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc3f800000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc3f800000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/cvtsd2ss.asm
+++ b/unittests/ASM/SSELanePreservation/cvtsd2ss.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28f3f800000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x4000000040000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0x4000000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x4000000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+cvtsd2ss xmm0, xmm1
+vcvtsd2ss xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28f3f800000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x3ff0000000000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0x4000000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x4000000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/cvtsi2sd.asm
+++ b/unittests/ASM/SSELanePreservation/cvtsi2sd.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "RAX": "1",
+    "RBX": "1",
+    "XMM0": ["0x3ff0000000000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x3ff0000000000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+mov rax, 1
+mov rbx, 1
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+
+cvtsi2sd xmm0, rax
+vcvtsi2sd xmm1, xmm2, rbx
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0xc4be43cc1b56970b, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/cvtsi2ss.asm
+++ b/unittests/ASM/SSELanePreservation/cvtsi2ss.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "RAX": "1",
+    "RBX": "1",
+    "XMM0": ["0xfdecd28f3f800000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc3f800000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+mov rax, 1
+mov rbx, 1
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+
+cvtsi2ss xmm0, rax
+vcvtsi2ss xmm1, xmm2, rbx
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0xc4be43cc1b56970b, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/cvtss2sd.asm
+++ b/unittests/ASM/SSELanePreservation/cvtss2sd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x3ff0000000000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x3ff0000000000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc3f800000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc3f800000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+cvtss2sd xmm0, xmm1
+vcvtss2sd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28f3f800000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad63f800000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc3f800000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc3f800000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/divsd.asm
+++ b/unittests/ASM/SSELanePreservation/divsd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x3ff0000000000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x3ff0000000000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0x4000000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x4000000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+divsd xmm0, xmm1
+vdivsd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0x4000000000000000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x4000000000000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0x4000000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x4000000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/divss.asm
+++ b/unittests/ASM/SSELanePreservation/divss.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28f3f800000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc3f800000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc40000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc40000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+divss xmm0, xmm1
+vdivss xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28f40000000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad640000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc40000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc40000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/maxsd.asm
+++ b/unittests/ASM/SSELanePreservation/maxsd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x4000000000000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x4000000000000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0x3ff0000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x4000000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+maxsd xmm0, xmm1
+vmaxsd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0x3ff0000000000000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x4000000000000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0x3ff0000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x4000000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/maxss.asm
+++ b/unittests/ASM/SSELanePreservation/maxss.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28f40000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc40000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc3f800000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc40000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+maxss xmm0, xmm1
+vmaxss xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28f3f800000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad640000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc3f800000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc40000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/minsd.asm
+++ b/unittests/ASM/SSELanePreservation/minsd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x3ff0000000000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x3ff0000000000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0x3ff0000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x4000000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+minsd xmm0, xmm1
+vminsd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0x3ff0000000000000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x4000000000000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0x3ff0000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x4000000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/minss.asm
+++ b/unittests/ASM/SSELanePreservation/minss.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28f3f800000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc3f800000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc3f800000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc40000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+minss xmm0, xmm1
+vminss xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28f3f800000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad640000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc3f800000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc40000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/mulsd.asm
+++ b/unittests/ASM/SSELanePreservation/mulsd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x4010000000000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x4010000000000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0x4000000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x4000000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+mulsd xmm0, xmm1
+vmulsd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0x4000000000000000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x4000000000000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0x4000000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x4000000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/mulss.asm
+++ b/unittests/ASM/SSELanePreservation/mulss.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28f40800000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc40800000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc40000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc40000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+mulss xmm0, xmm1
+vmulss xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28f40000000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad640000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc40000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc40000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/sqrtsd.asm
+++ b/unittests/ASM/SSELanePreservation/sqrtsd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x4008000000000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x4008000000000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x4022000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+sqrtsd xmm0, xmm1
+vsqrtsd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x4022000000000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x4022000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/sqrtss.asm
+++ b/unittests/ASM/SSELanePreservation/sqrtss.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28f40400000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc40400000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc41100000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+sqrtss xmm0, xmm1
+vsqrtss xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad641100000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc41100000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/subsd.asm
+++ b/unittests/ASM/SSELanePreservation/subsd.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0x0000000000000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0x0000000000000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0x3ff0000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x3ff0000000000000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+subsd xmm0, xmm1
+vsubsd xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0x3ff0000000000000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x3ff0000000000000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0x3ff0000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x3ff0000000000000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271

--- a/unittests/ASM/SSELanePreservation/subss.asm
+++ b/unittests/ASM/SSELanePreservation/subss.asm
@@ -1,0 +1,28 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM0": ["0xfdecd28f00000000", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
+    "XMM1": ["0xc4be43cc00000000", "0x4549bd7eb46a1278", "0", "0"],
+    "XMM2": ["0xc4be43cc3f800000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
+    "XMM3": ["0x000043cc3f800000", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+  }
+}
+%endif
+
+vmovaps ymm0, [rel .data]
+vmovaps ymm1, [rel .data + (1 * 32)]
+vmovaps ymm2, [rel .data + (2 * 32)]
+vmovaps ymm3, [rel .data + (3 * 32)]
+
+subss xmm0, xmm1
+vsubss xmm1, xmm2, xmm3
+
+hlt
+
+align 32
+.data:
+dq 0xfdecd28f3f800000, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
+dq 0x43cc1ad63f800000, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
+dq 0xc4be43cc3f800000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x000043cc3f800000, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271


### PR DESCRIPTION
See #3799

These were technically already covered when the work was done to make SSE insertion behavior conform to hardware, so this just adds tests that ensure that behavior holds over time.