### PR TITLE
AtomicOps: Avoid constrained unpredictable case in TelemetrySetValue()

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/AtomicOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/AtomicOps.cpp
@@ -342,8 +342,8 @@ DEF_OP(TelemetrySetValue) {
     (void)Bind(&LoopTop);
     ldaxr(ARMEmitter::SubRegSize::i64Bit, TMP3, TMP2);
     orr(ARMEmitter::Size::i32Bit, TMP3, TMP3, Src);
-    stlxr(ARMEmitter::SubRegSize::i64Bit, TMP3, TMP3, TMP2);
-    (void)cbnz(ARMEmitter::Size::i32Bit, TMP3, &LoopTop);
+    stlxr(ARMEmitter::SubRegSize::i64Bit, TMP4, TMP3, TMP2);
+    (void)cbnz(ARMEmitter::Size::i32Bit, TMP4, &LoopTop);
   }
 #endif
 }


### PR DESCRIPTION
STLXR cannot use the same register as both the status register and the value register, otherwise it's architecturally unpredictable behavior.

Only applies to hardware without FEAT_LSE, so this only meaningfully affects hardware using the v8.0 spec, since FEAT_LSE becomes mandatory in v8.1 and newer.