### PR TITLE
FEX: Remove FEXInterpreter binary

### DIFF
--- a/Source/Tools/FEXInterpreter/CMakeLists.txt
+++ b/Source/Tools/FEXInterpreter/CMakeLists.txt
@@ -31,12 +31,6 @@ install(TARGETS FEX RUNTIME
     DESTINATION bin
     COMPONENT Runtime)
 
-# Create a copy of FEX with legacy names until phased out.
-install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FEX
-  RENAME FEXInterpreter
-  DESTINATION bin
-  COMPONENT LegacyRuntime)
-
 if (ARCHITECTURE_arm64)
   if (NOT USE_LEGACY_BINFMTMISC)
     # Just restart the systemd service


### PR DESCRIPTION
It's been ten months, a bit longer than than I was expecting to keep this around. Go ahead and remove it now.