### PR TITLE
Config: Filter the `CPUFeatureRegisters` option on serialization

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.cpp
+++ b/FEXCore/Source/Interface/Config/Config.cpp
@@ -533,11 +533,13 @@ fextl::string SerializeForCache() {
   };
 
   const auto SerializeValue = [&Config, append_string_triple]<typename T, ConfigOption Option>(auto ConfigVal, const auto Default) {
-    if constexpr (Option == ConfigOption::CONFIG_ENV || Option == ConfigOption::CONFIG_HOSTENV || Option == ConfigOption::CONFIG_ADDITIONALARGUMENTS ||
-                  Option == ConfigOption::CONFIG_APP_CONFIG_NAME || Option == ConfigOption::CONFIG_APP_FILENAME ||
-                  Option == ConfigOption::CONFIG_IS64BIT_MODE || Option == ConfigOption::CONFIG_INTERPRETER_INSTALLED ||
-                  Option == ConfigOption::CONFIG_DISABLE_VIXL_INDIRECT_RUNTIME_CALLS || Option == ConfigOption::CONFIG_HOSTFEATURES) {
+    if constexpr (Option == ConfigOption::CONFIG_ENV || Option == ConfigOption::CONFIG_HOSTENV ||
+                  Option == ConfigOption::CONFIG_ADDITIONALARGUMENTS || Option == ConfigOption::CONFIG_APP_CONFIG_NAME ||
+                  Option == ConfigOption::CONFIG_APP_FILENAME || Option == ConfigOption::CONFIG_IS64BIT_MODE ||
+                  Option == ConfigOption::CONFIG_INTERPRETER_INSTALLED || Option == ConfigOption::CONFIG_DISABLE_VIXL_INDIRECT_RUNTIME_CALLS ||
+                  Option == ConfigOption::CONFIG_HOSTFEATURES || Option == ConfigOption::CONFIG_CPUFEATUREREGISTERS) {
       // Skip environment variables, meta arguments, and HostFeatures.
+      // Also skip CPUFeatureRegisters because it contains unfiltered data that is used in HostFeatures.
       return;
     }
 


### PR DESCRIPTION
This is unfiltered data that ends up in HostFeatures. If it was serialized when set then it would effectively never allow the code serialization to be used.