### PR TITLE
OpcodeDispatcher: Fixes CRC32 with high 8-bit register

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -5056,6 +5056,7 @@ void OpDispatchBuilder::CRC32(OpcodeArgs) {
     return;
   }
   const auto GPRSize = GetGPROpSize();
+  const auto SrcSize = OpSizeFromSrc(Op);
 
   // Destination GPR size is always 4 or 8 bytes depending on widening
   const auto DstSize = Op->Flags & FEXCore::X86Tables::DecodeFlags::FLAG_REX_WIDENING ? OpSize::i64Bit : OpSize::i32Bit;
@@ -5064,11 +5065,11 @@ void OpDispatchBuilder::CRC32(OpcodeArgs) {
   // Incoming memory is 8, 16, 32, or 64
   Ref Src {};
   if (Op->Src[0].IsGPR()) {
-    Src = LoadSourceGPR_WithOpSize(Op, Op->Src[0], GPRSize, Op->Flags);
+    Src = LoadSourceGPR_WithOpSize(Op, Op->Src[0], SrcSize, Op->Flags, {.AllowUpperGarbage = true});
   } else {
     Src = LoadSourceGPR(Op, Op->Src[0], Op->Flags, {.Align = OpSize::i8Bit});
   }
-  auto Result = _CRC32(Dest, Src, OpSizeFromSrc(Op));
+  auto Result = _CRC32(Dest, Src, SrcSize);
   StoreResultGPR_WithOpSize(Op, Op->Dest, Result, DstSize);
 }
 

--- a/unittests/ASM/FEX_bugs/crc32_8b.asm
+++ b/unittests/ASM/FEX_bugs/crc32_8b.asm
@@ -1,0 +1,17 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x9CB095B0",
+    "RCX": "0x0000000011223344"
+  }
+}
+%endif
+
+mov eax, 0xFFFFFFFF
+mov rcx, 0x11223344
+
+crc32 eax, cl
+
+crc32 eax, ch
+
+hlt

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -143,6 +143,16 @@
         "crc32cb w4, w4, w6"
       ]
     },
+    "crc32 eax, bh": {
+      "ExpectedInstructionCount": 2,
+      "Comment": [
+        "0xf2 0x0f 0x38 0xf0"
+      ],
+      "ExpectedArm64ASM": [
+        "lsr w20, w6, #8",
+        "crc32cb w4, w4, w20"
+      ]
+    },
     "crc32 eax, bx": {
       "ExpectedInstructionCount": 1,
       "Comment": [


### PR DESCRIPTION
Assertion failure in `_Bfe` IR operation when encountering this
instruction. Ensure the GPR source is sized appropriately.

Different way to fix the bug than #5608, still using their ASM test.