### PR TITLE
FEXCore: Resolve missing prototype warnings

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.cpp
+++ b/FEXCore/Source/Interface/Config/Config.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 #include "Common/StringConv.h"
-#include "FEXCore/Utils/EnumUtils.h"
+#include "Utils/Config.h"
 
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Utils/Allocator.h>
+#include <FEXCore/Utils/EnumUtils.h>
 #include <FEXCore/Utils/FileLoading.h>
 #include <FEXCore/Utils/LogManager.h>
 #include <FEXCore/Utils/StringUtils.h>
@@ -252,7 +253,7 @@ void Load() {
   }
 }
 
-fextl::string ExpandPath(const fextl::string& ContainerPrefix, const fextl::string& PathName) {
+static fextl::string ExpandPath(const fextl::string& ContainerPrefix, const fextl::string& PathName) {
   if (PathName.empty()) {
     return {};
   }

--- a/FEXCore/Source/Interface/Core/CPUBackend.cpp
+++ b/FEXCore/Source/Interface/Core/CPUBackend.cpp
@@ -346,10 +346,6 @@ namespace CPU {
     return nullptr;
   }
 
-  GuestToHostMap& GetLookupCache(const CodeBuffer& Buffer) {
-    return *Buffer.LookupCache;
-  }
-
   CodeBuffer::CodeBuffer(size_t Size)
     : AllocatedSize(Size) {
     Ptr = static_cast<uint8_t*>(FEXCore::Allocator::VirtualAlloc(Size, true));

--- a/FEXCore/Source/Interface/Core/CPUID.cpp
+++ b/FEXCore/Source/Interface/Core/CPUID.cpp
@@ -100,7 +100,7 @@ namespace ProductNames {
 #endif
 } // namespace ProductNames
 
-uint32_t GetCPUID_Syscall() {
+static uint32_t GetCPUID_Syscall() {
   uint32_t CPU {};
   FHU::Syscalls::getcpu(&CPU, nullptr);
   return CPU;
@@ -148,7 +148,7 @@ uint64_t GetCycleCounterFrequency() {
   return Result;
 }
 
-uint32_t GetCPUID_TPIDRRO() {
+static uint32_t GetCPUID_TPIDRRO() {
   uint64_t Result {};
   __asm("mrs %[Res], TPIDRRO_EL0" : [Res] "=r"(Result));
   return Result;

--- a/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -10,6 +10,7 @@ $end_info$
 #include "Interface/IR/IREmitter.h"
 #include "Interface/IR/PassManager.h"
 #include "Interface/IR/RegisterAllocationData.h"
+#include "Interface/IR/Passes.h"
 #include "Interface/IR/Passes/IRValidation.h"
 #include "Interface/IR/Passes/RegisterAllocationPass.h"
 

--- a/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/RedundantFlagCalculationElimination.cpp
@@ -7,6 +7,7 @@ $end_info$
 
 #include "Interface/IR/IR.h"
 #include "Interface/IR/IREmitter.h"
+#include "Interface/IR/Passes.h"
 #include "Interface/IR/PassManager.h"
 
 #include <FEXCore/Core/X86Enums.h>

--- a/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
@@ -3,6 +3,7 @@
 #include "Interface/Core/Interpreter/Fallbacks/FallbackOpHandler.h"
 #include "Interface/IR/IR.h"
 #include "Interface/IR/IREmitter.h"
+#include "Interface/IR/Passes.h"
 #include "Interface/IR/PassManager.h"
 #include "FEXCore/IR/IR.h"
 #include "FEXCore/Utils/Profiler.h"

--- a/FEXCore/Source/Utils/Allocator.cpp
+++ b/FEXCore/Source/Utils/Allocator.cpp
@@ -42,9 +42,9 @@ using GLIBC_MALLOC_Hook = void* (*)(size_t, const void* caller);
 using GLIBC_REALLOC_Hook = void* (*)(void*, size_t, const void* caller);
 using GLIBC_FREE_Hook = void (*)(void*, const void* caller);
 
-fextl::unique_ptr<Alloc::HostAllocator> Alloc64 {};
+static fextl::unique_ptr<Alloc::HostAllocator> Alloc64 {};
 
-void* FEX_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
+static void* FEX_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
   void* Result = Alloc64->Mmap(addr, length, prot, flags, fd, offset);
   if (Result >= (void*)-4096) {
     errno = -(uint64_t)Result;
@@ -68,7 +68,7 @@ void VirtualName(const char* Name, void* Ptr, size_t Size) {
   }
 }
 
-int FEX_munmap(void* addr, size_t length) {
+static int FEX_munmap(void* addr, size_t length) {
   int Result = Alloc64->Munmap(addr, length);
 
   if (Result != 0) {

--- a/FEXCore/Source/Utils/ForcedAssert.cpp
+++ b/FEXCore/Source/Utils/ForcedAssert.cpp
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+#include <FEXCore/Utils/CompilerDefs.h>
+
 namespace FEXCore::Assert {
 // This function can not be inlined
 [[noreturn]]


### PR DESCRIPTION
Makes sure we mark everything internally linked as necessary, or make declarations visible to their implementation.