### PR TITLE
FEXCore: Ignore inactive JIT guard ranges

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -576,7 +576,8 @@ bool SignalDelegator::HandleFrontendSIGSEGV(FEXCore::Core::InternalThreadState* 
   }
 
 #ifdef ARCHITECTURE_arm64
-  if (Signal == SIGSEGV && SigInfo.si_code == SEGV_ACCERR && SigInfo.si_addr >= reinterpret_cast<void*>(Thread->JITGuardPage) &&
+  if (Signal == SIGSEGV && SigInfo.si_code == SEGV_ACCERR && Thread->JITGuardPage &&
+      SigInfo.si_addr >= reinterpret_cast<void*>(Thread->JITGuardPage) &&
       SigInfo.si_addr < reinterpret_cast<void*>(Thread->JITGuardPage + FEXCore::Utils::FEX_PAGE_SIZE)) {
     FEXCore::UncheckedLongJump::ManuallyLoadJumpBuf(Thread->RestartJump, Thread->JITGuardOverflowArgument,
                                                     ArchHelpers::Context::GetArmGPRs(UContext), ArchHelpers::Context::GetArmFPRs(UContext),

--- a/Source/Windows/Common/JITGuardPage.h
+++ b/Source/Windows/Common/JITGuardPage.h
@@ -4,9 +4,17 @@
 #include <FEXCore/Utils/LongJump.h>
 
 namespace FEX::Windows::JITGuardPage {
+static constexpr bool IsAddressInJITGuardPage(uintptr_t GuardPage, uintptr_t Address) {
+  return GuardPage != 0 && Address >= GuardPage && Address < GuardPage + FEXCore::Utils::FEX_PAGE_SIZE;
+}
+
+static_assert(!IsAddressInJITGuardPage(0, 0));
+static_assert(IsAddressInJITGuardPage(0x1000, 0x1000));
+static_assert(IsAddressInJITGuardPage(0x1000, 0x1fff));
+static_assert(!IsAddressInJITGuardPage(0x1000, 0x2000));
+
 static inline bool HandleJITGuardPage(FEXCore::Core::InternalThreadState* Thread, void* Address, uint64_t* GPRs, __uint128_t* FPRs, uint64_t* PC) {
-  if (Address >= reinterpret_cast<void*>(Thread->JITGuardPage) &&
-      Address < reinterpret_cast<void*>(Thread->JITGuardPage + FEXCore::Utils::FEX_PAGE_SIZE)) {
+  if (IsAddressInJITGuardPage(Thread->JITGuardPage, reinterpret_cast<uintptr_t>(Address))) {
     FEXCore::UncheckedLongJump::ManuallyLoadJumpBuf(Thread->RestartJump, Thread->JITGuardOverflowArgument, GPRs, FPRs, PC);
     return true;
   }


### PR DESCRIPTION
This is one of the fixes required for #5399.