### PR TITLE
CodeCache: Mark executable memory as EC code on ARM64EC

### DIFF
--- a/FEXCore/Source/Interface/Core/CodeCache.cpp
+++ b/FEXCore/Source/Interface/Core/CodeCache.cpp
@@ -50,6 +50,10 @@ MappedCodeCacheFile::~MappedCodeCacheFile() {
   if (!CodeBuffer.empty()) {
     FEXCore::Allocator::munmap(CodeBuffer.data(), CodeBuffer.size_bytes());
   }
+#elif defined(_M_ARM64EC)
+  if (!CodeBuffer.empty()) {
+    FEXCore::Allocator::VirtualFree(CodeBuffer.data(), CodeBuffer.size_bytes());
+  }
 #endif
 }
 
@@ -600,7 +604,16 @@ CodeCache::LoadCache(std::span<std::byte> CacheFile, const ExecutableFileInfo& F
     return nullptr;
   }
   auto CodeBuffer = std::span {static_cast<std::byte*>(CodeBufferAllocation), header.CodeBufferSize};
-#else
+#elif defined(_M_ARM64EC)
+  // TODO: Implement lazy mapping on Windows
+  // NOTE: The executed code must have MEM_EXTENDED_PARAMETER_EC_CODE set, so we can't operate on the mapped cache file directly
+  void* CodeBufferAllocation = Allocator::VirtualAlloc(header.CodeBufferSize, true);
+  if (!CodeBufferAllocation) {
+    LogMan::Msg::EFmt("Failed to allocate code cache memory");
+    return nullptr;
+  }
+  auto CodeBuffer = std::span {reinterpret_cast<std::byte*>(CodeBufferAllocation), header.CodeBufferSize};
+#else // WoW64
   // TODO: Implement lazy mapping on Windows
   auto CodeBuffer = CodeDataInFile;
 #endif
@@ -870,6 +883,9 @@ void CodeCache::FinalizeCodePages(MappedCodeCacheFile& Code, std::span<std::byte
   Allocator::VirtualDontNeed(Code.CodeBufferInFile.data() + StartOffset, Size);
 #else
   // TODO: Implement lazy mapping on Windows
+#ifdef _M_ARM64EC
+  memcpy(Code.CodeBuffer.data() + StartOffset, Code.CodeBufferInFile.data() + StartOffset, Size);
+#endif
   for (size_t i = StartPage; i < EndPage; ++i) {
     auto PageRelocations = SpanPageRelocations(Code, i);
     (void)ApplyCodeRelocations(Code.GuestBase, Code.CodeBuffer, PageRelocations, 0, false);

--- a/Source/Windows/Common/ImageTracker.cpp
+++ b/Source/Windows/Common/ImageTracker.cpp
@@ -245,6 +245,11 @@ void ImageTracker::LoadAOTImages(MappedImageInfo& ImageInfo) {
                                    *FileHandle))) {
       void* LoadAddress = nullptr;
       SIZE_T MappedSize = 0;
+      // TODO: Consider NtMapViewOfSectionEx with MEM_EXTENDED_PARAMETER_EC_CODE;
+      //       instead, we're eagerly copying all cache data to a dedicated buffer currently
+      // MEM_EXTENDED_PARAMETER ECParam {};
+      // ECParam.Type = MemExtendedParameterAttributeFlags;
+      // ECParam.ULong64 = MEM_EXTENDED_PARAMETER_EC_CODE;
       if (NT_SUCCESS(NtMapViewOfSection(*SectionHandle, NtCurrentProcess(), &LoadAddress, 0, 0, nullptr, &MappedSize, ViewUnmap,
                                         MEM_RESERVE | MEM_TOP_DOWN, PAGE_EXECUTE_READ))) {
 


### PR DESCRIPTION
See bd5b817c3a01b6881b7f2ba5be70cd391806bbaf.

The additional branching will largely go away again once we implement lazy cache loading for WoA.
