### PR TITLE
Utils/File: Handle dual read/write case

### DIFF
--- a/FEXCore/include/FEXCore/Utils/File.h
+++ b/FEXCore/include/FEXCore/Utils/File.h
@@ -202,12 +202,18 @@ private:
   static constexpr int DEFAULT_USER_PERMS = S_IRWXU | S_IRWXG | S_IRWXO;
 
   static uint32_t TranslateModes(FileModes Modes) {
+    const auto IsRead = (Modes & FileModes::READ) == FileModes::READ;
+    const auto IsWrite = (Modes & FileModes::WRITE) == FileModes::WRITE;
+
     uint32_t Mode {};
-    if ((Modes & FileModes::READ) == FileModes::READ) {
-      Mode |= O_RDONLY;
-    }
-    if ((Modes & FileModes::WRITE) == FileModes::WRITE) {
-      Mode |= O_WRONLY;
+    if (IsRead && IsWrite) {
+      Mode |= O_RDWR;
+    } else {
+      if (IsRead) {
+        Mode |= O_RDONLY;
+      } else if (IsWrite) {
+        Mode |= O_WRONLY;
+      }
     }
     if ((Modes & FileModes::CREATE) == FileModes::CREATE) {
       Mode |= O_CREAT;


### PR DESCRIPTION
According to POSIX open docs, this is a completely separate flag that isn't a combination of O_RDONLY and O_WRONLY (TIL), so we need to handle this separately.

Makes the codepath behaviorally symmetric with the Windows one.