### PR TITLE
Windows: Fixes SHM stats reallocation

### DIFF
--- a/Source/Windows/Common/SHMStats.cpp
+++ b/Source/Windows/Common/SHMStats.cpp
@@ -19,13 +19,10 @@ uint32_t StatAlloc::FrontendAllocateSlots(uint32_t NewSize) {
     return CurrentSize;
   }
 
-  auto Result = UnixLib::AllocateSHMSlots(Base, std::min(CurrentSize * 2, MAX_STATS_SIZE), MAX_STATS_SIZE);
+  auto Result = UnixLib::AllocateSHMSlots(Base, std::min(NewSize, MAX_STATS_SIZE), MAX_STATS_SIZE);
 
-  if (Result.SHMBase) {
-    CurrentSize = Result.MappedSize;
-  }
-
-  return CurrentSize;
+  // Return the new size allocated, if it happened to change.
+  return Result.MappedSize;
 }
 
 StatAlloc::StatAlloc(FEXCore::SHMStats::AppType AppType) {


### PR DESCRIPTION
This was accidentally setting `CurrentSize` instead of just returning the newly allocated size to the frontend. This was causing the frontend to then fail to detect the reallocation actually occured and no longer get stats for new threads.

Also happened to not use `NewSize` but instead `CurrentSize * 2` which didn't matter as it matched the growth pattern, but was technically incorrect.

Fixes SHM stats since the introduction of the unixlib, ezpz.