### PR TITLE
AVX_128: Optimize VMOVMSKPS from 11 to 7 instructions

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -865,9 +865,12 @@ void OpDispatchBuilder::AVX128_MOVMSK(OpcodeArgs, IR::OpSize ElementSize) {
       GPR = Mask4Byte(Src.Low);
     }
   } else if (ElementSize == OpSize::i32Bit) {
-    auto GPRLow = Mask4Byte(Src.Low);
-    auto GPRHigh = Mask4Byte(Src.High);
-    GPR = _Orlshl(OpSize::i64Bit, GPRLow, GPRHigh, 4);
+    Ref Fused = _VUnZip2(OpSize::i128Bit, OpSize::i16Bit, Src.Low, Src.High);
+    Fused = _VUShrI(OpSize::i128Bit, OpSize::i16Bit, Fused, 15);
+    auto ConstantUSHL = LoadAndCacheNamedVectorConstant(OpSize::i128Bit, NAMED_VECTOR_INCREMENTAL_U16_INDEX);
+    Fused = _VUShl(OpSize::i128Bit, OpSize::i16Bit, Fused, ConstantUSHL, false);
+    Fused = _VAddV(OpSize::i128Bit, OpSize::i16Bit, Fused);
+    GPR = _VExtractToGPR(OpSize::i128Bit, OpSize::i16Bit, Fused, 0);
   } else {
     auto GPRLow = Mask8Byte(Src.Low);
     auto GPRHigh = Mask8Byte(Src.High);

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -492,22 +492,18 @@
       ]
     },
     "vmovmskps rax, ymm0": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 1 0b00 0x50 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #192]",
-        "ushr v3.4s, v16.4s, #31",
-        "ldr q4, [x28, #3280]",
-        "ushl v3.4s, v3.4s, v4.4s",
-        "addv s3, v3.4s",
-        "mov w20, v3.s[0]",
-        "ushr v2.4s, v2.4s, #31",
-        "ushl v2.4s, v2.4s, v4.4s",
-        "addv s2, v2.4s",
-        "mov w21, v2.s[0]",
-        "orr x4, x20, x21, lsl #4"
+        "uzp2 v2.8h, v16.8h, v2.8h",
+        "ushr v2.8h, v2.8h, #15",
+        "ldr q3, [x28, #3120]",
+        "ushl v2.8h, v2.8h, v3.8h",
+        "addv h2, v2.8h",
+        "umov w4, v2.h[0]"
       ]
     },
     "vmovmskpd rax, xmm0": {


### PR DESCRIPTION
### Summary
New vmovmsk, reducing instructions from 11 to 7


### Context
- #3782 

#### Logic
Instead of running 128bit movmsk algorithm on each half and merging both results in GPR, we narrow first uzp2 deinterleaves the sign-bearing part of elements (top 16 bits for floats / top 32 bits for doubles) from both 128bit halves into a single vector in one shot. 
From there the shift/weight/horizontal reduce/GPR extract sequence only needs to run once instead of twice, cutting out a redundant addv + umov and collapsing the whole thing to 7 instructions. vmovmskpd additionally reuses the existing {0,1,2,3} shift constant, so no new constant data needed

```asm
ldr  q2, [x28, #16]
uzp2 v3.8h, v16.8h, v2.8h
ushr v3.8h, v3.8h, #15
ldr  q4, [x28, MOVMSK_SHIFT16]
ushl v3.8h, v3.8h, v4.8h
addv h3, v3.8h
umov w4, v3.h[0]
```
