### PR TITLE
LookupCache: Clear L1 entries on dynamic cache growth

### DIFF
--- a/FEXCore/Source/Interface/Core/LookupCache.h
+++ b/FEXCore/Source/Interface/Core/LookupCache.h
@@ -242,6 +242,9 @@ public:
 
       if (AveragePerSecond >= DynamicL1CacheIncreaseCountHeuristic()) {
         if (CurrentL1Entries < MAX_L1_ENTRIES) {
+          // Entries whose address has the new mask bit set would be unreachable by InvalidateCache
+          FEXCore::Allocator::VirtualDontNeed(reinterpret_cast<void*>(L1Pointer), CurrentL1Entries * sizeof(LookupCacheEntry), false);
+
           CurrentL1Entries <<= 1;
           L1PointerMask = CurrentL1Entries - 1;
 


### PR DESCRIPTION
With the dynamic L1 cache, a translation invalidated between a grow and a later shrink  becomes reachable again, and FEX runs stale guest code.

The L1 index is `Address & L1PointerMask`. When the mask grows, an address with the new bit set maps to a different slot. The old entry remains, but `InvalidateCache` checks only the slot selected by the current mask. If the cache later shrinks, the old entry becomes reachable again:

```
call A        8192 entries, mask 0x1FFF        A & 0x1FFF = 7936
              +------------------------+
              |                     [A]|
              +------------------------+
                                    7936


grow          16384 entries, mask 0x3FFF       A & 0x3FFF = 16128 = 7936 + 8192 (bit  13)   
              +------------------------+------------------------+
              |                     [A]|                     [ ]|
              +------------------------+------------------------+
                                    7936                    16128
                  A's slot is no longer here      A's slot is here now     

rewrite A     guest overwrites A's code; InvalidateCache(A) looks only at L1[16128]
              +------------------------+------------------------+
              |                     [A]|                     [ ]|
              +------------------------+------------------------+
                            still there              nothing here, nothing cleared   

shrink        [8192, MAX_L1_ENTRIES) madvised away; mask is 0x1FFF again
              +------------------------+
              |                     [A]|  <- A's slot again: hit, old translation runs  
              +------------------------+
```

The shrink branch of UpdateDynamicL1Stats clears `[new, MAX)`; the grow branch now clears `[0, old)` ([old, new) is already zero).  This also evicts valid entries.
It avoids a full-table rehash at the cost of a burst of misses after growth.

### Testing

- The reproducer below takes about 15 seconds. It fails on FEX-2604 (Fedora package) and on main at 4ed80fd07; it passes with this change.   
- Without this change, it also passes with `FEX_DYNAMICL1CACHE=0` or `FEX_DYNAMICL1CACHEDECREASECOUNTHEURISTIC=0`. 
- Full ctest on c9b23eb0e: the same 48 pre-existing failures with and without the change.
- The code dates from f44cd9c54 (FEX-2511); 86acfb35a (FEX-2604) enabled it by default.
- Test environment: Apple M1 Pro, Fedora Asahi 44, muvm.

```
$ x86_64-linux-gnu-gcc -static -o repro repro.c
$ FEX ./repro                      # before
FAIL: target was rewritten to return 2 but returned 1
$ FEX ./repro                      # after
PASS: target was rewritten to return 2 and returned 2
```

<details><summary>repro.c</summary>

```c
#include <stdio.h>
#include <string.h>
#include <sys/mman.h>
#include <time.h>
#include <unistd.h>

typedef int (*fn)(void);

/* FEX: code rewritten between a grow and a shrink of the dynamic L1 cache runs stale */
static volatile fn target, miss0, miss1;	/* indirect calls: every call goes through the L1 lookup */

static void
emit(fn f, int v)	/* mov eax, v; ret */
{
	unsigned char op[] = {0xb8, v, 0, 0, 0, 0xc3};

	memcpy((void*)f, op, sizeof op);
}

int
main(void)
{
	char* p;
	time_t t;
	int r;

	p = mmap(NULL, 0x400000, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
	if (p == MAP_FAILED) {
		perror("mmap");
		return 2;
	}
	p = (char*)(((unsigned long)p + 0x1FFFFF) & ~0x1FFFFFUL);
	target = (fn)(p + 0x3F00);	/* bit 13: another L1 slot once the table grows past 8192 */
	miss0 = (fn)(p + 0x800);	/* bit 20 apart: the same L1 slot at every size */
	miss1 = (fn)(p + 0x100800);
	emit(target, 1);
	emit(miss0, 0);
	emit(miss1, 0);

	target();
	t = time(NULL) + 3;
	while (time(NULL) < t) {	/* >250 misses/s: L1 grows */
		miss0();
		miss1();
	}
	emit(target, 2);
	t = time(NULL) + 12;
	while (time(NULL) < t) {	/* <50/s: L1 shrinks back */
		miss0();
		miss1();
		usleep(100000);
	}
	r = target();

	if (r != 2) {
		printf("FAIL: target was rewritten to return 2 but returned %d\n", r);
		return 1;
	}
	printf("PASS: target was rewritten to return 2 and returned 2\n");
	return 0;
}
```
</details>