### PR TITLE
Utils/File: Fix handle releasing

### DIFF
--- a/FEXCore/include/FEXCore/Utils/File.h
+++ b/FEXCore/include/FEXCore/Utils/File.h
@@ -58,6 +58,8 @@ public:
     }
     IsValidHandle = Handle != INVALID_HANDLE_VALUE;
 #endif
+
+    ShouldClose = IsValidHandle;
   }
 
   /**


### PR DESCRIPTION
ShouldClose was never being set in the event we opened a regular file. The only time it was set (to false) is when it's used to encapsulate stderr and stdout.

So anything opened by a File instance was essentially held open.