### PR TITLE
POPF and PUSHF fail to preserve and clear specific flag bits

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.cpp
@@ -3625,7 +3625,10 @@ void OpDispatchBuilder::BSWAPOp(OpcodeArgs) {
 void OpDispatchBuilder::PUSHFOp(OpcodeArgs) {
   const auto Size = OpSizeFromSrc(Op);
 
-  Push(Size, GetPackedRFLAG());
+  // VM, RF cleared to 0
+  constexpr uint32_t FlagsMask = ~((1U << FEXCore::X86State::RFLAG_VM_LOC) | (1U << FEXCore::X86State::RFLAG_RF_LOC));
+
+  Push(Size, GetPackedRFLAG(FlagsMask));
 }
 
 void OpDispatchBuilder::POPFOp(OpcodeArgs) {
@@ -3638,7 +3641,21 @@ void OpDispatchBuilder::POPFOp(OpcodeArgs) {
 
   Src = _Or(OpSize::i64Bit, Src, Constant(0x202));
 
-  SetPackedRFLAG(false, Src);
+  // FEX always executes at CPL 3 and IOPL < CPL:
+  // VIP, VIF, VM, IOPL, IF unchanged
+  uint32_t FlagsMask =
+    ~((1U << FEXCore::X86State::RFLAG_VIP_LOC) | (1U << FEXCore::X86State::RFLAG_VIF_LOC) | (1U << FEXCore::X86State::RFLAG_VM_LOC) |
+      (1U << FEXCore::X86State::RFLAG_IOPL_LOC) | (1U << FEXCore::X86State::RFLAG_RF_LOC));
+
+  // ID, AC unchanged
+  if (Size == OpSize::i16Bit) {
+    FlagsMask &= ~((1U << FEXCore::X86State::RFLAG_ID_LOC) | (1U << FEXCore::X86State::RFLAG_AC_LOC));
+  }
+
+  SetPackedRFLAG(false, Src, FlagsMask);
+
+  // RF cleared to 0
+  SetRFLAG<FEXCore::X86State::RFLAG_RF_LOC>(Constant(0));
 
   auto NewRIP = GetRelocatedPC(Op);
   ExitFunction(NewRIP, BranchHint::CheckTF);

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -1120,7 +1120,7 @@ public:
   void InvalidOp(OpcodeArgs);
   void NoExecOp(OpcodeArgs);
 
-  void SetPackedRFLAG(bool Lower8, Ref Src);
+  void SetPackedRFLAG(bool Lower8, Ref Src, uint32_t FlagsMask = ~0U);
   Ref GetPackedRFLAG(uint32_t FlagsMask = ~0U);
 
   void SetMultiblock(bool _Multiblock) {

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Flags.cpp
@@ -32,7 +32,7 @@ void OpDispatchBuilder::ZeroPF_AF() {
   SetAF(0);
 }
 
-void OpDispatchBuilder::SetPackedRFLAG(bool Lower8, Ref Src) {
+void OpDispatchBuilder::SetPackedRFLAG(bool Lower8, Ref Src, uint32_t FlagsMask) {
   size_t NumFlags = FlagOffsets.size();
   if (Lower8) {
     // Calculate flags early.
@@ -46,6 +46,11 @@ void OpDispatchBuilder::SetPackedRFLAG(bool Lower8, Ref Src) {
 
   for (size_t i = 0; i < NumFlags; ++i) {
     const auto FlagOffset = FlagOffsets[i];
+
+    if (!((1U << FlagOffset) & FlagsMask)) {
+      // Leave current flag value unchanged
+      continue;
+    }
 
     if (FlagOffset == FEXCore::X86State::RFLAG_AF_RAW_LOC) {
       // AF is in bit 4 architecturally, and we need to store it to bit 4 of our

--- a/FEXCore/include/FEXCore/Core/DiskCache.h
+++ b/FEXCore/include/FEXCore/Core/DiskCache.h
@@ -210,7 +210,7 @@ namespace DiskCache {
 
   // TODO: This header is in global installed header path, but uses internal headers.
   // Migrate this once that is fixed.
-  static constexpr uint16_t FormatVersion = 13;
+  static constexpr uint16_t FormatVersion = 14;
   FEX_DEFAULT_VISIBILITY uint16_t GetFormatVersion();
 
 } // namespace DiskCache

--- a/unittests/ASM/FEX_bugs/popf_flags.asm
+++ b/unittests/ASM/FEX_bugs/popf_flags.asm
@@ -1,0 +1,43 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x244ed7",
+    "RBX": "0x240202"
+  }
+}
+%endif
+
+mov rsp, 0xe8000020
+
+; Try to set VIP, VIF VM, IOPL, IF and RF in EFLAGS
+mov rax, 0x3f7cd5
+push rax
+popfq
+
+pushfq
+mov rax, qword [rsp]
+
+
+; Pre-set AC and ID via a 64-bit POPFQ.
+mov rbx, 0x240000
+push rbx
+popfq
+
+; Try to clear AC and ID
+mov rbx, 0
+push rbx
+
+o16 popfq
+
+
+; Since AC is set, alignment checking is enabled -> realign RSP
+mov rsp, 0xe0000020
+pushfq
+pop rbx
+
+; Clear AC, as under native FEX host execution
+; the test will crash later in the TestHarnessRunner
+push 0
+popfq
+
+hlt

--- a/unittests/InstructionCountCI/AFP/H0F3A.json
+++ b/unittests/InstructionCountCI/AFP/H0F3A.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "roundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/Secondary.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vsqrtss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AFP/VEX_map3.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map3.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vroundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AVX128/FMA4.json
+++ b/unittests/InstructionCountCI/AVX128/FMA4.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -13,7 +13,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vmovntps [rax], xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
@@ -8,7 +8,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vfmadd132ss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vmovntdqa xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -11,7 +11,7 @@
       "SVE256",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -8,7 +8,7 @@
       "AFP",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vblendvps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F3A.json
+++ b/unittests/InstructionCountCI/Crypto/H0F3A.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "pclmulqdq xmm0, xmm1, 00000b": {

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -10,7 +10,7 @@
       "AFP",
       "RPRES"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "These 3DNow! instructions are optimal assuming that FEX doesn't SRA MMX registers",

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -13,7 +13,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/libnss.json
+++ b/unittests/InstructionCountCI/FEXOpt/libnss.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [],
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Chained add": {

--- a/unittests/InstructionCountCI/FlagM/H0F38.json
+++ b/unittests/InstructionCountCI/FlagM/H0F38.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "ptest xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "The Witcher 3": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Sonic Mania movie player": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "FMOD scalar loop": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "The Sims 1 hot block": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "add bl, cl": {
@@ -1663,7 +1663,7 @@
       ]
     },
     "o16 pushf": {
-      "ExpectedInstructionCount": 39,
+      "ExpectedInstructionCount": 35,
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
         "cset x20, lo",
@@ -1683,10 +1683,6 @@
         "orr x20, x20, x21, lsl #12",
         "ldrb w21, [x28, #1022]",
         "orr x20, x20, x21, lsl #14",
-        "ldrb w21, [x28, #1024]",
-        "orr x20, x20, x21, lsl #16",
-        "ldrb w21, [x28, #1025]",
-        "orr x20, x20, x21, lsl #17",
         "ldrb w21, [x28, #1026]",
         "orr x20, x20, x21, lsl #18",
         "ldrb w21, [x28, #1027]",
@@ -1708,7 +1704,7 @@
       ]
     },
     "pushfq": {
-      "ExpectedInstructionCount": 39,
+      "ExpectedInstructionCount": 35,
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
         "cset x20, lo",
@@ -1728,10 +1724,6 @@
         "orr x20, x20, x21, lsl #12",
         "ldrb w21, [x28, #1022]",
         "orr x20, x20, x21, lsl #14",
-        "ldrb w21, [x28, #1024]",
-        "orr x20, x20, x21, lsl #16",
-        "ldrb w21, [x28, #1025]",
-        "orr x20, x20, x21, lsl #17",
         "ldrb w21, [x28, #1026]",
         "orr x20, x20, x21, lsl #18",
         "ldrb w21, [x28, #1027]",
@@ -1753,7 +1745,7 @@
       ]
     },
     "popf": {
-      "ExpectedInstructionCount": 40,
+      "ExpectedInstructionCount": 31,
       "Comment": "0x9d",
       "ExpectedArm64ASM": [
         "ldr x20, [x8], #8",
@@ -1778,22 +1770,13 @@
         "sub x20, x22, x20, lsl #1",
         "msr nzcv, x23",
         "rmif x27, #11, #nzcV",
-        "ubfx w21, w27, #12, #1",
-        "strb w21, [x28, #1020]",
         "ubfx w21, w27, #14, #1",
         "strb w21, [x28, #1022]",
-        "ubfx w21, w27, #16, #1",
-        "strb w21, [x28, #1024]",
-        "ubfx w21, w27, #17, #1",
-        "strb w21, [x28, #1025]",
         "ubfx w21, w27, #18, #1",
         "strb w21, [x28, #1026]",
-        "ubfx w21, w27, #19, #1",
-        "strb w21, [x28, #1027]",
-        "ubfx w21, w27, #20, #1",
-        "strb w21, [x28, #1028]",
         "ubfx w21, w27, #21, #1",
         "strb w21, [x28, #1029]",
+        "strb wzr, [x28, #1024]",
         "mov w21, #0x10001",
         "strb w20, [x28, #1018]"
       ]

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "add al, 1": {

--- a/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "push es": {
@@ -314,7 +314,7 @@
       ]
     },
     "o16 pushf": {
-      "ExpectedInstructionCount": 39,
+      "ExpectedInstructionCount": 35,
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
         "cset x20, lo",
@@ -334,10 +334,6 @@
         "orr x20, x20, x21, lsl #12",
         "ldrb w21, [x28, #1022]",
         "orr x20, x20, x21, lsl #14",
-        "ldrb w21, [x28, #1024]",
-        "orr x20, x20, x21, lsl #16",
-        "ldrb w21, [x28, #1025]",
-        "orr x20, x20, x21, lsl #17",
         "ldrb w21, [x28, #1026]",
         "orr x20, x20, x21, lsl #18",
         "ldrb w21, [x28, #1027]",
@@ -359,7 +355,7 @@
       ]
     },
     "pushfd": {
-      "ExpectedInstructionCount": 39,
+      "ExpectedInstructionCount": 35,
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
         "cset x20, lo",
@@ -379,10 +375,6 @@
         "orr x20, x20, x21, lsl #12",
         "ldrb w21, [x28, #1022]",
         "orr x20, x20, x21, lsl #14",
-        "ldrb w21, [x28, #1024]",
-        "orr x20, x20, x21, lsl #16",
-        "ldrb w21, [x28, #1025]",
-        "orr x20, x20, x21, lsl #17",
         "ldrb w21, [x28, #1026]",
         "orr x20, x20, x21, lsl #18",
         "ldrb w21, [x28, #1027]",

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "ucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
@@ -11,7 +11,7 @@
       "AFP",
       "FCMA"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "ucomisd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -12,7 +12,7 @@
       "AFP",
       "CSSC"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -10,7 +10,7 @@
       "AFP",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map_group.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map_group.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "blsr eax, ebx": {

--- a/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -11,7 +11,7 @@
       "CSSC",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "pshufb mm0, mm1": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -8,7 +8,7 @@
       "AFP",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "SSE4.2 string instructions are skipped here.",

--- a/unittests/InstructionCountCI/H0F3A_SVE128.json
+++ b/unittests/InstructionCountCI/H0F3A_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "dpps xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/MOPS/Primary.json
+++ b/unittests/InstructionCountCI/MOPS/Primary.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "rep movsb": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "MOPS"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "add bl, cl": {
@@ -2682,7 +2682,7 @@
       "ExpectedArm64ASM": []
     },
     "pushf": {
-      "ExpectedInstructionCount": 39,
+      "ExpectedInstructionCount": 35,
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
         "cset x20, lo",
@@ -2702,10 +2702,6 @@
         "orr x20, x20, x21, lsl #12",
         "ldrb w21, [x28, #1022]",
         "orr x20, x20, x21, lsl #14",
-        "ldrb w21, [x28, #1024]",
-        "orr x20, x20, x21, lsl #16",
-        "ldrb w21, [x28, #1025]",
-        "orr x20, x20, x21, lsl #17",
         "ldrb w21, [x28, #1026]",
         "orr x20, x20, x21, lsl #18",
         "ldrb w21, [x28, #1027]",
@@ -2727,7 +2723,7 @@
       ]
     },
     "pushfq": {
-      "ExpectedInstructionCount": 39,
+      "ExpectedInstructionCount": 35,
       "Comment": "0x9c",
       "ExpectedArm64ASM": [
         "cset x20, lo",
@@ -2747,10 +2743,6 @@
         "orr x20, x20, x21, lsl #12",
         "ldrb w21, [x28, #1022]",
         "orr x20, x20, x21, lsl #14",
-        "ldrb w21, [x28, #1024]",
-        "orr x20, x20, x21, lsl #16",
-        "ldrb w21, [x28, #1025]",
-        "orr x20, x20, x21, lsl #17",
         "ldrb w21, [x28, #1026]",
         "orr x20, x20, x21, lsl #18",
         "ldrb w21, [x28, #1027]",
@@ -2772,7 +2764,7 @@
       ]
     },
     "popf": {
-      "ExpectedInstructionCount": 44,
+      "ExpectedInstructionCount": 35,
       "Comment": "0x9d",
       "ExpectedArm64ASM": [
         "ldr x20, [x8], #8",
@@ -2800,22 +2792,13 @@
         "sub x20, x23, x20, lsl #1",
         "ubfx x21, x27, #11, #1",
         "bfi w22, w21, #28, #1",
-        "ubfx w21, w27, #12, #1",
-        "strb w21, [x28, #1020]",
         "ubfx w21, w27, #14, #1",
         "strb w21, [x28, #1022]",
-        "ubfx w21, w27, #16, #1",
-        "strb w21, [x28, #1024]",
-        "ubfx w21, w27, #17, #1",
-        "strb w21, [x28, #1025]",
         "ubfx w21, w27, #18, #1",
         "strb w21, [x28, #1026]",
-        "ubfx w21, w27, #19, #1",
-        "strb w21, [x28, #1027]",
-        "ubfx w21, w27, #20, #1",
-        "strb w21, [x28, #1028]",
         "ubfx w21, w27, #21, #1",
         "strb w21, [x28, #1029]",
+        "strb wzr, [x28, #1024]",
         "mov w21, #0x10001",
         "msr nzcv, x22",
         "strb w20, [x28, #1018]"

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "Instructions in this table that are marked optimal don't have their flag calculation part of this assumption",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -9,7 +9,7 @@
       "FlagM",
       "FlagM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "pfrcpv mm0, mm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "rsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "rsqrtss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -8,7 +8,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Repeat.json
+++ b/unittests/InstructionCountCI/Repeat.json
@@ -6,7 +6,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {}
 }

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -33,7 +33,7 @@
       "      - 1b: ECX = MSB",
       "[7]   - Reserved"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "pcmpestrm xmm0, xmm1, 0_0_00_00_00b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Comment": [
     "MMX instructions are defined as optimal without SRA being used for these instructions.",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -7,7 +7,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "push fs": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "movupd xmm0, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "addsubpd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "psrlw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -12,7 +12,7 @@
       "FRINTTS",
       "CSSC"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "movss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "movsd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "addsubps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "cvtpd2dq xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "cvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "movmskps eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -13,7 +13,7 @@
       "FLAGM2",
       "FRINTTS"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -8,7 +8,7 @@
       "FCMA"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -13,7 +13,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vcvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map2_svebitperm.json
+++ b/unittests/InstructionCountCI/VEX_map2_svebitperm.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "pext eax, ebx, ecx": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -8,7 +8,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/X87ldst-SVE.json
+++ b/unittests/InstructionCountCI/X87ldst-SVE.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "RPRES"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "fstp tword [rax]": {

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/x87_32Bit.json
+++ b/unittests/InstructionCountCI/x87_32Bit.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "Multiple fld/fst": {

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/x87_f64_32Bit.json
+++ b/unittests/InstructionCountCI/x87_f64_32Bit.json
@@ -15,7 +15,7 @@
       "SVE256",
       "CSSC"
     ],
-    "BinaryCacheVersion": 13
+    "BinaryCacheVersion": 14
   },
   "Instructions": {
     "fstp dword [ebx*4+0x204a20]": {


### PR DESCRIPTION
## POPF

FEX executes in CPL=3 with IOCPL < CPL.
Per the Intel Manual entry for `POPF/POPFD/POPFQ` this then means that the flags should be updated the following way:

| Operand Size | CPL | IOPL | ID (21) | VIP (20) | VIF (19) | AC (18) | VM (17) | RF (16) | NT (14) | IOPL (13:12) | OF (11) | DF (10) | IF (9) | TF (8) | SF (7) | ZF (6) | AF (4) | PF (2) | CF (0) |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| 16 | 1-3 | < CPL | N | N | N | N | N | 0 | S | N | S | S | N | S | S | S | S | S | S |
| 32, 64 | 1-3 | < CPL | S | N | N | S | N | 0 | S | N | S | S | N | S | S | S | S | S | S |


| Key | Description |
|---|---|
| S | Updated from stack |
| SV | Updated from IF (bit 9) in FLAGS value on stack |
| N | No change in value |
| X | No EFLAGS update |
| 0 | Value is cleared |


I.e., `VIP, VIF, VM, IOPL, IF` should remain unchanged and `RF` cleared to zero.
For the case the instruction operates on 16bit also the `ID, AC` flags need to be preserved.

## PUSHF

Furthermore, also per the SDM, `VM, RF` need to be cleared to zero for `PUSHF`.

---

This PR, preserves and clears the aforementioned flags and also adds a unittest.