### PR TITLE
AVX: Shave some moves off 256-bit VPALIGNR

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3339,8 +3339,8 @@ Ref OpDispatchBuilder::PALIGNROpImpl(OpcodeArgs, const X86Tables::DecodedOperand
     return Low;
   }
 
-  Ref HighSrc1 = _VInsElement(DstSize, OpSize::i128Bit, 0, 1, Src1Node, Src1Node);
-  Ref HighSrc2 = _VInsElement(DstSize, OpSize::i128Bit, 0, 1, Src2Node, Src2Node);
+  Ref HighSrc1 = _VDupElement(DstSize, OpSize::i128Bit, Src1Node, 1);
+  Ref HighSrc2 = _VDupElement(DstSize, OpSize::i128Bit, Src2Node, 1);
   Ref High = _VExtr(SanitizedDstSize, OpSize::i8Bit, HighSrc1, HighSrc2, Index);
   return _VInsElement(DstSize, OpSize::i128Bit, 1, 0, Low, High);
 }

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -2365,18 +2365,14 @@
       ]
     },
     "vpalignr ymm0, ymm1, ymm2, 1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x0f 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ext v2.16b, v18.16b, v17.16b, #1",
-        "mov z1.q, z17.q[1]",
-        "mov z3.d, z17.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
-        "mov z4.d, z18.d",
-        "mov z4.b, p6/m, z1.b",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
         "ext v4.16b, v4.16b, v3.16b, #1",
         "mov z1.q, q4",
         "mov z16.d, z2.d",
@@ -2385,18 +2381,14 @@
       ]
     },
     "vpalignr ymm0, ymm1, ymm2, 15": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x0f 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ext v2.16b, v18.16b, v17.16b, #15",
-        "mov z1.q, z17.q[1]",
-        "mov z3.d, z17.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
-        "mov z4.d, z18.d",
-        "mov z4.b, p6/m, z1.b",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
         "ext v4.16b, v4.16b, v3.16b, #15",
         "mov z1.q, q4",
         "mov z16.d, z2.d",
@@ -2405,19 +2397,15 @@
       ]
     },
     "vpalignr ymm0, ymm1, ymm2, 16": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 10,
       "Comment": [
         "Map 3 0b01 0x0f 256-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v0.2d, #0x0",
         "ext v2.16b, v17.16b, v0.16b, #0",
-        "mov z1.q, z17.q[1]",
-        "mov z3.d, z17.d",
-        "mov z3.b, p6/m, z1.b",
-        "mov z1.q, z18.q[1]",
-        "mov z4.d, z18.d",
-        "mov z4.b, p6/m, z1.b",
+        "mov z3.q, z17.q[1]",
+        "mov z4.q, z18.q[1]",
         "movi v0.2d, #0x0",
         "ext v4.16b, v3.16b, v0.16b, #0",
         "mov z1.q, q4",


### PR DESCRIPTION
Arbitrary insertion of an element requires the use of a predicate register. Since we only care about a particular element in the vector, being replicated, we can broadcast that element instead of doing an insert, which is effectively the same thing without excessive busywork.