### PR TITLE
IRDumper: stringstream -> ostringstream

### DIFF
--- a/FEXCore/Source/Interface/Core/CodeCache.cpp
+++ b/FEXCore/Source/Interface/Core/CodeCache.cpp
@@ -476,7 +476,7 @@ void CodeCache::Validate(const ExecutableFileSectionInfo& Section, fextl::set<ui
           if (tail->RIP >= Section.BeginVA && tail->RIP < Section.EndVA) {
             auto [IRView, TotalInstructions, TotalInstructionsLength, StartAddr, Length, _] =
               ValidationCTX->GenerateIR(ValidationThread.get(), tail->RIP, false, FEXCore::Config::Get_MAXINST());
-            fextl::stringstream ss;
+            fextl::ostringstream ss;
             FEXCore::IR::Dump(&ss, &*IRView);
             LogMan::Msg::EFmt("IR:\n{}", ss.str());
           } else {

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -510,11 +510,11 @@ void ContextImpl::ClearCodeCache(FEXCore::Core::InternalThreadState* Thread, boo
 
 static void IRDumper(FEXCore::Core::InternalThreadState* Thread, IR::IREmitter* IREmitter, uint64_t GuestRIP) {
   FEXCore::File::File FD = FEXCore::File::File::GetStdERR();
-  fextl::stringstream out;
+  fextl::ostringstream out;
   auto NewIR = IREmitter->ViewIR();
   FEXCore::IR::Dump(&out, &NewIR);
   fextl::fmt::print(FD, "IR-ShouldDump-{} 0x{:x}:\n{}\n@@@@@\n", NewIR.PostRA() ? "post" : "pre", GuestRIP, out.str());
-};
+}
 
 bool ContextImpl::CheckIfBlockIsCacheable(FEXCore::Core::InternalThreadState& Thread, uint64_t GuestRIP, uint64_t MaxInst) {
   return Thread.FrontendDecoder->CheckIfCacheable(Thread, reinterpret_cast<const uint8_t*>(GuestRIP), GuestRIP, MaxInst);

--- a/FEXCore/Source/Interface/IR/IR.h
+++ b/FEXCore/Source/Interface/IR/IR.h
@@ -675,7 +675,7 @@ inline NodeID NodeWrapperBase<Type>::ID() const {
 [[nodiscard]]
 bool IsBlockExit(FEXCore::IR::IROps Op);
 
-void Dump(fextl::stringstream* out, const IRListView* IR);
+void Dump(fextl::ostringstream* out, const IRListView* IR);
 
 constexpr auto format_as(FEXCore::IR::NodeID ID) {
   return ID.Value;

--- a/FEXCore/Source/Interface/IR/IRDumper.cpp
+++ b/FEXCore/Source/Interface/IR/IRDumper.cpp
@@ -30,19 +30,19 @@ namespace FEXCore::IR {
 
 #include <FEXCore/IR/IRDefines.inc>
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, const SHA256Sum& Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, const SHA256Sum& Arg) {
   *out << fextl::fmt::format("sha256:{:02x}", fmt::join(Arg.data, ""));
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, uint64_t Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, uint64_t Arg) {
   *out << fextl::fmt::format("#{:#x}", Arg);
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, const char* const Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, const char* const Arg) {
   *out << fextl::fmt::format("'{}'", Arg);
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, CondClass Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, CondClass Arg) {
   if (Arg == CondClass::AL) {
     *out << "ALWAYS";
     return;
@@ -55,7 +55,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, CondClass Arg)
   *out << CondNames[FEXCore::ToUnderlying(Arg)];
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, MemOffsetType Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, MemOffsetType Arg) {
   static constexpr std::array<std::string_view, 3> Names = {
     "SXTX",
     "UXTW",
@@ -65,7 +65,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, MemOffsetType 
   *out << Names[FEXCore::ToUnderlying(Arg)];
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, RegClass Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, RegClass Arg) {
   *out << [Arg] {
     switch (Arg) {
     case RegClass::Invalid: return "Invalid";
@@ -79,7 +79,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, RegClass Arg) 
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView* IR, OrderedNodeWrapper Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView* IR, OrderedNodeWrapper Arg) {
   if (Arg.IsImmediate()) {
     auto PhyReg = PhysicalRegister(Arg);
 
@@ -128,7 +128,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView* IR, OrderedNode
   }
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, FenceType Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, FenceType Arg) {
   *out << [Arg] {
     switch (Arg) {
     case FenceType::Load: return "Loads";
@@ -140,7 +140,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, FenceType Arg)
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, RoundMode Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, RoundMode Arg) {
   *out << [Arg] {
     switch (Arg) {
     case RoundMode::Nearest: return "Nearest";
@@ -153,7 +153,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, RoundMode Arg)
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, ConstPad Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, ConstPad Arg) {
   *out << [Arg] {
     switch (Arg) {
     case ConstPad::NoPad: return "NoPad";
@@ -164,7 +164,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, ConstPad Arg) 
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, NamedVectorConstant Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, NamedVectorConstant Arg) {
   *out << [Arg] {
     // clang-format off
     switch (Arg) {
@@ -260,7 +260,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, NamedVectorCon
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, IndexNamedVectorConstant Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, IndexNamedVectorConstant Arg) {
   *out << [Arg] {
     // clang-format off
     switch (Arg) {
@@ -286,7 +286,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, IndexNamedVect
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, OpSize Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, OpSize Arg) {
   *out << [Arg] {
     switch (Arg) {
     case OpSize::iUnsized: return "Unsized";
@@ -303,7 +303,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, OpSize Arg) {
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, FloatCompareOp Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, FloatCompareOp Arg) {
   *out << [Arg] {
     switch (Arg) {
     case FloatCompareOp::EQ: return "FEQ";
@@ -317,14 +317,14 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, FloatCompareOp
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, FEXCore::IR::BreakDefinition Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, FEXCore::IR::BreakDefinition Arg) {
   *out << "{" << Arg.ErrorRegister << ".";
   *out << static_cast<uint32_t>(Arg.Signal) << ".";
   *out << static_cast<uint32_t>(Arg.TrapNumber) << ".";
   *out << static_cast<uint32_t>(Arg.si_code) << "}";
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, ShiftType Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, ShiftType Arg) {
   *out << [Arg] {
     switch (Arg) {
     case ShiftType::LSL: return "LSL";
@@ -336,7 +336,7 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, ShiftType Arg)
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, BranchHint Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, BranchHint Arg) {
   *out << [Arg] {
     switch (Arg) {
     case BranchHint::None: return "None";
@@ -348,11 +348,11 @@ static void PrintArg(fextl::stringstream* out, const IRListView*, BranchHint Arg
   }();
 }
 
-static void PrintArg(fextl::stringstream* out, const IRListView*, const std::array<uint8_t, 0x10>& Arg) {
+static void PrintArg(fextl::ostringstream* out, const IRListView*, const std::array<uint8_t, 0x10>& Arg) {
   *out << fextl::fmt::format("{:02x}", fmt::join(Arg, ""));
 }
 
-void Dump(fextl::stringstream* out, const IRListView* IR) {
+void Dump(fextl::ostringstream* out, const IRListView* IR) {
   auto HeaderOp = IR->GetHeader();
 
   int8_t CurrentIndent = 0;

--- a/FEXCore/Source/Interface/IR/Passes/IRDumperPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/IRDumperPass.cpp
@@ -57,7 +57,7 @@ void IRDumper::Run(IREmitter* IREmit) {
   }
 
   if (FD.IsValid() || DumpToLog) {
-    fextl::stringstream out;
+    fextl::ostringstream out;
     FEXCore::IR::Dump(&out, &IR);
     if (FD.IsValid()) {
       fextl::fmt::print(FD, "IR-{} 0x{:x}:\n{}\n@@@@@\n", IR.PostRA() ? "post" : "pre", +HeaderOp->OriginalRIP, out.str());

--- a/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/IRValidation.cpp
@@ -252,7 +252,7 @@ void IRValidation::Run(IREmitter* IREmit) {
 
   HadWarning = false;
   if (HadError || HadWarning) {
-    fextl::stringstream Out;
+    fextl::ostringstream Out;
     FEXCore::IR::Dump(&Out, &CurrentIR);
 
     if (HadError) {


### PR DESCRIPTION
These are purely output operations, so we don't need to use the more heavyweight class.