### PR TITLE
AVX128: Optimize 256-bit vmovmaskpd as well 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/AVX_128.cpp
@@ -872,9 +872,7 @@ void OpDispatchBuilder::AVX128_MOVMSK(OpcodeArgs, IR::OpSize ElementSize) {
     Fused = _VAddV(OpSize::i128Bit, OpSize::i16Bit, Fused);
     GPR = _VExtractToGPR(OpSize::i128Bit, OpSize::i16Bit, Fused, 0);
   } else {
-    auto GPRLow = Mask8Byte(Src.Low);
-    auto GPRHigh = Mask8Byte(Src.High);
-    GPR = _Orlshl(OpSize::i64Bit, GPRLow, GPRHigh, 2);
+    GPR = Mask4Byte(_VUnZip2(OpSize::i128Bit, OpSize::i32Bit, Src.Low, Src.High));
   }
   StoreResultGPR_WithOpSize(Op, Op->Dest, GPR, GetGPROpSize());
 }

--- a/unittests/ASM/VEX/vmovmskpd.asm
+++ b/unittests/ASM/VEX/vmovmskpd.asm
@@ -5,7 +5,9 @@
     "RAX": "0x2",
     "RBX": "0xA",
     "RDI": "0x0",
-    "RSI": "0x0"
+    "RSI": "0x0",
+    "RDX": "0x1",
+    "RSP": "0x9"
   }
 }
 %endif
@@ -14,12 +16,16 @@ lea rdx, [rel .data]
 
 vmovapd ymm0, [rdx]
 vmovapd ymm1, [rdx + 32]
+vmovapd ymm2, [rdx + 64]
 
 vmovmskpd rax, xmm0
 vmovmskpd rbx, ymm0
 
 vmovmskpd rdi, xmm1
 vmovmskpd rsi, ymm1
+
+vmovmskpd rdx, xmm2
+vmovmskpd rsp, ymm2
 
 hlt
 
@@ -34,3 +40,8 @@ dq 0x4142434445464748
 dq 0x5152535455565758
 dq 0x4142434445464748
 dq 0x5152535455565758
+
+dq 0x8000000000000000
+dq 0x0000000000000000
+dq 0x0000000000000000
+dq 0x8000000000000000

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -519,21 +519,18 @@
       ]
     },
     "vmovmskpd rax, ymm0": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "Map 1 0b01 0x50 256-bit"
       ],
       "ExpectedArm64ASM": [
         "ldr q2, [x28, #192]",
-        "uzp2 v3.4s, v16.4s, v16.4s",
-        "mov x20, v3.d[0]",
-        "bfi x20, x20, #31, #32",
-        "lsr x20, x20, #62",
-        "uzp2 v2.4s, v2.4s, v2.4s",
-        "mov x21, v2.d[0]",
-        "bfi x21, x21, #31, #32",
-        "lsr x21, x21, #62",
-        "orr x4, x20, x21, lsl #2"
+        "uzp2 v2.4s, v16.4s, v2.4s",
+        "ushr v2.4s, v2.4s, #31",
+        "ldr q3, [x28, #3280]",
+        "ushl v2.4s, v2.4s, v3.4s",
+        "addv s2, v2.4s",
+        "mov w4, v2.s[0]"
       ]
     },
     "vsqrtps xmm0, xmm1": {


### PR DESCRIPTION
Similar to https://github.com/FEX-Emu/FEX/pull/5757, but once the elements have been zipped together, we
can treat it identically to the 128-bit 32-bit element path.

Closes https://github.com/FEX-Emu/FEX/issues/3782