### PR TITLE
AVX: Handle trivial UZP/ZIP operations in VPERMQ

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -5038,6 +5038,23 @@ void OpDispatchBuilder::VPERMQOp(OpcodeArgs) {
     break;
   }
 
+  case 0b01'01'00'00: {
+    Result = _VZip(DstSize, OpSize::i64Bit, Src, Src);
+    break;
+  }
+  case 0b11'11'10'10: {
+    Result = _VZip2(DstSize, OpSize::i64Bit, Src, Src);
+    break;
+  }
+  case 0b10'00'10'00: {
+    Result = _VUnZip(DstSize, OpSize::i64Bit, Src, Src);
+    break;
+  }
+  case 0b11'01'11'01: {
+    Result = _VUnZip2(DstSize, OpSize::i64Bit, Src, Src);
+    break;
+  }
+
   case 0b10'10'00'00: {
     Result = _VTrn(DstSize, OpSize::i64Bit, Src, Src);
     break;

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -421,6 +421,42 @@
         "trn2 z16.d, z17.d, z17.d"
       ]
     },
+    "vpermq ymm0, ymm1, 01010000b": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "Map 3 0b01 0x00 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "zip1 z16.d, z17.d, z17.d"
+      ]
+    },
+    "vpermq ymm0, ymm1, 11111010b": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "Map 3 0b01 0x00 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "zip2 z16.d, z17.d, z17.d"
+      ]
+    },
+    "vpermq ymm0, ymm1, 10001000b": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "Map 3 0b01 0x00 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "uzp1 z16.d, z17.d, z17.d"
+      ]
+    },
+    "vpermq ymm0, ymm1, 11011101b": {
+      "ExpectedInstructionCount": 1,
+      "Comment": [
+        "Map 3 0b01 0x00 256-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "uzp2 z16.d, z17.d, z17.d"
+      ]
+    },
     "vpermq ymm0, ymm1, 01010101b": {
       "ExpectedInstructionCount": 1,
       "Comment": [


### PR DESCRIPTION
Handles cases where a permutation can be simplified into a single zip/unzip operation.