### PR TITLE
Vector: Only signify 128-bit vector loads in UCOMISxOp

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -630,7 +630,7 @@ void OpDispatchBuilder::AVX128_VPSIGN(OpcodeArgs, IR::OpSize ElementSize) {
 }
 
 void OpDispatchBuilder::AVX128_UCOMISx(OpcodeArgs, IR::OpSize ElementSize) {
-  const auto SrcSize = Op->Src[0].IsGPR() ? GetGuestVectorLength() : ElementSize;
+  const auto SrcSize = Op->Src[0].IsGPR() ? OpSize::i128Bit : ElementSize;
 
   auto Src1 = AVX128_LoadSource_WithOpSize(Op, Op->Dest, Op->Flags, false);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3357,8 +3357,8 @@ void OpDispatchBuilder::VPALIGNROp(OpcodeArgs) {
 }
 
 void OpDispatchBuilder::UCOMISxOp(OpcodeArgs, IR::OpSize ElementSize) {
-  const auto SrcSize = Op->Src[0].IsGPR() ? GetGuestVectorLength() : ElementSize;
-  Ref Src1 = LoadSourceFPR_WithOpSize(Op, Op->Dest, GetGuestVectorLength(), Op->Flags);
+  const auto SrcSize = Op->Src[0].IsGPR() ? OpSize::i128Bit : ElementSize;
+  Ref Src1 = LoadSourceFPR_WithOpSize(Op, Op->Dest, OpSize::i128Bit, Op->Flags);
   Ref Src2 = LoadSourceFPR_WithOpSize(Op, Op->Src[0], SrcSize, Op->Flags);
 
   Comiss(ElementSize, Src1, Src2);

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -2805,6 +2805,20 @@
         "ccmn x26, x0, #nzCv, le"
       ]
     },
+    "vucomiss xmm0, [rax]": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "Map 1 0b00 0x2e 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr s2, [x4]",
+        "fcmp s16, s2",
+        "cset x26, vc",
+        "mov w27, #0x0",
+        "csetm x0, eq",
+        "ccmn x26, x0, #nzCv, le"
+      ]
+    },
     "vucomisd xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
       "Comment": [
@@ -2812,6 +2826,20 @@
       ],
       "ExpectedArm64ASM": [
         "fcmp d16, d17",
+        "cset x26, vc",
+        "mov w27, #0x0",
+        "csetm x0, eq",
+        "ccmn x26, x0, #nzCv, le"
+      ]
+    },
+    "vucomisd xmm0, [rax]": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "Map 1 0b01 0x2e 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr d2, [x4]",
+        "fcmp d16, d2",
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
@@ -2831,6 +2859,20 @@
         "ccmn x26, x0, #nzCv, le"
       ]
     },
+    "vcomiss xmm0, [rax]": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "Map 1 0b00 0x2f 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr s2, [x4]",
+        "fcmp s16, s2",
+        "cset x26, vc",
+        "mov w27, #0x0",
+        "csetm x0, eq",
+        "ccmn x26, x0, #nzCv, le"
+      ]
+    },
     "vcomisd xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
       "Comment": [
@@ -2838,6 +2880,20 @@
       ],
       "ExpectedArm64ASM": [
         "fcmp d16, d17",
+        "cset x26, vc",
+        "mov w27, #0x0",
+        "csetm x0, eq",
+        "ccmn x26, x0, #nzCv, le"
+      ]
+    },
+    "vcomisd xmm0, [rax]": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "Map 1 0b01 0x2f 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr d2, [x4]",
+        "fcmp d16, d2",
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -2940,6 +2940,20 @@
         "ccmn x26, x0, #nzCv, le"
       ]
     },
+    "vucomiss xmm0, [rax]": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "Map 1 0b00 0x2e 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr s2, [x4]",
+        "fcmp s16, s2",
+        "cset x26, vc",
+        "mov w27, #0x0",
+        "csetm x0, eq",
+        "ccmn x26, x0, #nzCv, le"
+      ]
+    },
     "vucomisd xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
       "Comment": [
@@ -2947,6 +2961,20 @@
       ],
       "ExpectedArm64ASM": [
         "fcmp d16, d17",
+        "cset x26, vc",
+        "mov w27, #0x0",
+        "csetm x0, eq",
+        "ccmn x26, x0, #nzCv, le"
+      ]
+    },
+    "vucomisd xmm0, [rax]": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "Map 1 0b01 0x2e 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr d2, [x4]",
+        "fcmp d16, d2",
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
@@ -2966,6 +2994,20 @@
         "ccmn x26, x0, #nzCv, le"
       ]
     },
+    "vcomiss xmm0, [rax]": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "Map 1 0b00 0x2f 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr s2, [x4]",
+        "fcmp s16, s2",
+        "cset x26, vc",
+        "mov w27, #0x0",
+        "csetm x0, eq",
+        "ccmn x26, x0, #nzCv, le"
+      ]
+    },
     "vcomisd xmm0, xmm1": {
       "ExpectedInstructionCount": 5,
       "Comment": [
@@ -2973,6 +3015,20 @@
       ],
       "ExpectedArm64ASM": [
         "fcmp d16, d17",
+        "cset x26, vc",
+        "mov w27, #0x0",
+        "csetm x0, eq",
+        "ccmn x26, x0, #nzCv, le"
+      ]
+    },
+    "vcomisd xmm0, [rax]": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "Map 1 0b01 0x2f 128-bit"
+      ],
+      "ExpectedArm64ASM": [
+        "ldr d2, [x4]",
+        "fcmp d16, d2",
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",


### PR DESCRIPTION
Mainly a correctness change more than anything. The COMISX and UCOMISX group of operations only ever load 128 bits when given a vector source.

No change in codegen, but ensures this doesn't change if any backing handling changes.