### PR TITLE
Signals: Preprocessor disable intentional dead code

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Signals.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Signals.cpp
@@ -43,8 +43,10 @@ void RegisterSignals(FEX::HLE::SyscallHandler* Handler) {
     // Disable userfaultfd until we can properly emulate it
     // This is okay because the kernel configuration allows you to disable it at compile time
     return -ENOSYS;
+#if 0
     uint64_t Result = ::syscall(SYSCALL_DEF(userfaultfd), flags);
     SYSCALL_ERRNO();
+#endif
   });
 
   REGISTER_SYSCALL_IMPL(signalfd, [](FEXCore::Core::CpuStateFrame* Frame, int fd, const uint64_t* mask, size_t sigsetsize) -> uint64_t {


### PR DESCRIPTION
Noticed this when going through the syscalls. Avoids potential warnings.