### PR TITLE
HostFeatures: Put SVE support querying into single function

### DIFF
--- a/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
+++ b/FEXCore/Source/Interface/Core/ArchHelpers/Arm64Emitter.cpp
@@ -659,7 +659,7 @@ void Arm64Emitter::FillSpecialRegs(ARMEmitter::Register TmpReg, ARMEmitter::Regi
   }
 #endif
 
-  if (SetPredRegs && (EmitterCTX->HostFeatures.SupportsSVE256 || EmitterCTX->HostFeatures.SupportsSVE128)) {
+  if (SetPredRegs && EmitterCTX->HostFeatures.SupportsSVE()) {
     // Set up predicate registers.
     // We don't bother spilling these in SpillStaticRegs,
     // since all that matters is we restore them on a fill.

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -4446,7 +4446,7 @@ Ref OpDispatchBuilder::LoadSource_WithOpSize(RegClass Class, const X86Tables::De
   if (ShouldLoad) {
     if (OpSize == OpSize::f80Bit) {
       Ref MemSrc = LoadEffectiveAddress(this, A, GetGPROpSize(), true);
-      if (CTX->HostFeatures.SupportsSVE128 || CTX->HostFeatures.SupportsSVE256) {
+      if (CTX->HostFeatures.SupportsSVE()) {
         Result = _LoadMemX87SVEOptPredicate(OpSize::i128Bit, OpSize::i16Bit, MemSrc);
       } else {
         // For X87 extended doubles, Split the load.
@@ -4585,7 +4585,7 @@ void OpDispatchBuilder::StoreResult_WithOpSize(RegClass Class, FEXCore::X86Table
 
   if (OpSize == OpSize::f80Bit) {
     Ref MemStoreDst = LoadEffectiveAddress(this, A, GetGPROpSize(), true);
-    if (CTX->HostFeatures.SupportsSVE128 || CTX->HostFeatures.SupportsSVE256) {
+    if (CTX->HostFeatures.SupportsSVE()) {
       _StoreMemX87SVEOptPredicate(OpSize::i128Bit, OpSize::i16Bit, Src, MemStoreDst);
     } else {
       // For X87 extended doubles, split before storing

--- a/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
@@ -188,7 +188,7 @@ private:
 
   void Store80BitToMem(const IROp_StoreStackMem* Op, Ref StackNode, Ref AddrNode, Ref Offset, OpSize Align, MemOffsetType OffsetType,
                        uint8_t OffsetScale) {
-    if (Features.SupportsSVE128 || Features.SupportsSVE256) {
+    if (Features.SupportsSVE()) {
       AddressMode A {.Base = AddrNode,
                      .Index = Op->Offset.IsInvalid() ? nullptr : Offset,
                      .IndexType = MemOffsetType::SXTX,

--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -5,13 +5,20 @@
 #include <cstdint>
 
 namespace FEXCore {
+
+/**
+ * @brief Backend features that change how codegen is generated from IR
+ *
+ * Specifically things that affect the IR->Codegen process
+ * Not the x86->IR process
+ */
 struct HostFeatures {
-  /**
-   * @brief Backend features that change how codegen is generated from IR
-   *
-   * Specifically things that affect the IR->Codegen process
-   * Not the x86->IR process
-   */
+  // Whether or not the host supports any kind of SVE implementation.
+  [[nodiscard]]
+  bool SupportsSVE() const {
+    return SupportsSVE128 || SupportsSVE256;
+  }
+
   uint32_t DCacheLineSize {};
   uint32_t ICacheLineSize {};
   bool SupportsCacheMaintenanceOps {};


### PR DESCRIPTION
Lets us avoid open-coding long checks for the existence of either SVE-128 or SVE-256.