### PR TITLE
OpcodeDispatcher: Fix missing zeroing for vcvtps2ph

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -2293,9 +2293,8 @@ void OpDispatchBuilder::AVX128_VCVTPS2PH(OpcodeArgs) {
     _PopRoundingMode(OldFPCR);
   }
 
-  // We need to eliminate upper junk if we're storing into a register with
-  // a 256-bit source (VCVTPS2PH's destination for registers is an XMM).
-  if (Op->Src[0].IsGPR() && SrcSize == OpSize::i256Bit) {
+  // We need to zero the upper 128 bits if we're storing into a register
+  if (Op->Dest.IsGPR()) {
     Result = AVX128_Zext(Result.Low);
   }
 

--- a/unittests/ASM/Disabled_Tests_Simulator
+++ b/unittests/ASM/Disabled_Tests_Simulator
@@ -101,6 +101,7 @@ Test_VEX/vcvtps2ph_rd_mxcsr.asm
 Test_VEX/vcvtps2ph_ru_mxcsr.asm
 Test_VEX/vcvtps2ph_trunc_mxcsr.asm
 Test_X87_F64/Rounding_F64.asm
+Test_FEX_bugs/vcvtps2ph_zeroing.asm
 
 # Simulator doesn't support cycle counter reading
 Test_TwoByte/0F_31.asm

--- a/unittests/ASM/FEX_bugs/vcvtps2ph_zeroing.asm
+++ b/unittests/ASM/FEX_bugs/vcvtps2ph_zeroing.asm
@@ -1,0 +1,55 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "RegData": {
+    "XMM1": [
+      "0xd89f3a05a4322f49", 
+      "0x7fd09a85846a3fbb", 
+      "0xc5e072b814de6cb0", 
+      "0xb7050315bf62d810"
+    ],
+    "XMM2": [
+      "0x7e848001fc008001", 
+      "0", 
+      "0", 
+      "0"
+    ],
+    "XMM3": [
+      "0x7e848001fc008001", 
+      "0x8086bb17ef040000", 
+      "0", 
+      "0"
+    ],
+    "XMM4": [
+      "0x7e848001fc008001", 
+      "0x8086bb17ef040000", 
+      "0x3333333333333333", 
+      "0x4444444444444444"
+    ]
+  }
+}
+%endif
+
+lea rdx, [rel .data]
+
+vmovdqa ymm1, [rdx]
+vmovdqa ymm2, [rdx + 32]
+vmovdqa ymm3, [rdx + 32]
+
+vcvtps2ph xmm2, xmm1, 0x1
+
+vcvtps2ph xmm3, ymm1, 0x1
+
+vcvtps2ph [rdx + 64], ymm1, 0x1
+vmovdqa ymm4, [rdx + 64]
+
+hlt
+
+align 4096
+.data:
+; ymm1
+dq 0xd89f3a05a4322f49, 0x7fd09a85846a3fbb, 0xc5e072b814de6cb0, 0xb7050315bf62d810
+; ymm2
+dq 0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF
+; ymm4 memory
+dq 0x1111111111111111, 0x2222222222222222, 0x3333333333333333, 0x4444444444444444

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -2079,7 +2079,7 @@
       ]
     },
     "vcvtps2ph xmm0, xmm1, 00000000b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "nearest rounding",
         "Map 3 0b01 0x1D 128-bit"
@@ -2089,11 +2089,12 @@
         "and x0, x20, #0xffffffffff3fffff",
         "msr fpcr, x0",
         "fcvtn v16.4h, v17.4s",
-        "msr fpcr, x20"
+        "msr fpcr, x20",
+        "stp xzr, xzr, [x28, #192]"
       ]
     },
     "vcvtps2ph xmm0, xmm1, 00000001b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "-inf rounding",
         "Map 3 0b01 0x1D 128-bit"
@@ -2104,11 +2105,12 @@
         "orr x0, x0, #0x800000",
         "msr fpcr, x0",
         "fcvtn v16.4h, v17.4s",
-        "msr fpcr, x20"
+        "msr fpcr, x20",
+        "stp xzr, xzr, [x28, #192]"
       ]
     },
     "vcvtps2ph xmm0, xmm1, 00000010b": {
-      "ExpectedInstructionCount": 6,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "+inf rounding",
         "Map 3 0b01 0x1D 128-bit"
@@ -2119,11 +2121,12 @@
         "orr x0, x0, #0x400000",
         "msr fpcr, x0",
         "fcvtn v16.4h, v17.4s",
-        "msr fpcr, x20"
+        "msr fpcr, x20",
+        "stp xzr, xzr, [x28, #192]"
       ]
     },
     "vcvtps2ph xmm0, xmm1, 00000011b": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "truncate rounding",
         "Map 3 0b01 0x1D 128-bit"
@@ -2133,17 +2136,19 @@
         "orr x0, x20, #0xc00000",
         "msr fpcr, x0",
         "fcvtn v16.4h, v17.4s",
-        "msr fpcr, x20"
+        "msr fpcr, x20",
+        "stp xzr, xzr, [x28, #192]"
       ]
     },
     "vcvtps2ph xmm0, xmm1, 00000100b": {
-      "ExpectedInstructionCount": 1,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "host mode rounding",
         "Map 3 0b01 0x1D 128-bit"
       ],
       "ExpectedArm64ASM": [
-        "fcvtn v16.4h, v17.4s"
+        "fcvtn v16.4h, v17.4s",
+        "stp xzr, xzr, [x28, #192]"
       ]
     },
     "vcvtps2ph xmm0, ymm1, 00000000b": {


### PR DESCRIPTION
The vcvtps2ph instruction should always zero the upper 128 bits of the destination if it is a  **register**. See the Intel Manual:

```
VEX.128 version: The source operand is a XMM register. The destination operand is a XMM register or 64-bit memory location. If the destination operand is a register then the upper bits (MAXVL-1:64) of corresponding register are zeroed.

VEX.256 version: The source operand is a YMM register. The destination operand is a XMM register or 128-bit memory location. If the destination operand is a register, the upper bits (MAXVL-1:128) of the corresponding destination register are zeroed.
```

This PR adds a fix and an ASM unit test.
I also ran the `instcountci_update_tests` target which updated the `unittests/InstructionCountCI/AVX128/VEX_map3.json` file, however, there is also `unittests/InstructionCountCI/VEX_map3.json` which did not get updated by this. Is this legacy code or should it also be updated?