### PR TITLE
RegisterAllocationPass: Ensure pair reg invariant

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/JIT.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/JIT.cpp
@@ -630,7 +630,7 @@ Arm64JITCore::Arm64JITCore(FEXCore::Context::ContextImpl* ctx, FEXCore::Core::In
   RAPass->AddRegisters(IR::RegClass::GPRFixed, StaticRegisters.size());
   RAPass->AddRegisters(IR::RegClass::FPR, GeneralFPRegisters.size());
   RAPass->AddRegisters(IR::RegClass::FPRFixed, StaticFPRegisters.size());
-  RAPass->PairRegs = PairRegisters;
+  RAPass->SetNumPairRegs(PairRegisters);
 
   {
     // Set up pointers that the JIT needs to load

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.cpp
@@ -52,6 +52,11 @@ namespace {
   }
 } // Anonymous namespace
 
+void RegisterAllocationPass::SetNumPairRegs(uint32_t NumRegs) {
+  LOGMAN_THROW_A_FMT((NumRegs % 2) == 0, "Number of pair regs must be even. (Given: {})", NumRegs);
+  PairRegs = NumRegs;
+}
+
 class ConstrainedRAPass final : public RegisterAllocationPass {
 public:
   explicit ConstrainedRAPass(const FEXCore::CPUIDEmu* CPUID)

--- a/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
+++ b/FEXCore/Source/Interface/IR/Passes/RegisterAllocationPass.h
@@ -6,10 +6,11 @@ $end_info$
 */
 
 #pragma once
+
 #include "Interface/IR/PassManager.h"
 
+#include <cstdint>
 #include <memory>
-#include <stdint.h>
 
 namespace FEXCore::IR {
 enum class RegClass : uint32_t;
@@ -18,6 +19,9 @@ class RegisterAllocationPass : public FEXCore::IR::Pass {
 public:
   virtual void AddRegisters(RegClass Class, uint32_t RegisterCount) = 0;
 
+  void SetNumPairRegs(uint32_t NumRegs);
+
+protected:
   // Number of GPRs usable for pairs at start of GPR set. Must be even.
   uint32_t PairRegs {};
 };


### PR DESCRIPTION
Allows us to actually catch if this requirement ever gets broken in the future.