### PR TITLE
Fix building for Windows with libc++ 23

### DIFF
--- a/FEXCore/Source/Common/StringConv.h
+++ b/FEXCore/Source/Common/StringConv.h
@@ -4,6 +4,7 @@
 
 #include <concepts>
 #include <string_view>
+#include <cstdlib>
 
 namespace FEXCore::StrConv {
 template<std::integral T>

--- a/Source/Windows/Common/CRT/Alloc.cpp
+++ b/Source/Windows/Common/CRT/Alloc.cpp
@@ -2,6 +2,7 @@
 #define _SECIMP
 #define _CRTIMP
 #include <cstdint>
+#include <cstdlib>
 #include "../Priv.h"
 #include <rpmalloc/rpmalloc.h>
 

--- a/Source/Windows/Common/CRT/IO.cpp
+++ b/Source/Windows/Common/CRT/IO.cpp
@@ -14,6 +14,7 @@ struct FILE;
 #include <cerrno>
 #include <io.h>
 #include <ctype.h>
+#include <stdarg.h>
 #include <wchar.h>
 #include <windef.h>
 #include <winternl.h>

--- a/Source/Windows/Common/WinAPI/Misc.cpp
+++ b/Source/Windows/Common/WinAPI/Misc.cpp
@@ -188,3 +188,11 @@ DLLEXPORT_FUNC(LONG, RegCloseKey, (HKEY hKey)) {
 DLLEXPORT_FUNC(DWORD, GetActiveProcessorCount, (WORD group)) {
   UNIMPLEMENTED();
 }
+
+DLLEXPORT_FUNC(UINT, GetACP, ()) {
+  UNIMPLEMENTED();
+}
+
+DLLEXPORT_FUNC(int, GetLocaleInfoEx, (LPCWSTR lpLocaleName, LCTYPE LCType, LPWSTR lpLCData, int cchData)) {
+  UNIMPLEMENTED();
+}


### PR DESCRIPTION
Add missing includes, add a couple of function stubs.