### PR TITLE
DiskCache: use memory-mapped IO for reads when possible

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -140,6 +140,13 @@
           "Enables disk caching for code blocks"
         ]
       },
+      "DiskCacheFileMapping": {
+        "Type": "bool",
+        "Default": "true",
+        "Desc": [
+          "Maps cache files for faster reading"
+        ]
+      },
       "DiskCacheRelocationFilter": {
         "Type": "bool",
         "Default": "true",

--- a/FEXCore/Source/Interface/Core/DiskCache.cpp
+++ b/FEXCore/Source/Interface/Core/DiskCache.cpp
@@ -4,6 +4,7 @@
 #include "FEXCore/fextl/string.h"
 #include "FEXHeaderUtils/Filesystem.h"
 #include "FEXCore/Core/DiskCache.h"
+#include "FEXCore/Core/DiskCacheFileMapper.h"
 #include "FEXCore/Utils/LogManager.h"
 #include "Interface/Context/Context.h"
 #include "FEXCore/HLE/SyscallHandler.h"
@@ -37,6 +38,8 @@ namespace DiskCache {
     };
 
   } // namespace MesaFOZ
+
+  static FileMapperFunc FileMapper = nullptr;
 
   bool FOZFile::Open(const fextl::string& FOZFileName, bool ReadOnly) {
     FileName = FOZFileName;
@@ -157,6 +160,12 @@ namespace DiskCache {
       return false;
     }
 
+    File::File::FileHandleType CacheFileHandle = CacheFOZ.GetHandle();
+    if (FileMapper && CacheFileHandle != (File::File::FileHandleType)-1) {
+      CacheFileMapping = reinterpret_cast<uint8_t*>(FileMapper(CacheFileHandle, ReadOnly ? CacheFOZ.Size() : BIG_MAPPING_SIZE));
+      CacheFileSize = CacheFOZ.Size();
+    }
+
     this->ReadOnly = ReadOnly;
     return true;
   }
@@ -207,7 +216,16 @@ namespace DiskCache {
   }
 
   bool IndexedDB::ReadCacheBlob(uint64_t Offset, std::span<uint8_t> OutBlob) {
-    return CacheFOZ.ReadBlob(Offset, OutBlob);
+    if (CacheFileMapping && (ReadOnly || Offset + OutBlob.size() <= BIG_MAPPING_SIZE)) {
+      if (Offset + OutBlob.size() > CacheFileSize) {
+        return false;
+      }
+      // todo could reduce copies by having a private mapping for relocs, etc
+      memcpy(OutBlob.data(), CacheFileMapping + Offset, OutBlob.size());
+      return true;
+    } else {
+      return CacheFOZ.ReadBlob(Offset, OutBlob);
+    }
   }
 
   bool IndexedDB::StoreCacheBlob(const MesaFOZ::foz_payload_key& Key, std::span<const uint8_t> Blob, Index& Index, std::mutex& IndexMutex) {
@@ -260,6 +278,11 @@ namespace DiskCache {
     CacheFOZ.Unlock();
     IndexFOZ.Unlock();
 
+    // publish new file size for memory-mapped reads
+    if (CacheFileMapping) {
+      CacheFileSize = BlobOffset + Blob.size();
+    }
+
     std::lock_guard Guard(IndexMutex);
     Index[Hash] = {this, BlobOffset, (uint32_t)Blob.size()};
     return true;
@@ -294,6 +317,10 @@ namespace DiskCache {
     return true;
   }
 
+  FEX_DEFAULT_VISIBILITY void SetFileMapper(FileMapperFunc Func) {
+    FileMapper = Func;
+  }
+
   void DiskCache::Init(FEXCore::Context::ContextImpl* CTX) {
     this->CTX = CTX;
 
@@ -321,6 +348,10 @@ namespace DiskCache {
       BasePath += fextl::fmt::format("{:016x}{:016x}", BucketHash.high64, BucketHash.low64) + "/";
     }
     FHU::Filesystem::CreateDirectories(BasePath);
+
+    if (!MapDiskCacheFiles) {
+      FileMapper = nullptr;
+    }
 
     fextl::string RWDBBasePath = BasePath + "RWCacheDB";
     OpenCacheDB(RWDBBasePath, false);

--- a/FEXCore/include/FEXCore/Core/DiskCache.h
+++ b/FEXCore/include/FEXCore/Core/DiskCache.h
@@ -124,6 +124,9 @@ namespace DiskCache {
       }
       return FD->Unlock();
     }
+    File::File::FileHandleType GetHandle() {
+      return FD ? FD->GetHandle() : (File::File::FileHandleType)-1;
+    }
     ssize_t Size();
     bool ReadAll(fextl::vector<uint8_t>& Out); // from first blob
     bool ReadBlob(uint64_t Offset, std::span<uint8_t> OutBlob);
@@ -147,8 +150,11 @@ namespace DiskCache {
   private:
     // stores run on the Writer, so returning quick isn't as important
     static constexpr uint32_t STORE_LOCK_TIMEOUT_MS = 1000;
+    static constexpr uint64_t BIG_MAPPING_SIZE = 1ULL << 33;
 
     FOZFile CacheFOZ;
+    uint8_t* CacheFileMapping = nullptr;
+    std::atomic<uint64_t> CacheFileSize;
     FOZFile IndexFOZ;
     bool ReadOnly = false;
   };
@@ -187,6 +193,7 @@ namespace DiskCache {
     fextl::unique_ptr<WorkQueueThread> Writer;
 
     FEX_CONFIG_OPT(EnableDiskCache, DISKCACHE);
+    FEX_CONFIG_OPT(MapDiskCacheFiles, DISKCACHEFILEMAPPING);
     FEX_CONFIG_OPT(RelocationFilter, DISKCACHERELOCATIONFILTER);
     FEX_CONFIG_OPT(BasePathOverride, DISKCACHEPATH);
     FEX_CONFIG_OPT(RODBNames, DISKCACHERODBNAMES);

--- a/FEXCore/include/FEXCore/Core/DiskCacheFileMapper.h
+++ b/FEXCore/include/FEXCore/Core/DiskCacheFileMapper.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "FEXCore/Utils/CompilerDefs.h"
+#include "FEXCore/Utils/File.h"
+
+namespace FEXCore::DiskCache {
+using FileMapperFunc = void* (*)(FEXCore::File::File::FileHandleType Handle, uint64_t MapSize);
+
+FEX_DEFAULT_VISIBILITY void SetFileMapper(FileMapperFunc Func);
+} // namespace FEXCore::DiskCache

--- a/FEXCore/include/FEXCore/Utils/File.h
+++ b/FEXCore/include/FEXCore/Utils/File.h
@@ -69,6 +69,10 @@ public:
     ShouldClose = IsValidHandle;
   }
 
+  FileHandleType GetHandle() {
+    return Handle;
+  }
+
   /**
    * @brief Write Bytes to File
    *

--- a/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
+++ b/Source/Tools/FEXInterpreter/FEXInterpreter.cpp
@@ -28,6 +28,7 @@ $end_info$
 #include <FEXCore/Config/Config.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CoreState.h>
+#include <FEXCore/Core/DiskCacheFileMapper.h>
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/FileLoading.h>
 #include <FEXCore/Utils/LogManager.h>
@@ -191,6 +192,16 @@ void Shutdown(fextl::vector<FEXCore::Allocator::MemoryRegion>&& MemoryRegions) {
   FEXCore::Allocator::ReclaimMemoryRegion(MemoryRegions);
 }
 } // namespace FEX::Allocator
+
+static void* DiskCacheFilemapper(FEXCore::File::File::FileHandleType Handle, uint64_t MapSize) {
+  int mapFD = dup(Handle);
+  void* Result = FEXCore::Allocator::mmap(nullptr, MapSize, PROT_READ, MAP_SHARED | MAP_NORESERVE, mapFD, 0);
+  close(mapFD);
+  if (Result == (void*)-1) {
+    return nullptr;
+  }
+  return Result;
+}
 
 bool InterpreterHandler(fextl::string* Filename, const fextl::string& RootFS, fextl::vector<fextl::string>* args) {
   int FD {-1};
@@ -520,6 +531,8 @@ int main(int argc, char** argv, char** const envp) {
 
   // Setup Thread handlers, so FEXCore can create threads.
   auto StackTracker = FEX::LinuxEmulation::Threads::SetupThreadHandlers();
+
+  FEXCore::DiskCache::SetFileMapper(DiskCacheFilemapper);
 
   auto MemoryRegions = FEX::Allocator::InitMemoryRegions(Loader.Is64BitMode());
   auto Allocator = FEX::Allocator::InitAllocator(Loader.Is64BitMode());

--- a/Source/Windows/ARM64EC/Module.cpp
+++ b/Source/Windows/ARM64EC/Module.cpp
@@ -11,6 +11,7 @@ $end_info$
 #include <FEXCore/Core/SignalDelegator.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CoreState.h>
+#include <FEXCore/Core/DiskCacheFileMapper.h>
 #include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <FEXCore/Config/Config.h>
@@ -606,6 +607,9 @@ NTSTATUS ProcessInit() {
 
   FEX::Windows::Allocator::SetupHooks(NtDll);
   FEX::Windows::UnixLib::Init(NtDll);
+  if (FEX::Windows::UnixLib::Available()) {
+    FEXCore::DiskCache::SetFileMapper(FEX::Windows::UnixLib::MapFile);
+  }
 
   {
     auto HostFeatures = FEX::Windows::CPUFeatures::FetchHostFeatures(IsWine, FEXCore::HostFeatures::HostTypeEnum::Arm64ec);

--- a/Source/Windows/Common/FEXUnixLib.cpp
+++ b/Source/Windows/Common/FEXUnixLib.cpp
@@ -26,6 +26,9 @@ unixlib_handle_t UnixLibHandle {};
 
 decltype(__wine_unix_call_dispatcher) UnixCallDispatcher {};
 
+using wine_server_handle_to_fd_t = NTSTATUS(CDECL*)(HANDLE, unsigned int, int*, unsigned int*);
+static wine_server_handle_to_fd_t WineServerHandleToFd {};
+
 #ifdef ARCHITECTURE_arm64ec
 // On ARM64EC, indirect calls go through __os_arm64x_dispatch_icall which invokes
 // FEX's custom call checker. Use a naked trampoline to bypass the dispatch mechanism
@@ -88,6 +91,7 @@ namespace Illegal {
 
 bool Init(HMODULE NtDll) {
   const auto Sym = GetProcAddress(NtDll, "__wine_unix_call_dispatcher");
+  WineServerHandleToFd = reinterpret_cast<wine_server_handle_to_fd_t>(GetProcAddress(NtDll, "wine_server_handle_to_fd"));
 
   if (!Sym) {
     return false;
@@ -134,12 +138,12 @@ bool Init(HMODULE NtDll) {
   return true;
 }
 
-static bool UnixLibAvailable() {
+bool Available() {
   return UnixLibHandle != 0;
 }
 
 bool TryEnableHardwareTSO() {
-  if (UnixLibAvailable()) {
+  if (Available()) {
     // UnixLib path.
     FEXUnixLib_SetHardwareTSOControlArgs Args {
       .Enable = true,
@@ -155,7 +159,7 @@ bool TryEnableHardwareTSO() {
 }
 
 bool SetKernelUnalignedAtomicControl(uint64_t Flags) {
-  if (UnixLibAvailable()) {
+  if (Available()) {
     // UnixLib path.
     FEXUnixLib_SetKernelUnalignedAtomicControl Args {
       .Flags = Flags,
@@ -169,7 +173,7 @@ bool SetKernelUnalignedAtomicControl(uint64_t Flags) {
 }
 
 void VirtualTHPControl(const void* Ptr, size_t Size, FEXCore::Allocator::THPControl Control) {
-  if (UnixLibAvailable()) {
+  if (Available()) {
     // UnixLib path.
     FEXUnixLib_Madvise Args {
       .Addr = Ptr,
@@ -190,7 +194,7 @@ void VirtualName(const char* Name, const void* Ptr, size_t Size) {
     return;
   }
 
-  if (UnixLibAvailable()) {
+  if (Available()) {
     // UnixLib path.
     FEXUnixLib_SetVMAName Args {
       .Addr = Ptr,
@@ -209,7 +213,7 @@ void VirtualName(const char* Name, const void* Ptr, size_t Size) {
 }
 
 SHMSlotResult AllocateSHMSlots(void* SHMBase, uint32_t MapSize, uint32_t MaxSize) {
-  if (UnixLibAvailable()) {
+  if (Available()) {
     // UnixLib path.
     FEXUnixLib_GetSHMStatsVMA Args {
       .SHMBase = SHMBase,
@@ -277,7 +281,7 @@ SHMSlotResult AllocateSHMSlots(void* SHMBase, uint32_t MapSize, uint32_t MaxSize
 }
 
 void DeleteSHMStatsFile() {
-  if (UnixLibAvailable()) {
+  if (Available()) {
     // UnixLib path.
     Call(FEXUnixLibFunctions::DeleteSHMStatsFile, nullptr);
     return;
@@ -285,6 +289,27 @@ void DeleteSHMStatsFile() {
 
   // Legacy Proton path.
   DeleteFileA(fextl::fmt::format("/dev/shm/fex-{}-stats", Illegal::linux_getpid()).c_str());
+}
+
+void* MapFile(HANDLE FileHandle, uint64_t MapSize) {
+  if (Available() && WineServerHandleToFd) {
+    FEXUnixLib_MapFile Args {
+      .FD = -1,
+      .MapSize = MapSize,
+    };
+
+    // this is a dup equivalent
+    auto Result = WineServerHandleToFd(FileHandle, FILE_READ_DATA, &Args.FD, nullptr);
+    if (Result != STATUS_SUCCESS || Args.FD == -1) {
+      return nullptr;
+    }
+
+    if (Call(FEXUnixLibFunctions::MapFile, &Args) == STATUS_SUCCESS) {
+      return Args.Result;
+    }
+  }
+
+  return nullptr;
 }
 
 } // namespace FEX::Windows::UnixLib

--- a/Source/Windows/Common/FEXUnixLib.h
+++ b/Source/Windows/Common/FEXUnixLib.h
@@ -19,6 +19,7 @@ inline NTSTATUS Call(FEXUnixLibFunctions code, void* args) {
 }
 
 bool Init(HMODULE NtDll);
+bool Available();
 
 /**
  * @brief Tries to enable hardware TSO if supported.
@@ -45,4 +46,6 @@ struct SHMSlotResult {
 };
 SHMSlotResult AllocateSHMSlots(void* SHMBase, uint32_t MapSize, uint32_t MaxSize);
 void DeleteSHMStatsFile();
+
+void* MapFile(HANDLE FileHandle, uint64_t MapSize);
 } // namespace FEX::Windows::UnixLib

--- a/Source/Windows/UnixLib/FEXUnixLib.cpp
+++ b/Source/Windows/UnixLib/FEXUnixLib.cpp
@@ -163,6 +163,19 @@ static NTSTATUS FEXUnixLib_DeleteSHMStatsFileHandler(void* _Args) {
   return STATUS_SUCCESS;
 }
 
+static NTSTATUS FEXUnixLib_MapFileHandler(void* _Args) {
+  auto Args = reinterpret_cast<FEXUnixLib_MapFile*>(_Args);
+  // could find a way to dedupe with DiskCacheFilemapper in FEXInterpreter but it's barely any code
+  // fd was already duped by Wine handle translation
+  Args->Result = mmap(nullptr, Args->MapSize, PROT_READ, MAP_SHARED | MAP_NORESERVE, Args->FD, 0);
+  close(Args->FD);
+  if (Args->Result == (void*)-1) {
+    Args->Result = nullptr;
+    return STATUS_INTERNAL_ERROR;
+  }
+  return STATUS_SUCCESS;
+}
+
 extern "C" const unixlib_entry_t __wine_unix_call_funcs[] = {
   FEXUnixLib_SetHardwareTSOControlHandler,
   FEXUnixLib_SetKernelUnalignedAtomicControlHandler,
@@ -170,6 +183,7 @@ extern "C" const unixlib_entry_t __wine_unix_call_funcs[] = {
   FEXUnixLib_SetVMANameHandler,
   FEXUnixLib_GetSHMStatsVMAHandler,
   FEXUnixLib_DeleteSHMStatsFileHandler,
+  FEXUnixLib_MapFileHandler,
 };
 
 static_assert(sizeof(__wine_unix_call_funcs) / sizeof(__wine_unix_call_funcs[0]) == ToUnderlying(FEXUnixLibFunctions::MAX));

--- a/Source/Windows/UnixLib/FEXUnixLib.h
+++ b/Source/Windows/UnixLib/FEXUnixLib.h
@@ -10,6 +10,7 @@ enum class FEXUnixLibFunctions : uint32_t {
   SetVMAName,
   GetSHMStatsVMA,
   DeleteSHMStatsFile,
+  MapFile,
   MAX,
 };
 
@@ -51,3 +52,10 @@ struct FEXUnixLib_GetSHMStatsVMA {
   uint32_t MaxSize;
 };
 static_assert(sizeof(FEXUnixLib_GetSHMStatsVMA) == 16);
+
+struct FEXUnixLib_MapFile {
+  int32_t FD;
+  uint64_t MapSize;
+  void* Result;
+};
+static_assert(sizeof(FEXUnixLib_MapFile) == 24);

--- a/Source/Windows/WOW64/Module.cpp
+++ b/Source/Windows/WOW64/Module.cpp
@@ -13,6 +13,7 @@ $end_info$
 #include <FEXCore/Core/SignalDelegator.h>
 #include <FEXCore/Core/Context.h>
 #include <FEXCore/Core/CoreState.h>
+#include <FEXCore/Core/DiskCacheFileMapper.h>
 #include <FEXCore/Debug/InternalThreadState.h>
 #include <FEXCore/HLE/SyscallHandler.h>
 #include <FEXCore/Config/Config.h>
@@ -538,6 +539,9 @@ void BTCpuProcessInit() {
 
   FEX::Windows::Allocator::SetupHooks(NtDll);
   FEX::Windows::UnixLib::Init(NtDll);
+  if (FEX::Windows::UnixLib::Available()) {
+    FEXCore::DiskCache::SetFileMapper(FEX::Windows::UnixLib::MapFile);
+  }
 
   {
     auto HostFeatures = FEX::Windows::CPUFeatures::FetchHostFeatures(IsWine, FEXCore::HostFeatures::HostTypeEnum::Wow64);


### PR DESCRIPTION
On Wine, use a unixlib call to get a quality mapping that can track a growing file.