### PR TITLE
Syscalls: Remove unnecessary usages of namespace FEXCore::IR

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -909,7 +909,6 @@ CPUBackend::CompiledCode Arm64JITCore::CompileCode(uint64_t Entry, uint64_t Size
   PendingCallReturnTargetLabel = nullptr;
 
   for (auto [BlockNode, BlockHeader] : IR->GetBlocks()) {
-    using namespace FEXCore::IR;
     auto BlockIROp = BlockHeader->CW<FEXCore::IR::IROp_CodeBlock>();
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED
     LOGMAN_THROW_A_FMT(BlockIROp->Header.Op == IR::OP_CODEBLOCK, "IR type failed to be a code block");

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/EPoll.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/EPoll.cpp
@@ -10,15 +10,11 @@ $end_info$
 #include "LinuxSyscalls/x64/Syscalls.h"
 #include "LinuxSyscalls/x32/Syscalls.h"
 
-#include <FEXCore/IR/IR.h>
-
 #include <stdint.h>
 #include <sys/epoll.h>
 
 namespace FEX::HLE {
 void RegisterEpoll(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
-
   REGISTER_SYSCALL_IMPL(epoll_create, [](FEXCore::Core::CpuStateFrame* Frame, int size) -> uint64_t {
     uint64_t Result = epoll_create(size);
     SYSCALL_ERRNO();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/FD.cpp
@@ -9,8 +9,6 @@ $end_info$
 #include "LinuxSyscalls/x64/Syscalls.h"
 #include "LinuxSyscalls/x32/Syscalls.h"
 
-#include <FEXCore/IR/IR.h>
-
 #include <FEXHeaderUtils/Syscalls.h>
 
 #include <fcntl.h>
@@ -30,7 +28,6 @@ $end_info$
 
 namespace FEX::HLE {
 void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
   REGISTER_SYSCALL_IMPL(poll, [](FEXCore::Core::CpuStateFrame* Frame, struct pollfd* fds, nfds_t nfds, int timeout) -> uint64_t {
     if (nfds) {
       // fds is allowed to be garbage if nfds is zero.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/FS.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/FS.cpp
@@ -9,8 +9,6 @@ $end_info$
 #include "LinuxSyscalls/x64/Syscalls.h"
 #include "LinuxSyscalls/x32/Syscalls.h"
 
-#include <FEXCore/IR/IR.h>
-
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/mount.h>
@@ -23,8 +21,6 @@ $end_info$
 
 namespace FEX::HLE {
 void RegisterFS(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
-
   REGISTER_SYSCALL_IMPL(rename, [](FEXCore::Core::CpuStateFrame* Frame, const char* oldpath, const char* newpath) -> uint64_t {
     uint64_t Result = ::rename(oldpath, newpath);
     SYSCALL_ERRNO();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/IO.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/IO.cpp
@@ -9,16 +9,12 @@ $end_info$
 #include "LinuxSyscalls/x64/Syscalls.h"
 #include "LinuxSyscalls/x32/Syscalls.h"
 
-#include <FEXCore/IR/IR.h>
-
 #include <linux/aio_abi.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
 namespace FEX::HLE {
 void RegisterIO(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
-
   REGISTER_SYSCALL_IMPL(iopl, [](FEXCore::Core::CpuStateFrame* Frame, int level) -> uint64_t {
     // Just claim we don't have permission
     return -EPERM;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Info.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Info.cpp
@@ -9,7 +9,6 @@ $end_info$
 #include "LinuxSyscalls/x64/Syscalls.h"
 #include "LinuxSyscalls/x32/Syscalls.h"
 
-#include <FEXCore/IR/IR.h>
 #include <FEXCore/Utils/LogManager.h>
 
 #include <cstring>
@@ -35,8 +34,6 @@ using cap_user_header_t = void*;
 using cap_user_data_t = void*;
 
 void RegisterInfo(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
-
   REGISTER_SYSCALL_IMPL(uname, [](FEXCore::Core::CpuStateFrame* Frame, struct utsname* buf) -> uint64_t {
     auto Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Memory.cpp
@@ -10,7 +10,6 @@ $end_info$
 #include "LinuxSyscalls/x32/Syscalls.h"
 
 #include <FEXCore/Debug/InternalThreadState.h>
-#include <FEXCore/IR/IR.h>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -20,8 +19,6 @@ $end_info$
 
 namespace FEX::HLE {
 void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
-
   REGISTER_SYSCALL_IMPL(brk, [](FEXCore::Core::CpuStateFrame* Frame, void* addr) -> uint64_t {
     uint64_t Result = FEX::HLE::_SyscallHandler->HandleBRK(Frame, addr);
     SYSCALL_ERRNO();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
@@ -10,8 +10,6 @@ $end_info$
 #include "LinuxSyscalls/x64/Syscalls.h"
 #include "LinuxSyscalls/x32/Syscalls.h"
 
-#include <FEXCore/IR/IR.h>
-
 #include <stdint.h>
 #include <sys/epoll.h>
 
@@ -212,7 +210,6 @@ uint64_t SyscallPassthrough7(FEXCore::Core::CpuStateFrame* Frame, uint64_t arg1,
 #endif
 
 void RegisterCommon(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
   REGISTER_SYSCALL_IMPL(read, SyscallPassthrough3<SYSCALL_DEF(read)>);
   REGISTER_SYSCALL_IMPL(write, SyscallPassthrough3<SYSCALL_DEF(write)>);
   REGISTER_SYSCALL_IMPL(lseek, SyscallPassthrough3<SYSCALL_DEF(lseek)>);
@@ -417,7 +414,6 @@ void RegisterCommon(FEX::HLE::SyscallHandler* Handler) {
 
 namespace x64 {
   void RegisterPassthrough(FEX::HLE::SyscallHandler* Handler) {
-    using namespace FEXCore::IR;
     RegisterCommon(Handler);
     REGISTER_SYSCALL_IMPL_X64(ftruncate, SyscallPassthrough2<SYSCALL_DEF(ftruncate)>);
     REGISTER_SYSCALL_IMPL_X64(ioctl, SyscallPassthrough3<SYSCALL_DEF(ioctl)>);
@@ -505,7 +501,6 @@ namespace x64 {
 
 namespace x32 {
   void RegisterPassthrough(FEX::HLE::SyscallHandler* Handler) {
-    using namespace FEXCore::IR;
     RegisterCommon(Handler);
     REGISTER_SYSCALL_IMPL_X32(getuid32, SyscallPassthrough0<SYSCALL_DEF(getuid)>);
     REGISTER_SYSCALL_IMPL_X32(getgid32, SyscallPassthrough0<SYSCALL_DEF(getgid)>);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Thread.cpp
@@ -394,8 +394,6 @@ uint64_t ForkGuest(FEXCore::Core::InternalThreadState* Thread, FEXCore::Core::Cp
 }
 
 void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
-
   REGISTER_SYSCALL_IMPL(rt_sigreturn, [](FEXCore::Core::CpuStateFrame* Frame) -> uint64_t {
     FEX::HLE::_SyscallHandler->GetSignalDelegator()->HandleSignalHandlerReturn(true);
     FEX_UNREACHABLE;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Timer.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Timer.cpp
@@ -10,20 +10,16 @@ $end_info$
 #include "LinuxSyscalls/x64/Syscalls.h"
 #include "LinuxSyscalls/x32/Syscalls.h"
 
-#include <FEXCore/IR/IR.h>
-
-#include <stddef.h>
-#include <stdint.h>
-#include <signal.h>
+#include <cstddef>
+#include <cstdint>
+#include <csignal>
+#include <ctime>
 #include <sys/time.h>
-#include <time.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
 namespace FEX::HLE {
 void RegisterTimer(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
-
   REGISTER_SYSCALL_IMPL(alarm, [](FEXCore::Core::CpuStateFrame* Frame, unsigned int seconds) -> uint64_t {
     uint64_t Result = ::alarm(seconds);
     SYSCALL_ERRNO();

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Info.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Info.cpp
@@ -16,8 +16,6 @@ $end_info$
 
 namespace FEX::HLE::x64 {
 void RegisterInfo(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
-
   if (Handler->IsHostKernelVersionAtLeast(6, 6, 0)) {
     REGISTER_SYSCALL_IMPL_X64(map_shadow_stack, [](FEXCore::Core::CpuStateFrame* Frame, uint64_t addr, uint64_t size, uint32_t flags) -> uint64_t {
       // Claim that shadow stack isn't supported.

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Memory.cpp
@@ -11,8 +11,6 @@ $end_info$
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Debug/InternalThreadState.h>
 
-#include <FEXCore/IR/IR.h>
-
 #include <sys/mman.h>
 #include <sys/shm.h>
 #include <unistd.h>
@@ -25,8 +23,6 @@ $end_info$
 namespace FEX::HLE::x64 {
 
 void RegisterMemory(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
-
   REGISTER_SYSCALL_IMPL_X64(
     mmap, [](FEXCore::Core::CpuStateFrame* Frame, void* addr, size_t length, int prot, int flags, int fd, off_t offset) -> uint64_t {
       return (uint64_t)FEX::HLE::_SyscallHandler->GuestMmap(Frame->Thread, addr, length, prot, flags, fd, offset);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Thread.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Thread.cpp
@@ -12,7 +12,6 @@ $end_info$
 
 #include <FEXCore/Core/CoreState.h>
 #include <FEXCore/Debug/InternalThreadState.h>
-#include <FEXCore/IR/IR.h>
 #include <FEXCore/fextl/vector.h>
 
 #include <sched.h>
@@ -234,7 +233,6 @@ enum Modify_ldt_func : int32_t {
 };
 
 void RegisterThread(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
   REGISTER_SYSCALL_IMPL_X64(modify_ldt, [](FEXCore::Core::CpuStateFrame* Frame, int func, void* ptr, unsigned long bytecount) -> uint64_t {
     switch (func) {
     case Modify_ldt_func::LDT_READ: return FEX::HLE::_SyscallHandler->read_ldt(Frame, ptr, bytecount);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Time.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Time.cpp
@@ -21,8 +21,6 @@ $end_info$
 
 namespace FEX::HLE::x64 {
 void RegisterTime(FEX::HLE::SyscallHandler* Handler) {
-  using namespace FEXCore::IR;
-
   REGISTER_SYSCALL_IMPL_X64(gettimeofday, [](FEXCore::Core::CpuStateFrame* Frame, timeval* tv, struct timezone* tz) -> uint64_t {
     FaultSafeUserMemAccess::VerifyIsWritableOrNull(tv, sizeof(*tv));
     FaultSafeUserMemAccess::VerifyIsWritableOrNull(tz, sizeof(*tz));


### PR DESCRIPTION
These aren't necessary.