### PR TITLE
thunkgen: satisfy the clang 22 ComplierInstance VFS invariant.

### DIFF
--- a/ThunkLibs/Generator/gen.cpp
+++ b/ThunkLibs/Generator/gen.cpp
@@ -813,6 +813,9 @@ bool GenerateThunkLibsActionFactory::runInvocation(std::shared_ptr<clang::Compil
   clang::CompilerInstance Compiler(std::move(PCHContainerOps));
   Compiler.setInvocation(std::move(Invocation));
 #endif
+#if LLVM_VERSION_MAJOR >= 22
+  Compiler.setVirtualFileSystem(Files->getVirtualFileSystemPtr());
+#endif
   Compiler.setFileManager(Files);
 
   GenerateThunkLibsAction Action(libname, output_filenames, abi);


### PR DESCRIPTION
Fixes 

Clang 22's CompilerInstance expects its virtual file system to match the FileManager's VFS. Set it when building against LLVM 22+.

Follow up to [#5064](https://github.com/FEX-Emu/FEX/pull/5064).

Context: https://github.com/ROCKNIX/distribution/pull/3103