### PR TITLE
x64/Signals: Amend set size in rt_sigtimedwait

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -1317,11 +1317,7 @@ uint64_t SignalDelegator::GuestSigSuspend(FEX::HLE::ThreadStateObject* Thread, u
 }
 
 uint64_t SignalDelegator::GuestSigTimedWait(uint64_t* set, siginfo_t* info, const struct timespec* timeout, size_t sigsetsize) {
-  if (sigsetsize > sizeof(uint64_t)) {
-    return -EINVAL;
-  }
-
-  uint64_t Result = ::syscall(SYS_rt_sigtimedwait, set, info, timeout);
+  uint64_t Result = ::syscall(SYS_rt_sigtimedwait, set, info, timeout, sigsetsize);
 
   return Result == -1 ? -errno : Result;
 }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Signals.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Signals.cpp
@@ -34,7 +34,7 @@ void RegisterSignals(FEX::HLE::SyscallHandler* Handler) {
   REGISTER_SYSCALL_IMPL_X64(
     rt_sigtimedwait,
     [](FEXCore::Core::CpuStateFrame* Frame, uint64_t* set, siginfo_t* info, const struct timespec* timeout, size_t sigsetsize) -> uint64_t {
-      FaultSafeUserMemAccess::VerifyIsReadable(set, sizeof(sigsetsize));
+      FaultSafeUserMemAccess::VerifyIsReadable(set, sigsetsize);
       FaultSafeUserMemAccess::VerifyIsWritableOrNull(info, sizeof(siginfo_t));
       FaultSafeUserMemAccess::VerifyIsReadableOrNull(timeout, sizeof(timespec));
       return FEX::HLE::_SyscallHandler->GetSignalDelegator()->GuestSigTimedWait(set, info, timeout, sigsetsize);


### PR DESCRIPTION
We should be checking the size passed in, not the sizeof of it.