### PR TITLE
Common/Bitset: Minor API changes

### DIFF
--- a/FEXCore/Source/Common/BitSet.h
+++ b/FEXCore/Source/Common/BitSet.h
@@ -33,7 +33,8 @@ struct BitSet final {
     FEXCore::Allocator::free(Memory);
     Memory = nullptr;
   }
-  bool Get(T Element) {
+  [[nodiscard]]
+  bool Get(T Element) const {
     return (Memory[Element / MinimumSizeBits] & (1ULL << (Element % MinimumSizeBits))) != 0;
   }
   void Set(T Element) {
@@ -48,13 +49,15 @@ struct BitSet final {
   void MemSet(size_t Elements) {
     memset(Memory, 0xFF, ToBytes(Elements));
   }
-  uint32_t ToBytes(size_t Elements) {
+  [[nodiscard]]
+  uint32_t ToBytes(size_t Elements) const {
     return AlignUp(Elements, MinimumSizeBits) / MinimumSize;
   }
 
   // This very explicitly doesn't let you take an address
   // Is only a getter
-  bool operator[](T Element) {
+  [[nodiscard]]
+  bool operator[](T Element) const {
     return Get(Element);
   }
 };
@@ -72,7 +75,8 @@ struct BitSetView final {
     Memory = &Set.Memory[ElementOffset / MinimumSizeBits];
   }
 
-  bool Get(T Element) {
+  [[nodiscard]]
+  bool Get(T Element) const {
     return (Memory[Element / MinimumSizeBits] & (1ULL << (Element % MinimumSizeBits))) != 0;
   }
   void Set(T Element) {
@@ -90,7 +94,8 @@ struct BitSetView final {
 
   // This very explicitly doesn't let you take an address
   // Is only a getter
-  bool operator[](T Element) {
+  [[nodiscard]]
+  bool operator[](T Element) const {
     return Get(Element);
   }
 };

--- a/FEXCore/Source/Common/BitSet.h
+++ b/FEXCore/Source/Common/BitSet.h
@@ -40,7 +40,7 @@ struct BitSet final {
     Memory[Element / MinimumSizeBits] |= (1ULL << (Element % MinimumSizeBits));
   }
   void Clear(T Element) {
-    Memory[Element / MinimumSizeBits] &= (1ULL << (Element % MinimumSizeBits));
+    Memory[Element / MinimumSizeBits] &= ~(1ULL << (Element % MinimumSizeBits));
   }
   void MemClear(size_t Elements) {
     memset(Memory, 0, ToBytes(Elements));
@@ -79,7 +79,7 @@ struct BitSetView final {
     Memory[Element / MinimumSizeBits] |= (1ULL << (Element % MinimumSizeBits));
   }
   void Clear(T Element) {
-    Memory[Element / MinimumSizeBits] &= (1ULL << (Element % MinimumSizeBits));
+    Memory[Element / MinimumSizeBits] &= ~(1ULL << (Element % MinimumSizeBits));
   }
   void MemClear(size_t Elements) {
     memset(Memory, 0, AlignUp(Elements / MinimumSizeBits, MinimumSizeBits));

--- a/FEXCore/Source/Common/BitSet.h
+++ b/FEXCore/Source/Common/BitSet.h
@@ -18,7 +18,7 @@ struct BitSet final {
   constexpr static size_t MinimumSize = sizeof(ElementType);
   constexpr static size_t MinimumSizeBits = sizeof(ElementType) * 8;
 
-  ElementType* Memory;
+  ElementType* Memory {};
   void Allocate(size_t Elements) {
     size_t AllocateSize = ToBytes(Elements);
     LOGMAN_THROW_A_FMT((AllocateSize * MinimumSize) >= Elements, "Fail");
@@ -68,7 +68,7 @@ struct BitSetView final {
   constexpr static size_t MinimumSize = sizeof(ElementType);
   constexpr static size_t MinimumSizeBits = sizeof(ElementType) * 8;
 
-  ElementType* Memory;
+  ElementType* Memory {};
 
   void GetView(BitSet<T>& Set, uint64_t ElementOffset) {
     LOGMAN_THROW_A_FMT((ElementOffset % MinimumSize) == 0, "Bitset view offset needs to be aligned to size of backing element");


### PR DESCRIPTION
A fix to clearing and tidying up. Much of the interface is unused, since the only usage of this is in the IR validation pass