### PR TITLE
Do not exec FEX if it is a folder in FEXBash

### DIFF
--- a/Source/Tools/FEXBash/FEXBash.cpp
+++ b/Source/Tools/FEXBash/FEXBash.cpp
@@ -53,14 +53,14 @@ int main(int argc, char** argv, char** const envp) {
 
   // Check if a local FEX to FEXBash exists
   // If it does then it takes priority over the installed one
-  if (!std::filesystem::exists(FEXPath)) {
+  if (!std::filesystem::is_regular_file(FEXPath)) {
     std::error_code ec;
     auto FEXBashPath = std::filesystem::read_symlink("/proc/self/exe", ec);
     if (!ec) {
       FEXPath = FEXBashPath.replace_filename("FEX");
     }
 
-    if (!std::filesystem::exists(FEXPath)) {
+    if (!std::filesystem::is_regular_file(FEXPath)) {
       fmt::print(stderr, "Could not locate FEX executable\n");
       std::abort();
     }


### PR DESCRIPTION
FEXBash crashes when there is a FEX named folder (for example the repo checkout) in the cwd because it tries to execve it. Checks only regular files and not folders.