### PR TITLE
VectorOps: Make use of unpredicated shifts

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -2791,17 +2791,17 @@ DEF_OP(VUShrSWide) {
   const auto Vector = GetVReg(Op->Vector);
 
   if (HostSupportsSVE256 && Is256Bit) {
-    const auto Mask = PRED_TMP_32B.Merging();
-
     dup(ARMEmitter::SubRegSize::i64Bit, VTMP1.Z(), ShiftScalar.Z(), 0);
-    if (Dst != Vector) {
-      // NOTE: SVE LSR is a destructive operation.
-      movprfx(Dst.Z(), Vector.Z());
-    }
     if (ElementSize == IR::OpSize::i64Bit) {
+      const auto Mask = PRED_TMP_32B.Merging();
+
+      if (Dst != Vector) {
+        // NOTE: SVE LSR is a destructive operation.
+        movprfx(Dst.Z(), Vector.Z());
+      }
       lsr(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP1.Z());
     } else {
-      lsr_wide(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP1.Z());
+      lsr_wide(SubRegSize, Dst.Z(), Vector.Z(), VTMP1.Z());
     }
   } else if (HostSupportsSVE128) {
     const auto Mask = PRED_TMP_16B.Merging();
@@ -2857,17 +2857,17 @@ DEF_OP(VSShrSWide) {
   const auto Vector = GetVReg(Op->Vector);
 
   if (HostSupportsSVE256 && Is256Bit) {
-    const auto Mask = PRED_TMP_32B.Merging();
-
     dup(ARMEmitter::SubRegSize::i64Bit, VTMP1.Z(), ShiftScalar.Z(), 0);
-    if (Dst != Vector) {
-      // NOTE: SVE LSR is a destructive operation.
-      movprfx(Dst.Z(), Vector.Z());
-    }
     if (ElementSize == IR::OpSize::i64Bit) {
+      const auto Mask = PRED_TMP_32B.Merging();
+
+      if (Dst != Vector) {
+        // NOTE: SVE LSR is a destructive operation.
+        movprfx(Dst.Z(), Vector.Z());
+      }
       asr(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP1.Z());
     } else {
-      asr_wide(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP1.Z());
+      asr_wide(SubRegSize, Dst.Z(), Vector.Z(), VTMP1.Z());
     }
   } else if (HostSupportsSVE128) {
     const auto Mask = PRED_TMP_16B.Merging();
@@ -2923,17 +2923,17 @@ DEF_OP(VUShlSWide) {
   const auto Vector = GetVReg(Op->Vector);
 
   if (HostSupportsSVE256 && Is256Bit) {
-    const auto Mask = PRED_TMP_32B.Merging();
-
     dup(ARMEmitter::SubRegSize::i64Bit, VTMP1.Z(), ShiftScalar.Z(), 0);
-    if (Dst != Vector) {
-      // NOTE: SVE LSR is a destructive operation.
-      movprfx(Dst.Z(), Vector.Z());
-    }
     if (ElementSize == IR::OpSize::i64Bit) {
+      const auto Mask = PRED_TMP_32B.Merging();
+
+      if (Dst != Vector) {
+        // NOTE: SVE LSR is a destructive operation.
+        movprfx(Dst.Z(), Vector.Z());
+      }
       lsl(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP1.Z());
     } else {
-      lsl_wide(SubRegSize, Dst.Z(), Mask, Dst.Z(), VTMP1.Z());
+      lsl_wide(SubRegSize, Dst.Z(), Vector.Z(), VTMP1.Z());
     }
   } else if (HostSupportsSVE128) {
     const auto Mask = PRED_TMP_16B.Merging();

--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -3181,19 +3181,12 @@ DEF_OP(VUShrI) {
     movi(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), 0);
   } else {
     if (HostSupportsSVE256 && Is256Bit) {
-      const auto Mask = PRED_TMP_32B.Merging();
-
       if (BitShift == 0) {
         if (Dst != Vector) {
           mov(Dst.Z(), Vector.Z());
         }
       } else {
-        // SVE LSR is destructive, so lets set up the destination if
-        // Vector doesn't already alias it.
-        if (Dst != Vector) {
-          movprfx(Dst.Z(), Vector.Z());
-        }
-        lsr(SubRegSize, Dst.Z(), Mask, Dst.Z(), BitShift);
+        lsr(SubRegSize, Dst.Z(), Vector.Z(), BitShift);
       }
     } else {
       if (BitShift == 0) {
@@ -3222,19 +3215,12 @@ DEF_OP(VSShrI) {
   const auto Vector = GetVReg(Op->Vector);
 
   if (HostSupportsSVE256 && Is256Bit) {
-    const auto Mask = PRED_TMP_32B.Merging();
-
     if (Shift == 0) {
       if (Dst != Vector) {
         mov(Dst.Z(), Vector.Z());
       }
     } else {
-      // SVE ASR is destructive, so lets set up the destination if
-      // Vector doesn't already alias it.
-      if (Dst != Vector) {
-        movprfx(Dst.Z(), Vector.Z());
-      }
-      asr(SubRegSize, Dst.Z(), Mask, Dst.Z(), Shift);
+      asr(SubRegSize, Dst.Z(), Vector.Z(), Shift);
     }
   } else {
     if (Shift == 0) {
@@ -3264,19 +3250,12 @@ DEF_OP(VShlI) {
     movi(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), 0);
   } else {
     if (HostSupportsSVE256 && Is256Bit) {
-      const auto Mask = PRED_TMP_32B.Merging();
-
       if (BitShift == 0) {
         if (Dst != Vector) {
           mov(Dst.Z(), Vector.Z());
         }
       } else {
-        // SVE LSL is destructive, so lets set up the destination if
-        // Vector doesn't already alias it.
-        if (Dst != Vector) {
-          movprfx(Dst.Z(), Vector.Z());
-        }
-        lsl(SubRegSize, Dst.Z(), Mask, Dst.Z(), BitShift);
+        lsl(SubRegSize, Dst.Z(), Vector.Z(), BitShift);
       }
     } else {
       if (BitShift == 0) {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -4408,14 +4408,13 @@
       ]
     },
     "vpsrlw ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xd1 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z0.d, d18",
-        "movprfx z16, z17",
-        "lsr z16.h, p7/m, z16.h, z0.d"
+        "lsr z16.h, z17.h, z0.d"
       ]
     },
     "vpsrld xmm0, xmm1, xmm2": {
@@ -4431,14 +4430,13 @@
       ]
     },
     "vpsrld ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xd2 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z0.d, d18",
-        "movprfx z16, z17",
-        "lsr z16.s, p7/m, z16.s, z0.d"
+        "lsr z16.s, z17.s, z0.d"
       ]
     },
     "vpsrlq xmm0, xmm1, xmm2": {
@@ -4788,14 +4786,13 @@
       ]
     },
     "vpsraw ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xe1 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z0.d, d18",
-        "movprfx z16, z17",
-        "asr z16.h, p7/m, z16.h, z0.d"
+        "asr z16.h, z17.h, z0.d"
       ]
     },
     "vpsrad xmm0, xmm1, xmm2": {
@@ -4811,14 +4808,13 @@
       ]
     },
     "vpsrad ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xe2 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z0.d, d18",
-        "movprfx z16, z17",
-        "asr z16.s, p7/m, z16.s, z0.d"
+        "asr z16.s, z17.s, z0.d"
       ]
     },
     "vpavgw xmm0, xmm1, xmm2": {
@@ -5257,14 +5253,13 @@
       ]
     },
     "vpsllw ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xf1 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z0.d, d18",
-        "movprfx z16, z17",
-        "lsl z16.h, p7/m, z16.h, z0.d"
+        "lsl z16.h, z17.h, z0.d"
       ]
     },
     "vpslld xmm0, xmm1, xmm2": {
@@ -5280,14 +5275,13 @@
       ]
     },
     "vpslld ymm0, ymm1, xmm2": {
-      "ExpectedInstructionCount": 3,
+      "ExpectedInstructionCount": 2,
       "Comment": [
         "Map 1 0b01 0xf2 256-bit"
       ],
       "ExpectedArm64ASM": [
         "mov z0.d, d18",
-        "movprfx z16, z17",
-        "lsl z16.s, p7/m, z16.s, z0.d"
+        "lsl z16.s, z17.s, z0.d"
       ]
     },
     "vpsllq xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -325,8 +325,8 @@
         "smullb z0.s, z17.h, z18.h",
         "smullt z1.s, z17.h, z18.h",
         "zip2 z3.s, z0.s, z1.s",
-        "asr z2.s, p7/m, z2.s, #14",
-        "asr z3.s, p7/m, z3.s, #14",
+        "asr z2.s, z2.s, #14",
+        "asr z3.s, z3.s, #14",
         "mov z4.s, #1",
         "add z2.s, z2.s, z4.s",
         "add z3.s, z3.s, z4.s",
@@ -366,7 +366,7 @@
         "and z2.d, z18.d, z2.d",
         "trn1 z2.b, z2.b, z2.b",
         "trn1 z2.h, z2.h, z2.h",
-        "lsl z2.b, p7/m, z2.b, #2",
+        "lsl z2.b, z2.b, #2",
         "mov w20, #0x100",
         "movk w20, #0x302, lsl #16",
         "mov z3.s, w20",
@@ -404,19 +404,18 @@
       ]
     },
     "vpermilpd ymm0, ymm1, ymm2": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "Map 2 0b01 0x0d 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z2, z18",
-        "lsr z2.d, p7/m, z2.d, #1",
+        "lsr z2.d, z18.d, #1",
         "mov z3.d, #1",
         "and z2.d, z2.d, z3.d",
         "trn1 z2.b, z2.b, z2.b",
         "trn1 z2.h, z2.h, z2.h",
         "trn1 z2.s, z2.s, z2.s",
-        "lsl z2.b, p7/m, z2.b, #3",
+        "lsl z2.b, z2.b, #3",
         "mov x20, #0x100",
         "movk x20, #0x302, lsl #16",
         "movk x20, #0x504, lsl #32",
@@ -589,7 +588,7 @@
         "and z2.d, z17.d, z2.d",
         "trn1 z2.b, z2.b, z2.b",
         "trn1 z2.h, z2.h, z2.h",
-        "lsl z2.b, p7/m, z2.b, #2",
+        "lsl z2.b, z2.b, #2",
         "add z2.b, z2.b, z3.b",
         "tbl z16.b, {z18.b}, z2.b"
       ]
@@ -1162,7 +1161,7 @@
         "and z2.d, z17.d, z2.d",
         "trn1 z2.b, z2.b, z2.b",
         "trn1 z2.h, z2.h, z2.h",
-        "lsl z2.b, p7/m, z2.b, #2",
+        "lsl z2.b, z2.b, #2",
         "add z2.b, z2.b, z3.b",
         "tbl z16.b, {z18.b}, z2.b"
       ]

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -3925,13 +3925,12 @@
       ]
     },
     "vblendvps ymm0, ymm1, ymm2, ymm3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x4a 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z2, z19",
-        "asr z2.s, p7/m, z2.s, #31",
+        "asr z2.s, z19.s, #31",
         "movprfx z0, z18",
         "bsl z0.d, z0.d, z17.d, z2.d",
         "mov z16.d, z0.d"
@@ -3949,13 +3948,12 @@
       ]
     },
     "vblendvpd ymm0, ymm1, ymm2, ymm3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x4b 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z2, z19",
-        "asr z2.d, p7/m, z2.d, #63",
+        "asr z2.d, z19.d, #63",
         "movprfx z0, z18",
         "bsl z0.d, z0.d, z17.d, z2.d",
         "mov z16.d, z0.d"
@@ -3973,13 +3971,12 @@
       ]
     },
     "vpblendvb ymm0, ymm1, ymm2, ymm3": {
-      "ExpectedInstructionCount": 5,
+      "ExpectedInstructionCount": 4,
       "Comment": [
         "Map 3 0b01 0x4c 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z2, z19",
-        "asr z2.b, p7/m, z2.b, #7",
+        "asr z2.b, z19.b, #7",
         "movprfx z0, z18",
         "bsl z0.d, z0.d, z17.d, z2.d",
         "mov z16.d, z0.d"

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -48,13 +48,12 @@
       ]
     },
     "vpsrlw ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map group 12 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z16, z17",
-        "lsr z16.h, p7/m, z16.h, #15"
+        "lsr z16.h, z17.h, #15"
       ]
     },
     "vpsrlw ymm0, ymm1, 16": {
@@ -103,23 +102,21 @@
       ]
     },
     "vpsraw ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map group 12 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z16, z17",
-        "asr z16.h, p7/m, z16.h, #15"
+        "asr z16.h, z17.h, #15"
       ]
     },
     "vpsraw ymm0, ymm1, 16": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map group 12 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z16, z17",
-        "asr z16.h, p7/m, z16.h, #15"
+        "asr z16.h, z17.h, #15"
       ]
     },
     "vpsllw xmm0, xmm1, 0": {
@@ -159,13 +156,12 @@
       ]
     },
     "vpsllw ymm0, ymm1, 15": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map group 12 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z16, z17",
-        "lsl z16.h, p7/m, z16.h, #15"
+        "lsl z16.h, z17.h, #15"
       ]
     },
     "vpsllw ymm0, ymm1, 16": {
@@ -214,13 +210,12 @@
       ]
     },
     "vpsrld ymm0, ymm1, 31": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map group 13 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z16, z17",
-        "lsr z16.s, p7/m, z16.s, #31"
+        "lsr z16.s, z17.s, #31"
       ]
     },
     "vpsrld ymm0, ymm1, 32": {
@@ -269,23 +264,21 @@
       ]
     },
     "vpsrad ymm0, ymm1, 31": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map group 13 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z16, z17",
-        "asr z16.s, p7/m, z16.s, #31"
+        "asr z16.s, z17.s, #31"
       ]
     },
     "vpsrad ymm0, ymm1, 32": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map group 13 0b100 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z16, z17",
-        "asr z16.s, p7/m, z16.s, #31"
+        "asr z16.s, z17.s, #31"
       ]
     },
     "vpslld xmm0, xmm1, 0": {
@@ -325,13 +318,12 @@
       ]
     },
     "vpslld ymm0, ymm1, 31": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map group 13 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z16, z17",
-        "lsl z16.s, p7/m, z16.s, #31"
+        "lsl z16.s, z17.s, #31"
       ]
     },
     "vpslld ymm0, ymm1, 32": {
@@ -380,13 +372,12 @@
       ]
     },
     "vpsrlq ymm0, ymm1, 63": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map group 14 0b010 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z16, z17",
-        "lsr z16.d, p7/m, z16.d, #63"
+        "lsr z16.d, z17.d, #63"
       ]
     },
     "vpsrlq ymm0, ymm1, 64": {
@@ -498,13 +489,12 @@
       ]
     },
     "vpsllq ymm0, ymm1, 63": {
-      "ExpectedInstructionCount": 2,
+      "ExpectedInstructionCount": 1,
       "Comment": [
         "Map group 14 0b110 256-bit"
       ],
       "ExpectedArm64ASM": [
-        "movprfx z16, z17",
-        "lsl z16.d, p7/m, z16.d, #63"
+        "lsl z16.d, z17.d, #63"
       ]
     },
     "vpsllq ymm0, ymm1, 64": {


### PR DESCRIPTION
Same behavior, just without introducing a predicate register dependency. Largely just an artifact from initial bringup.