### PR TITLE
[SVE256] More comprehensively test SSE insertions for scalar comparisons

### DIFF
--- a/unittests/ASM/Includes/sse_scalar_compare_utils.mac
+++ b/unittests/ASM/Includes/sse_scalar_compare_utils.mac
@@ -1,0 +1,56 @@
+%ifndef SSE_SCALAR_COMPARE_UTILS_INC
+%define SSE_SCALAR_COMPARE_UTILS_INC
+
+; We load the same initial data into two registers, since we need to
+; execute the SSE and AVX version of the instruction test.
+;
+; This takes a ymm index and a memory index
+%macro load_initial_data_test 2
+  %assign sse_reg %1
+  %assign avx_reg %1+1
+
+  vmovaps ymm %+ sse_reg, [rel .data + (%2 * 32)]
+  vmovaps ymm %+ avx_reg, [rel .data + (%2 * 32)]
+%endmacro
+
+; Loads all of our initial data at once
+%macro load_all_initial_data 0
+  %assign mem_idx 0
+  %assign reg_idx 0
+  %rep 8
+    load_initial_data_test reg_idx, mem_idx
+    %assign mem_idx mem_idx+1
+    %assign reg_idx reg_idx+2
+  %endrep
+%endmacro
+
+; Runs a series of 16 tests with the comparison immediate incrementing
+; after each test pair being run.
+;
+; Takes the stem of the scalar instruction and the initial type of comparison to perform.
+; e.g. perform_compare_tests cmpss, 0 will run cmpss and vcmpss tests starting at comparison
+;      immediate 0 and go up to and including 7
+%macro perform_compare_tests 2
+  %assign reg_sse 0
+  %assign reg_avx 1
+  %assign scalar_idx 0
+  %assign cmp_idx %2
+
+  %ifidni %1, cmpss
+    %assign mem_size 4
+  %else
+    %assign mem_size 8
+  %endif
+
+  %rep 8
+    %1  xmm %+ reg_sse,                 [rel .scalar_data + (scalar_idx * mem_size)], cmp_idx
+    v%1 xmm %+ reg_avx, xmm %+ reg_avx, [rel .scalar_data + (scalar_idx * mem_size)], cmp_idx
+
+    %assign reg_sse reg_sse+2
+    %assign reg_avx reg_avx+2
+    %assign scalar_idx scalar_idx+1
+    %assign cmp_idx cmp_idx+1
+  %endrep
+%endmacro
+
+%endif

--- a/unittests/ASM/SSELanePreservation/cmpsd.asm
+++ b/unittests/ASM/SSELanePreservation/cmpsd.asm
@@ -2,27 +2,57 @@
 {
   "HostFeatures": ["AVX"],
   "RegData": {
-    "XMM0": ["0xffffffffffffffff", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
-    "XMM1": ["0xffffffffffffffff", "0x4549bd7eb46a1278", "0", "0"],
-    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
-    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+    "XMM0":  ["0xffffffffffffffff", "0xbdd640fb06671ad1", "0x3eb13b9046685257", "0x23b8c1e9392456de"],
+    "XMM1":  ["0xffffffffffffffff", "0xbdd640fb06671ad1", "0x0000000000000000", "0x0000000000000000"],
+    "XMM2":  ["0x0000000000000000", "0xbd9c66b3ad3c2d6d", "0x8b9d2434e465e150", "0x972a846916419f82"],
+    "XMM3":  ["0x0000000000000000", "0xbd9c66b3ad3c2d6d", "0x0000000000000000", "0x0000000000000000"],
+    "XMM4":  ["0xffffffffffffffff", "0x17fc695a07a0ca6e", "0x3b8faa1837f8a88b", "0x9a1de644815ef6d1"],
+    "XMM5":  ["0xffffffffffffffff", "0x17fc695a07a0ca6e", "0x0000000000000000", "0x0000000000000000"],
+    "XMM6":  ["0xffffffffffffffff", "0xb74d0fb132e70629", "0xb38a088ca65ed389", "0x6b65a6a48b8148f6"],
+    "XMM7":  ["0xffffffffffffffff", "0xb74d0fb132e70629", "0x0000000000000000", "0x0000000000000000"],
+    "XMM8":  ["0xffffffffffffffff", "0x4737819096da1dac", "0xde8a774bcf36d58b", "0xc241330b01a9e71f"],
+    "XMM9":  ["0xffffffffffffffff", "0x4737819096da1dac", "0x0000000000000000", "0x0000000000000000"],
+    "XMM10": ["0x0000000000000000", "0x6c307511b2b9437a", "0x47229389571aa876", "0x371ecd7b27cd8130"],
+    "XMM11": ["0x0000000000000000", "0x6c307511b2b9437a", "0x0000000000000000", "0x0000000000000000"],
+    "XMM12": ["0xffffffffffffffff", "0x1a2a73ed562b0f79", "0x6142ea7d17be3111", "0x5be6128e18c26797"],
+    "XMM13": ["0xffffffffffffffff", "0x1a2a73ed562b0f79", "0x0000000000000000", "0x0000000000000000"],
+    "XMM14": ["0x0000000000000000", "0x43b7a3a69a8dca03", "0x0b1f9163ce9ff57f", "0x759cde66bacfb3d0"],
+    "XMM15": ["0x0000000000000000", "0x43b7a3a69a8dca03", "0x0000000000000000", "0x0000000000000000"]
   }
 }
 %endif
 
-vmovaps ymm0, [rel .data]
-vmovaps ymm1, [rel .data + (1 * 32)]
-vmovaps ymm2, [rel .data + (2 * 32)]
-vmovaps ymm3, [rel .data + (3 * 32)]
+; Test to ensure every path of cmpsd is covered and handles lane
+; preservation properly.
 
-cmpsd xmm0, xmm1, 1
-vcmpsd xmm1, xmm2, xmm3, 1
+%include "sse_scalar_compare_utils.mac"
+
+load_all_initial_data
+perform_compare_tests cmpsd, 0
 
 hlt
 
+; Initial data to put into registers before the test.
+; Consists of a valid float geared for the particular test followed by junk data for the upper lanes.
 align 32
 .data:
-dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
-dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
-dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
-dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x3ff0000000000000, 0xbdd640fb06671ad1, 0x3eb13b9046685257, 0x23b8c1e9392456de
+dq 0x4000000000000000, 0xbd9c66b3ad3c2d6d, 0x8b9d2434e465e150, 0x972a846916419f82
+dq 0x3ff0000000000000, 0x17fc695a07a0ca6e, 0x3b8faa1837f8a88b, 0x9a1de644815ef6d1
+dq 0x3ff0000000000000, 0xb74d0fb132e70629, 0xb38a088ca65ed389, 0x6b65a6a48b8148f6
+dq 0x3ff0000000000000, 0x4737819096da1dac, 0xde8a774bcf36d58b, 0xc241330b01a9e71f
+dq 0x3ff0000000000000, 0x6c307511b2b9437a, 0x47229389571aa876, 0x371ecd7b27cd8130
+dq 0x3ff0000000000000, 0x1a2a73ed562b0f79, 0x6142ea7d17be3111, 0x5be6128e18c26797
+dq 0x3ff0000000000000, 0x43b7a3a69a8dca03, 0x0b1f9163ce9ff57f, 0x759cde66bacfb3d0
+
+; What we use as the source memory operand for a particular test.
+align 32
+.scalar_data:
+dq 0x3ff0000000000000 ; 1.0
+dq 0x3ff0000000000000 ; 1.0
+dq 0x4000000000000000 ; 2.0
+dq 0x7ff8000000000000 ; NaN (positive)
+dq 0x0000000000000000 ; 0.0
+dq 0x4000000000000000 ; 2.0
+dq 0x0000000000000000 ; 0.0
+dq 0xfff8000000000000 ; NaN (negative)

--- a/unittests/ASM/SSELanePreservation/cmpss.asm
+++ b/unittests/ASM/SSELanePreservation/cmpss.asm
@@ -2,27 +2,57 @@
 {
   "HostFeatures": ["AVX"],
   "RegData": {
-    "XMM0": ["0xfdecd28fffffffff", "0x7d7ccd8836d09fc2", "0xccdbcfc31f3ff0f3", "0x108390defebac4be"],
-    "XMM1": ["0xc4be43cc00000000", "0x4549bd7eb46a1278", "0", "0"],
-    "XMM2": ["0xc4be43cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"],
-    "XMM3": ["0x000043cc1ad6970b", "0x4549bd7eb46a1278", "0xf793ef673dac6e4c", "0xbb7b5b3d85d34271"]
+    "XMM0":  ["0x1c80317fffffffff", "0xbdd640fb06671ad1", "0x3eb13b9046685257", "0x23b8c1e9392456de"],
+    "XMM1":  ["0x1c80317fffffffff", "0xbdd640fb06671ad1", "0x0000000000000000", "0x0000000000000000"],
+    "XMM2":  ["0x1a3d1fa700000000", "0xbd9c66b3ad3c2d6d", "0x8b9d2434e465e150", "0x972a846916419f82"],
+    "XMM3":  ["0x1a3d1fa700000000", "0xbd9c66b3ad3c2d6d", "0x0000000000000000", "0x0000000000000000"],
+    "XMM4":  ["0x0822e8f3ffffffff", "0x17fc695a07a0ca6e", "0x3b8faa1837f8a88b", "0x9a1de644815ef6d1"],
+    "XMM5":  ["0x0822e8f3ffffffff", "0x17fc695a07a0ca6e", "0x0000000000000000", "0x0000000000000000"],
+    "XMM6":  ["0x8fadc1a6ffffffff", "0xb74d0fb132e70629", "0xb38a088ca65ed389", "0x6b65a6a48b8148f6"],
+    "XMM7":  ["0x8fadc1a6ffffffff", "0xb74d0fb132e70629", "0x0000000000000000", "0x0000000000000000"],
+    "XMM8":  ["0x72ff5d2affffffff", "0x4737819096da1dac", "0xde8a774bcf36d58b", "0xc241330b01a9e71f"],
+    "XMM9":  ["0x72ff5d2affffffff", "0x4737819096da1dac", "0x0000000000000000", "0x0000000000000000"],
+    "XMM10": ["0x28df6ec400000000", "0x6c307511b2b9437a", "0x47229389571aa876", "0x371ecd7b27cd8130"],
+    "XMM11": ["0x28df6ec400000000", "0x6c307511b2b9437a", "0x0000000000000000", "0x0000000000000000"],
+    "XMM12": ["0xc37459eeffffffff", "0x1a2a73ed562b0f79", "0x6142ea7d17be3111", "0x5be6128e18c26797"],
+    "XMM13": ["0xc37459eeffffffff", "0x1a2a73ed562b0f79", "0x0000000000000000", "0x0000000000000000"],
+    "XMM14": ["0x580d7b7100000000", "0x43b7a3a69a8dca03", "0x0b1f9163ce9ff57f", "0x759cde66bacfb3d0"],
+    "XMM15": ["0x580d7b7100000000", "0x43b7a3a69a8dca03", "0x0000000000000000", "0x0000000000000000"]
   }
 }
 %endif
 
-vmovaps ymm0, [rel .data]
-vmovaps ymm1, [rel .data + (1 * 32)]
-vmovaps ymm2, [rel .data + (2 * 32)]
-vmovaps ymm3, [rel .data + (3 * 32)]
+; Test to ensure every path of cmpsd is covered and handles lane
+; preservation properly.
 
-cmpss xmm0, xmm1, 1
-vcmpss xmm1, xmm2, xmm3, 1
+%include "sse_scalar_compare_utils.mac"
+
+load_all_initial_data
+perform_compare_tests cmpss, 0
 
 hlt
 
+; Initial data to put into registers before the test.
+; Consists of a valid float geared for the particular test followed by junk data for the upper lanes.
 align 32
 .data:
-dq 0xfdecd28fab3fa4a5, 0x7d7ccd8836d09fc2, 0xccdbcfc31f3ff0f3, 0x108390defebac4be
-dq 0x43cc1ad6970b4549, 0xbd7eb46a1278f793, 0xef673dac6e4cbb7b, 0x5b3d85d342718be9
-dq 0xc4be43cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
-dq 0x000043cc1ad6970b, 0x4549bd7eb46a1278, 0xf793ef673dac6e4c, 0xbb7b5b3d85d34271
+dq 0x1c80317f3f800000, 0xbdd640fb06671ad1, 0x3eb13b9046685257, 0x23b8c1e9392456de
+dq 0x1a3d1fa740000000, 0xbd9c66b3ad3c2d6d, 0x8b9d2434e465e150, 0x972a846916419f82
+dq 0x0822e8f33f800000, 0x17fc695a07a0ca6e, 0x3b8faa1837f8a88b, 0x9a1de644815ef6d1
+dq 0x8fadc1a63f800000, 0xb74d0fb132e70629, 0xb38a088ca65ed389, 0x6b65a6a48b8148f6
+dq 0x72ff5d2a3f800000, 0x4737819096da1dac, 0xde8a774bcf36d58b, 0xc241330b01a9e71f
+dq 0x28df6ec43f800000, 0x6c307511b2b9437a, 0x47229389571aa876, 0x371ecd7b27cd8130
+dq 0xc37459ee3f800000, 0x1a2a73ed562b0f79, 0x6142ea7d17be3111, 0x5be6128e18c26797
+dq 0x580d7b713f800000, 0x43b7a3a69a8dca03, 0x0b1f9163ce9ff57f, 0x759cde66bacfb3d0
+
+; What we use as the source memory operand for a particular test.
+align 32
+.scalar_data:
+dd 0x3f800000 ; 1.0
+dd 0x3f800000 ; 1.0
+dd 0x40000000 ; 2.0
+dd 0x7fc00000 ; NaN (positive)
+dd 0x00000000 ; 0.0
+dd 0x40000000 ; 2.0
+dd 0x00000000 ; 0.0
+dd 0xffc00000 ; NaN (negative)


### PR DESCRIPTION
See #3799

Drops in the facilities to ensure all of the available SSE scalar comparison paths are tested for proper insertion behavior.