### PR TITLE
Fix cvttss2si when prefixed with 0x66

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -2581,9 +2581,10 @@ Ref OpDispatchBuilder::CVTGPR_To_FPRImpl(OpcodeArgs, IR::OpSize DstElementSize, 
 }
 
 Ref OpDispatchBuilder::CVTFPR_To_GPRImpl(OpcodeArgs, Ref Src, IR::OpSize SrcElementSize, bool HostRoundingMode) {
-  // GPR size is determined by REX.W
   // Source Element size is determined by instruction
-  const auto GPRSize = OpSizeFromDst(Op);
+  // GPR size is determined by REX.W
+  // But instruction does not support 16bit register operands
+  const auto GPRSize = std::max(OpSize::i32Bit, OpSizeFromDst(Op));
 
   if (CTX->HostFeatures.SupportsFRINTTS) {
     // When we have FRINTTS, this is a two-step process. First, we round to the
@@ -2616,7 +2617,9 @@ void OpDispatchBuilder::CVTFPR_To_GPR(OpcodeArgs, IR::OpSize SrcElementSize, boo
   const auto SrcSize = Op->Src[0].IsGPR() ? OpSize::i128Bit : SrcElementSize;
   Ref Src = LoadSourceFPR_WithOpSize(Op, Op->Src[0], SrcSize, Op->Flags);
   Ref Result = CVTFPR_To_GPRImpl(Op, Src, SrcElementSize, HostRoundingMode);
-  StoreResultGPR(Op, Result);
+
+  const auto DestSize = std::max(OpSize::i32Bit, OpSizeFromDst(Op));
+  StoreResultGPR_WithOpSize(Op, Op->Dest, Result, DestSize);
 }
 
 Ref OpDispatchBuilder::Vector_CVT_Int_To_FloatImpl(OpcodeArgs, IR::OpSize SrcElementSize, bool Widen) {

--- a/unittests/ASM/FEX_bugs/o16_cvttss2si.asm
+++ b/unittests/ASM/FEX_bugs/o16_cvttss2si.asm
@@ -1,0 +1,27 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000003ce0950",
+     "XMM0": [
+      "0x04a6e5eb4c738254",
+      "0xc7f69988a166b329", 
+      "0xf47e815854c72b11", 
+      "0x77d12321b16b61ad" 
+    ]
+  }
+}
+%endif
+
+lea rdx, [rel .data]
+vmovdqa ymm0, [rdx]
+
+mov rax, 0xDEADBEEFCAFEBABE
+
+o16 cvttss2si eax, XMM0
+
+hlt
+
+
+align 16
+.data:
+dq 0x04a6e5eb4c738254, 0xc7f69988a166b329, 0xf47e815854c72b11, 0x77d12321b16b61ad


### PR DESCRIPTION
When the instruction `cvttss2si` is prefixed with the operand-size override prefix (0x66), FEX computes the result only for the lower 16bits. However, `cvttss2si` does not support 16bit register operands.
Hence, for such cases fall back to 32bit operations.