### PR TITLE
Windows: Adds empty Linux side unix library

### DIFF
--- a/.github/workflows/wine_build/action.yml
+++ b/.github/workflows/wine_build/action.yml
@@ -33,3 +33,17 @@ runs:
     - name: Install
       shell: bash
       run: DESTDIR="$PWD"/install cmake --build build_${{ inputs.target }} -t install
+
+    - name: Configure UnixLib
+      shell: bash
+      run: |
+        cmake -S Source/Windows/UnixLib -B build_unixlib_${{ inputs.target }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -G Ninja -DCMAKE_INSTALL_LIBDIR=/usr/lib/wine/aarch64-unix -DCMAKE_INSTALL_PREFIX=/usr
+
+    - name: Build UnixLib
+      shell: bash
+      run: cmake --build build_unixlib_${{ inputs.target }}
+
+    - name: Install UnixLib
+      shell: bash
+      run: DESTDIR="$PWD"/install cmake --build build_unixlib_${{ inputs.target }} -t install

--- a/.github/workflows/wine_dll_artifacts.yml
+++ b/.github/workflows/wine_dll_artifacts.yml
@@ -50,6 +50,8 @@ jobs:
       with:
         overwrite: true
         name: wine_dll_artifacts
-        path: ${{ github.workspace }}/install/usr/lib/wine/aarch64-windows/lib*.dll
+        path: |
+          ${{ github.workspace }}/install/usr/lib/wine/aarch64-windows/lib*.dll
+          ${{ github.workspace }}/install/usr/lib/wine/aarch64-unix/lib*.so
         retention-days: 60
         compression-level: 9

--- a/Source/Windows/UnixLib/CMakeLists.txt
+++ b/Source/Windows/UnixLib/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.14)
+project(FEXUnixLib CXX)
+
+include(GNUInstallDirs)
+
+function(CreateLib TargetName LibName)
+  add_library(${TargetName} SHARED FEXUnixLib.cpp)
+  set_target_properties(${TargetName} PROPERTIES OUTPUT_NAME ${LibName} PREFIX "lib" SUFFIX ".so")
+  target_link_libraries(${TargetName} PRIVATE rt)
+  install(TARGETS ${TargetName} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Runtime)
+endfunction()
+
+CreateLib(wow64fex_unixlib wow64fex)
+CreateLib(arm64ecfex_unixlib arm64ecfex)

--- a/Source/Windows/UnixLib/FEXUnixLib.cpp
+++ b/Source/Windows/UnixLib/FEXUnixLib.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+#include <cstdint>
+#include <type_traits>
+
+#include "FEXUnixLib.h"
+
+// Equivalent to C++23's std::to_underlying.
+template<typename Enum>
+[[nodiscard]]
+constexpr std::underlying_type_t<Enum> ToUnderlying(Enum e) noexcept {
+  return static_cast<std::underlying_type_t<Enum>>(e);
+}
+
+using NTSTATUS = int32_t;
+using unixlib_entry_t = NTSTATUS (*)(void*);
+
+constexpr NTSTATUS STATUS_SUCCESS = 0;
+constexpr NTSTATUS STATUS_NOT_SUPPORTED = 0xC00000BB;
+constexpr NTSTATUS STATUS_INTERNAL_ERROR = 0xC00000E5;
+
+extern "C" const unixlib_entry_t __wine_unix_call_funcs[] = {};
+
+static_assert(sizeof(__wine_unix_call_funcs) / sizeof(__wine_unix_call_funcs[0]) == ToUnderlying(FEXUnixLibFunctions::MAX));

--- a/Source/Windows/UnixLib/FEXUnixLib.h
+++ b/Source/Windows/UnixLib/FEXUnixLib.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+enum class FEXUnixLibFunctions {
+  // Empty for now.
+  MAX,
+};


### PR DESCRIPTION
We are going to need a unix library. Going to take this one step at a time without AI/ML so I fully understand all the pieces of the puzzle, and to ensure we don't lose any functionality before we're ready.

This only ensures that we are building the Linux facing .so files for arm64ec and wow64, but they are empty today. Next PR will be initializing it on the PE side.