### PR TITLE
VectorOps: Fix 256-bit FADDV path

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -1165,8 +1165,7 @@ DEF_OP(VFAddV) {
   if (HostSupportsSVE256 && Is256Bit) {
     const auto Pred = PRED_TMP_32B.Merging();
     faddv(SubRegSize.Vector, Dst, Pred, Vector.Z());
-  }
-  if (HostSupportsSVE128) {
+  } else if (HostSupportsSVE128) {
     const auto Pred = PRED_TMP_16B.Merging();
     faddv(SubRegSize.Vector, Dst, Pred, Vector.Z());
   } else {


### PR DESCRIPTION
Avoids falling down to the SVE-128 path. Never actually occurred in practice, since we have no (current) 256-bit usages.