### PR TITLE
LibraryForwarding/cuda: Convert constexpr to const

### DIFF
--- a/ThunkLibs/libcuda/libcuda_Guest.cpp
+++ b/ThunkLibs/libcuda/libcuda_Guest.cpp
@@ -56,7 +56,7 @@ struct override_entry {
   void* ptr;
 };
 
-constexpr static std::array<override_entry, 2> proc_override = {
+const static std::array<override_entry, 2> proc_override = {
   {{"cuGetProcAddress", (void*)cuGetProcAddress_v2}, {"cuGetProcAddress_v2", (void*)cuGetProcAddress_v2}}};
 
 CUresult cuGetProcAddress_v2(const char* symbol, void** pfn, int cudaVersion, cuuint64_t flags, CUdriverProcAddressQueryResult* symbolStatus) {

--- a/ThunkLibs/libcuda/libcuda_Host.cpp
+++ b/ThunkLibs/libcuda/libcuda_Host.cpp
@@ -17,7 +17,7 @@ struct override_entry {
   void* ptr;
 };
 
-constexpr static std::array<override_entry, 2> proc_override = {
+const static std::array<override_entry, 2> proc_override = {
   {{"cuCtxCreate_v2", (void*)FEXFN_IMPL(cuCtxCreate_v2)}, {"cuGetExportTable", (void*)FEXFN_IMPL(cuGetExportTable)}}};
 
 static CUresult FEXFN_IMPL(cuGetProcAddress_v2)(const char* symbol, guest_layout<void**> pfn, int cudaVersion, cuuint64_t flags,


### PR DESCRIPTION
Apparently some compilers or libstdc++ or libc++ takes offence to constexpr std::array that gets filled by GOT. My compiler this generates the same code regardless but I guess this'll probably fix #5582.