### PR TITLE
Fix precision loss for F64 to i32 conversion

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ConversionOps.cpp
@@ -558,16 +558,18 @@ DEF_OP(Vector_F64ToI32) {
     }
   } else {
     ///< Round float to integral depending on rounding mode.
+    ///< skip TowardsZero as fcvtzs below already truncates toward zero on its own
+    auto CVTReg = Dst.Q();
     switch (Round) {
     case IR::RoundMode::Nearest: frintn(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), Vector.Q()); break;
     case IR::RoundMode::NegInfinity: frintm(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), Vector.Q()); break;
     case IR::RoundMode::PosInfinity: frintp(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), Vector.Q()); break;
-    case IR::RoundMode::TowardsZero: frintz(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), Vector.Q()); break;
+    case IR::RoundMode::TowardsZero: CVTReg = Vector.Q(); break;
     case IR::RoundMode::Host: frinti(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), Vector.Q()); break;
     }
 
     ///< Convert f64 directly to i64
-    fcvtzs(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), Dst.Q());
+    fcvtzs(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), CVTReg);
 
     ///< Saturating narrow i64 -> i32
     ///

--- a/FEXCore/Source/Interface/Core/JIT/ConversionOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/ConversionOps.cpp
@@ -557,12 +557,6 @@ DEF_OP(Vector_F64ToI32) {
       }
     }
   } else {
-    // This has a known precision issue that isn't easily resolvable without throwing away performance.
-    // Doing the conversion in multi-stage steps has an issue that you can lose precision in the f32->i32 step if your source was f64.
-    // To get around this with ASIMD FEX needs to use fcvtzs (Scalar, Integer, to GPR) for each F64 to be directly converted to i32.
-    // This is a very costly transform that the SVE path doesn't need to do since it supports f64->i32 directly.
-    // If this precision issue is necessary then we can add an option for it in the future.
-
     ///< Round float to integral depending on rounding mode.
     switch (Round) {
     case IR::RoundMode::Nearest: frintn(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), Vector.Q()); break;
@@ -572,11 +566,19 @@ DEF_OP(Vector_F64ToI32) {
     case IR::RoundMode::Host: frinti(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), Vector.Q()); break;
     }
 
-    // Now narrow from f64 to f32.
-    fcvtn(ARMEmitter::SubRegSize::i32Bit, Dst.Q(), Dst.Q());
+    ///< Convert f64 directly to i64
+    fcvtzs(ARMEmitter::SubRegSize::i64Bit, Dst.Q(), Dst.Q());
 
-    ///< Convert the two F32 integrals to real integers.
-    fcvtzs(ARMEmitter::SubRegSize::i32Bit, Dst.D(), Dst.D());
+    ///< Saturating narrow i64 -> i32
+    ///
+    ///< The caller(Vector_CVT_Float_To_Int32Impl) only fixes up positive overflow:
+    ///< it tests MaxF > Src (MaxF = 2^31) and swaps in CVTMAX_I32 (0x80000000) where
+    ///< the test fails.
+    ///
+    ///< Sources below INT32_MIN are handled by sqxtn:
+    ///< ARM saturates to INT32_MIN, which is 0x80000000 the same value as
+    ///< x86's integer-indefinite value.
+    sqxtn(ARMEmitter::SubRegSize::i32Bit, Dst.D(), Dst.D());
   }
 }
 

--- a/unittests/ASM/FEX_bugs/f64_to_i32_precision.asm
+++ b/unittests/ASM/FEX_bugs/f64_to_i32_precision.asm
@@ -1,0 +1,21 @@
+%ifdef CONFIG
+{
+  "HostFeatures": ["AVX"],
+  "Env": { "FEX_HOSTFEATURES": "disablesve,disablefrintts" },
+  "RegData": {
+    "XMM0": ["0x297e3ce700000000", "0x0000000000000000", "0x0000000000000000", "0x0000000000000000"]
+  }
+}
+%endif
+
+; The non-SVE path in Vector_F64ToI32 (JIT/ConversionOps.cpp) had a precision issue:
+; Used to narrow the 64-bit float down to a 32-bit float before
+; converting to an integer, rather than converting directly to a 64-bit integer and
+; narrowing that to a 32-bit float.
+lea rdx, [rel .data]
+vcvttpd2dq xmm0, oword [rdx]
+hlt
+
+align 16
+.data:
+dq 0x8d482dd627d581f1, 0x41c4bf1e7380f30a


### PR DESCRIPTION
Fixes the precision issue the comment in the non-SVE fallback path in `Vector_F64ToI32` already described.

First convert f64 to i64 and then narrow the i64 to an i32.
This means nothing is rounded before the integer conversion, so sources needing more than f32's 24-bit mantissa survive intact.

Contrary to what the comment assumed, there shouldn't be a performance penalty: the new sequence is two vector instructions, exactly like the `fcvtn` + `fcvtzs` pair it replace (not the per-element scalar `fcvtzs` to GPR the comment had in mind).

The code uses `sqxtn` rather than `xtn` because `Vector_CVT_Float_To_Int32Impl` only fixes up
positive overflow, so the clamp to `INT32_MIN` is what gives negative out-of-range sources the `0x80000000` x86 expects (integer-indefinite value).

Also `RoundMode::TowardsZero` no longer needs its `frintz`, since `fcvtzs` already truncates.