### PR TITLE
x32/Thread: Move writability check around in waitpid

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Thread.cpp
@@ -138,8 +138,8 @@ void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
     }));
 
   REGISTER_SYSCALL_IMPL_X32(waitpid, [](FEXCore::Core::CpuStateFrame* Frame, pid_t pid, int32_t* status, int32_t options) -> uint64_t {
-    uint64_t Result = ::waitpid(pid, status, options);
     FaultSafeUserMemAccess::VerifyIsWritableOrNull(status, sizeof(*status));
+    uint64_t Result = ::waitpid(pid, status, options);
     SYSCALL_ERRNO();
   });
 


### PR DESCRIPTION
Same behavior, but catches the write before it actually occurs.