### PR TITLE
x32/FD: Fix readahead upper offset type

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/FD.cpp
@@ -944,7 +944,7 @@ void RegisterFD(FEX::HLE::SyscallHandler* Handler) {
     });
 
   REGISTER_SYSCALL_IMPL_X32(
-    readahead, [](FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t offset_low, uint64_t offset_high, size_t count) -> uint64_t {
+    readahead, [](FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t offset_low, uint32_t offset_high, size_t count) -> uint64_t {
       uint64_t Offset = offset_high;
       Offset <<= 32;
       Offset |= offset_low;


### PR DESCRIPTION
This should be a uint32_t