### PR TITLE
DiskCache: add some SHM stats

### DIFF
--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -865,6 +865,7 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
   bool DiskCacheHitRelocationsApplied = false;
   bool LoadDiskCacheCode = true;
   if (Region && Region->FileStartVA != 0) {
+    FEXCORE_PROFILE_ACCUMULATION(Thread, AccumulatedDiskCacheLookupTime);
     Hit = DiskCache.Lookup(Thread, *Region, GuestRIP);
     if (Hit) {
       DiskCacheHitRelocationsApplied = CodeCache.ApplyCodeRelocations(GuestRIP, std::as_writable_bytes(Hit->HostCode), Hit->Relocations, 0, false);
@@ -888,10 +889,12 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
           }
 
           uint64_t ModuleOffset = GuestRIP - Region->FileStartVA;
+          FEXCORE_PROFILE_INSTANT_INCREMENT(Thread, AccumulatedDiskCacheHitCount, 1);
           return reinterpret_cast<uintptr_t>(LoadedCode.EntryPoints[ModuleOffset]);
         }
       }
     }
+    FEXCORE_PROFILE_INSTANT_INCREMENT(Thread, AccumulatedDiskCacheMissCount, 1);
   }
 
   // Accumulate a JIT count now, as even if another thread raced us, it should count as a compile.

--- a/FEXCore/include/FEXCore/Utils/SHMStats.h
+++ b/FEXCore/include/FEXCore/Utils/SHMStats.h
@@ -70,6 +70,11 @@ struct ThreadStats {
   uint64_t AccumulatedCacheWriteLockTime;
 
   uint64_t AccumulatedJITCount;
+
+  uint64_t AccumulatedDiskCacheHitCount;
+  uint64_t AccumulatedDiskCacheMissCount;
+  uint64_t AccumulatedDiskCacheLookupTime;
+  uint64_t Padding;
 };
 
 // Ensure 16-byte alignment to take advantage of ARM single-copy atomicity.


### PR DESCRIPTION
I have a WTF local change that consumes that I could also push, and we could put something in MangoHUD as well. Is align OK here?

I'd imagine at some point we can replace some of the other cache stats but for now they're two separate things.