### PR TITLE
x87StackOptimizationPass: Remove shadowing variable in PUSHSTACK case

### DIFF
--- a/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
@@ -933,7 +933,6 @@ void X87StackOptimization::Run(IREmitter* Emit) {
           UpdateTopForPush_Slow();
           StoreStackValueAtOffset_Slow(SourceNode);
         } else {
-          auto* SourceNode = CurrentIR.GetNode(Op->X80Src);
           if (Op->OriginalValue.IsInvalid()) {
             // No original value to track - just push the converted data
             StackData.push(StackMemberInfo {SourceNode});


### PR DESCRIPTION
No behavioral change, since the one in the outer scope does the same thing.