### PR TITLE
Windows/UnixLib: Fix enabling TSO through legacy Proton codepath

### DIFF
--- a/Source/Windows/Common/FEXUnixLib.cpp
+++ b/Source/Windows/Common/FEXUnixLib.cpp
@@ -149,7 +149,7 @@ bool TryEnableHardwareTSO() {
   }
 
   // Legacy Proton path.
-  bool Enable = TRUE;
+  BOOL Enable = TRUE;
   NTSTATUS Status = NtSetInformationProcess(NtCurrentProcess(), ProcessFexHardwareTso, &Enable, sizeof(Enable));
   return Status == STATUS_SUCCESS;
 }


### PR DESCRIPTION
I don't have a setup to test this, but I don't think it could be working: `sizeof(BOOL) == 4`, `sizeof(bool) == 1`