### PR TITLE
FEXOfflineCompiler: Fixes HostFeature detection under Win32

### DIFF
--- a/Source/Tools/FEXOfflineCompiler/Main.cpp
+++ b/Source/Tools/FEXOfflineCompiler/Main.cpp
@@ -404,14 +404,19 @@ static std::optional<std::string> GenerateSingleCache(FEXCore::ExecutableFileInf
   FEXCore::Config::Set(FEXCore::Config::CONFIG_IS64BIT_MODE, Is64Bit ? "1" : "0");
 
   // Load HostFeatures
+#ifndef _WIN32
   auto HostFeatures = FEX::FetchHostFeatures();
+#else
+  const auto NtDll = GetModuleHandle("ntdll.dll");
+  const bool IsWine = !!GetProcAddress(NtDll, "wine_get_version");
+  auto HostFeatures = FEX::Windows::CPUFeatures::FetchHostFeatures(
+    IsWine, Is64Bit ? FEXCore::HostFeatures::HostTypeEnum::Arm64ec : FEXCore::HostFeatures::HostTypeEnum::Wow64);
+#endif
 
   auto CTX = FEXCore::Context::Context::CreateNewContext(HostFeatures);
   CTX->GetCodeCache().InitiateCacheGeneration();
 
 #ifdef _WIN32
-  const auto NtDll = GetModuleHandle("ntdll.dll");
-  const bool IsWine = !!GetProcAddress(NtDll, "wine_get_version");
   OvercommitTracker = std::make_unique<FEX::Windows::OvercommitTracker>(IsWine);
 
   auto SyscallOSABI = Is64Bit ? FEXCore::HLE::SyscallOSABI::OS_LINUX64 : FEXCore::HLE::SyscallOSABI::OS_LINUX32;


### PR DESCRIPTION
CPUFeature detection is marginally different between Linux and Windows. FOC was only using the Linux path which had two broken things happening to it.
- Feature detection was incorrect and enabling/disabling features differently from wow64/arm64ec .dll files
- HostType was being set as Linux even though it was generating code for WINE

Ensure that when built for Win32 that it uses the correct feature fetching.

One thing that is still incorrect is that 64-bit or 32-bit is determined at compile time on win32, whereas the Linux side parses an ELF and determines bitness at runtime. This doesn't fix that remaining problem there.