### PR TITLE
FEXServer: Fix some missing declaration warnings

### DIFF
--- a/Source/Tools/FEXServer/ArgumentLoader.cpp
+++ b/Source/Tools/FEXServer/ArgumentLoader.cpp
@@ -9,11 +9,11 @@
 #include <fmt/format.h>
 
 namespace FEXServer::Config {
-static fextl::string Version = "FEX-Emu (" GIT_DESCRIBE_STRING ") ";
+constexpr std::string_view Version = "FEX-Emu (" GIT_DESCRIBE_STRING ") ";
 
 FEXServerOptions Load(int argc, char** argv) {
   FEXServerOptions FEXOptions {};
-  optparse::OptionParser Parser = optparse::OptionParser().version(Version);
+  optparse::OptionParser Parser = optparse::OptionParser().version(fextl::string(Version));
 
   Parser.add_option("-k", "--kill").action("store_true").set_default(false).help("Shutdown an already active FEXServer");
 

--- a/Source/Tools/FEXServer/Logger.cpp
+++ b/Source/Tools/FEXServer/Logger.cpp
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+#include "Logger.h"
+
 #include <Common/Async.h>
 #include <Common/FEXServerClient.h>
 
@@ -10,10 +12,10 @@ void ClientMsgHandler(int FD, FEXServerClient::Logging::PacketMsg* const Msg, co
 }
 
 namespace Logger {
-int LogClientQueuePipe[2];
-std::thread LogThread;
+static int LogClientQueuePipe[2];
+static std::thread LogThread;
 
-void HandleLogData(int Socket) {
+static void HandleLogData(int Socket) {
   std::vector<uint8_t> Data(1500);
   size_t CurrentRead {};
   while (true) {
@@ -54,7 +56,7 @@ void HandleLogData(int Socket) {
   }
 }
 
-void LogThreadFunc() {
+static void LogThreadFunc() {
   fasio::poll_reactor Reactor;
 
   auto Pipe = fasio::posix_descriptor {Reactor, LogClientQueuePipe[0]};

--- a/Source/Tools/FEXServer/Main.cpp
+++ b/Source/Tools/FEXServer/Main.cpp
@@ -37,12 +37,12 @@ static timespec StartTime {};
 static std::optional<fmt::text_style> DisableColors = isatty(STDOUT_FILENO) ? std::nullopt : std::optional {fmt::text_style {}};
 
 namespace Logging {
-void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
+static void MsgHandler(LogMan::DebugLevels Level, const char* Message) {
   const auto Output = fmt::format("{} {}\n", fmt::styled(LogMan::DebugLevelStr(Level), DisableColors.value_or(DebugLevelStyle(Level))), Message);
   write(STDOUT_FILENO, Output.c_str(), Output.size());
 }
 
-void AssertHandler(const char* Message) {
+static void AssertHandler(const char* Message) {
   return MsgHandler(LogMan::ASSERT, Message);
 }
 
@@ -77,9 +77,9 @@ void ActionHandler(int sig, siginfo_t* info, void* context) {
   _exit(1);
 }
 
-void ActionIgnore(int sig, siginfo_t* info, void* context) {}
+static void ActionIgnore(int sig, siginfo_t* info, void* context) {}
 
-void SetupSignals() {
+static void SetupSignals() {
   // Setup our signal handlers now so we can capture some events
   struct sigaction act {};
   act.sa_sigaction = ActionHandler;
@@ -104,7 +104,7 @@ void SetupSignals() {
 /**
  * @brief Deparents itself by forking and terminating the parent process.
  */
-void DeparentSelf() {
+static void DeparentSelf() {
   auto SystemdEnv = getenv("INVOCATION_ID");
   if (SystemdEnv) {
     // If FEXServer was launched through systemd then don't deparent, otherwise systemd kills the entire server.

--- a/Source/Tools/FEXServer/PipeScanner.cpp
+++ b/Source/Tools/FEXServer/PipeScanner.cpp
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: MIT
+#include "PipeScanner.h"
+
 #include <dirent.h>
+#include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <vector>
-#include <fcntl.h>
 
 namespace PipeScanner {
-std::vector<int> IncomingPipes {};
+static std::vector<int> IncomingPipes {};
+
 void SetWaitPipe(int FD) {
   int flags = fcntl(FD, F_GETFD);
   flags |= FD_CLOEXEC;

--- a/Source/Tools/FEXServer/ProcessPipe.cpp
+++ b/Source/Tools/FEXServer/ProcessPipe.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #include "FEXHeaderUtils/Syscalls.h"
 #include "Logger.h"
+#include "ProcessPipe.h"
 #include "SquashFS.h"
 
 #include <Common/AsyncNet.h>
@@ -31,7 +32,7 @@
 #include <xxhash.h>
 
 namespace FEXCore {
-inline bool operator<(const FEXCore::ExecutableFileInfo& a, const FEXCore::ExecutableFileInfo& b) noexcept {
+static bool operator<(const FEXCore::ExecutableFileInfo& a, const FEXCore::ExecutableFileInfo& b) noexcept {
   return a.FileId < b.FileId;
 }
 } // namespace FEXCore
@@ -45,19 +46,19 @@ struct std::hash<FEXCore::ExecutableFileInfo> {
 
 namespace ProcessPipe {
 constexpr int USER_PERMS = S_IRWXU | S_IRWXG | S_IRWXO;
-int ServerLockFD {-1};
-int WatchFD {-1};
-std::optional<fasio::tcp_acceptor> ServerAcceptor;
-std::optional<fasio::tcp_acceptor> ServerFSAcceptor;
-int NumClients = 0;
-time_t RequestTimeout {10};
-bool Foreground {false};
-std::vector<struct pollfd> PollFDs {};
+static int ServerLockFD {-1};
+static int WatchFD {-1};
+static std::optional<fasio::tcp_acceptor> ServerAcceptor;
+static std::optional<fasio::tcp_acceptor> ServerFSAcceptor;
+static int NumClients = 0;
+static time_t RequestTimeout {10};
+static bool Foreground {false};
+static std::vector<struct pollfd> PollFDs {};
 
 // FD count watching
-constexpr size_t static MAX_FD_DISTANCE = 32;
-rlimit MaxFDs {};
-std::atomic<size_t> NumFilesOpened {};
+constexpr size_t MAX_FD_DISTANCE = 32;
+static rlimit MaxFDs {};
+static std::atomic<size_t> NumFilesOpened {};
 
 // Path to directory for unprocessed code maps dumped by FEX
 static std::string NewCodeMapDirectory;
@@ -72,14 +73,14 @@ void SetWatchFD(int FD) {
   WatchFD = FD;
 }
 
-size_t GetNumFilesOpen() {
+static size_t GetNumFilesOpen() {
   // Walk /proc/self/fd/ to see how many open files we currently have
   const std::filesystem::path self {"/proc/self/fd/"};
 
   return std::distance(std::filesystem::directory_iterator {self}, std::filesystem::directory_iterator {});
 }
 
-void GetMaxFDs() {
+static void GetMaxFDs() {
   // Get our kernel limit for the number of open files
   if (getrlimit(RLIMIT_NOFILE, &MaxFDs) != 0) {
     fprintf(stderr, "[FEXMountDaemon] getrlimit(RLIMIT_NOFILE) returned error %d %s\n", errno, strerror(errno));
@@ -89,7 +90,7 @@ void GetMaxFDs() {
   NumFilesOpened = GetNumFilesOpen();
 }
 
-void CheckRaiseFDLimit() {
+static void CheckRaiseFDLimit() {
   if (NumFilesOpened < (MaxFDs.rlim_cur - MAX_FD_DISTANCE)) {
     // No need to raise the limit.
     return;
@@ -221,7 +222,7 @@ bool InitializeServerPipe() {
 
 static fasio::poll_reactor Reactor;
 
-void HandleSocketData(fasio::tcp_socket&);
+static void HandleSocketData(fasio::tcp_socket&);
 
 bool InitializeServerSocket(bool abstract) {
   fextl::string ServerSocketName;
@@ -281,7 +282,7 @@ bool InitializeServerSocket(bool abstract) {
   return true;
 }
 
-void SendEmptyErrorPacket(fasio::tcp_socket& Socket) {
+static void SendEmptyErrorPacket(fasio::tcp_socket& Socket) {
   FEXServerClient::FEXServerResultPacket Res {
     .Header {
       .Type = FEXServerClient::PacketType::TYPE_ERROR,
@@ -293,7 +294,7 @@ void SendEmptyErrorPacket(fasio::tcp_socket& Socket) {
   write(Socket, Data, ec);
 }
 
-void SendFDSuccessPacket(fasio::tcp_socket& Socket, int FD) {
+static void SendFDSuccessPacket(fasio::tcp_socket& Socket, int FD) {
   FEXServerClient::FEXServerResultPacket Res {
     .Header {
       .Type = FEXServerClient::PacketType::TYPE_SUCCESS,
@@ -466,7 +467,7 @@ static std::map<FEXCore::ExecutableFileInfo, NeedsCacheRefresh> AggregateCodeMap
   return Result;
 }
 
-int32_t EmbedSubprocess(const char* path, char* const* args) {
+static int32_t EmbedSubprocess(const char* path, char* const* args) {
   pid_t pid = fork();
   if (pid == 0) {
     execvp(path, args);
@@ -491,7 +492,7 @@ static int RunOfflineCompiler(const char* CodeMap) {
   return EmbedSubprocess(OfflineCompilerPath.c_str(), const_cast<char* const*>(&ExecveArgs[0]));
 };
 
-void HandleSocketData(fasio::tcp_socket& Socket) {
+static void HandleSocketData(fasio::tcp_socket& Socket) {
   std::vector<uint8_t> Data(1500);
 
   // Get the current number of FDs of the process before we start handling sockets.
@@ -726,7 +727,7 @@ void HandleSocketData(fasio::tcp_socket& Socket) {
   }
 }
 
-void CloseConnections() {
+static void CloseConnections() {
   // Close the server pipe so new processes will know to spin up a new FEXServer.
   // This one is closing
   close(ServerLockFD);

--- a/Source/Tools/FEXServer/SquashFS.cpp
+++ b/Source/Tools/FEXServer/SquashFS.cpp
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+#include "SquashFS.h"
+
 #include "Common/FEXServerClient.h"
 #include "Common/FileFormatCheck.h"
 
@@ -17,17 +19,17 @@
 namespace SquashFS {
 
 constexpr int USER_PERMS = S_IRWXU | S_IRWXG | S_IRWXO;
-int ServerRootFSLockFD {-1};
-int FuseMountPID {};
-fextl::string MountFolder {};
+static int ServerRootFSLockFD {-1};
+static int FuseMountPID {};
+static fextl::string MountFolder {};
 
-void ShutdownImagePID() {
+static void ShutdownImagePID() {
   if (FuseMountPID) {
     FHU::Syscalls::tgkill(FuseMountPID, FuseMountPID, SIGINT);
   }
 }
 
-bool InitializeSquashFSPipe() {
+static bool InitializeSquashFSPipe() {
   auto RootFSLockFile = FEXServerClient::GetServerRootFSLockFile();
 
   int Ret = open(RootFSLockFile.c_str(), O_CREAT | O_RDWR | O_TRUNC | O_EXCL | O_CLOEXEC, USER_PERMS);
@@ -84,7 +86,7 @@ bool InitializeSquashFSPipe() {
   return true;
 }
 
-bool DowngradeRootFSPipeToReadLock() {
+static bool DowngradeRootFSPipeToReadLock() {
   flock lk {
     .l_type = F_RDLCK,
     .l_whence = SEEK_SET,
@@ -104,7 +106,7 @@ bool DowngradeRootFSPipeToReadLock() {
   return true;
 }
 
-bool MountRootFSImagePath(const fextl::string& SquashFS, bool EroFS) {
+static bool MountRootFSImagePath(const fextl::string& SquashFS, bool EroFS) {
   pid_t ParentTID = ::getpid();
   MountFolder = fmt::format("{}/.FEXMount{}-XXXXXX", FEXServerClient::GetServerMountFolder(), ParentTID);
   char* MountFolderStr = MountFolder.data();


### PR DESCRIPTION
Makes sure prototypes are visible to their implementation. Also marks functions internally linked where applicable.

Also makes it a little more visibly obvious which bits are exposed for use elsewhere.