### PR TITLE
CMake: Fix MINGW compilation under ArchLinux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,11 +428,16 @@ else ()
   file(GENERATE OUTPUT CTestTestfile.cmake CONTENT "# No tests since BUILD_TESTING is disabled")
 endif()
 
-find_package(fmt QUIET)
-if (NOT fmt_FOUND)
-  # Disable fmt install
+if (MINGW)
   set(FMT_INSTALL OFF)
   add_subdirectory(External/fmt/)
+else()
+  find_package(fmt QUIET)
+  if (NOT fmt_FOUND)
+    # Disable fmt install
+    set(FMT_INSTALL OFF)
+    add_subdirectory(External/fmt/)
+  endif()
 endif()
 
 find_package(range-v3 QUIET)


### PR DESCRIPTION
TLDR: Under MINGW, just use the `External/fmt` submodule instead of searching for the system's libfmt.

Currently, trying to compile the project for WINE under ArchLinux (cmake 4.4.2, libfmt 12.2.0-1.1, [llvm-mingw 20260519](https://github.com/mstorsjo/llvm-mingw/releases/tag/20260519)) fails with a influx of the following message:

```
CMake Error in CMakeLists.txt:
  IMPORTED_IMPLIB not set for imported target "fmt::fmt" configuration "RELEASE".
```

It seems that arch's native `libfmt` only has the config for the `none` build-type or something among those lines.

That said, the system's `libfmt` shouldn't (and probably can't) be used anyway when trying to build for mingw/wine, so this PR forces CMake to not even try to search for the system's libfmt and just use the `External/fmt` submodule instead.