### PR TITLE
Crypto: Clarify zero vector size in SHA1RNDS4Op()

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Crypto.cpp
@@ -107,7 +107,7 @@ void OpDispatchBuilder::SHA1RNDS4Op(OpcodeArgs) {
     break;
   }
 
-  const auto ZeroRegister = LoadZeroVector(OpSize::i32Bit);
+  const auto ZeroRegister = LoadZeroVector(OpSize::i128Bit);
 
   Ref Src1 = SHADataShuffle(Dest);
   Ref Src2 = SHADataShuffle(Src);


### PR DESCRIPTION
This ends up zeroing out the whole 128-bit vector. No behavior change, this just makes it more clear.