### PR TITLE
AVX: Handle easily broadcastable permutations in VPERMQ

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -4990,6 +4990,37 @@ void OpDispatchBuilder::VPERMQOp(OpcodeArgs) {
   const auto Selector = Op->Src[1].Literal();
   Ref Result {};
 
+  // Determines if we have any sort of pattern where we have
+  // a sequence of 0baa'bb'cc'dd where three of these match
+  // with one another alongside a lone outlier.
+  //
+  // In the event that three element subselectors match, then
+  // the operation can be reduced down to a broadcast and a
+  // single insert. We return the insertion index, the selector of the unique
+  // elemenet, followed by any element that would be fine to broadcast from.
+  using BroadcastIndices = std::optional<std::tuple<uint32_t, uint32_t, uint32_t>>;
+  const auto BroadcastableInsert = [Selector]() -> BroadcastIndices {
+    const auto a = (Selector >> 6) & 0b11;
+    const auto b = (Selector >> 4) & 0b11;
+    const auto c = (Selector >> 2) & 0b11;
+    const auto d = Selector & 0b11;
+
+    if (a == b && b == c && a != d) {
+      return std::make_tuple(0, d, a);
+    }
+    if (a == b && b == d && a != c) {
+      return std::make_tuple(1, c, a);
+    }
+    if (a == c && c == d && a != b) {
+      return std::make_tuple(2, b, a);
+    }
+    if (b == c && c == d && b != a) {
+      return std::make_tuple(3, a, b);
+    }
+
+    return std::nullopt;
+  };
+
   switch (Selector) {
   case 0b00'00'00'00:
   case 0b01'01'01'01:
@@ -5012,6 +5043,14 @@ void OpDispatchBuilder::VPERMQOp(OpcodeArgs) {
   }
 
   default: {
+    // See if we have an easily broadcastable permutation.
+    if (const auto Indices = BroadcastableInsert()) {
+      const auto [DstIdx, InsertIdx, BroadcastIdx] = *Indices;
+      Result = _VDupElement(DstSize, OpSize::i64Bit, Src, BroadcastIdx);
+      Result = _VInsElement(DstSize, OpSize::i64Bit, DstIdx, InsertIdx, Result, Src);
+      break;
+    }
+
     Result = Src;
     for (size_t i = 0; i < IR::NumElements(DstSize, IR::OpSize::i64Bit); i++) {
       // If we have a matching index, then we don't need to perform an insert,

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -11,125 +11,65 @@
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
+        "mov z2.d, d17",
         "mov z1.d, z17.d[1]",
-        "mov z2.d, z17.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
         "mov z16.d, z2.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
         "mov z16.d, p0/m, z1.d",
         "msr nzcv, x0"
       ]
     },
     "vpermq ymm0, ymm1, 2": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
+        "mov z2.d, d17",
         "mov z1.d, z17.d[2]",
-        "mov z2.d, z17.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
         "mov z16.d, z2.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
         "mov z16.d, p0/m, z1.d",
         "msr nzcv, x0"
       ]
     },
     "vpermq ymm0, ymm1, 3": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
+        "mov z2.d, d17",
         "mov z1.d, z17.d[3]",
-        "mov z2.d, z17.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
         "mov z16.d, z2.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-2",
         "mov z16.d, p0/m, z1.d",
         "msr nzcv, x0"
       ]
     },
     "vpermq ymm0, ymm1, 4": {
-      "ExpectedInstructionCount": 14,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z1.d, d17",
-        "mov z2.d, z17.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
+        "mov z2.d, d17",
+        "mov z1.d, z17.d[1]",
         "mov z16.d, z2.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z16.d, p0/m, z1.d",
         "msr nzcv, x0"
       ]
@@ -219,29 +159,17 @@
       ]
     },
     "vpermq ymm0, ymm1, 8": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
+        "mov z2.d, d17",
         "mov z1.d, z17.d[2]",
-        "mov z2.d, z17.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
         "mov z16.d, z2.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z16.d, p0/m, z1.d",
         "msr nzcv, x0"
       ]
@@ -349,29 +277,17 @@
       ]
     },
     "vpermq ymm0, ymm1, 12": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
+        "mov z2.d, d17",
         "mov z1.d, z17.d[3]",
-        "mov z2.d, z17.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
         "mov z16.d, z2.d",
         "mrs x0, nzcv",
         "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
+        "cmpeq p0.d, p7/z, z0.d, #-1",
         "mov z16.d, p0/m, z1.d",
         "msr nzcv, x0"
       ]


### PR DESCRIPTION
When we have a 3 element identical permutation followed by a single unique outlier, we can simplify the whole operation into a single broadcast followed by an insert. Technically we could do 2 element ones as well, but I am simply sleepy atm, so that will come later

e.g.

```
0b00'00'00'01
0b00'01'01'01
0b11'11'00'11
```

are all examples of cases where we can broadcast and then insert.