### PR TITLE
WinAPI/IO: Fix handling of end of file offset in SetFilePointerEx

### DIFF
--- a/Source/Windows/Common/WinAPI/IO.cpp
+++ b/Source/Windows/Common/WinAPI/IO.cpp
@@ -147,9 +147,18 @@ DLLEXPORT_FUNC(WINBOOL, SetFilePointerEx, (HANDLE hFile, LARGE_INTEGER liDistanc
   }
 
   switch (dwMoveMethod) {
-  case FILE_BEGIN: PositionInfo.CurrentByteOffset = liDistanceToMove; break;
-  case FILE_CURRENT: PositionInfo.CurrentByteOffset.QuadPart += liDistanceToMove.QuadPart; break;
-  case FILE_END: PositionInfo.CurrentByteOffset = StandardInfo.EndOfFile; break;
+  case FILE_BEGIN: {
+    PositionInfo.CurrentByteOffset = liDistanceToMove;
+    break;
+  }
+  case FILE_CURRENT: {
+    PositionInfo.CurrentByteOffset.QuadPart += liDistanceToMove.QuadPart;
+    break;
+  }
+  case FILE_END: {
+    PositionInfo.CurrentByteOffset.QuadPart = StandardInfo.EndOfFile.QuadPart + liDistanceToMove.QuadPart;
+    break;
+  }
   default: UNIMPLEMENTED();
   }
   if (NTSTATUS Status = NtSetInformationFile(hFile, &IOSB, &PositionInfo, sizeof(PositionInfo), FilePositionInformation); Status) {


### PR DESCRIPTION
This just means the end of the file is being used as the base offset.

Also note that according to the documentation for SetFilePositionEx, that setting the position beyond the current file size is not considered an error as far as the API is concerned.