### PR TITLE
ALUOps: Fix 32-bit MulH case

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ALUOps.cpp
@@ -418,8 +418,8 @@ DEF_OP(MulH) {
   if (OpSize == IR::OpSize::i32Bit) {
     sxtw(TMP1, Src1.W());
     sxtw(TMP2, Src2.W());
-    mul(ARMEmitter::Size::i32Bit, Dst, TMP1, TMP2);
-    ubfx(ARMEmitter::Size::i32Bit, Dst, Dst, 32, 32);
+    mul(ARMEmitter::Size::i64Bit, Dst, TMP1, TMP2);
+    ubfx(ARMEmitter::Size::i64Bit, Dst, Dst, 32, 32);
   } else {
     smulh(Dst.X(), Src1.X(), Src2.X());
   }


### PR DESCRIPTION
These need to be 64-bit multiply and ubfx. Thankfully this case wasn't actually hit in practice.