### PR TITLE
Allocator: fix the caching of host va size

### DIFF
--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -125,6 +125,7 @@ FEX_DEFAULT_VISIBILITY size_t DetermineVASize() {
       ::munmap(Ptr, FEXCore::Utils::FEX_PAGE_SIZE);
     }
     if (Ptr != (void*)~0ULL || errno == EEXIST) {
+      HostVASize = Bits;
       return Bits;
     }
   }

--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -38,8 +38,6 @@ namespace FEXCore::Allocator {
 MMAP_Hook mmap {::mmap};
 MUNMAP_Hook munmap {::munmap};
 
-uint64_t HostVASize {};
-
 using GLIBC_MALLOC_Hook = void* (*)(size_t, const void* caller);
 using GLIBC_REALLOC_Hook = void* (*)(void*, size_t, const void* caller);
 using GLIBC_FREE_Hook = void (*)(void*, const void* caller);
@@ -104,9 +102,11 @@ void ClearHooks() {
 }
 #pragma GCC diagnostic pop
 
-FEX_DEFAULT_VISIBILITY size_t DetermineVASize() {
-  if (HostVASize) {
-    return HostVASize;
+FEX_DEFAULT_VISIBILITY size_t GetHostVABits() {
+  static uint64_t HostVABits = 0;
+
+  if (HostVABits) {
+    return HostVABits;
   }
 
   static constexpr std::array<uintptr_t, 7> TLBSizes = {
@@ -125,7 +125,7 @@ FEX_DEFAULT_VISIBILITY size_t DetermineVASize() {
       ::munmap(Ptr, FEXCore::Utils::FEX_PAGE_SIZE);
     }
     if (Ptr != (void*)~0ULL || errno == EEXIST) {
-      HostVASize = Bits;
+      HostVABits = Bits;
       return Bits;
     }
   }
@@ -274,7 +274,7 @@ fextl::vector<MemoryRegion> StealMemoryRegion(uintptr_t Begin, uintptr_t End) {
 }
 
 fextl::vector<MemoryRegion> Setup48BitAllocatorIfExists(size_t PageSize) {
-  size_t Bits = FEXCore::Allocator::DetermineVASize();
+  size_t Bits = FEXCore::Allocator::GetHostVABits();
   if (Bits < 48) {
     return {};
   }

--- a/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
+++ b/FEXCore/Source/Utils/Allocator/64BitAllocator.cpp
@@ -187,7 +187,7 @@ private:
 };
 
 void OSAllocator_64Bit::DetermineVASize() {
-  size_t Bits = FEXCore::Allocator::DetermineVASize();
+  size_t Bits = FEXCore::Allocator::GetHostVABits();
   uintptr_t Size = 1ULL << Bits;
 
   UPPER_BOUND = Size;

--- a/FEXCore/include/FEXCore/Utils/Allocator.h
+++ b/FEXCore/include/FEXCore/Utils/Allocator.h
@@ -12,7 +12,7 @@ struct InternalThreadState;
 }
 
 namespace FEXCore::Allocator {
-FEX_DEFAULT_VISIBILITY size_t DetermineVASize();
+FEX_DEFAULT_VISIBILITY size_t GetHostVABits();
 
 #ifdef GLIBC_ALLOCATOR_FAULT
 // Glibc hooks should only fault once we are in main.

--- a/Source/Tools/FEXInterpreter/ELFCodeLoader.h
+++ b/Source/Tools/FEXInterpreter/ELFCodeLoader.h
@@ -454,16 +454,16 @@ public:
     // On the upside, this more accurately emulates how the kernel allocates stack space for the application when hinting at the location.
     //
     void* StackPointerBase {};
-    auto VASize = FEXCore::Allocator::DetermineVASize();
+    auto VABits = FEXCore::Allocator::GetHostVABits();
     uint64_t StackHint {};
     if (Is64BitMode()) {
-      if (VASize > 47) {
+      if (VABits > 47) {
         // If VA size is at least as large as minimum x86 specification, then set to max.
-        VASize = 47;
+        VABits = 47;
       }
 
       // Calculate the highest point the stack could go.
-      StackHint = (1ULL << VASize) - FULL_STACK_SIZE;
+      StackHint = (1ULL << VABits) - FULL_STACK_SIZE;
     } else {
       // Needs to be under the 4GB VA space.
       StackHint = 0x1'0000'0000ULL - FULL_STACK_SIZE;
@@ -557,8 +557,8 @@ public:
       if (Is64BitMode()) {
         // Ensure that if we are running on a 36-bit VA system, we don't try hinting that an ELF should
         // live way outside the VA space.
-        uint64_t HostVASize = 1ULL << FEXCore::Allocator::DetermineVASize();
-        ELFLoadHint = std::min(HostVASize, TASK_SIZE_64) / 3 * 2;
+        uint64_t HostVABits = 1ULL << FEXCore::Allocator::GetHostVABits();
+        ELFLoadHint = std::min(HostVABits, TASK_SIZE_64) / 3 * 2;
       } else {
         ELFLoadHint = TASK_SIZE_32 / 3 * 2;
       }

--- a/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
+++ b/Source/Tools/LinuxEmulation/VDSO_Emulation.cpp
@@ -803,16 +803,16 @@ VDSOMapping LoadVDSOThunks(FEXCore::Core::InternalThreadState* Thread, bool Is64
       lseek(VDSOFD, 0, SEEK_SET);
       Mapping.VDSOSize = FEXCore::AlignUp(Mapping.VDSOSize, FEXCore::Utils::FEX_PAGE_SIZE);
 
-      auto VASize = FEXCore::Allocator::DetermineVASize();
+      auto VABits = FEXCore::Allocator::GetHostVABits();
       uint64_t VDSOHint {};
       if (Is64Bit) {
-        if (VASize > 47) {
+        if (VABits > 47) {
           // If VA size is at least as large as minimum x86 specification, then set to max.
-          VASize = 47;
+          VABits = 47;
         }
 
         // Calculate the highest point the vdso could go.
-        VDSOHint = (1ULL << VASize) - Mapping.VDSOSize;
+        VDSOHint = (1ULL << VABits) - Mapping.VDSOSize;
       } else {
         VDSOHint = 0x1'0000'0000ULL - Mapping.VDSOSize;
       }


### PR DESCRIPTION
`HostVASize` global was never set and so each call to `DetermineVASize` would redo all the work. Set the global to fix this.
Additionally do some renaming to specify that the returned value is a number of bits and not the size of the VA.