### PR TITLE
Decoder: fix illegal LEA encoding

### DIFF
--- a/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/BaseTables.cpp
@@ -318,7 +318,7 @@ const std::array<X86InstInfo, MAX_PRIMARY_TABLE_SIZE> BaseOps = []() consteval {
     {0x8A, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_8BIT) | FLAGS_MODRM,         0}},
     {0x8B, 1, X86InstInfo{"MOV",    TYPE_INST, FLAGS_MODRM,                         0}},
     {0x8C, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSrcSize(SIZE_16BIT) | FLAGS_MODRM | FLAGS_SF_MOD_DST,                      0}},
-    {0x8D, 1, X86InstInfo{"LEA",    TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_MODRM,                         0}},
+    {0x8D, 1, X86InstInfo{"LEA",    TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_MODRM | FLAGS_SF_MOD_MEM_ONLY, 0}},
     {0x8E, 1, X86InstInfo{"MOV",    TYPE_INST, GenFlagsSameSize(SIZE_16BIT) | FLAGS_MODRM,                      0}},
     {0x8F, 1, X86InstInfo{"POP",    TYPE_INST, GenFlagsSameSize(SIZE_64BITDEF) | FLAGS_MODRM | FLAGS_SF_MOD_DST | FLAGS_SF_MOD_ZERO_REG | FLAGS_DEBUG_MEM_ACCESS, 0}},
     {0x90, 8, X86InstInfo{"XCHG",   TYPE_INST, FLAGS_SF_REX_IN_BYTE | FLAGS_SF_SRC_RAX, 0}},

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -2461,6 +2461,21 @@
         "mov w4, w20"
       ]
     },
+    "db 0x48, 0x8D, 0xC0": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "0x8d",
+        "LEA rax, rax illegal register to register encoding"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w20, #0x10000",
+        "str x20, [x28, #24]",
+        "mov w0, #0x401",
+        "str x0, [x28, #1496]",
+        "ldr x0, [x28, #2968]",
+        "br x0"
+      ]
+    },
     "mov cs, ax": {
       "ExpectedInstructionCount": 4,
       "Skip": "Yes",

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -2461,6 +2461,36 @@
         "mov w4, w20"
       ]
     },
+    "db 0x66, 0x8D, 0xC0": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "0x8d",
+        "LEA ax, ax illegal register to register encoding"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w20, #0x10000",
+        "str x20, [x28, #24]",
+        "mov w0, #0x401",
+        "str x0, [x28, #1496]",
+        "ldr x0, [x28, #2968]",
+        "br x0"
+      ]
+    },
+    "db 0x8D, 0xC0": {
+      "ExpectedInstructionCount": 6,
+      "Comment": [
+        "0x8d",
+        "LEA eax, eax illegal register to register encoding"
+      ],
+      "ExpectedArm64ASM": [
+        "mov w20, #0x10000",
+        "str x20, [x28, #24]",
+        "mov w0, #0x401",
+        "str x0, [x28, #1496]",
+        "ldr x0, [x28, #2968]",
+        "br x0"
+      ]
+    },
     "db 0x48, 0x8D, 0xC0": {
       "ExpectedInstructionCount": 6,
       "Comment": [


### PR DESCRIPTION
Fixes subtle decoder bug allowing execution of illegal register-to-register variants of LEA.

For example, before this fix these bytes:
`0x66, 0x8D, 0xC0 (ie. LEA ax, ax)`

Would be translated as 
```
uxth w20, w4
bfxil x4, x20, #0, #16
```

We now treat all of these encodings as illegal.
