### PR TITLE
AVX: Remove unnecessary moves from PINSRX ops 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -658,9 +658,8 @@ public:
   void VPHSUBOp(OpcodeArgs, IR::OpSize ElementSize);
   void VPHSUBSWOp(OpcodeArgs);
 
-  void VPINSRBOp(OpcodeArgs);
+  void VPINSRBWOp(OpcodeArgs, IR::OpSize ElementSize);
   void VPINSRDQOp(OpcodeArgs);
-  void VPINSRWOp(OpcodeArgs);
 
   void VPMADDUBSWOp(OpcodeArgs);
   void VPMADDWDOp(OpcodeArgs);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2066,26 +2066,17 @@ void OpDispatchBuilder::PINSROp(OpcodeArgs, IR::OpSize ElementSize) {
 
 void OpDispatchBuilder::VPINSRBOp(OpcodeArgs) {
   Ref Result = PINSROpImpl(Op, OpSize::i8Bit, Op->Src[0], Op->Src[1], Op->Src[2]);
-  if (Op->Dest.Data.GPR.GPR == Op->Src[0].Data.GPR.GPR) {
-    Result = _VMov(OpSize::i128Bit, Result);
-  }
   StoreResultFPR(Op, Result);
 }
 
 void OpDispatchBuilder::VPINSRDQOp(OpcodeArgs) {
   const auto SrcSize = OpSizeFromSrc(Op);
   Ref Result = PINSROpImpl(Op, SrcSize, Op->Src[0], Op->Src[1], Op->Src[2]);
-  if (Op->Dest.Data.GPR.GPR == Op->Src[0].Data.GPR.GPR) {
-    Result = _VMov(OpSize::i128Bit, Result);
-  }
   StoreResultFPR(Op, Result);
 }
 
 void OpDispatchBuilder::VPINSRWOp(OpcodeArgs) {
   Ref Result = PINSROpImpl(Op, OpSize::i16Bit, Op->Src[0], Op->Src[1], Op->Src[2]);
-  if (Op->Dest.Data.GPR.GPR == Op->Src[0].Data.GPR.GPR) {
-    Result = _VMov(OpSize::i128Bit, Result);
-  }
   StoreResultFPR(Op, Result);
 }
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2064,19 +2064,14 @@ void OpDispatchBuilder::PINSROp(OpcodeArgs, IR::OpSize ElementSize) {
   StoreResult_WithAVXInsert(VectorOpType::SSE, RegClass::FPR, Op, Result);
 }
 
-void OpDispatchBuilder::VPINSRBOp(OpcodeArgs) {
-  Ref Result = PINSROpImpl(Op, OpSize::i8Bit, Op->Src[0], Op->Src[1], Op->Src[2]);
+void OpDispatchBuilder::VPINSRBWOp(OpcodeArgs, IR::OpSize ElementSize) {
+  Ref Result = PINSROpImpl(Op, ElementSize, Op->Src[0], Op->Src[1], Op->Src[2]);
   StoreResultFPR(Op, Result);
 }
 
 void OpDispatchBuilder::VPINSRDQOp(OpcodeArgs) {
   const auto SrcSize = OpSizeFromSrc(Op);
   Ref Result = PINSROpImpl(Op, SrcSize, Op->Src[0], Op->Src[1], Op->Src[2]);
-  StoreResultFPR(Op, Result);
-}
-
-void OpDispatchBuilder::VPINSRWOp(OpcodeArgs) {
-  Ref Result = PINSROpImpl(Op, OpSize::i16Bit, Op->Src[0], Op->Src[1], Op->Src[2]);
   StoreResultFPR(Op, Result);
 }
 

--- a/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/VEXTables.cpp
@@ -623,7 +623,7 @@ namespace AVX256 {
     {OPD(1, 0b10, 0xC2), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::AVXInsertScalarFCMPOp, OpSize::i32Bit>},
     {OPD(1, 0b11, 0xC2), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::AVXInsertScalarFCMPOp, OpSize::i64Bit>},
 
-    {OPD(1, 0b01, 0xC4), 1, &OpDispatchBuilder::VPINSRWOp},
+    {OPD(1, 0b01, 0xC4), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VPINSRBWOp, OpSize::i16Bit>},
     {OPD(1, 0b01, 0xC5), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::PExtrOp, OpSize::i16Bit>},
 
     {OPD(1, 0b00, 0xC6), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VSHUFOp, OpSize::i32Bit>},
@@ -837,7 +837,7 @@ namespace AVX256 {
     {OPD(3, 0b01, 0x18), 1, &OpDispatchBuilder::VINSERTOp},
     {OPD(3, 0b01, 0x19), 1, &OpDispatchBuilder::VEXTRACT128Op},
     {OPD(3, 0b01, 0x1D), 1, &OpDispatchBuilder::VCVTPS2PHOp},
-    {OPD(3, 0b01, 0x20), 1, &OpDispatchBuilder::VPINSRBOp},
+    {OPD(3, 0b01, 0x20), 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VPINSRBWOp, OpSize::i8Bit>},
     {OPD(3, 0b01, 0x21), 1, &OpDispatchBuilder::VINSERTPSOp},
     {OPD(3, 0b01, 0x22), 1, &OpDispatchBuilder::VPINSRDQOp},
 

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -2615,14 +2615,12 @@
       ]
     },
     "vpinsrw xmm0, xmm0, eax, 000b": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map 1 0b01 0xC4 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v16.16b",
-        "mov v2.h[0], w4",
-        "mov v16.16b, v2.16b"
+        "mov v16.h[0], w4"
       ]
     },
     "vpinsrw xmm0, xmm1, eax, 000b": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -3714,14 +3714,12 @@
       ]
     },
     "vpinsrb xmm0, xmm0, eax, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map 3 0b01 0x20 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v16.16b",
-        "mov v2.b[0], w4",
-        "mov v16.16b, v2.16b"
+        "mov v16.b[0], w4"
       ]
     },
     "vpinsrb xmm0, xmm1, eax, 0": {
@@ -3774,14 +3772,12 @@
       ]
     },
     "vpinsrd xmm0, xmm0, eax, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v16.16b",
-        "mov v2.s[0], w4",
-        "mov v16.16b, v2.16b"
+        "mov v16.s[0], w4"
       ]
     },
     "vpinsrd xmm0, xmm1, eax, 0": {
@@ -3805,14 +3801,12 @@
       ]
     },
     "vpinsrq xmm0, xmm0, rax, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map 3 0b01 0x22 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov v2.16b, v16.16b",
-        "mov v2.d[0], x4",
-        "mov v16.16b, v2.16b"
+        "mov v16.d[0], x4"
       ]
     },
     "vpinsrq xmm0, xmm1, rax, 0": {


### PR DESCRIPTION
These are old paths still around from when StoreResult used to automatically perform truncating moves. These aren't necessary anymore, since the AdvSIMD operation already ensures zero-extension.

Reduces insertion overhead from 3 instructions to 1 instruction when the source and destination are the same.