### PR TITLE
VectorOps: Avoid temporary if able in 256-bit VFRecp

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -1536,9 +1536,14 @@ DEF_OP(VFRecp) {
       return;
     }
 
-    fmov(SubRegSize.Vector, VTMP1.Z(), 1.0);
-    fdiv(SubRegSize.Vector, VTMP1.Z(), Pred, VTMP1.Z(), Vector.Z());
-    mov(Dst.Z(), VTMP1.Z());
+    if (Dst != Vector) {
+      fmov(SubRegSize.Vector, Dst.Z(), 1.0);
+      fdiv(SubRegSize.Vector, Dst.Z(), Pred, Dst.Z(), Vector.Z());
+    } else {
+      fmov(SubRegSize.Vector, VTMP1.Z(), 1.0);
+      fdiv(SubRegSize.Vector, VTMP1.Z(), Pred, VTMP1.Z(), Vector.Z());
+      mov(Dst.Z(), VTMP1.Z());
+    }
   } else {
     if (IsScalar) {
       if (ElementSize == IR::OpSize::i32Bit && HostSupportsRPRES) {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -631,14 +631,13 @@
       ]
     },
     "vrcpps ymm0, ymm1": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b00 0x53 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "fmov z0.s, #0x70 (1.0000)",
-        "fdiv z0.s, p7/m, z0.s, z17.s",
-        "mov z16.d, z0.d"
+        "fmov z16.s, #0x70 (1.0000)",
+        "fdiv z16.s, p7/m, z16.s, z17.s"
       ]
     },
     "vrcpss xmm0, xmm1, xmm2": {


### PR DESCRIPTION
If we're non-aliasing, we can make use of the destination reg directly. Makes the non-RPRES path a little nicer.