### PR TITLE
Externals: Update fmt to 12.2.0

### DIFF
--- a/.github/workflows/steamrt4.yml
+++ b/.github/workflows/steamrt4.yml
@@ -43,7 +43,7 @@ jobs:
         distrobox upgrade steamrt4
         distrobox enter --name steamrt4 -- sudo apt-get install -y \
           git cmake ninja-build ccache \
-          lld clang \
+          lld clang clang-tools \
           libclang-dev llvm-dev \
           libstdc++-14-dev-i386-cross libgcc-14-dev-i386-cross \
           libstdc++-14-dev-amd64-cross libgcc-14-dev-amd64-cross

--- a/FEXCore/include/FEXCore/fextl/fmt.h
+++ b/FEXCore/include/FEXCore/fextl/fmt.h
@@ -6,6 +6,7 @@
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
+#include <fmt/std.h>
 #include <unistd.h>
 
 namespace fextl::fmt {
@@ -15,7 +16,7 @@ using memory_buffer = fextl::fmt::basic_memory_buffer<char>;
 
 template<class OutputIt, class... Args>
 OutputIt format_to(OutputIt out, ::fmt::format_string<Args...> fmt, Args&&... args) {
-  return ::fmt::vformat_to(out, fmt.str, ::fmt::make_format_args(args...));
+  return ::fmt::vformat_to(out, fmt.get(), ::fmt::make_format_args(args...));
 }
 
 template<typename Char, size_t SIZE>
@@ -35,44 +36,44 @@ FMT_INLINE fextl::string vformat(::fmt::string_view fmt, ::fmt::format_args args
 
 template<typename... T>
 FMT_NODISCARD FMT_INLINE auto format(::fmt::format_string<T...> fmt, T&&... args) -> fextl::string {
-  return fextl::fmt::vformat(fmt, ::fmt::make_format_args(args...));
+  return fextl::fmt::vformat(fmt.get(), ::fmt::make_format_args(args...));
 }
 
 #ifndef _WIN32
 template<typename... T>
 FMT_INLINE auto print(::fmt::format_string<T...> fmt, T&&... args) -> void {
-  auto String = fextl::fmt::vformat(fmt, ::fmt::make_format_args(args...));
+  auto String = fextl::fmt::vformat(fmt.get(), ::fmt::make_format_args(args...));
   write(STDOUT_FILENO, String.c_str(), String.size());
 }
 
 template<typename... T>
 FMT_INLINE auto print(int FD, ::fmt::format_string<T...> fmt, T&&... args) -> void {
-  auto String = fextl::fmt::vformat(fmt, ::fmt::make_format_args(args...));
+  auto String = fextl::fmt::vformat(fmt.get(), ::fmt::make_format_args(args...));
   write(FD, String.c_str(), String.size());
 }
 #else
 template<typename... T>
 FMT_INLINE auto print(::fmt::format_string<T...> fmt, T&&... args) -> void {
-  auto String = fextl::fmt::vformat(fmt, ::fmt::make_format_args(args...));
+  auto String = fextl::fmt::vformat(fmt.get(), ::fmt::make_format_args(args...));
   auto f = FEXCore::File::File::GetStdOUT();
   f.Write(String.c_str(), String.size());
 }
 
 template<typename... T>
 FMT_INLINE auto print(HANDLE File, ::fmt::format_string<T...> fmt, T&&... args) -> void {
-  auto String = fextl::fmt::vformat(fmt, ::fmt::make_format_args(args...));
+  auto String = fextl::fmt::vformat(fmt.get(), ::fmt::make_format_args(args...));
   WriteFile(File, String.c_str(), String.size(), nullptr, nullptr);
 }
 #endif
 template<typename... T>
 FMT_INLINE auto print(FEXCore::File::File& f, ::fmt::format_string<T...> fmt, T&&... args) -> void {
-  auto String = fextl::fmt::vformat(fmt, ::fmt::make_format_args(args...));
+  auto String = fextl::fmt::vformat(fmt.get(), ::fmt::make_format_args(args...));
   f.Write(String.c_str(), String.size());
 }
 
 template<typename... T>
 FMT_INLINE auto print(std::FILE* f, ::fmt::format_string<T...> fmt, T&&... args) -> void {
-  auto String = fextl::fmt::vformat(fmt, ::fmt::make_format_args(args...));
+  auto String = fextl::fmt::vformat(fmt.get(), ::fmt::make_format_args(args...));
   write(fileno(f), String.c_str(), String.size());
 }
 } // namespace fextl::fmt


### PR DESCRIPTION
Keeps fmt up to date.

[12.2.0 Changelog](https://github.com/fmtlib/fmt/releases/tag/12.2.0)