### PR TITLE
StringUtils: Handle strings entirely composed of whitespace in trims

### DIFF
--- a/FEXCore/include/FEXCore/Utils/StringUtils.h
+++ b/FEXCore/include/FEXCore/Utils/StringUtils.h
@@ -5,21 +5,21 @@
 namespace FEXCore::StringUtils {
 // Trim the left side of the string of whitespace and new lines
 inline fextl::string LeftTrim(fextl::string String, std::string_view TrimTokens = " \t\n\r\f\v") {
-  size_t pos = fextl::string::npos;
-  if ((pos = String.find_first_not_of(TrimTokens)) != fextl::string::npos) {
-    String.erase(0, pos);
+  const size_t pos = String.find_first_not_of(TrimTokens);
+  if (pos == fextl::string::npos) {
+    return "";
   }
-
-  return String;
+  return String.erase(0, pos);
 }
 
 // Trim the right side of the string of whitespace and new lines
 inline fextl::string RightTrim(fextl::string String, std::string_view TrimTokens = " \t\n\r\f\v") {
-  size_t pos = fextl::string::npos;
-  if ((pos = String.find_last_not_of(TrimTokens)) != fextl::string::npos) {
-    String.erase(String.begin() + pos + 1, String.end());
+  const size_t pos = String.find_last_not_of(TrimTokens);
+  if (pos == fextl::string::npos) {
+    return "";
   }
 
+  String.erase(String.begin() + pos + 1, String.end());
   return String;
 }
 

--- a/unittests/APITests/StringUtils.cpp
+++ b/unittests/APITests/StringUtils.cpp
@@ -5,6 +5,8 @@ using namespace FEXCore::StringUtils;
 
 TEST_CASE("ltrim") {
   CHECK(LeftTrim("") == "");
+  CHECK(LeftTrim(" ") == "");
+  CHECK(LeftTrim(" \t\n\r\f\v") == "");
   CHECK(LeftTrim("FEXInterpreter") == "FEXInterpreter");
 
   CHECK(LeftTrim("FEXInterpreter\n") == "FEXInterpreter\n");
@@ -31,6 +33,8 @@ TEST_CASE("ltrim") {
 
 TEST_CASE("rtrim") {
   CHECK(RightTrim("") == "");
+  CHECK(RightTrim(" ") == "");
+  CHECK(RightTrim(" \t\n\r\f\v") == "");
   CHECK(RightTrim("FEXInterpreter") == "FEXInterpreter");
 
   CHECK(RightTrim("FEXInterpreter\n") == "FEXInterpreter");
@@ -57,6 +61,8 @@ TEST_CASE("rtrim") {
 
 TEST_CASE("trim") {
   CHECK(Trim("") == "");
+  CHECK(Trim(" ") == "");
+  CHECK(Trim(" \t\n\r\f\v") == "");
   CHECK(Trim("FEXInterpreter") == "FEXInterpreter");
 
   CHECK(Trim("FEXInterpreter\n") == "FEXInterpreter");


### PR DESCRIPTION
Previously this wouldn't handle fully whitespaced strings.