### PR TITLE
Fix UAF of PS1

### DIFF
--- a/Source/Tools/FEXBash/FEXBash.cpp
+++ b/Source/Tools/FEXBash/FEXBash.cpp
@@ -97,7 +97,9 @@ int main(int argc, char** argv, char** const envp) {
       Envp.emplace_back(envp[i]);
     }
   }
-  Envp.emplace_back(EnchantedPS1(PS1Env).c_str());
+  // Keep the string alive until after execve.
+  const std::string PS1 = EnchantedPS1(PS1Env);
+  Envp.emplace_back(PS1.c_str());
   Envp.emplace_back(nullptr);
 
   return execve(Argv[0], const_cast<char* const*>(Argv.data()), const_cast<char* const*>(&Envp[0]));


### PR DESCRIPTION
PS1 std::string was getting deallocated before the usage as c_str in execve.
The bug was not really triggered as there was no allocation after that but the memory was in fact deallocated.