### PR TITLE
AVX: Handle two field insertions in VPERMQ

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -5064,6 +5064,18 @@ void OpDispatchBuilder::VPERMQOp(OpcodeArgs) {
     break;
   }
 
+  case 0b00'00'01'01:
+  case 0b00'00'10'10:
+  case 0b00'00'11'11:
+  case 0b01'01'11'11:
+  case 0b10'10'11'11:
+  case 0b11'11'00'00: {
+    auto Top = _VDupElement(DstSize, OpSize::i64Bit, Src, (Selector >> 6) & 0b11);
+    auto Bottom = _VDupElement(DstSize, OpSize::i64Bit, Src, Selector & 0b11);
+    Result = _VInsElement(DstSize, OpSize::i128Bit, 1, 0, Bottom, Top);
+    break;
+  }
+
   default: {
     // See if we have an easily broadcastable permutation.
     if (const auto Indices = BroadcastableInsert()) {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -75,31 +75,17 @@
       ]
     },
     "vpermq ymm0, ymm1, 5": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z1.d, z17.d[1]",
-        "mov z2.d, z17.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mov z16.d, z2.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z16.d, p0/m, z1.d",
-        "msr nzcv, x0"
+        "mov z2.d, d17",
+        "mov z3.d, z17.d[1]",
+        "mov z1.q, q2",
+        "mov z16.d, z3.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermq ymm0, ymm1, 6": {
@@ -209,37 +195,17 @@
       ]
     },
     "vpermq ymm0, ymm1, 10": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z1.d, z17.d[2]",
-        "mov z2.d, z17.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, z17.d[2]",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mov z16.d, z2.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z16.d, p0/m, z1.d",
-        "msr nzcv, x0"
+        "mov z2.d, d17",
+        "mov z3.d, z17.d[2]",
+        "mov z1.q, q2",
+        "mov z16.d, z3.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermq ymm0, ymm1, 11": {
@@ -361,37 +327,17 @@
       ]
     },
     "vpermq ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 6,
       "Comment": [
         "Map 3 0b01 0x00 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "mov z1.d, z17.d[3]",
-        "mov z2.d, z17.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-2",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, z17.d[3]",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #-1",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #0",
-        "mov z2.d, p0/m, z1.d",
-        "msr nzcv, x0",
-        "mov z1.d, d17",
-        "mov z16.d, z2.d",
-        "mrs x0, nzcv",
-        "index z0.d, #-2, #1",
-        "cmpeq p0.d, p7/z, z0.d, #1",
-        "mov z16.d, p0/m, z1.d",
-        "msr nzcv, x0"
+        "mov z2.d, d17",
+        "mov z3.d, z17.d[3]",
+        "mov z1.q, q2",
+        "mov z16.d, z3.d",
+        "not p0.b, p7/z, p6.b",
+        "mov z16.b, p0/m, z1.b"
       ]
     },
     "vpermq ymm0, ymm1, 00000000b": {


### PR DESCRIPTION
Lets us trivially handle fields like 0baa'aa'bb'bb as broadcasts and an insert.