### PR TITLE
AVX: Remove unnecessary dup if sources are the same in SHUFOpImpl

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -1954,8 +1954,9 @@ Ref OpDispatchBuilder::SHUFOpImpl(IR::OpSize DstSize, IR::OpSize ElementSize, Re
       }
     }
 
+    const auto SameSources = Src1 == Src2;
     auto UpperLaneLHS = _VDupElement(OpSize::i256Bit, OpSize::i128Bit, Src1, 1);
-    auto UpperLaneRHS = _VDupElement(OpSize::i256Bit, OpSize::i128Bit, Src2, 1);
+    auto UpperLaneRHS = SameSources ? UpperLaneLHS : _VDupElement(OpSize::i256Bit, OpSize::i128Bit, Src2, 1);
 
     // VSHUFPS uses the full immediate for each lane, where as VSHUFPD
     // uses pairs for each operation.

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -989,229 +989,215 @@
       ]
     },
     "vpermilpd ymm0, ymm1, 0001b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "ext v4.16b, v17.16b, v17.16b, #8",
-        "zip1 v2.2d, v2.2d, v3.2d",
+        "ext v3.16b, v17.16b, v17.16b, #8",
+        "mov z2.d, d2",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 0010b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "mov v4.16b, v17.16b",
-        "mov v4.d[1], v17.d[1]",
-        "zip1 v2.2d, v2.2d, v3.2d",
+        "mov v3.16b, v17.16b",
+        "mov v3.d[1], v17.d[1]",
+        "mov z2.d, d2",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 0011b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "zip2 v4.2d, v17.2d, v17.2d",
-        "zip1 v2.2d, v2.2d, v3.2d",
+        "zip2 v3.2d, v17.2d, v17.2d",
+        "mov z2.d, d2",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 0100b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "mov z4.d, d17",
-        "ext v2.16b, v2.16b, v3.16b, #8",
+        "mov z3.d, d17",
+        "ext v2.16b, v2.16b, v2.16b, #8",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 0101b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "ext v4.16b, v17.16b, v17.16b, #8",
-        "ext v2.16b, v2.16b, v3.16b, #8",
+        "ext v3.16b, v17.16b, v17.16b, #8",
+        "ext v2.16b, v2.16b, v2.16b, #8",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 0110b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "mov v4.16b, v17.16b",
-        "mov v4.d[1], v17.d[1]",
-        "ext v2.16b, v2.16b, v3.16b, #8",
+        "mov v3.16b, v17.16b",
+        "mov v3.d[1], v17.d[1]",
+        "ext v2.16b, v2.16b, v2.16b, #8",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 0111b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "zip2 v4.2d, v17.2d, v17.2d",
-        "ext v2.16b, v2.16b, v3.16b, #8",
+        "zip2 v3.2d, v17.2d, v17.2d",
+        "ext v2.16b, v2.16b, v2.16b, #8",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 1000b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "mov z4.d, d17",
-        "mov v2.d[1], v3.d[1]",
+        "mov z3.d, d17",
+        "mov v2.d[1], v2.d[1]",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 1001b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "ext v4.16b, v17.16b, v17.16b, #8",
-        "mov v2.d[1], v3.d[1]",
+        "ext v3.16b, v17.16b, v17.16b, #8",
+        "mov v2.d[1], v2.d[1]",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 1010b": {
-      "ExpectedInstructionCount": 9,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "mov v4.16b, v17.16b",
-        "mov v4.d[1], v17.d[1]",
-        "mov v2.d[1], v3.d[1]",
+        "mov v3.16b, v17.16b",
+        "mov v3.d[1], v17.d[1]",
+        "mov v2.d[1], v2.d[1]",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 1011b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "zip2 v4.2d, v17.2d, v17.2d",
-        "mov v2.d[1], v3.d[1]",
+        "zip2 v3.2d, v17.2d, v17.2d",
+        "mov v2.d[1], v2.d[1]",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 1100b": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "mov z4.d, d17",
-        "zip2 v2.2d, v2.2d, v3.2d",
+        "mov z3.d, d17",
+        "zip2 v2.2d, v2.2d, v2.2d",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermilpd ymm0, ymm1, 1101b": {
+      "ExpectedInstructionCount": 7,
+      "Comment": [
+        "Map 3 0b01 0x05 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "mov z2.q, z17.q[1]",
+        "ext v3.16b, v17.16b, v17.16b, #8",
+        "zip2 v2.2d, v2.2d, v2.2d",
+        "mov z1.q, q2",
+        "mov z16.d, z3.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
+      ]
+    },
+    "vpermilpd ymm0, ymm1, 1110b": {
       "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x05 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "ext v4.16b, v17.16b, v17.16b, #8",
-        "zip2 v2.2d, v2.2d, v3.2d",
+        "mov v3.16b, v17.16b",
+        "mov v3.d[1], v17.d[1]",
+        "zip2 v2.2d, v2.2d, v2.2d",
         "mov z1.q, q2",
-        "mov z16.d, z4.d",
-        "not p0.b, p7/z, p6.b",
-        "mov z16.b, p0/m, z1.b"
-      ]
-    },
-    "vpermilpd ymm0, ymm1, 1110b": {
-      "ExpectedInstructionCount": 9,
-      "Comment": [
-        "Map 3 0b01 0x05 256-bit"
-      ],
-      "ExpectedArm64ASM": [
-        "mov z2.q, z17.q[1]",
-        "mov z3.q, z17.q[1]",
-        "mov v4.16b, v17.16b",
-        "mov v4.d[1], v17.d[1]",
-        "zip2 v2.2d, v2.2d, v3.2d",
-        "mov z1.q, q2",
-        "mov z16.d, z4.d",
+        "mov z16.d, z3.d",
         "not p0.b, p7/z, p6.b",
         "mov z16.b, p0/m, z1.b"
       ]


### PR DESCRIPTION
Eliminates a trivial move.