### PR TITLE
CodeCache: Use maximal code buffer size when generating code caches, too

### DIFF
--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -412,13 +412,7 @@ namespace CPU {
 
   fextl::shared_ptr<CodeBuffer> CodeBufferManager::GetLatest() {
     if (!Latest) {
-      if (FEXCore::Config::Get_ENABLECODECACHINGWIP()) {
-        // Start with a larger code buffer to avoid resizes that would discard
-        // code loaded from caches
-        AllocateNew(MAX_CODE_SIZE);
-      } else {
-        AllocateNew(INITIAL_CODE_SIZE);
-      }
+      AllocateNew(INITIAL_CODE_SIZE);
     }
     return Latest;
   }
@@ -432,6 +426,10 @@ namespace CPU {
     auto NewCodeBufferSize = GetLatest()->AllocatedSize;
     NewCodeBufferSize = std::min<size_t>(NewCodeBufferSize * 2, MAX_CODE_SIZE);
     return AllocateNew(NewCodeBufferSize);
+  }
+
+  fextl::shared_ptr<CodeBuffer> CodeBufferManager::StartMaximalCodeBuffer() {
+    return AllocateNew(MAX_CODE_SIZE);
   }
 
 

--- a/FEXCore/Source/Interface/Core/CPUBackend.h
+++ b/FEXCore/Source/Interface/Core/CPUBackend.h
@@ -80,6 +80,10 @@ namespace CPU {
     // Subsequent calls to GetLatest will point to the returned buffer.
     fextl::shared_ptr<CodeBuffer> StartLargerCodeBuffer();
 
+    // Allocate a new CodeBuffer with maximum internal size.
+    // Subsequent calls to GetLatest will point to the returned buffer.
+    fextl::shared_ptr<CodeBuffer> StartMaximalCodeBuffer();
+
     // Write offset into the latest CodeBuffer
     std::size_t LatestOffset {};
 

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -342,6 +342,11 @@ void ContextImpl::SetFlagsFromCompactedEFLAGS(FEXCore::Core::InternalThreadState
 }
 
 bool ContextImpl::InitCore() {
+  if (CodeCache.IsGeneratingCache || FEXCore::Config::Get_ENABLECODECACHINGWIP()) {
+    // Start with a larger code buffer to avoid resizes that would discard code
+    StartMaximalCodeBuffer();
+  }
+
   // Initialize the CPU core signal handlers & DispatcherConfig
   Dispatcher = FEXCore::CPU::Dispatcher::Create(this);
 


### PR DESCRIPTION
This is less likely to happen (since FEXOfflineCompiler only loads one individual binary at a time), but will still be required for very large libraries to avoid throwing away code halfway through cache generation.

My first function name choice was `StartLargestCodeBuffer`, but using the slightly awkward `StartMaximalCodeBuffer` is easier to distinguish from the existing `StartLargerCodeBuffer`.
