### PR TITLE
Thread: Amend new thread handling in HandleNewClone()

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -181,19 +181,18 @@ uint64_t HandleNewClone(FEX::HLE::ThreadStateObject* Thread, FEXCore::Context::C
   FEXCore::Allocator::InitializeThread();
   auto GuestArgs = &CloneArgs->args;
   uint64_t flags = GuestArgs->flags;
-  auto NewThread = Thread;
   bool CreatedNewThreadObject {};
 
   if (flags & CLONE_THREAD) {
     // Overwrite thread
-    NewThread = FEX::HLE::_SyscallHandler->TM.CreateThread(0, 0, &Frame->State, GuestArgs->parent_tid,
-                                                           FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame));
+    Thread = FEX::HLE::_SyscallHandler->TM.CreateThread(0, 0, &Frame->State, GuestArgs->parent_tid,
+                                                        FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame));
 
-    NewThread->Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RAX] = 0;
+    Thread->Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RAX] = 0;
     if (GuestArgs->stack == 0) {
       // Copies in the original thread's stack
     } else {
-      NewThread->Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RSP] = GuestArgs->stack;
+      Thread->Thread->CurrentFrame->State.gregs[FEXCore::X86State::REG_RSP] = GuestArgs->stack;
     }
 
     // CLONE_PARENT_SETTID, CLONE_CHILD_SETTID, CLONE_CHILD_CLEARTID, CLONE_PIDFD will be handled by kernel
@@ -223,15 +222,15 @@ uint64_t HandleNewClone(FEX::HLE::ThreadStateObject* Thread, FEXCore::Context::C
 
   if (FEX::HLE::_SyscallHandler->Is64BitMode()) {
     if (flags & CLONE_SETTLS) {
-      x64::SetThreadArea(NewThread->Thread->CurrentFrame, reinterpret_cast<void*>(GuestArgs->tls));
+      x64::SetThreadArea(Thread->Thread->CurrentFrame, reinterpret_cast<void*>(GuestArgs->tls));
     }
     // Set us to start just after the syscall instruction
-    x64::AdjustRipForNewThread(NewThread->Thread->CurrentFrame);
+    x64::AdjustRipForNewThread(Thread->Thread->CurrentFrame);
   } else {
     if (flags & CLONE_SETTLS) {
-      x32::SetThreadArea(NewThread->Thread->CurrentFrame, reinterpret_cast<void*>(GuestArgs->tls));
+      x32::SetThreadArea(Thread->Thread->CurrentFrame, reinterpret_cast<void*>(GuestArgs->tls));
     }
-    x32::AdjustRipForNewThread(NewThread->Thread->CurrentFrame);
+    x32::AdjustRipForNewThread(Thread->Thread->CurrentFrame);
   }
 
   // Depending on clone settings, our TID and PID could have changed


### PR DESCRIPTION
Ensures that newly cloned threads get tracked properly.