### PR TITLE
AVX: Skip identity insertions in VPERMQ

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -5012,9 +5012,15 @@ void OpDispatchBuilder::VPERMQOp(OpcodeArgs) {
   }
 
   default: {
-    Result = LoadZeroVector(DstSize);
+    Result = Src;
     for (size_t i = 0; i < IR::NumElements(DstSize, IR::OpSize::i64Bit); i++) {
+      // If we have a matching index, then we don't need to perform an insert,
+      // since all we'd be doing is inserting the same data.
       const auto SrcIndex = (Selector >> (i * 2)) & 0b11;
+      if (i == SrcIndex) {
+        continue;
+      }
+
       Result = _VInsElement(DstSize, OpSize::i64Bit, i, SrcIndex, Result, Src);
     }
     break;

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -16,8 +16,8 @@
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[1]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -50,8 +50,8 @@
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[2]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -84,8 +84,8 @@
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[3]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -113,25 +113,13 @@
       ]
     },
     "vpermq ymm0, ymm1, 4": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 14,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, z17.d[1]",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #0",
@@ -147,22 +135,16 @@
       ]
     },
     "vpermq ymm0, ymm1, 5": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[1]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, z17.d[1]",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z2.d, p0/m, z1.d",
         "msr nzcv, x0",
         "mov z1.d, d17",
@@ -181,22 +163,16 @@
       ]
     },
     "vpermq ymm0, ymm1, 6": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[2]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, z17.d[1]",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z2.d, p0/m, z1.d",
         "msr nzcv, x0",
         "mov z1.d, d17",
@@ -215,22 +191,16 @@
       ]
     },
     "vpermq ymm0, ymm1, 7": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[3]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, z17.d[1]",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z2.d, p0/m, z1.d",
         "msr nzcv, x0",
         "mov z1.d, d17",
@@ -249,19 +219,13 @@
       ]
     },
     "vpermq ymm0, ymm1, 8": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
         "mov z1.d, z17.d[2]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
@@ -288,8 +252,8 @@
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[1]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -322,8 +286,8 @@
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[2]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -356,8 +320,8 @@
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[3]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -385,19 +349,13 @@
       ]
     },
     "vpermq ymm0, ymm1, 12": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
         "mov z1.d, z17.d[3]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-1",
@@ -424,8 +382,8 @@
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[1]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -458,8 +416,8 @@
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[2]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",
@@ -492,8 +450,8 @@
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movi v2.2d, #0x0",
         "mov z1.d, z17.d[3]",
+        "mov z2.d, z17.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
         "cmpeq p0.d, p7/z, z0.d, #-2",


### PR DESCRIPTION
In the slower case, if our iteration index and the selector index match, then all that means is that we'd be inserting the same data that already exists at that location, so we can skip the insertion in that case.