### PR TITLE
Core: Start a new block for the next op in full SMC check

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -650,6 +650,7 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
           Thread->OpDispatcher->SetTrueJumpTarget(InvalidateCodeCond, CodeWasChangedBlock);
 
           Thread->OpDispatcher->SetCurrentCodeBlock(CodeWasChangedBlock);
+          Thread->OpDispatcher->StartNewBlock();
           Thread->OpDispatcher->_ThreadRemoveCodeEntry();
           Thread->OpDispatcher->ExitFunction(Thread->OpDispatcher->_InlineEntrypointOffset(GPRSize, InstAddress - GuestRIP));
 
@@ -657,6 +658,7 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
 
           Thread->OpDispatcher->SetFalseJumpTarget(InvalidateCodeCond, NextOpBlock);
           Thread->OpDispatcher->SetCurrentCodeBlock(NextOpBlock);
+          Thread->OpDispatcher->StartNewBlock();
         }
 
         if (TableInfo && TableInfo->OpcodeDispatcher.OpDispatch) {


### PR DESCRIPTION
Under FEX_SMCCHECKS=full, FEX splits each x86 instruction into its own block but forgot to clear its per-block vector-constant cache at those splits. So back-to-back pmovmskb instructions shared one constant across blocks, and the block-local register allocator then reused the same register for the constant and its operand, producing VAnd v1, v1. That made pmovmskb return garbage, breaking glibc strlen (when hwcaps x86-64-v3), which corrupted loader paths and made Vivado fail. The fix clears all creating a new block.