### PR TITLE
x32/Semaphore: Fix storing of message type in msgrcv

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
@@ -216,7 +216,6 @@ _ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first, uint32_
         src->mtype = TmpMsg->mtype;
         memcpy(src->mtext, TmpMsg->mtext, Result);
       }
-
     } else {
       struct compat_ipc_kludge {
         compat_uptr_t msgp;
@@ -228,7 +227,7 @@ _ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first, uint32_
         msgbuf_32* src = reinterpret_cast<msgbuf_32*>(ipck->msgp);
         FaultSafeUserMemAccess::VerifyIsWritable(src, sizeof(*src));
         FaultSafeUserMemAccess::VerifyIsWritable(src->mtext, Result);
-        ipck->msgtyp = TmpMsg->mtype;
+        src->mtype = TmpMsg->mtype;
         memcpy(src->mtext, TmpMsg->mtext, Result);
       }
     }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Semaphore.cpp
@@ -86,7 +86,8 @@ union semun {
   void* __pad;
 };
 
-uint64_t _ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first, uint32_t second, uint32_t third, uint32_t ptr, uint32_t fifth) {
+static uint64_t
+_ipc(FEXCore::Core::CpuStateFrame* Frame, uint32_t call, uint32_t first, uint32_t second, uint32_t third, uint32_t ptr, uint32_t fifth) {
   uint64_t Result {};
 
   const int Version = call >> 16;


### PR DESCRIPTION
This was previously storing into the local compat handler, not the actual managed message.