### PR TITLE
instcountci: Add 16-bit pcmpxstrx variants 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -5301,8 +5301,6 @@ void OpDispatchBuilder::PCMPXSTRXOpImpl(OpcodeArgs, bool IsExplicit, bool IsMask
     IntermediateResult = _VPCMPISTRX(Src1, Src2, Control);
   }
 
-  Ref ZeroConst = Constant(0);
-
   if (IsMask) {
     // For the masked variant of the instructions, if control[6] is set, then we
     // need to expand the intermediate result into a byte or word mask (depending
@@ -5342,6 +5340,8 @@ void OpDispatchBuilder::PCMPXSTRXOpImpl(OpcodeArgs, bool IsExplicit, bool IsMask
       }
     }
   } else {
+    Ref ZeroConst = Constant(0);
+
     // For the indexed variant of the instructions, if control[6] is set, then we
     // store the index of the most significant bit into ECX. If it's not set,
     // then we store the least significant bit.

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -53,10 +53,10 @@
         "blr x3",
         "ldp xzr, x30, [sp], #16",
         "mov w20, w0",
-        "mov w27, #0x0",
         "uxth w0, w20",
         "fmov s16, w0",
         "mov w26, #0x1",
+        "mov w27, #0x0",
         "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
@@ -79,10 +79,10 @@
         "blr x3",
         "ldp xzr, x30, [sp], #16",
         "mov w20, w0",
-        "mov w27, #0x0",
         "uxth w0, w20",
         "fmov s16, w0",
         "mov w26, #0x1",
+        "mov w27, #0x0",
         "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
@@ -105,7 +105,6 @@
         "blr x3",
         "ldp xzr, x30, [sp], #16",
         "mov w20, w0",
-        "mov w27, #0x0",
         "movi v2.2d, #0x0",
         "sbfx x21, x20, #0, #1",
         "mov v2.b[0], w21",
@@ -141,6 +140,7 @@
         "mov v16.16b, v2.16b",
         "mov v16.b[15], w21",
         "mov w26, #0x1",
+        "mov w27, #0x0",
         "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
@@ -163,7 +163,6 @@
         "blr x3",
         "ldp xzr, x30, [sp], #16",
         "mov w20, w0",
-        "mov w27, #0x0",
         "movi v2.2d, #0x0",
         "sbfx x21, x20, #0, #1",
         "mov v2.h[0], w21",
@@ -183,6 +182,7 @@
         "mov v16.16b, v2.16b",
         "mov v16.h[7], w21",
         "mov w26, #0x1",
+        "mov w27, #0x0",
         "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
@@ -263,10 +263,10 @@
         "blr x1",
         "ldr x30, [sp], #16",
         "mov w20, w0",
-        "mov w27, #0x0",
         "uxth w0, w20",
         "fmov s16, w0",
         "mov w26, #0x1",
+        "mov w27, #0x0",
         "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
@@ -287,10 +287,10 @@
         "blr x1",
         "ldr x30, [sp], #16",
         "mov w20, w0",
-        "mov w27, #0x0",
         "uxth w0, w20",
         "fmov s16, w0",
         "mov w26, #0x1",
+        "mov w27, #0x0",
         "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
@@ -311,7 +311,6 @@
         "blr x1",
         "ldr x30, [sp], #16",
         "mov w20, w0",
-        "mov w27, #0x0",
         "movi v2.2d, #0x0",
         "sbfx x21, x20, #0, #1",
         "mov v2.b[0], w21",
@@ -347,6 +346,7 @@
         "mov v16.16b, v2.16b",
         "mov v16.b[15], w21",
         "mov w26, #0x1",
+        "mov w27, #0x0",
         "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]
@@ -367,7 +367,6 @@
         "blr x1",
         "ldr x30, [sp], #16",
         "mov w20, w0",
-        "mov w27, #0x0",
         "movi v2.2d, #0x0",
         "sbfx x21, x20, #0, #1",
         "mov v2.h[0], w21",
@@ -387,6 +386,7 @@
         "mov v16.16b, v2.16b",
         "mov v16.h[7], w21",
         "mov w26, #0x1",
+        "mov w27, #0x0",
         "eor w20, w20, #0x20000000",
         "msr nzcv, x20"
       ]

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -38,6 +38,7 @@
     "pcmpestrm xmm0, xmm1, 0_0_00_00_00b": {
       "ExpectedInstructionCount": 17,
       "Comment": [
+        "Bit mask (8-bit)",
         "0x66 0x0f 0x3A 0x60"
       ],
       "ExpectedArm64ASM": [
@@ -60,9 +61,136 @@
         "msr nzcv, x20"
       ]
     },
+    "pcmpestrm xmm0, xmm1, 0_0_00_00_01b": {
+      "ExpectedInstructionCount": 17,
+      "Comment": [
+        "Bit mask (16-bit)",
+        "0x66 0x0f 0x3A 0x60"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr x3, [x28, #2328]",
+        "ldr x0, [x28, #2336]",
+        "stp x0, x30, [sp, #-16]!",
+        "mov x0, x4",
+        "mov x1, x5",
+        "mov w2, #0x1",
+        "mov v0.16b, v16.16b",
+        "mov v1.16b, v17.16b",
+        "blr x3",
+        "ldp xzr, x30, [sp], #16",
+        "mov w20, w0",
+        "mov w27, #0x0",
+        "uxth w0, w20",
+        "fmov s16, w0",
+        "mov w26, #0x1",
+        "eor w20, w20, #0x20000000",
+        "msr nzcv, x20"
+      ]
+    },
+    "pcmpestrm xmm0, xmm1, 0_1_00_00_00b": {
+      "ExpectedInstructionCount": 49,
+      "Comment": [
+        "Expanded mask (8-bit)",
+        "0x66 0x0f 0x3A 0x60"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr x3, [x28, #2328]",
+        "ldr x0, [x28, #2336]",
+        "stp x0, x30, [sp, #-16]!",
+        "mov x0, x4",
+        "mov x1, x5",
+        "mov w2, #0x40",
+        "mov v0.16b, v16.16b",
+        "mov v1.16b, v17.16b",
+        "blr x3",
+        "ldp xzr, x30, [sp], #16",
+        "mov w20, w0",
+        "mov w27, #0x0",
+        "movi v2.2d, #0x0",
+        "sbfx x21, x20, #0, #1",
+        "mov v2.b[0], w21",
+        "sbfx x21, x20, #1, #1",
+        "mov v2.b[1], w21",
+        "sbfx x21, x20, #2, #1",
+        "mov v2.b[2], w21",
+        "sbfx x21, x20, #3, #1",
+        "mov v2.b[3], w21",
+        "sbfx x21, x20, #4, #1",
+        "mov v2.b[4], w21",
+        "sbfx x21, x20, #5, #1",
+        "mov v2.b[5], w21",
+        "sbfx x21, x20, #6, #1",
+        "mov v2.b[6], w21",
+        "sbfx x21, x20, #7, #1",
+        "mov v2.b[7], w21",
+        "sbfx x21, x20, #8, #1",
+        "mov v2.b[8], w21",
+        "sbfx x21, x20, #9, #1",
+        "mov v2.b[9], w21",
+        "sbfx x21, x20, #10, #1",
+        "mov v2.b[10], w21",
+        "sbfx x21, x20, #11, #1",
+        "mov v2.b[11], w21",
+        "sbfx x21, x20, #12, #1",
+        "mov v2.b[12], w21",
+        "sbfx x21, x20, #13, #1",
+        "mov v2.b[13], w21",
+        "sbfx x21, x20, #14, #1",
+        "mov v2.b[14], w21",
+        "sbfx x21, x20, #15, #1",
+        "mov v16.16b, v2.16b",
+        "mov v16.b[15], w21",
+        "mov w26, #0x1",
+        "eor w20, w20, #0x20000000",
+        "msr nzcv, x20"
+      ]
+    },
+    "pcmpestrm xmm0, xmm1, 0_1_00_00_01b": {
+      "ExpectedInstructionCount": 33,
+      "Comment": [
+        "Expanded mask (16-bit)",
+        "0x66 0x0f 0x3A 0x60"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr x3, [x28, #2328]",
+        "ldr x0, [x28, #2336]",
+        "stp x0, x30, [sp, #-16]!",
+        "mov x0, x4",
+        "mov x1, x5",
+        "mov w2, #0x41",
+        "mov v0.16b, v16.16b",
+        "mov v1.16b, v17.16b",
+        "blr x3",
+        "ldp xzr, x30, [sp], #16",
+        "mov w20, w0",
+        "mov w27, #0x0",
+        "movi v2.2d, #0x0",
+        "sbfx x21, x20, #0, #1",
+        "mov v2.h[0], w21",
+        "sbfx x21, x20, #1, #1",
+        "mov v2.h[1], w21",
+        "sbfx x21, x20, #2, #1",
+        "mov v2.h[2], w21",
+        "sbfx x21, x20, #3, #1",
+        "mov v2.h[3], w21",
+        "sbfx x21, x20, #4, #1",
+        "mov v2.h[4], w21",
+        "sbfx x21, x20, #5, #1",
+        "mov v2.h[5], w21",
+        "sbfx x21, x20, #6, #1",
+        "mov v2.h[6], w21",
+        "sbfx x21, x20, #7, #1",
+        "mov v16.16b, v2.16b",
+        "mov v16.h[7], w21",
+        "mov w26, #0x1",
+        "eor w20, w20, #0x20000000",
+        "msr nzcv, x20"
+      ]
+    },
     "pcmpestri xmm0, xmm1, 0_0_00_00_00b": {
       "ExpectedInstructionCount": 21,
       "Comment": [
+        "8-bit",
         "0x66 0x0f 0x3A 0x61"
       ],
       "ExpectedArm64ASM": [
@@ -89,9 +217,40 @@
         "msr nzcv, x20"
       ]
     },
+    "pcmpestri xmm0, xmm1, 0_0_00_00_01b": {
+      "ExpectedInstructionCount": 21,
+      "Comment": [
+        "16-bit",
+        "0x66 0x0f 0x3A 0x61"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr x3, [x28, #2328]",
+        "ldr x0, [x28, #2336]",
+        "stp x0, x30, [sp, #-16]!",
+        "mov x0, x4",
+        "mov x1, x5",
+        "mov w2, #0x1",
+        "mov v0.16b, v16.16b",
+        "mov v1.16b, v17.16b",
+        "blr x3",
+        "ldp xzr, x30, [sp], #16",
+        "mov w20, w0",
+        "mov w27, #0x0",
+        "uxth w21, w20",
+        "mov w22, #0x8",
+        "rbit w0, w21",
+        "clz w23, w0",
+        "cmp x21, #0x0 (0)",
+        "csel x7, x22, x23, eq",
+        "mov w26, #0x1",
+        "eor w20, w20, #0x20000000",
+        "msr nzcv, x20"
+      ]
+    },
     "pcmpistrm xmm0, xmm1, 0_0_00_00_00b": {
       "ExpectedInstructionCount": 15,
       "Comment": [
+        "Bit mask (8-bit)",
         "0x66 0x0f 0x3A 0x62"
       ],
       "ExpectedArm64ASM": [
@@ -112,9 +271,130 @@
         "msr nzcv, x20"
       ]
     },
+    "pcmpistrm xmm0, xmm1, 0_0_00_00_01b": {
+      "ExpectedInstructionCount": 15,
+      "Comment": [
+        "Bit mask (16-bit)",
+        "0x66 0x0f 0x3A 0x62"
+      ],
+      "ExpectedArm64ASM": [
+        "str x30, [sp, #-16]!",
+        "mov v0.16b, v16.16b",
+        "mov v1.16b, v17.16b",
+        "mov w0, #0x1",
+        "ldr x1, [x28, #2344]",
+        "ldr x3, [x28, #2352]",
+        "blr x1",
+        "ldr x30, [sp], #16",
+        "mov w20, w0",
+        "mov w27, #0x0",
+        "uxth w0, w20",
+        "fmov s16, w0",
+        "mov w26, #0x1",
+        "eor w20, w20, #0x20000000",
+        "msr nzcv, x20"
+      ]
+    },
+    "pcmpistrm xmm0, xmm1, 0_1_00_00_00b": {
+      "ExpectedInstructionCount": 47,
+      "Comment": [
+        "Expanded mask (8-bit)",
+        "0x66 0x0f 0x3A 0x62"
+      ],
+      "ExpectedArm64ASM": [
+        "str x30, [sp, #-16]!",
+        "mov v0.16b, v16.16b",
+        "mov v1.16b, v17.16b",
+        "mov w0, #0x40",
+        "ldr x1, [x28, #2344]",
+        "ldr x3, [x28, #2352]",
+        "blr x1",
+        "ldr x30, [sp], #16",
+        "mov w20, w0",
+        "mov w27, #0x0",
+        "movi v2.2d, #0x0",
+        "sbfx x21, x20, #0, #1",
+        "mov v2.b[0], w21",
+        "sbfx x21, x20, #1, #1",
+        "mov v2.b[1], w21",
+        "sbfx x21, x20, #2, #1",
+        "mov v2.b[2], w21",
+        "sbfx x21, x20, #3, #1",
+        "mov v2.b[3], w21",
+        "sbfx x21, x20, #4, #1",
+        "mov v2.b[4], w21",
+        "sbfx x21, x20, #5, #1",
+        "mov v2.b[5], w21",
+        "sbfx x21, x20, #6, #1",
+        "mov v2.b[6], w21",
+        "sbfx x21, x20, #7, #1",
+        "mov v2.b[7], w21",
+        "sbfx x21, x20, #8, #1",
+        "mov v2.b[8], w21",
+        "sbfx x21, x20, #9, #1",
+        "mov v2.b[9], w21",
+        "sbfx x21, x20, #10, #1",
+        "mov v2.b[10], w21",
+        "sbfx x21, x20, #11, #1",
+        "mov v2.b[11], w21",
+        "sbfx x21, x20, #12, #1",
+        "mov v2.b[12], w21",
+        "sbfx x21, x20, #13, #1",
+        "mov v2.b[13], w21",
+        "sbfx x21, x20, #14, #1",
+        "mov v2.b[14], w21",
+        "sbfx x21, x20, #15, #1",
+        "mov v16.16b, v2.16b",
+        "mov v16.b[15], w21",
+        "mov w26, #0x1",
+        "eor w20, w20, #0x20000000",
+        "msr nzcv, x20"
+      ]
+    },
+    "pcmpistrm xmm0, xmm1, 0_1_00_00_01b": {
+      "ExpectedInstructionCount": 31,
+      "Comment": [
+        "Expanded mask (16-bit)",
+        "0x66 0x0f 0x3A 0x62"
+      ],
+      "ExpectedArm64ASM": [
+        "str x30, [sp, #-16]!",
+        "mov v0.16b, v16.16b",
+        "mov v1.16b, v17.16b",
+        "mov w0, #0x41",
+        "ldr x1, [x28, #2344]",
+        "ldr x3, [x28, #2352]",
+        "blr x1",
+        "ldr x30, [sp], #16",
+        "mov w20, w0",
+        "mov w27, #0x0",
+        "movi v2.2d, #0x0",
+        "sbfx x21, x20, #0, #1",
+        "mov v2.h[0], w21",
+        "sbfx x21, x20, #1, #1",
+        "mov v2.h[1], w21",
+        "sbfx x21, x20, #2, #1",
+        "mov v2.h[2], w21",
+        "sbfx x21, x20, #3, #1",
+        "mov v2.h[3], w21",
+        "sbfx x21, x20, #4, #1",
+        "mov v2.h[4], w21",
+        "sbfx x21, x20, #5, #1",
+        "mov v2.h[5], w21",
+        "sbfx x21, x20, #6, #1",
+        "mov v2.h[6], w21",
+        "sbfx x21, x20, #7, #1",
+        "mov v16.16b, v2.16b",
+        "mov v16.h[7], w21",
+        "mov w26, #0x1",
+        "eor w20, w20, #0x20000000",
+        "msr nzcv, x20"
+      ]
+    },
     "pcmpistri xmm0, xmm1, 0_0_00_00_00b": {
       "ExpectedInstructionCount": 19,
       "Comment": [
+        "8-bit",
         "0x66 0x0f 0x3A 0x63"
       ],
       "ExpectedArm64ASM": [
@@ -130,6 +410,34 @@
         "mov w27, #0x0",
         "uxth w21, w20",
         "mov w22, #0x10",
+        "rbit w0, w21",
+        "clz w23, w0",
+        "cmp x21, #0x0 (0)",
+        "csel x7, x22, x23, eq",
+        "mov w26, #0x1",
+        "eor w20, w20, #0x20000000",
+        "msr nzcv, x20"
+      ]
+    },
+    "pcmpistri xmm0, xmm1, 0_0_00_00_01b": {
+      "ExpectedInstructionCount": 19,
+      "Comment": [
+        "16-bit",
+        "0x66 0x0f 0x3A 0x63"
+      ],
+      "ExpectedArm64ASM": [
+        "str x30, [sp, #-16]!",
+        "mov v0.16b, v16.16b",
+        "mov v1.16b, v17.16b",
+        "mov w0, #0x1",
+        "ldr x1, [x28, #2344]",
+        "ldr x3, [x28, #2352]",
+        "blr x1",
+        "ldr x30, [sp], #16",
+        "mov w20, w0",
+        "mov w27, #0x0",
+        "uxth w21, w20",
+        "mov w22, #0x8",
         "rbit w0, w21",
         "clz w23, w0",
         "cmp x21, #0x0 (0)",


### PR DESCRIPTION
Mainly just to get coverage of the expanded mask and 16-bit paths to get a better overview the ops in general.