### PR TITLE
VectorOps: Avoid move in 256-bit VAddP/VFAddP if possible

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -1095,16 +1095,21 @@ DEF_OP(VAddP) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
-    // SVE ADDP is a destructive operation, so we need a temporary
-    movprfx(VTMP1.Z(), VectorLower.Z());
+    // SVE ADDP is a destructive operation, so we need a temporary if
+    // the destination and the lower vector don't alias.
+    auto LHS = Dst;
+    if (Dst != VectorLower) {
+      movprfx(VTMP1.Z(), VectorLower.Z());
+      LHS = VTMP1;
+    }
 
     // Unlike Adv. SIMD's version of ADDP, which acts like it concats the
     // upper vector onto the end of the lower vector and then performs
     // pairwise addition, the SVE version actually interleaves the
     // results of the pairwise addition (gross!), so we need to undo that.
-    addp(SubRegSize, VTMP1.Z(), Pred, VTMP1.Z(), VectorUpper.Z());
-    uzp1(SubRegSize, Dst.Z(), VTMP1.Z(), VTMP1.Z());
-    uzp2(SubRegSize, VTMP2.Z(), VTMP1.Z(), VTMP1.Z());
+    addp(SubRegSize, LHS.Z(), Pred, LHS.Z(), VectorUpper.Z());
+    uzp1(SubRegSize, Dst.Z(), LHS.Z(), LHS.Z());
+    uzp2(SubRegSize, VTMP2.Z(), LHS.Z(), LHS.Z());
 
     // Merge upper half with lower half.
     splice<ARMEmitter::OpType::Destructive>(ARMEmitter::SubRegSize::i64Bit, Dst.Z(), PRED_TMP_16B, Dst.Z(), VTMP2.Z());
@@ -1298,16 +1303,21 @@ DEF_OP(VFAddP) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
 
-    // SVE FADDP is a destructive operation, so we need a temporary
-    movprfx(VTMP1.Z(), VectorLower.Z());
+    // SVE FADDP is a destructive operation, so we need a temporary if
+    // the destination and the lower vector don't alias.
+    auto LHS = Dst;
+    if (Dst != VectorLower) {
+      movprfx(VTMP1.Z(), VectorLower.Z());
+      LHS = VTMP1;
+    }
 
     // Unlike Adv. SIMD's version of FADDP, which acts like it concats the
     // upper vector onto the end of the lower vector and then performs
     // pairwise addition, the SVE version actually interleaves the
     // results of the pairwise addition (gross!), so we need to undo that.
-    faddp(SubRegSize, VTMP1.Z(), Pred, VTMP1.Z(), VectorUpper.Z());
-    uzp1(SubRegSize, Dst.Z(), VTMP1.Z(), VTMP1.Z());
-    uzp2(SubRegSize, VTMP2.Z(), VTMP1.Z(), VTMP1.Z());
+    faddp(SubRegSize, LHS.Z(), Pred, LHS.Z(), VectorUpper.Z());
+    uzp1(SubRegSize, Dst.Z(), LHS.Z(), LHS.Z());
+    uzp2(SubRegSize, VTMP2.Z(), LHS.Z(), LHS.Z());
 
     // Merge upper half with lower half.
     splice<ARMEmitter::OpType::Destructive>(ARMEmitter::SubRegSize::i64Bit, Dst.Z(), PRED_TMP_16B, Dst.Z(), VTMP2.Z());

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -78,7 +78,7 @@
       ]
     },
     "vpmovmskb rax, ymm0": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "Map 1 0b01 0xd7 256-bit"
       ],
@@ -93,10 +93,9 @@
         "mov z3.d, z0.d",
         "msr nzcv, x0",
         "and z2.d, z3.d, z2.d",
-        "movprfx z0, z2",
-        "addp z0.b, p7/m, z0.b, z2.b",
-        "uzp1 z2.b, z0.b, z0.b",
-        "uzp2 z1.b, z0.b, z0.b",
+        "addp z2.b, p7/m, z2.b, z2.b",
+        "uzp1 z2.b, z2.b, z2.b",
+        "uzp2 z1.b, z2.b, z2.b",
         "splice z2.d, p6, z2.d, z1.d",
         "addp v2.16b, v2.16b, v2.16b",
         "addp v2.8b, v2.8b, v2.8b",

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -4202,7 +4202,7 @@
       ]
     },
     "vpmovmskb rax, ymm0": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "Map 1 0b01 0xd7 256-bit"
       ],
@@ -4217,10 +4217,9 @@
         "mov z3.d, z0.d",
         "msr nzcv, x0",
         "and z2.d, z3.d, z2.d",
-        "movprfx z0, z2",
-        "addp z0.b, p7/m, z0.b, z2.b",
-        "uzp1 z2.b, z0.b, z0.b",
-        "uzp2 z1.b, z0.b, z0.b",
+        "addp z2.b, p7/m, z2.b, z2.b",
+        "uzp1 z2.b, z2.b, z2.b",
+        "uzp2 z1.b, z2.b, z2.b",
         "splice z2.d, p6, z2.d, z1.d",
         "addp v2.16b, v2.16b, v2.16b",
         "addp v2.8b, v2.8b, v2.8b",

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -3329,17 +3329,16 @@
       ]
     },
     "vdpps ymm0, ymm1, ymm2, 11111111b": {
-      "ExpectedInstructionCount": 13,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "Map 3 0b01 0x40 128-bit"
       ],
       "ExpectedArm64ASM": [
         "movi v2.2d, #0x0",
         "fmul z3.s, z17.s, z18.s",
-        "movprfx z0, z3",
-        "faddp z0.s, p7/m, z0.s, z2.s",
-        "uzp1 z3.s, z0.s, z0.s",
-        "uzp2 z1.s, z0.s, z0.s",
+        "faddp z3.s, p7/m, z3.s, z2.s",
+        "uzp1 z3.s, z3.s, z3.s",
+        "uzp2 z1.s, z3.s, z3.s",
         "splice z3.d, p6, z3.d, z1.d",
         "movprfx z0, z3",
         "faddp z0.s, p7/m, z0.s, z2.s",


### PR DESCRIPTION
If the first source and destination alias, then it's fine to use the register in destructive operations, since the source data doesn't need to be preserved.

Tiny saving, but reduces overall register use in some cases.