### PR TITLE
JIT: Arm64: fix the loop in CacheLineClear/Clean

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MemoryOps.cpp
@@ -2400,11 +2400,12 @@ DEF_OP(CacheLineClear) {
 
   // Clear dcache only
   // icache doesn't matter here since the guest application shouldn't be calling clflush on JIT code.
+  // check host cacheline size again x86_64 size to ensure at least 64 bytes are cleaned
   if (CTX->HostFeatures.DCacheLineSize >= 64U) {
     dc(ARMEmitter::DataCacheOperation::CIVAC, MemReg);
   } else {
     auto CurrentWorkingReg = MemReg.X();
-    for (size_t i = 0; i < std::max(1U, CTX->HostFeatures.DCacheLineSize / 64U); ++i) {
+    for (size_t i = 0; i < std::max(1U, 64U / CTX->HostFeatures.DCacheLineSize); ++i) {
       dc(ARMEmitter::DataCacheOperation::CIVAC, TMP1);
       add(ARMEmitter::Size::i64Bit, TMP1, CurrentWorkingReg, CTX->HostFeatures.DCacheLineSize);
       CurrentWorkingReg = TMP1;
@@ -2428,11 +2429,12 @@ DEF_OP(CacheLineClean) {
   auto MemReg = GetReg(Op->Addr);
 
   // Clean dcache only
+  // check host cacheline size again x86_64 size to ensure at least 64 bytes are cleaned
   if (CTX->HostFeatures.DCacheLineSize >= 64U) {
     dc(ARMEmitter::DataCacheOperation::CVAC, MemReg);
   } else {
     auto CurrentWorkingReg = MemReg.X();
-    for (size_t i = 0; i < std::max(1U, CTX->HostFeatures.DCacheLineSize / 64U); ++i) {
+    for (size_t i = 0; i < std::max(1U, 64U / CTX->HostFeatures.DCacheLineSize); ++i) {
       dc(ARMEmitter::DataCacheOperation::CVAC, TMP1);
       add(ARMEmitter::Size::i64Bit, TMP1, CurrentWorkingReg, CTX->HostFeatures.DCacheLineSize);
       CurrentWorkingReg = TMP1;

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -717,7 +717,7 @@
         "HasSideEffects": true
       },
       "CacheLineClean GPR:$Addr": {
-        "Desc": ["Does a 64 byte cacheline cleanat the address specified",
+        "Desc": ["Does a 64 byte cacheline clean at the address specified",
                  "Only cleans the data cachelines. Doesn't do any zeroing",
                  "Skips the invalidation step of the CacheLineClear operation"
                 ],


### PR DESCRIPTION
These functions need to clean at least 64 bytes of cache since this is the default on x86_64, but previously they could clean less if DCacheLineSize was smaller than 64 bytes.