### PR TITLE
SignalDelegator: Remove unused Required parameter in handler setting

### DIFF
--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.cpp
@@ -99,7 +99,7 @@ void SignalDelegator::HandleSignal(FEX::HLE::ThreadStateObject* Thread, int Sign
 }
 
 void SignalDelegator::RegisterHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
-  SetHostSignalHandler(Signal, std::move(Func), Required);
+  SetHostSignalHandler(Signal, std::move(Func));
   FrontendRegisterHostSignalHandler(Signal, Required);
 }
 
@@ -1077,7 +1077,7 @@ void SignalDelegator::RegisterHostSignalHandlerForGuest(int Signal, FEX::HLE::Ho
 }
 
 void SignalDelegator::RegisterFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
-  SetFrontendHostSignalHandler(Signal, std::move(Func), Required);
+  SetFrontendHostSignalHandler(Signal, std::move(Func));
   FrontendRegisterFrontendHostSignalHandler(Signal, Required);
 }
 

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SignalDelegator.h
@@ -209,10 +209,10 @@ private:
   void FrontendRegisterHostSignalHandler(int Signal, bool Required);
   void FrontendRegisterFrontendHostSignalHandler(int Signal, bool Required);
 
-  void SetHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
+  void SetHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) {
     HostHandlers[Signal].Handlers.push_back(std::move(Func));
   }
-  void SetFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func, bool Required) {
+  void SetFrontendHostSignalHandler(int Signal, HostSignalDelegatorFunction Func) {
     HostHandlers[Signal].FrontendHandler = std::move(Func);
   }
 


### PR DESCRIPTION
The required flag is set by the subsequent frontend functions that follow the calls to these functions.