### PR TITLE
AllocatorHooks: Amend VirtualProtect for Windows

### DIFF
--- a/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
+++ b/FEXCore/include/FEXCore/Utils/AllocatorHooks.h
@@ -97,7 +97,8 @@ inline bool VirtualProtect(void* Ptr, size_t Size, ProtectOptions options) {
     LOGMAN_MSG_A_FMT("Unknown VirtualProtect options combination");
   }
 
-  return ::VirtualProtect(Ptr, Size, prot, nullptr) == 0;
+  DWORD OldProt {};
+  return ::VirtualProtect(Ptr, Size, prot, &OldProt) != 0;
 }
 
 FEX_DEFAULT_VISIBILITY extern VirtualNamePtr VirtualName;


### PR DESCRIPTION
VirtualProtect returns non-zero on success, also the old protection flag parameter isn't allowed to be null.