### PR TITLE
VectorOps: Avoid dup if able in VInsElement 128-bit element path

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -2980,9 +2980,14 @@ DEF_OP(VInsElement) {
   auto Reg = GetVReg(Op->DestVector);
 
   if (HostSupportsSVE256 && Is256Bit) {
-    // Broadcast our source value across a temporary,
-    // then combine with the destination.
-    dup(SubRegSize, VTMP2.Z(), SrcVector.Z(), SrcIdx);
+    // Broadcast our source value across a temporary, then combine
+    // with the destination.
+    //
+    // We don't need to perform the dup if we're just merging a 128-bit vector into
+    // into an equivalent position since we have a predicate set up already.
+    if (!(ElementSize == IR::OpSize::i128Bit && SrcIdx == DestIdx)) {
+      dup(SubRegSize, VTMP2.Z(), SrcVector.Z(), SrcIdx);
+    }
 
     // We don't need to move the data unnecessarily if
     // DestVector just so happens to also be the IR op
@@ -2995,10 +3000,12 @@ DEF_OP(VInsElement) {
 
     if (ElementSize == IR::OpSize::i128Bit) {
       if (DestIdx == 0) {
-        mov(ARMEmitter::SubRegSize::i8Bit, Dst.Z(), PRED_TMP_16B.Merging(), VTMP2.Z());
+        const auto Source = SrcIdx == 0 ? SrcVector : VTMP2;
+        mov(ARMEmitter::SubRegSize::i8Bit, Dst.Z(), PRED_TMP_16B.Merging(), Source.Z());
       } else {
+        const auto Source = SrcIdx == 1 ? SrcVector : VTMP2;
         not_(Predicate, PRED_TMP_32B.Zeroing(), PRED_TMP_16B);
-        mov(ARMEmitter::SubRegSize::i8Bit, Dst.Z(), Predicate.Merging(), VTMP2.Z());
+        mov(ARMEmitter::SubRegSize::i8Bit, Dst.Z(), Predicate.Merging(), Source.Z());
       }
     } else {
       const auto UpperBound = 16 >> FEXCore::ilog2(IR::OpSizeToSize(ElementSize));

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -195,7 +195,7 @@
       ]
     },
     "cmpss xmm0, xmm1, 5": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -205,12 +205,11 @@
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
-        "mov z1.q, q2",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z2.b"
       ]
     },
     "cmpss xmm0, xmm1, 6": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "0xf3 0x0f 0xc2"
       ],
@@ -220,8 +219,7 @@
         "mov v0.16b, v16.16b",
         "mov v0.s[0], v2.s[0]",
         "mov v2.16b, v0.16b",
-        "mov z1.q, q2",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z2.b"
       ]
     },
     "cmpss xmm0, xmm1, 7": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -183,7 +183,7 @@
       ]
     },
     "cmpsd xmm0, xmm1, 5": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -193,12 +193,11 @@
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
-        "mov z1.q, q2",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z2.b"
       ]
     },
     "cmpsd xmm0, xmm1, 6": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "0xf2 0x0f 0xc2"
       ],
@@ -208,8 +207,7 @@
         "mov v0.16b, v16.16b",
         "mov v0.d[0], v2.d[0]",
         "mov v2.16b, v0.16b",
-        "mov z1.q, q2",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z2.b"
       ]
     },
     "cmpsd xmm0, xmm1, 7": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -10,7 +10,7 @@
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "SVE-256bit changes behaviour slightly",
         "0x66 0x0f 0xe4"
@@ -18,12 +18,11 @@
       "ExpectedArm64ASM": [
         "movprfx z2, z16",
         "umulh z2.h, p6/m, z2.h, z17.h",
-        "mov z1.q, q2",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z2.b"
       ]
     },
     "pmulhw xmm0, xmm1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "SVE-256bit changes behaviour slightly",
         "0x66 0x0f 0xe5"
@@ -31,8 +30,7 @@
       "ExpectedArm64ASM": [
         "movprfx z2, z16",
         "smulh z2.h, p6/m, z2.h, z17.h",
-        "mov z1.q, q2",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z2.b"
       ]
     }
   }

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -1727,14 +1727,13 @@
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00000000b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q17",
-        "mov z2.b, p6/m, z1.b",
+        "mov z2.b, p6/m, z17.b",
         "mov z1.q, q17",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
@@ -1757,14 +1756,13 @@
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00000010b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q18",
-        "mov z2.b, p6/m, z1.b",
+        "mov z2.b, p6/m, z18.b",
         "mov z1.q, q17",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
@@ -1787,22 +1785,20 @@
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00010000b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q17",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z17.b",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z17.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00010001b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1810,29 +1806,26 @@
         "movi v2.2d, #0x0",
         "mov z1.q, z17.q[1]",
         "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z17.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z17.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00010010b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q18",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z18.b",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z17.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00010011b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1840,21 +1833,19 @@
         "movi v2.2d, #0x0",
         "mov z1.q, z18.q[1]",
         "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z17.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z17.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00100000b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q17",
-        "mov z2.b, p6/m, z1.b",
+        "mov z2.b, p6/m, z17.b",
         "mov z1.q, q18",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
@@ -1877,14 +1868,13 @@
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00100010b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q18",
-        "mov z2.b, p6/m, z1.b",
+        "mov z2.b, p6/m, z18.b",
         "mov z1.q, q18",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
@@ -1907,22 +1897,20 @@
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00110000b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q17",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z17.b",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z18.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00110001b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1930,29 +1918,26 @@
         "movi v2.2d, #0x0",
         "mov z1.q, z17.q[1]",
         "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z18.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00110010b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q18",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z18.b",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z18.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00110011b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
@@ -1960,10 +1945,9 @@
         "movi v2.2d, #0x0",
         "mov z1.q, z18.q[1]",
         "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z18.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00001000b": {
@@ -1980,16 +1964,15 @@
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00011000b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, z17.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z17.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00101000b": {
@@ -2006,16 +1989,15 @@
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 00111000b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, z18.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z18.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10001000b": {
@@ -2028,15 +2010,14 @@
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q17",
         "mov z16.d, z2.d",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z17.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000001b": {
@@ -2052,15 +2033,14 @@
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000010b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x06 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q18",
         "mov z16.d, z2.d",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z18.b"
       ]
     },
     "vperm2f128 ymm0, ymm1, ymm2, 10000011b": {
@@ -3074,14 +3054,13 @@
       ]
     },
     "vinsertf128 ymm0, ymm1, xmm2, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x18 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z1.q, q18",
         "mov z16.d, z17.d",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z18.b"
       ]
     },
     "vinsertf128 ymm0, ymm1, xmm2, 1": {
@@ -3378,14 +3357,13 @@
       ]
     },
     "vinserti128 ymm0, ymm1, xmm2, 0": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 3 0b01 0x38 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z1.q, q18",
         "mov z16.d, z17.d",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z18.b"
       ]
     },
     "vinserti128 ymm0, ymm1, xmm2, 1": {
@@ -4278,14 +4256,13 @@
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00000000b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q17",
-        "mov z2.b, p6/m, z1.b",
+        "mov z2.b, p6/m, z17.b",
         "mov z1.q, q17",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
@@ -4308,14 +4285,13 @@
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00000010b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q18",
-        "mov z2.b, p6/m, z1.b",
+        "mov z2.b, p6/m, z18.b",
         "mov z1.q, q17",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
@@ -4338,22 +4314,20 @@
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00010000b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q17",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z17.b",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z17.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00010001b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4361,29 +4335,26 @@
         "movi v2.2d, #0x0",
         "mov z1.q, z17.q[1]",
         "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z17.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z17.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00010010b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q18",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z17.q[1]",
+        "mov z2.b, p6/m, z18.b",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z17.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00010011b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4391,21 +4362,19 @@
         "movi v2.2d, #0x0",
         "mov z1.q, z18.q[1]",
         "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z17.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z17.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00100000b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q17",
-        "mov z2.b, p6/m, z1.b",
+        "mov z2.b, p6/m, z17.b",
         "mov z1.q, q18",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
@@ -4428,14 +4397,13 @@
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00100010b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q18",
-        "mov z2.b, p6/m, z1.b",
+        "mov z2.b, p6/m, z18.b",
         "mov z1.q, q18",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
@@ -4458,22 +4426,20 @@
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00110000b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q17",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z17.b",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z18.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00110001b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4481,29 +4447,26 @@
         "movi v2.2d, #0x0",
         "mov z1.q, z17.q[1]",
         "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z18.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00110010b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q18",
-        "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
+        "mov z2.b, p6/m, z18.b",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z18.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00110011b": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
@@ -4511,10 +4474,9 @@
         "movi v2.2d, #0x0",
         "mov z1.q, z18.q[1]",
         "mov z2.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z18.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00001000b": {
@@ -4531,16 +4493,15 @@
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00011000b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, z17.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z17.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00101000b": {
@@ -4557,16 +4518,15 @@
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 00111000b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, z18.q[1]",
         "mov z16.d, z2.d",
         "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
+        "mov z16.b, p0/m, z18.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10001000b": {
@@ -4579,15 +4539,14 @@
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000000b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q17",
         "mov z16.d, z2.d",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z17.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000001b": {
@@ -4603,15 +4562,14 @@
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000010b": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 3,
       "Comment": [
         "Map 3 0b01 0x46 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
-        "mov z1.q, q18",
         "mov z16.d, z2.d",
-        "mov z16.b, p6/m, z1.b"
+        "mov z16.b, p6/m, z18.b"
       ]
     },
     "vperm2i128 ymm0, ymm1, ymm2, 10000011b": {


### PR DESCRIPTION
We don't need to broadcast if we're inserting 128-bit elements across registers into an equivalent position, since we already have a predicate around that can satisfy that.