### PR TITLE
FlexBitSet: Simplify MemClear/MemSet

### DIFF
--- a/FEXCore/Source/Utils/Allocator/FlexBitSet.h
+++ b/FEXCore/Source/Utils/Allocator/FlexBitSet.h
@@ -39,10 +39,10 @@ struct FlexBitSet final {
     Memory[Element / MinimumSizeBits] &= ~(1ULL << (Element % MinimumSizeBits));
   }
   void MemClear(size_t Elements) {
-    memset(Memory, 0, FEXCore::AlignUp(Elements / MinimumSizeBits, MinimumSizeBits));
+    memset(Memory, 0, SizeInBytes(Elements));
   }
   void MemSet(size_t Elements) {
-    memset(Memory, 0xFF, FEXCore::AlignUp(Elements / MinimumSizeBits, MinimumSizeBits));
+    memset(Memory, 0xFF, SizeInBytes(Elements));
   }
 
   // Range scanning results


### PR DESCRIPTION
We can just make use of the helpers already in the interface.