### PR TITLE
OpcodeDispatcher: Fix 32bit cmpxchg zero extension with eax as first operand

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3877,7 +3877,6 @@ void OpDispatchBuilder::CMPXCHGOp(OpcodeArgs) {
         // This allows us to only hit the ZEXT case on failure
         Ref RAXResult = NZCVSelect(OpSize::i64Bit, CondClass::EQ, Src3, Src1Lower);
 
-        // When the size is 4 we need to make sure not zext the GPR when the comparison fails
         StoreGPRRegister(X86State::REG_RAX, RAXResult);
       } else {
         StoreGPRRegister(X86State::REG_RAX, Src1Lower, Size);
@@ -3891,7 +3890,7 @@ void OpDispatchBuilder::CMPXCHGOp(OpcodeArgs) {
     if (GPRSize == OpSize::i64Bit && Size == OpSize::i32Bit) {
       Src2Lower = _Bfe(GPRSize, IR::OpSizeAsBits(Size), 0, Src2);
     }
-    Ref DestResult = Trivial ? Src2 : NZCVSelect(OpSize::i64Bit, CondClass::EQ, Src2Lower, Src1);
+    Ref DestResult = Trivial ? Src2Lower : NZCVSelect(OpSize::i64Bit, CondClass::EQ, Src2Lower, Src1);
 
     // Store in to GPR Dest
     if (GPRSize == OpSize::i64Bit && Size == OpSize::i32Bit) {

--- a/unittests/ASM/FEX_bugs/cmpxchg_eax.asm
+++ b/unittests/ASM/FEX_bugs/cmpxchg_eax.asm
@@ -1,0 +1,15 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x00000000ccddff00",
+    "RBX": "0x8899aabbccddff00"
+  }
+}
+%endif
+
+mov rax, 0x0011223344556677
+mov rbx, 0x8899AABBCCDDFF00
+
+cmpxchg eax, ebx
+
+hlt

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -1145,7 +1145,7 @@
       "ExpectedArm64ASM": [
         "mov w27, #0x0",
         "subs w26, w4, w4",
-        "mov x4, x6"
+        "mov w4, w6"
       ]
     },
     "cmpxchg [rcx], ebx": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -2120,7 +2120,7 @@
       "ExpectedArm64ASM": [
         "mov w27, #0x0",
         "subs w26, w4, w4",
-        "mov x4, x6"
+        "mov w4, w6"
       ]
     },
     "cmpxchg [rcx], ebx": {


### PR DESCRIPTION
This PR fixes a bug in `CMPXCHGOp` where the destination register was not properly zero extended when `eax` was used as the first operand.
Also removed an incorrect comment in the function.