### PR TITLE
Windows/UnixLib: Adds support for Hardware TSO support

### DIFF
--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -629,11 +629,6 @@ NTSTATUS ProcessInit() {
   const uintptr_t KiUserExceptionDispatcherFFS = reinterpret_cast<uintptr_t>(GetProcAddress(NtDll, "KiUserExceptionDispatcher"));
   Exception::KiUserExceptionDispatcher = NtDllRedirectionLUT[KiUserExceptionDispatcherFFS - NtDllBase] + NtDllBase;
 
-  FEX_CONFIG_OPT(TSOEnabled, TSOENABLED);
-  if (TSOEnabled() && FEX::Windows::UnixLib::TryEnableHardwareTSO()) {
-    CTX->SetHardwareTSOSupport(true);
-  }
-
   FEX_CONFIG_OPT(ProfileStats, PROFILESTATS);
   FEX_CONFIG_OPT(StartupSleep, STARTUPSLEEP);
   FEX_CONFIG_OPT(StartupSleepProcName, STARTUPSLEEPPROCNAME);

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -630,12 +630,8 @@ NTSTATUS ProcessInit() {
   Exception::KiUserExceptionDispatcher = NtDllRedirectionLUT[KiUserExceptionDispatcherFFS - NtDllBase] + NtDllBase;
 
   FEX_CONFIG_OPT(TSOEnabled, TSOENABLED);
-  if (TSOEnabled()) {
-    BOOL Enable = TRUE;
-    NTSTATUS Status = NtSetInformationProcess(NtCurrentProcess(), ProcessFexHardwareTso, &Enable, sizeof(Enable));
-    if (Status == STATUS_SUCCESS) {
-      CTX->SetHardwareTSOSupport(true);
-    }
+  if (TSOEnabled() && FEX::Windows::UnixLib::TryEnableHardwareTSO()) {
+    CTX->SetHardwareTSOSupport(true);
   }
 
   FEX_CONFIG_OPT(ProfileStats, PROFILESTATS);

--- a/Source/Windows/Common/FEXUnixLib.cpp
+++ b/Source/Windows/Common/FEXUnixLib.cpp
@@ -7,7 +7,6 @@
 #include <winternl.h>
 #include <libloaderapi.h>
 #include "FEXUnixLib.h"
-#include "../UnixLib/FEXUnixLib.h"
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
@@ -82,6 +81,22 @@ bool Init(HMODULE NtDll) {
 
 static bool UnixLibAvailable() {
   return UnixLibHandle != 0;
+}
+
+bool TryEnableHardwareTSO() {
+  if (UnixLibAvailable()) {
+    // UnixLib path.
+    FEXUnixLib_SetHardwareTSOControlArgs Args {
+      .Enable = true,
+    };
+
+    return Call(FEXUnixLibFunctions::SetHardwareTSOControl, &Args) == STATUS_SUCCESS;
+  }
+
+  // Legacy Proton path.
+  bool Enable = TRUE;
+  NTSTATUS Status = NtSetInformationProcess(NtCurrentProcess(), ProcessFexHardwareTso, &Enable, sizeof(Enable));
+  return Status == STATUS_SUCCESS;
 }
 
 } // namespace FEX::Windows::UnixLib

--- a/Source/Windows/Common/FEXUnixLib.h
+++ b/Source/Windows/Common/FEXUnixLib.h
@@ -1,19 +1,28 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 #include <cstdint>
+#include <FEXCore/Utils/EnumUtils.h>
+#include "../UnixLib/FEXUnixLib.h"
 #include "wine/unixlib.h"
 
 namespace FEX::Windows::UnixLib {
 extern decltype(__wine_unix_call_dispatcher) UnixCallDispatcher;
 extern unixlib_handle_t UnixLibHandle;
 
-inline NTSTATUS Call(uint32_t code, void* args) {
+inline NTSTATUS Call(FEXUnixLibFunctions code, void* args) {
   if (!UnixCallDispatcher) {
     return STATUS_NOT_SUPPORTED;
   }
 
-  return UnixCallDispatcher(UnixLibHandle, code, args);
+  return UnixCallDispatcher(UnixLibHandle, FEXCore::ToUnderlying(code), args);
 }
 
 bool Init(HMODULE NtDll);
+
+/**
+ * @brief Tries to enable hardware TSO if supported.
+ *
+ * @return true if hardware TSO is supported and enabled.
+ */
+bool TryEnableHardwareTSO();
 } // namespace FEX::Windows::UnixLib

--- a/Source/Windows/Common/TSOHandlerConfig.h
+++ b/Source/Windows/Common/TSOHandlerConfig.h
@@ -5,6 +5,8 @@
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Utils/ArchHelpers/Arm64.h>
 
+#include "Windows/Common/FEXUnixLib.h"
+
 namespace FEX::Windows {
 class TSOHandlerConfig final {
 public:
@@ -15,12 +17,8 @@ public:
       UnalignedHandlerType = FEXCore::ArchHelpers::Arm64::UnalignedHandlerType::NonAtomic;
     }
 
-    if (TSOEnabled()) {
-      BOOL Enable = TRUE;
-      NTSTATUS Status = NtSetInformationProcess(NtCurrentProcess(), ProcessFexHardwareTso, &Enable, sizeof(Enable));
-      if (Status == STATUS_SUCCESS) {
-        CTX.SetHardwareTSOSupport(true);
-      }
+    if (TSOEnabled() && FEX::Windows::UnixLib::TryEnableHardwareTSO()) {
+      CTX.SetHardwareTSOSupport(true);
     }
 
     uint64_t Flags = (StrictInProcessSplitLocks() ? FEX_UNALIGN_ATOMIC_STRICT_SPLIT_LOCKS : 0) |

--- a/Source/Windows/UnixLib/FEXUnixLib.cpp
+++ b/Source/Windows/UnixLib/FEXUnixLib.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include <cstdint>
 #include <type_traits>
+#include <sys/prctl.h>
 
 #include "FEXUnixLib.h"
 
@@ -18,6 +19,33 @@ constexpr NTSTATUS STATUS_SUCCESS = 0;
 constexpr NTSTATUS STATUS_NOT_SUPPORTED = 0xC00000BB;
 constexpr NTSTATUS STATUS_INTERNAL_ERROR = 0xC00000E5;
 
-extern "C" const unixlib_entry_t __wine_unix_call_funcs[] = {};
+#ifndef PR_GET_MEM_MODEL
+#define PR_GET_MEM_MODEL 0x6d4d444c
+#endif
+#ifndef PR_SET_MEM_MODEL
+#define PR_SET_MEM_MODEL 0x4d4d444c
+#endif
+#ifndef PR_SET_MEM_MODEL_DEFAULT
+#define PR_SET_MEM_MODEL_DEFAULT 0
+#endif
+#ifndef PR_SET_MEM_MODEL_TSO
+#define PR_SET_MEM_MODEL_TSO 1
+#endif
+
+static NTSTATUS FEXUnixLib_SetHardwareTSOControlHandler(void* _Args) {
+  auto Args = reinterpret_cast<const FEXUnixLib_SetHardwareTSOControlArgs*>(_Args);
+  if (Args->Enable) {
+    int ret = prctl(PR_GET_MEM_MODEL, 0, 0, 0, 0);
+    if (ret == PR_SET_MEM_MODEL_DEFAULT) {
+      return prctl(PR_SET_MEM_MODEL, PR_SET_MEM_MODEL_TSO, 0, 0, 0) ? STATUS_NOT_SUPPORTED : STATUS_SUCCESS;
+    }
+    return ret == PR_SET_MEM_MODEL_TSO ? STATUS_SUCCESS : STATUS_NOT_SUPPORTED;
+  }
+
+  prctl(PR_SET_MEM_MODEL, PR_SET_MEM_MODEL_DEFAULT, 0, 0, 0);
+  return STATUS_SUCCESS;
+}
+
+extern "C" const unixlib_entry_t __wine_unix_call_funcs[] = {FEXUnixLib_SetHardwareTSOControlHandler};
 
 static_assert(sizeof(__wine_unix_call_funcs) / sizeof(__wine_unix_call_funcs[0]) == ToUnderlying(FEXUnixLibFunctions::MAX));

--- a/Source/Windows/UnixLib/FEXUnixLib.h
+++ b/Source/Windows/UnixLib/FEXUnixLib.h
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: MIT
 #pragma once
+#include <cstdint>
 
-enum class FEXUnixLibFunctions {
-  // Empty for now.
+enum class FEXUnixLibFunctions : uint32_t {
+  SetHardwareTSOControl,
   MAX,
 };
+
+// Structures for passing arguments to unix library handlers.
+// This must match between wow64, arm64ec, and Linux.
+struct FEXUnixLib_SetHardwareTSOControlArgs {
+  bool Enable;
+};
+static_assert(sizeof(FEXUnixLib_SetHardwareTSOControlArgs) == 1);

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -572,12 +572,8 @@ void BTCpuProcessInit() {
   GetTLS().Wow64Info().CpuFlags = WOW64_CPUFLAGS_SOFTWARE;
 
   FEX_CONFIG_OPT(TSOEnabled, TSOENABLED);
-  if (TSOEnabled()) {
-    BOOL Enable = TRUE;
-    NTSTATUS Status = NtSetInformationProcess(NtCurrentProcess(), ProcessFexHardwareTso, &Enable, sizeof(Enable));
-    if (Status == STATUS_SUCCESS) {
-      CTX->SetHardwareTSOSupport(true);
-    }
+  if (TSOEnabled() && FEX::Windows::UnixLib::TryEnableHardwareTSO()) {
+    CTX->SetHardwareTSOSupport(true);
   }
 
   FEX_CONFIG_OPT(ProfileStats, PROFILESTATS);

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -571,11 +571,6 @@ void BTCpuProcessInit() {
   // wow64.dll will only initialise the cross-process queue if this is set
   GetTLS().Wow64Info().CpuFlags = WOW64_CPUFLAGS_SOFTWARE;
 
-  FEX_CONFIG_OPT(TSOEnabled, TSOENABLED);
-  if (TSOEnabled() && FEX::Windows::UnixLib::TryEnableHardwareTSO()) {
-    CTX->SetHardwareTSOSupport(true);
-  }
-
   FEX_CONFIG_OPT(ProfileStats, PROFILESTATS);
   FEX_CONFIG_OPT(StartupSleep, STARTUPSLEEP);
   FEX_CONFIG_OPT(StartupSleepProcName, STARTUPSLEEPPROCNAME);


### PR DESCRIPTION
Including fallback to non-unixlib path because we need to support both.

Showcases how these are going to be implemented without throwing the
entire world at it right away. Next PR will be implementing the
remaining four necessary unixlib handlers that we will require:

- Kernel unaligned atomic control
- shm_stats thing
- madvise operation
- prctl vma naming