### PR TITLE
HostRunner: Tidy up interface

### DIFF
--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner.cpp
@@ -394,7 +394,7 @@ int main(int argc, char** argv, char** const envp) {
       return -ENOEXEC;
     }
 
-    RunAsHost(SignalDelegation, Loader.DefaultRIP(), &State);
+    RunAsHost(SignalDelegation.get(), Loader.DefaultRIP(), &State);
     SignalDelegation->UninstallTLSState(ParentThread);
     FEX::HLE::_SyscallHandler->TM.DestroyThread(ParentThread, true);
   }

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.cpp
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.cpp
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+#include "HostRunner.h"
+
 #include "ArchHelpers/UContext.h"
 #include "LinuxSyscalls/SignalDelegator.h"
 #include <FEXCore/Config/Config.h>
@@ -16,12 +18,12 @@
 #include <asm/ldt.h>
 #include <sys/syscall.h>
 #endif
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
-#include <ucontext.h>
 
-#include <signal.h>
+#include <csignal>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <ucontext.h>
 
 #ifdef ARCHITECTURE_x86_64
 static inline int modify_ldt(int func, void* ldt) {
@@ -298,7 +300,7 @@ private:
   }
 };
 
-void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, uintptr_t InitialRip, FEXCore::Core::CPUState* OutputState) {
+void RunAsHost(FEX::HLE::SignalDelegator* SignalDelegation, uintptr_t InitialRip, FEXCore::Core::CPUState* OutputState) {
   x86HostRunner runner;
   SignalDelegation->RegisterHostSignalHandler(
     SIGSEGV,
@@ -310,7 +312,7 @@ void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, u
   runner.Dispatch(InitialRip);
 }
 #else
-void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, uintptr_t InitialRip, FEXCore::Core::CPUState* OutputState) {
+void RunAsHost(FEX::HLE::SignalDelegator* SignalDelegation, uintptr_t InitialRip, FEXCore::Core::CPUState* OutputState) {
   LOGMAN_MSG_A_FMT("RunAsHost doesn't exist for this host");
 }
 #endif

--- a/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.h
+++ b/Source/Tools/TestHarnessRunner/TestHarnessRunner/HostRunner.h
@@ -1,16 +1,9 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <FEXCore/fextl/memory.h>
+#include <cstdint>
 
-namespace FEXCore::CPU {
-class CPUBackend;
-}
-namespace FEXCore::Context {
-class Context;
-}
 namespace FEXCore::Core {
-struct InternalThreadState;
 struct CPUState;
 } // namespace FEXCore::Core
 
@@ -18,4 +11,4 @@ namespace FEX::HLE {
 class SignalDelegator;
 }
 
-void RunAsHost(fextl::unique_ptr<FEX::HLE::SignalDelegator>& SignalDelegation, uintptr_t InitialRip, FEXCore::Core::CPUState* OutputState);
+void RunAsHost(FEX::HLE::SignalDelegator* SignalDelegation, uintptr_t InitialRip, FEXCore::Core::CPUState* OutputState);


### PR DESCRIPTION
We've accumulated a bunch of forward declarations that are no longer necessary. We also don't need to pass the signal delegator as a reference, since we're not modifying the pointer itself, it's just passed in to register a signal handler.