### PR TITLE
unittests/ASM: Ensure ffreep always has an operand

### DIFF
--- a/unittests/ASM/FEX_bugs/fxrstor_bug.asm
+++ b/unittests/ASM/FEX_bugs/fxrstor_bug.asm
@@ -23,7 +23,7 @@ fninit
 times 8 fldz
 
 ; Empty them
-times 8 ffreep
+times 8 ffreep st0
 
 ; Load seven of them with random data
 fld tword [rel .random_data + (0 * 10)]

--- a/unittests/ASM/FEX_bugs/fxsave_bug.asm
+++ b/unittests/ASM/FEX_bugs/fxsave_bug.asm
@@ -22,7 +22,7 @@ fninit
 times 8 fldz
 
 ; Empty them
-times 8 ffreep
+times 8 ffreep st0
 
 ; Load seven of them with random data
 fld tword [rel .random_data + (0 * 10)]

--- a/unittests/ASM/modrm_oob/X87.asm
+++ b/unittests/ASM/modrm_oob/X87.asm
@@ -23,14 +23,14 @@ mov rax, 0
 fldz
 w3_size %1, 4, dword
 w3_size %1, 8, qword
-ffreep
+ffreep st0
 %endmacro
 
 %macro x87_i24_op 1
 fldz
 w3_size %1, 2, word
 w3_size %1, 4, dword
-ffreep
+ffreep st0
 %endmacro
 
 x87_f48_op fadd
@@ -50,11 +50,11 @@ x87_f48_op fdivr
 
 ; fld is special
 w3_size fld, 4, dword
-ffreep
+ffreep st0
 w3_size fld, 8, qword
-ffreep
+ffreep st0
 w3_size fld, 10, tword
-ffreep
+ffreep st0
 
 ; fst is special
 fldz
@@ -96,11 +96,11 @@ x87_i24_op fidivr
 
 ; fild is special
 w3_size fild, 2, word
-ffreep
+ffreep st0
 w3_size fild, 4, dword
-ffreep
+ffreep st0
 w3_size fild, 8, qword
-ffreep
+ffreep st0
 
 ; fist is special
 fldz

--- a/unittests/ASM/modrm_oob/X87_Reduced.asm
+++ b/unittests/ASM/modrm_oob/X87_Reduced.asm
@@ -24,14 +24,14 @@ mov rax, 0
 fldz
 w3_size %1, 4, dword
 w3_size %1, 8, qword
-ffreep
+ffreep st0
 %endmacro
 
 %macro x87_i24_op 1
 fldz
 w3_size %1, 2, word
 w3_size %1, 4, dword
-ffreep
+ffreep st0
 %endmacro
 
 x87_f48_op fadd
@@ -51,11 +51,11 @@ x87_f48_op fdivr
 
 ; fld is special
 w3_size fld, 4, dword
-ffreep
+ffreep st0
 w3_size fld, 8, qword
-ffreep
+ffreep st0
 w3_size fld, 10, tword
-ffreep
+ffreep st0
 
 ; fst is special
 fldz
@@ -97,11 +97,11 @@ x87_i24_op fidivr
 
 ; fild is special
 w3_size fild, 2, word
-ffreep
+ffreep st0
 w3_size fild, 4, dword
-ffreep
+ffreep st0
 w3_size fild, 8, qword
-ffreep
+ffreep st0
 
 ; fist is special
 fldz


### PR DESCRIPTION
It seems that on nasm `ffreep` without an operand assembles to `dfc1` which is `ffreep st1`. 
Added an operand to all the ffreep instructions that didn't have one to avoid surprises, as I assume st0 was the intended operand.