### PR TITLE
x32/Msg: Fix result comparison in mq_getsetattr

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Msg.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Msg.cpp
@@ -95,7 +95,7 @@ void RegisterMsg(FEX::HLE::SyscallHandler* Handler) {
 
                               uint64_t Result = ::syscall(SYSCALL_DEF(mq_getsetattr), mqdes, HostNew_p, HostOld_p);
 
-                              if (Result != 1 && oldattr) {
+                              if (Result != -1 && oldattr) {
                                 FaultSafeUserMemAccess::VerifyIsWritable(oldattr, sizeof(*oldattr));
                                 *oldattr = HostOld;
                               }


### PR DESCRIPTION
Checks against failure instead of 1.