### PR TITLE
HostFeatures: Fixes crash in mingw build

### DIFF
--- a/FEXCore/include/FEXCore/Core/HostFeatures.h
+++ b/FEXCore/include/FEXCore/Core/HostFeatures.h
@@ -14,7 +14,7 @@ namespace FEXCore {
  */
 struct HostFeatures {
   // Changes code generation slightly.
-  enum class HostTypeEnum {
+  enum class HostTypeEnum : uint32_t {
     Unknown,
     Linux,
     Wow64,


### PR DESCRIPTION
Turns out packed enum classes without specifying an underlying type causes problems. Declare its underlying type as uint32_t to match everything else here.