### PR TITLE
IR: Enclose straggler Desc comments in brackets

### DIFF
--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -251,6 +251,10 @@ def parse_ops(ops):
 
             if "Desc" in op_val:
                 OpDef.Desc = op_val["Desc"]
+                if not isinstance(OpDef.Desc, list):
+                    ExitError(f"Desc field for op {OpDef.Name} must be an array of strings")
+                if not all(isinstance(item, str) for item in OpDef.Desc):
+                    ExitError(f"Desc field for op {OpDef.Name} must only contain strings")
 
             if "DynamicDispatch" in op_val:
                 OpDef.DynamicDispatch = bool(op_val["DynamicDispatch"])

--- a/FEXCore/Scripts/json_ir_generator.py
+++ b/FEXCore/Scripts/json_ir_generator.py
@@ -607,77 +607,77 @@ def print_validation(op):
 def print_ir_allocator_helpers():
     output_file.write("#ifdef IROP_ALLOCATE_HELPERS\n")
 
-    output_file.write("\ttemplate <class T>\n")
-    output_file.write("\tstruct Wrapper final {\n")
-    output_file.write("\t\tT *first;\n")
-    output_file.write("\t\tOrderedNode *Node; ///< Actual offset of this IR in ths list\n")
-    output_file.write("\n")
-    output_file.write("\t\toperator Wrapper<IROp_Header>() const { return Wrapper<IROp_Header> {reinterpret_cast<IROp_Header*>(first), Node}; }\n")
-    output_file.write("\t\toperator OrderedNode *() { return Node; }\n")
-    output_file.write("\t\toperator const OrderedNode *() const { return Node; }\n")
-    output_file.write("\t\toperator OpNodeWrapper () const { return Node->Header.Value; }\n")
-    output_file.write("\t};\n")
+    output_file.write("\ttemplate <class T>\n"
+                      "\tstruct Wrapper final {\n"
+                      "\t\tT *first;\n"
+                      "\t\tOrderedNode *Node; ///< Actual offset of this IR in ths list\n"
+                      "\n"
+                      "\t\toperator Wrapper<IROp_Header>() const { return Wrapper<IROp_Header> {reinterpret_cast<IROp_Header*>(first), Node}; }\n"
+                      "\t\toperator OrderedNode *() { return Node; }\n"
+                      "\t\toperator const OrderedNode *() const { return Node; }\n"
+                      "\t\toperator OpNodeWrapper () const { return Node->Header.Value; }\n"
+                      "\t};\n")
 
-    output_file.write("\ttemplate <class T>\n")
-    output_file.write("\tusing IRPair = Wrapper<T>;\n\n")
+    output_file.write("\ttemplate <class T>\n"
+                      "\tusing IRPair = Wrapper<T>;\n\n")
 
-    output_file.write("\tIRPair<IROp_Header> AllocateRawOp(size_t HeaderSize) {\n")
-    output_file.write("\t\tauto Op = reinterpret_cast<IROp_Header*>(DualListData.DataAllocate(HeaderSize));\n")
-    output_file.write("\t\tmemset(Op, 0, HeaderSize);\n")
-    output_file.write("\t\tOp->Op = IROps::OP_DUMMY;\n")
-    output_file.write("\t\treturn IRPair<IROp_Header>{Op, CreateNode(Op)};\n")
-    output_file.write("\t}\n\n")
+    output_file.write("\tIRPair<IROp_Header> AllocateRawOp(size_t HeaderSize) {\n"
+                      "\t\tauto Op = reinterpret_cast<IROp_Header*>(DualListData.DataAllocate(HeaderSize));\n"
+                      "\t\tmemset(Op, 0, HeaderSize);\n"
+                      "\t\tOp->Op = IROps::OP_DUMMY;\n"
+                      "\t\treturn IRPair<IROp_Header>{Op, CreateNode(Op)};\n"
+                      "\t}\n\n")
 
-    output_file.write("\ttemplate<class T, IROps T2>\n")
-    output_file.write("\tT *AllocateOrphanOp() {\n")
-    output_file.write("\t\tsize_t Size = FEXCore::IR::GetSize(T2);\n")
-    output_file.write("\t\tauto Op = reinterpret_cast<T*>(DualListData.DataAllocate(Size));\n")
-    output_file.write("\t\tmemset(Op, 0, Size);\n")
-    output_file.write("\t\tOp->Header.Op = T2;\n")
-    output_file.write("\t\treturn Op;\n")
-    output_file.write("\t}\n\n")
+    output_file.write("\ttemplate<class T, IROps T2>\n"
+                      "\tT *AllocateOrphanOp() {\n"
+                      "\t\tsize_t Size = FEXCore::IR::GetSize(T2);\n"
+                      "\t\tauto Op = reinterpret_cast<T*>(DualListData.DataAllocate(Size));\n"
+                      "\t\tmemset(Op, 0, Size);\n"
+                      "\t\tOp->Header.Op = T2;\n"
+                      "\t\treturn Op;\n"
+                      "\t}\n\n")
 
-    output_file.write("\ttemplate<class T, IROps T2>\n")
-    output_file.write("\tIRPair<T> AllocateOp() {\n")
-    output_file.write("\t\tsize_t Size = FEXCore::IR::GetSize(T2);\n")
-    output_file.write("\t\tauto Op = reinterpret_cast<T*>(DualListData.DataAllocate(Size));\n")
-    output_file.write("\t\tmemset(Op, 0, Size);\n")
-    output_file.write("\t\tOp->Header.Op = T2;\n")
-    output_file.write("\t\treturn IRPair<T>{Op, CreateNode(&Op->Header)};\n")
-    output_file.write("\t}\n\n")
+    output_file.write("\ttemplate<class T, IROps T2>\n"
+                      "\tIRPair<T> AllocateOp() {\n"
+                      "\t\tsize_t Size = FEXCore::IR::GetSize(T2);\n"
+                      "\t\tauto Op = reinterpret_cast<T*>(DualListData.DataAllocate(Size));\n"
+                      "\t\tmemset(Op, 0, Size);\n"
+                      "\t\tOp->Header.Op = T2;\n"
+                      "\t\treturn IRPair<T>{Op, CreateNode(&Op->Header)};\n"
+                      "\t}\n\n")
 
-    output_file.write("\tIR::OpSize GetOpSize(const OrderedNode *Op) const {\n")
-    output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n")
-    output_file.write("\t\treturn HeaderOp->Size;\n")
-    output_file.write("\t}\n\n")
+    output_file.write("\tIR::OpSize GetOpSize(const OrderedNode *Op) const {\n"
+                      "\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n"
+                      "\t\treturn HeaderOp->Size;\n"
+                      "\t}\n\n")
 
-    output_file.write("\tIR::OpSize GetOpElementSize(const OrderedNode *Op) const {\n")
-    output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n")
-    output_file.write("\t\treturn HeaderOp->ElementSize;\n")
-    output_file.write("\t}\n\n")
+    output_file.write("\tIR::OpSize GetOpElementSize(const OrderedNode *Op) const {\n"
+                      "\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n"
+                      "\t\treturn HeaderOp->ElementSize;\n"
+                      "\t}\n\n")
 
-    output_file.write("\tuint8_t GetOpElements(const OrderedNode *Op) const {\n")
-    output_file.write("\t\tLOGMAN_THROW_A_FMT(OpHasDest(Op), \"Op {} has no dest\\n\", GetOpName(Op));\n")
-    output_file.write("\t\treturn IR::OpSizeToSize(GetOpSize(Op)) / IR::OpSizeToSize(GetOpElementSize(Op));\n")
-    output_file.write("\t}\n\n")
+    output_file.write("\tuint8_t GetOpElements(const OrderedNode *Op) const {\n"
+                      "\t\tLOGMAN_THROW_A_FMT(OpHasDest(Op), \"Op {} has no dest\\n\", GetOpName(Op));\n"
+                      "\t\treturn IR::OpSizeToSize(GetOpSize(Op)) / IR::OpSizeToSize(GetOpElementSize(Op));\n"
+                      "\t}\n\n")
 
-    output_file.write("\tbool OpHasDest(const OrderedNode *Op) const {\n")
-    output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n")
-    output_file.write("\t\treturn GetHasDest(HeaderOp->Op);\n")
-    output_file.write("\t}\n\n")
+    output_file.write("\tbool OpHasDest(const OrderedNode *Op) const {\n"
+                      "\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n"
+                      "\t\treturn GetHasDest(HeaderOp->Op);\n"
+                      "\t}\n\n")
 
-    output_file.write("\tIROps GetOpType(const OrderedNode *Op) const {\n")
-    output_file.write("\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n")
-    output_file.write("\t\treturn HeaderOp->Op;\n")
-    output_file.write("\t}\n\n")
+    output_file.write("\tIROps GetOpType(const OrderedNode *Op) const {\n"
+                      "\t\tauto HeaderOp = Op->Header.Value.GetNode(DualListData.DataBegin());\n"
+                      "\t\treturn HeaderOp->Op;\n"
+                      "\t}\n\n")
 
-    output_file.write("\tFEXCore::IR::RegClass GetOpRegClass(const OrderedNode *Op) const {\n")
-    output_file.write("\t\treturn GetRegClass(GetOpType(Op));\n")
-    output_file.write("\t}\n\n")
+    output_file.write("\tFEXCore::IR::RegClass GetOpRegClass(const OrderedNode *Op) const {\n"
+                      "\t\treturn GetRegClass(GetOpType(Op));\n"
+                      "\t}\n\n")
 
-    output_file.write("\tstd::string_view const& GetOpName(const OrderedNode *Op) const {\n")
-    output_file.write("\t\treturn IR::GetName(GetOpType(Op));\n")
-    output_file.write("\t}\n\n")
+    output_file.write("\tstd::string_view const& GetOpName(const OrderedNode *Op) const {\n"
+                      "\t\treturn IR::GetName(GetOpType(Op));\n"
+                      "\t}\n\n")
 
     # Generate helpers with operands
     for op in IROps:

--- a/FEXCore/Source/Interface/IR/IR.json
+++ b/FEXCore/Source/Interface/IR/IR.json
@@ -2016,7 +2016,7 @@
 
       "FPR = VUShrNI OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector, u8:$BitShift": {
         "TiedSource": 0,
-        "Desc": "Unsigned shifts right each element and then narrows to the next lower element size",
+        "Desc": ["Unsigned shifts right each element and then narrows to the next lower element size"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize >> 1",
         "EmitValidation": [
@@ -2038,7 +2038,7 @@
         ]
       },
       "FPR = VSXTL OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector": {
-        "Desc": "Sign extends elements from the source element size to the next size up",
+        "Desc": ["Sign extends elements from the source element size to the next size up"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize << 1"
       },
@@ -2050,7 +2050,7 @@
         "ElementSize": "ElementSize << 1"
       },
       "FPR = VSSHLL OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector, u8:$BitShift{0}": {
-        "Desc": "Sign extends elements from the source element size to the next size up",
+        "Desc": ["Sign extends elements from the source element size to the next size up"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize << 1"
       },
@@ -2062,7 +2062,7 @@
         "ElementSize": "ElementSize << 1"
       },
       "FPR = VUXTL OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector": {
-        "Desc": "Zero extends elements from the source element size to the next size up",
+        "Desc": ["Zero extends elements from the source element size to the next size up"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize << 1"
       },
@@ -2217,7 +2217,7 @@
       },
 
       "FPR = VAddP OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$VectorLower, FPR:$VectorUpper": {
-        "Desc": "Does a horizontal pairwise add of elements across the two source vectors",
+        "Desc": ["Does a horizontal pairwise add of elements across the two source vectors"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize"
       },
@@ -2274,7 +2274,7 @@
         "ElementSize": "ElementSize"
       },
       "FPR = VFAddP OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$VectorLower, FPR:$VectorUpper": {
-        "Desc": "Does a horizontal pairwise add of elements across the two source vectors with float element types",
+        "Desc": ["Does a horizontal pairwise add of elements across the two source vectors with float element types"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize"
       },
@@ -2324,29 +2324,27 @@
         "ElementSize": "ElementSize << 1"
       },
       "FPR = VUMull2 OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector1, FPR:$Vector2": {
-        "Desc": "Multiplies the high elements with size extension",
+        "Desc": ["Multiplies the high elements with size extension"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize << 1"
       },
       "FPR = VSMull2 OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector1, FPR:$Vector2": {
-        "Desc": "Multiplies the high elements with size extension",
+        "Desc": ["Multiplies the high elements with size extension"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize << 1"
       },
       "FPR = VUMulH OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector1, FPR:$Vector2": {
-        "Desc": "Wide unsigned multiply returning the high results",
+        "Desc": ["Wide unsigned multiply returning the high results"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize"
       },
       "FPR = VSMulH OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector1, FPR:$Vector2": {
-        "Desc": "Wide signed multiply returning the high results",
-
+        "Desc": ["Wide signed multiply returning the high results"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize"
       },
       "FPR = VUABDL OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector1, FPR:$Vector2": {
-        "Desc": ["Unsigned Absolute Difference Long"
-                ],
+        "Desc": ["Unsigned Absolute Difference Long"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize << 1"
       },
@@ -2622,7 +2620,7 @@
       },
 
       "FPR = Vector_SToF OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector": {
-        "Desc": "Vector op: Converts signed integer to same size float",
+        "Desc": ["Vector op: Converts signed integer to same size float"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize"
       },
@@ -2634,12 +2632,12 @@
         "ElementSize": "ElementSize"
       },
       "FPR = Vector_FToZS OpSize:#RegisterSize, OpSize:#ElementSize, FPR:$Vector": {
-        "Desc": "Vector op: Converts float to signed integer, rounding towards zero",
+        "Desc": ["Vector op: Converts float to signed integer, rounding towards zero"],
         "DestSize": "RegisterSize",
         "ElementSize": "ElementSize"
       },
       "FPR = Vector_FToF OpSize:#RegisterSize, OpSize:#DestElementSize, FPR:$Vector, OpSize:$SrcElementSize": {
-        "Desc": "Vector op: Converts float from source element size to destination size (fp32<->fp64)",
+        "Desc": ["Vector op: Converts float from source element size to destination size (fp32<->fp64)"],
         "DestSize": "RegisterSize",
         "ElementSize": "DestElementSize"
       },
@@ -2694,75 +2692,74 @@
     },
     "Crypto": {
       "FPR = VAESImc FPR:$Vector": {
-        "Desc": "Does a stage of the inverse mix column transformation",
+        "Desc": ["Does a stage of the inverse mix column transformation"],
         "DestSize": "OpSize::i128Bit"
       },
       "FPR = VAESEnc OpSize:#RegisterSize, FPR:$State, FPR:$Key, FPR:$ZeroReg": {
-        "Desc": "Does a step of AES encryption",
+        "Desc": ["Does a step of AES encryption"],
         "DestSize": "RegisterSize"
       },
       "FPR = VAESEncLast OpSize:#RegisterSize, FPR:$State, FPR:$Key, FPR:$ZeroReg": {
-        "Desc": "Does the last step of AES encryption",
+        "Desc": ["Does the last step of AES encryption"],
         "DestSize": "RegisterSize"
       },
       "FPR = VAESDec OpSize:#RegisterSize, FPR:$State, FPR:$Key, FPR:$ZeroReg": {
-        "Desc": "Does a step of AES decryption",
+        "Desc": ["Does a step of AES decryption"],
         "DestSize": "RegisterSize"
       },
       "FPR = VAESDecLast OpSize:#RegisterSize, FPR:$State, FPR:$Key, FPR:$ZeroReg": {
-        "Desc": "Does the last step of AES decryption",
+        "Desc": ["Does the last step of AES decryption"],
         "DestSize": "RegisterSize"
       },
       "FPR = VAESKeyGenAssist FPR:$Src, FPR:$KeyGenTBLSwizzle, FPR:$ZeroReg, u8:$RCON": {
-        "Desc": "Assists in key generation",
+        "Desc": ["Assists in key generation"],
         "DestSize": "OpSize::i128Bit"
       },
       "FPR = VSha1H FPR:$Src": {
-        "Desc": "Does vector scalar SHA1H instruction",
+        "Desc": ["Does vector scalar SHA1H instruction"],
         "DestSize": "FEXCore::IR::OpSize::i32Bit"
       },
       "FPR = VSha1C FPR:$Src1, FPR:$Src2, FPR:$Src3": {
-        "Desc": "Does vector SHA1C instruction",
+        "Desc": ["Does vector SHA1C instruction"],
         "DestSize": "FEXCore::IR::OpSize::i128Bit",
         "TiedSource": 0
       },
       "FPR = VSha1M FPR:$Src1, FPR:$Src2, FPR:$Src3": {
-        "Desc": "Does vector SHA1M instruction",
+        "Desc": ["Does vector SHA1M instruction"],
         "DestSize": "FEXCore::IR::OpSize::i128Bit",
         "TiedSource": 0
       },
       "FPR = VSha1P FPR:$Src1, FPR:$Src2, FPR:$Src3": {
-        "Desc": "Does vector SHA1P instruction",
+        "Desc": ["Does vector SHA1P instruction"],
         "DestSize": "FEXCore::IR::OpSize::i128Bit",
         "TiedSource": 0
       },
       "FPR = VSha1SU1 FPR:$Src1, FPR:$Src2": {
-        "Desc": "Does vector scalar SHA1H instruction",
+        "Desc": ["Does vector scalar SHA1H instruction"],
         "DestSize": "FEXCore::IR::OpSize::i128Bit",
         "TiedSource": 0
       },
       "FPR = VSha256U0 FPR:$Src1, FPR:$Src2": {
-        "Desc": "Does vector scalar VSha256U0 instruction",
+        "Desc": ["Does vector scalar VSha256U0 instruction"],
         "DestSize": "FEXCore::IR::OpSize::i128Bit",
         "TiedSource": 0
       },
       "FPR = VSha256U1 FPR:$Src1, FPR:$Src2": {
-        "Desc": "Does vector scalar VSha256U1 instruction",
+        "Desc": ["Does vector scalar VSha256U1 instruction"],
         "DestSize": "FEXCore::IR::OpSize::i128Bit"
       },
       "FPR = VSha256H FPR:$Src1, FPR:$Src2, FPR:$Src3": {
-        "Desc": "Does vector scalar VSha256H instruction",
+        "Desc": ["Does vector scalar VSha256H instruction"],
         "DestSize": "FEXCore::IR::OpSize::i128Bit",
         "TiedSource": 0
       },
       "FPR = VSha256H2 FPR:$Src1, FPR:$Src2, FPR:$Src3": {
-        "Desc": "Does vector scalar VSha256H2 instruction",
+        "Desc": ["Does vector scalar VSha256H2 instruction"],
         "DestSize": "FEXCore::IR::OpSize::i128Bit",
         "TiedSource": 0
       },
       "GPR = CRC32 GPR:$Src1, GPR:$Src2, OpSize:$SrcSize": {
-        "Desc": ["CRC32 using polynomial 0x1EDC6F41"
-                ],
+        "Desc": ["CRC32 using polynomial 0x1EDC6F41"],
         "DestSize": "OpSize::i32Bit"
       },
       "FPR = PCLMUL OpSize:#RegisterSize, FPR:$Src1, FPR:$Src2, u8:$Selector": {


### PR DESCRIPTION
Ensures the comments get rendered properly in output. We can also make sure that the IR generation script catches this in the future.