### PR TITLE
LinuxEmulation: Resolve missing prototype warnings

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/EmulatedFiles/EmulatedFiles.cpp
@@ -67,7 +67,7 @@ static void SealTmpFD(int fd) {
   }
 }
 
-fextl::string GenerateCPUInfo(FEXCore::Context::Context* ctx, uint32_t CPUCores) {
+static fextl::string GenerateCPUInfo(FEXCore::Context::Context* ctx, uint32_t CPUCores) {
   fextl::ostringstream cpu_stream {};
   auto res_0 = ctx->RunCPUIDFunction(0, 0);
   auto res_1 = ctx->RunCPUIDFunction(1, 0);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/FaultSafeUserMemAccess.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/FaultSafeUserMemAccess.cpp
@@ -48,7 +48,7 @@ extern "C" uint64_t CopyToUser_FaultInst;
 void* const CopyToUser_FaultLocation = &CopyToUser_FaultInst;
 
 #if defined(ASSERTIONS_ENABLED) && ASSERTIONS_ENABLED && defined(ARCHITECTURE_arm64)
-__attribute__((naked)) bool VerifyIsReadableImpl(const void* Src, size_t Size) {
+__attribute__((naked)) static bool VerifyIsReadableImpl(const void* Src, size_t Size) {
   __asm volatile(R"(
   // Early exit if size is zero.
   cbz x1, 2f;
@@ -67,7 +67,7 @@ __attribute__((naked)) bool VerifyIsReadableImpl(const void* Src, size_t Size) {
                    : "memory");
 }
 
-__attribute__((naked)) bool VerifyIsOnlyWritable(void* Src, size_t Size) {
+__attribute__((naked)) static bool VerifyIsOnlyWritable(void* Src, size_t Size) {
   __asm volatile(R"(
   // Early exit if size is zero.
   cbz x1, 2f;
@@ -88,7 +88,7 @@ __attribute__((naked)) bool VerifyIsOnlyWritable(void* Src, size_t Size) {
                    : "memory");
 }
 
-__attribute__((naked)) bool VerifyIsStringReadableMaxSizeImpl(const char* Src, size_t MaxSize) {
+__attribute__((naked)) static bool VerifyIsStringReadableMaxSizeImpl(const char* Src, size_t MaxSize) {
   __asm volatile(R"(
   1:
   cbz x1, 2f;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -64,16 +64,10 @@ static void SignalHandlerThunk(int Signal, siginfo_t* Info, void* UContext) {
   ThreadObject->SignalInfo.Delegator->HandleSignal(ThreadObject, Signal, Info, UContext);
 }
 
-uint64_t SigIsMember(GuestSAMask* Set, int Signal) {
+static uint64_t SigIsMember(GuestSAMask* Set, int Signal) {
   // Signal 0 isn't real, so everything is offset by one inside the set
   Signal -= 1;
   return (Set->Val >> Signal) & 1;
-}
-
-uint64_t SetSignal(GuestSAMask* Set, int Signal) {
-  // Signal 0 isn't real, so everything is offset by one inside the set
-  Signal -= 1;
-  return Set->Val | (1ULL << Signal);
 }
 
 /**

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
@@ -209,7 +209,7 @@ uint64_t SyscallPassthrough7(FEXCore::Core::CpuStateFrame* Frame, uint64_t arg1,
 }
 #endif
 
-void RegisterCommon(FEX::HLE::SyscallHandler* Handler) {
+static void RegisterCommon(FEX::HLE::SyscallHandler* Handler) {
   REGISTER_SYSCALL_IMPL(read, SyscallPassthrough3<SYSCALL_DEF(read)>);
   REGISTER_SYSCALL_IMPL(write, SyscallPassthrough3<SYSCALL_DEF(write)>);
   REGISTER_SYSCALL_IMPL(lseek, SyscallPassthrough3<SYSCALL_DEF(lseek)>);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Utils/Threads.cpp
@@ -138,7 +138,7 @@ void StackTracker::DeallocateStackObjectAndExit(void* Ptr, int Status) {
 }
 
 #ifdef ARCHITECTURE_arm64
-__attribute__((naked)) void StackPivotAndCall(void* Arg, FEXCore::Threads::ThreadFunc Func, uint64_t StackPivot) {
+__attribute__((naked)) static void StackPivotAndCall(void* Arg, FEXCore::Threads::ThreadFunc Func, uint64_t StackPivot) {
   // x0: Arg
   // x1: Function to call
   // x2: StackPivot
@@ -164,7 +164,7 @@ __attribute__((naked)) void StackPivotAndCall(void* Arg, FEXCore::Threads::Threa
                    : "memory");
 }
 #else
-__attribute__((naked)) void StackPivotAndCall(void* Arg, FEXCore::Threads::ThreadFunc Func, uint64_t StackPivot) {
+__attribute__((naked)) static void StackPivotAndCall(void* Arg, FEXCore::Threads::ThreadFunc Func, uint64_t StackPivot) {
   // rdi: Arg
   // rsi: Function to call
   // rdx: StackPivot
@@ -352,13 +352,13 @@ namespace PThreads {
     return (void*)(uint64_t)Status;
   }
 
-  StackTracker* STracker {};
+  static StackTracker* STracker {};
 
-  fextl::unique_ptr<FEXCore::Threads::Thread> CreateThread_PThread(FEXCore::Threads::ThreadFunc Func, void* Arg) {
+  static fextl::unique_ptr<FEXCore::Threads::Thread> CreateThread_PThread(FEXCore::Threads::ThreadFunc Func, void* Arg) {
     return fextl::make_unique<PThread>(STracker, Func, Arg);
   }
 
-  void CleanupAfterFork_PThread() {
+  static void CleanupAfterFork_PThread() {
     STracker->CleanupAfterFork_PThread();
   }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/IoctlEmulation.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/IoctlEmulation.cpp
@@ -37,14 +37,14 @@ static void UnhandledIoctl(const char* Type, int fd, uint32_t cmd, uint32_t args
 }
 
 namespace BasicHandler {
-  uint32_t BasicHandler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t BasicHandler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     uint64_t Result = ::ioctl(fd, cmd, args);
     SYSCALL_ERRNO();
   }
 } // namespace BasicHandler
 
 namespace V4l2 {
-  uint32_t V4l2Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t V4l2Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     switch (_IOC_NR(cmd)) {
     case _IOC_NR(FEX_VIDIOC_G_FMT): {
       fex_v4l2_format* format = reinterpret_cast<fex_v4l2_format*>(args);
@@ -277,10 +277,7 @@ namespace V4l2 {
 } // namespace V4l2
 
 namespace DRM {
-  uint32_t AddAndRunHandler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args);
-  void AssignDeviceTypeToFD(FEXCore::Core::CpuStateFrame* Frame, int fd, const drm_version& Version);
-
-  DRMLRUCacheFDCache::HandlerType FindHandler(FEXCore::Core::CpuStateFrame* Frame, int32_t FD) {
+  static DRMLRUCacheFDCache::HandlerType FindHandler(FEXCore::Core::CpuStateFrame* Frame, int32_t FD) {
     auto Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
     if (!Thread->DRMLRUCache) {
       Thread->DRMLRUCache = fextl::make_unique<DRMLRUCacheFDCache>();
@@ -288,7 +285,7 @@ namespace DRM {
     return Thread->DRMLRUCache->FindHandler(FD);
   }
 
-  uint32_t AddAndRunHandler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t AddAndRunHandler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     auto Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
     if (!Thread->DRMLRUCache) {
       Thread->DRMLRUCache = fextl::make_unique<DRMLRUCacheFDCache>();
@@ -297,7 +294,7 @@ namespace DRM {
     return Thread->DRMLRUCache->AddAndRunMapHandler(Frame, fd, cmd, args);
   }
 
-  void CheckAndAddFDDuplication(FEXCore::Core::CpuStateFrame* Frame, int fd, int NewFD) {
+  static void CheckAndAddFDDuplication(FEXCore::Core::CpuStateFrame* Frame, int fd, int NewFD) {
     auto Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
     if (!Thread->DRMLRUCache) {
       Thread->DRMLRUCache = fextl::make_unique<DRMLRUCacheFDCache>();
@@ -305,7 +302,7 @@ namespace DRM {
     Thread->DRMLRUCache->DuplicateFD(fd, NewFD);
   }
 
-  uint32_t AMDGPU_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t AMDGPU_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     switch (_IOC_NR(cmd)) {
     case _IOC_NR(FEX_DRM_IOCTL_AMDGPU_GEM_METADATA): {
       AMDGPU::fex_drm_amdgpu_gem_metadata* val = reinterpret_cast<AMDGPU::fex_drm_amdgpu_gem_metadata*>(args);
@@ -340,7 +337,7 @@ namespace DRM {
     return -EPERM;
   }
 
-  uint32_t RADEON_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t RADEON_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     switch (_IOC_NR(cmd)) {
     case _IOC_NR(FEX_DRM_IOCTL_RADEON_CP_INIT): {
       RADEON::fex_drm_radeon_init_t* val = reinterpret_cast<RADEON::fex_drm_radeon_init_t*>(args);
@@ -475,7 +472,7 @@ namespace DRM {
     return -EPERM;
   }
 
-  uint32_t MSM_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t MSM_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     switch (_IOC_NR(cmd)) {
     case _IOC_NR(FEX_DRM_IOCTL_MSM_WAIT_FENCE): {
       MSM::fex_drm_msm_wait_fence* val = reinterpret_cast<MSM::fex_drm_msm_wait_fence*>(args);
@@ -511,7 +508,7 @@ namespace DRM {
     return -EPERM;
   }
 
-  uint32_t Nouveau_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t Nouveau_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     switch (_IOC_NR(cmd)) {
 #define _BASIC_META(x) case _IOC_NR(x):
 #define _BASIC_META_VAR(x, args...) case _IOC_NR(x):
@@ -537,7 +534,7 @@ namespace DRM {
     return -EPERM;
   }
 
-  uint32_t I915_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t I915_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
 #define SIMPLE(enum, type)                                               \
   case _IOC_NR(FEX_##enum): {                                            \
     I915::fex_##type* guest = reinterpret_cast<I915::fex_##type*>(args); \
@@ -582,7 +579,7 @@ namespace DRM {
     return -EPERM;
   }
 
-  uint32_t Panfrost_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t Panfrost_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     switch (_IOC_NR(cmd)) {
 #define _BASIC_META(x) case _IOC_NR(x):
 #define _BASIC_META_VAR(x, args...) case _IOC_NR(x):
@@ -607,7 +604,7 @@ namespace DRM {
     return -EPERM;
   }
 
-  uint32_t Lima_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t Lima_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     switch (_IOC_NR(cmd)) {
 #define _BASIC_META(x) case _IOC_NR(x):
 #define _BASIC_META_VAR(x, args...) case _IOC_NR(x):
@@ -632,7 +629,7 @@ namespace DRM {
     return -EPERM;
   }
 
-  uint32_t VC4_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t VC4_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     switch (_IOC_NR(cmd)) {
     case _IOC_NR(FEX_DRM_IOCTL_VC4_PERFMON_GET_VALUES): {
       FEX::HLE::x32::VC4::fex_drm_vc4_perfmon_get_values* val = reinterpret_cast<FEX::HLE::x32::VC4::fex_drm_vc4_perfmon_get_values*>(args);
@@ -668,7 +665,7 @@ namespace DRM {
     return -EPERM;
   }
 
-  uint32_t V3D_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t V3D_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     switch (_IOC_NR(cmd)) {
     case _IOC_NR(FEX_DRM_IOCTL_V3D_SUBMIT_CSD): {
       FEX::HLE::x32::V3D::fex_drm_v3d_submit_csd* val = reinterpret_cast<FEX::HLE::x32::V3D::fex_drm_v3d_submit_csd*>(args);
@@ -704,7 +701,7 @@ namespace DRM {
     return -EPERM;
   }
 
-  uint32_t Virtio_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t Virtio_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     switch (_IOC_NR(cmd)) {
 #define _BASIC_META(x) case _IOC_NR(x):
 #define _BASIC_META_VAR(x, args...) case _IOC_NR(x):
@@ -729,13 +726,13 @@ namespace DRM {
     return -EPERM;
   }
 
-  uint32_t Default_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t Default_Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
     // Default handler assumes everything is correct and doesn't need to do any work.
     uint64_t Result = ::ioctl(fd, cmd, args);
     SYSCALL_ERRNO();
   }
 
-  void AssignDeviceTypeToFD(FEXCore::Core::CpuStateFrame* Frame, int fd, const drm_version& Version) {
+  static void AssignDeviceTypeToFD(FEXCore::Core::CpuStateFrame* Frame, int fd, const drm_version& Version) {
     if (Version.name) {
       auto Thread = FEX::HLE::ThreadManager::GetStateObjectFromCPUState(Frame);
       if (!Thread->DRMLRUCache) {
@@ -773,7 +770,7 @@ namespace DRM {
     }
   }
 
-  uint32_t Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
+  static uint32_t Handler(FEXCore::Core::CpuStateFrame* Frame, int fd, uint32_t cmd, uint32_t args) {
 #define SIMPLE(enum, type)                                             \
   case _IOC_NR(FEX_##enum): {                                          \
     DRM::fex_##type* guest = reinterpret_cast<DRM::fex_##type*>(args); \
@@ -950,7 +947,7 @@ uint32_t DRMLRUCacheFDCache::AddAndRunMapHandler(FEXCore::Core::CpuStateFrame* F
   SYSCALL_ERRNO();
 }
 
-std::array<DRMLRUCacheFDCache::HandlerType, 1U << _IOC_TYPEBITS> Handlers = []() consteval {
+static constexpr std::array<DRMLRUCacheFDCache::HandlerType, 1U << _IOC_TYPEBITS> Handlers = []() consteval {
   using namespace DRM;
   using namespace sockios;
   using namespace V4l2;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Signals.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Signals.cpp
@@ -28,7 +28,7 @@ struct CpuStateFrame;
 ARG_TO_STR(FEX::HLE::x32::compat_ptr<FEXCore::x86::siginfo_t>, "%lx")
 
 namespace FEX::HLE::x32 {
-void CopySigInfo(FEXCore::x86::siginfo_t* Info, const siginfo_t& Host) {
+static void CopySigInfo(FEXCore::x86::siginfo_t* Info, const siginfo_t& Host) {
   // Copy the basic things first
   Info->si_signo = Host.si_signo;
   Info->si_errno = Host.si_errno;

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Socket.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Socket.cpp
@@ -246,8 +246,8 @@ static uint64_t RecvMsg(int sockfd, struct msghdr32* msg, int flags) {
   SYSCALL_ERRNO();
 }
 
-void ConvertHeaderToHost(fextl::vector<iovec>& iovec, struct msghdr* Host, const struct msghdr32* Guest, fextl::vector<uint8_t>& ControlLen,
-                         size_t& ControlLenOffset) {
+static void ConvertHeaderToHost(fextl::vector<iovec>& iovec, struct msghdr* Host, const struct msghdr32* Guest,
+                                fextl::vector<uint8_t>& ControlLen, size_t& ControlLenOffset) {
   size_t CurrentIOVecSize = iovec.size();
   iovec.resize(CurrentIOVecSize + Guest->msg_iovlen);
   for (size_t i = 0; i < Guest->msg_iovlen; ++i) {
@@ -267,7 +267,7 @@ void ConvertHeaderToHost(fextl::vector<iovec>& iovec, struct msghdr* Host, const
   Host->msg_flags = Guest->msg_flags;
 }
 
-void ConvertHeaderToGuest(struct msghdr32* Guest, struct msghdr* Host) {
+static void ConvertHeaderToGuest(struct msghdr32* Guest, struct msghdr* Host) {
   for (size_t i = 0; i < Guest->msg_iovlen; ++i) {
     Guest->msg_iov[i] = Host->msg_iov[i];
   }

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.cpp
@@ -24,23 +24,6 @@ $end_info$
 #include <utility>
 
 namespace FEX::HLE::x32 {
-void RegisterEpoll(FEX::HLE::SyscallHandler* Handler);
-void RegisterFD(FEX::HLE::SyscallHandler* Handler);
-void RegisterFS(FEX::HLE::SyscallHandler* Handler);
-void RegisterInfo(FEX::HLE::SyscallHandler* Handler);
-void RegisterIO(FEX::HLE::SyscallHandler* Handler);
-void RegisterMemory(FEX::HLE::SyscallHandler* Handler);
-void RegisterMsg(FEX::HLE::SyscallHandler* Handler);
-void RegisterNotImplemented(FEX::HLE::SyscallHandler* Handler);
-void RegisterSched(FEX::HLE::SyscallHandler* Handler);
-void RegisterSemaphore(FEX::HLE::SyscallHandler* Handler);
-void RegisterSignals(FEX::HLE::SyscallHandler* Handler);
-void RegisterSocket(FEX::HLE::SyscallHandler* Handler);
-void RegisterStubs(FEX::HLE::SyscallHandler* Handler);
-void RegisterThread(FEX::HLE::SyscallHandler* Handler);
-void RegisterTime(FEX::HLE::SyscallHandler* Handler);
-void RegisterTimer(FEX::HLE::SyscallHandler* Handler);
-void RegisterPassthrough(FEX::HLE::SyscallHandler* Handler);
 
 x32SyscallHandler::x32SyscallHandler(FEXCore::Context::Context* ctx, FEX::HLE::SignalDelegator* _SignalDelegation,
                                      FEX::HLE::ThunkHandler* ThunkHandler, fextl::unique_ptr<MemAllocator> Allocator)

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x32/Syscalls.h
@@ -73,6 +73,24 @@ private:
   fextl::unique_ptr<MemAllocator> AllocHandler {};
 };
 
+void RegisterEpoll(FEX::HLE::SyscallHandler* Handler);
+void RegisterFD(FEX::HLE::SyscallHandler* Handler);
+void RegisterFS(FEX::HLE::SyscallHandler* Handler);
+void RegisterInfo(FEX::HLE::SyscallHandler* Handler);
+void RegisterIO(FEX::HLE::SyscallHandler* Handler);
+void RegisterMemory(FEX::HLE::SyscallHandler* Handler);
+void RegisterMsg(FEX::HLE::SyscallHandler* Handler);
+void RegisterNotImplemented(FEX::HLE::SyscallHandler* Handler);
+void RegisterPassthrough(FEX::HLE::SyscallHandler* Handler);
+void RegisterSched(FEX::HLE::SyscallHandler* Handler);
+void RegisterSemaphore(FEX::HLE::SyscallHandler* Handler);
+void RegisterSignals(FEX::HLE::SyscallHandler* Handler);
+void RegisterSocket(FEX::HLE::SyscallHandler* Handler);
+void RegisterStubs(FEX::HLE::SyscallHandler* Handler);
+void RegisterThread(FEX::HLE::SyscallHandler* Handler);
+void RegisterTime(FEX::HLE::SyscallHandler* Handler);
+void RegisterTimer(FEX::HLE::SyscallHandler* Handler);
+
 fextl::unique_ptr<FEX::HLE::SyscallHandler> CreateHandler(FEXCore::Context::Context* ctx, FEX::HLE::SignalDelegator* _SignalDelegation,
                                                           FEX::HLE::ThunkHandler* ThunkHandler, fextl::unique_ptr<MemAllocator> Allocator);
 //////

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.cpp
@@ -12,16 +12,6 @@ $end_info$
 #include <FEXCore/HLE/SyscallHandler.h>
 
 namespace FEX::HLE::x64 {
-void RegisterEpoll(FEX::HLE::SyscallHandler* Handler);
-void RegisterFD(FEX::HLE::SyscallHandler* Handler);
-void RegisterInfo(FEX::HLE::SyscallHandler* Handler);
-void RegisterMemory(FEX::HLE::SyscallHandler* Handler);
-void RegisterSemaphore(FEX::HLE::SyscallHandler* Handler);
-void RegisterSignals(FEX::HLE::SyscallHandler* Handler);
-void RegisterThread(FEX::HLE::SyscallHandler* Handler);
-void RegisterTime(FEX::HLE::SyscallHandler* Handler);
-void RegisterNotImplemented(FEX::HLE::SyscallHandler* Handler);
-void RegisterPassthrough(FEX::HLE::SyscallHandler* Handler);
 
 x64SyscallHandler::x64SyscallHandler(FEXCore::Context::Context* ctx, FEX::HLE::SignalDelegator* _SignalDelegation, FEX::HLE::ThunkHandler* ThunkHandler)
   : SyscallHandler {ctx, _SignalDelegation, ThunkHandler} {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/x64/Syscalls.h
@@ -95,6 +95,17 @@ void RegisterSyscall(SyscallHandler* _Handler, int num, const char* name, F f) {
   RegisterSyscall(_Handler, num, name, +f);
 }
 
+void RegisterEpoll(FEX::HLE::SyscallHandler* Handler);
+void RegisterFD(FEX::HLE::SyscallHandler* Handler);
+void RegisterInfo(FEX::HLE::SyscallHandler* Handler);
+void RegisterMemory(FEX::HLE::SyscallHandler* Handler);
+void RegisterNotImplemented(FEX::HLE::SyscallHandler* Handler);
+void RegisterPassthrough(FEX::HLE::SyscallHandler* Handler);
+void RegisterSemaphore(FEX::HLE::SyscallHandler* Handler);
+void RegisterSignals(FEX::HLE::SyscallHandler* Handler);
+void RegisterThread(FEX::HLE::SyscallHandler* Handler);
+void RegisterTime(FEX::HLE::SyscallHandler* Handler);
+
 } // namespace FEX::HLE::x64
 
 // Registers syscall for 64bit only


### PR DESCRIPTION
Ensures all functions are marked whether they're intended to be internally linked or not.