### PR TITLE
Windows/CRT: Add printf and puts stubs

### DIFF
--- a/Source/Windows/Common/CRT/IO.cpp
+++ b/Source/Windows/Common/CRT/IO.cpp
@@ -471,3 +471,11 @@ int access(const char* Path, int AccessMode) {
 int rename(const char* _OldFilename, const char* _NewFilename) {
   UNIMPLEMENTED();
 }
+
+int printf(const char* Format, ...) {
+  UNIMPLEMENTED();
+}
+
+int puts(const char* Str) {
+  UNIMPLEMENTED();
+}


### PR DESCRIPTION
Fixes PE builds with VIXL disassembler enabled.