### PR TITLE
FEXCore: Isolate multiblock error state per block

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -560,10 +560,14 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
     }
 #endif
 
-    bool HadDispatchError {false};
-    bool HadInvalidInst {false};
     for (size_t j = 0; j < CodeBlocks.size(); ++j) {
       const auto& Block = CodeBlocks[j];
+
+      // Dispatch failures and invalid instructions terminate only the decoded
+      // block that contains them. Other block targets in the same multiblock
+      // compilation unit are independent entry paths.
+      bool HadDispatchError {false};
+      bool HadInvalidInst {false};
 
 #ifdef ZYDIS_DISASSEMBLER
       if (FEXCore::Config::Get_X86DISASSEMBLE() && CodeBlocks.size() > 1) {

--- a/unittests/ASM/Multiblock/InvalidBlockStateIsolation.asm
+++ b/unittests/ASM/Multiblock/InvalidBlockStateIsolation.asm
@@ -1,0 +1,30 @@
+%ifdef CONFIG
+{
+  "Match": "All",
+  "RegData": {
+    "RAX": "0x20"
+  }
+}
+%endif
+
+; A decoded block containing an unsupported operation must not poison later,
+; independently reachable blocks in the same multiblock unit.
+; The conditional branch is always taken, so the invalid block is compiled
+; but never executed.
+xor eax, eax
+test eax, eax
+jz valid_block
+
+invalid_block:
+mov fs, ax
+
+valid_block:
+jmp success
+
+wrong_fallthrough:
+mov rax, 0x10
+hlt
+
+success:
+mov rax, 0x20
+hlt


### PR DESCRIPTION
## What changed

- Reset `HadDispatchError` and `HadInvalidInst` for each decoded block in a multiblock compilation unit.
- Add an ASM regression where an unreachable block contains a valid but unsupported `mov fs, ax`, while a later independent block must still compile and return the expected result.

## Why

These flags describe whether the current decoded block needs an early exit, but they were scoped to the entire multiblock compilation unit. A dispatcher failure in one independently reachable block therefore leaked into later blocks and caused them to emit premature exits.

Keeping the state block-local lets the failing block terminate without truncating unrelated entry paths.

## Validation

ARM64 Ubuntu, Clang 21.1.8:

| Configuration | Before | After |
| --- | --- | --- |
| `jit_1` | Pass | Pass |
| `jit_500` | Pass | Pass |
| `jit_500_m` | Fail (`RAX=0x10`) | Pass (`RAX=0x20`) |

All 64-bit Multiblock ASM tests pass after the change: 6/6.

This is one generic frontend correctness issue encountered while investigating #5399; it is not intended to be a complete fix for that issue.
