### PR TITLE
Windows: Split CMAKE_CXX_FLAGS before passing to execute_process

### DIFF
--- a/Source/Windows/CMakeLists.txt
+++ b/Source/Windows/CMakeLists.txt
@@ -15,7 +15,8 @@ function(patch_library_wine target)
     COMMAND dd bs=32 count=1 seek=2 conv=notrunc if=${CMAKE_SOURCE_DIR}/Source/Windows/wine_builtin.bin of=$<TARGET_FILE:${target}>)
 endfunction()
 
-execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -print-libgcc-file-name
+separate_arguments(CXX_FLAGS_LIST NATIVE_COMMAND "${CMAKE_CXX_FLAGS}")
+execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CXX_FLAGS_LIST} -print-libgcc-file-name
   OUTPUT_VARIABLE LIBGCC_PATH
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 


### PR DESCRIPTION
We need to specify extra `CXXFLAGS` like `-no-canonical-prefixes` to build FEX to achieve better bit identity for the build artifacts. However, the current build script won't work out of box.

<details>
In `Source/Windows/CMakeLists.txt`, `execute_process` is used to query the compiler runtime library path via `-print-libgcc-file-name`:

```cmake
execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} -print-libgcc-file-name
  OUTPUT_VARIABLE LIBGCC_PATH
  OUTPUT_STRIP_TRAILING_WHITESPACE)
```

In CMake, `CMAKE_CXX_FLAGS` is a space-separated string (initialized from the `CXXFLAGS` environment variable) rather than a semicolon-delimited CMake list.

When a scalar string containing whitespace is evaluated inside `execute_process(COMMAND ...)`, CMake does **not** word-split the string. Instead, it passes the entire multi-flag string as a **single `argv` argument** with embedded spaces to the compiler.

When multiple compiler flags are present in `CXXFLAGS` (e.g., `CXXFLAGS="-no-canonical-prefixes -Wno-variadic-macro-arguments-omitted"`), `clang++` fails to parse the combined argument:

```text
clang: error: unknown argument: '-no-canonical-prefixes -Wno-variadic-macro-arguments-omitted'
libgcc.a
```

Because `clang++` exits with an error and falls back to printing `libgcc.a`, CMake sets `LIBGCC_PATH` to `libgcc.a`. Linking `wow64fex` / `arm64ecfex` subsequently fails with `lld: error: unable to find library -lgcc` when building with `llvm-mingw` (which ships `compiler-rt` builtins rather than GCC's `libgcc`).

---

### Fix

Use `separate_arguments()` to parse `${CMAKE_CXX_FLAGS}` into a CMake argument list (`${CXX_FLAGS_LIST}`) before passing it to `execute_process`:

```cmake
separate_arguments(CXX_FLAGS_LIST NATIVE_COMMAND "${CMAKE_CXX_FLAGS}")
execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CXX_FLAGS_LIST} -print-libgcc-file-name
  OUTPUT_VARIABLE LIBGCC_PATH
  OUTPUT_STRIP_TRAILING_WHITESPACE)
```

---

### Demonstration & Verification

A standalone CMake demonstration project reproducing this argument-passing behavior is available in [this commit](https://github.com/06393993/FEX/commit/59bed556d34ca7796c9a675c0416fa1c6162837b):

```bash
CXXFLAGS="-no-canonical-prefixes -Wno-variadic-macro-arguments-omitted" cmake -B cmake_args_demo/build -S cmake_args_demo
```

#### Output Comparison

**Before (`${CMAKE_CXX_FLAGS}`):**
```text
Total arguments received (argc): 3
  argv[0] = ".../print_args"
  argv[1] = "-no-canonical-prefixes -Wno-variadic-macro-arguments-omitted"
  argv[2] = "-print-libgcc-file-name"
```
*(Compiler fails trying to match `argv[1]` as a single flag name)*

**After (`separate_arguments` -> `${CXX_FLAGS_LIST}`):**
```text
Total arguments received (argc): 4
  argv[0] = ".../print_args"
  argv[1] = "-no-canonical-prefixes"
  argv[2] = "-Wno-variadic-macro-arguments-omitted"
  argv[3] = "-print-libgcc-file-name"
```
*(Compiler successfully parses each flag and prints the correct `libclang_rt.builtins-*.a` path)*

</details>


EDIT: hide the novel, so that the next time this PR is reviewed there won't be a wall of texts.