### PR TITLE
Fix pf2iw to saturate on 32-to-16-bit truncation

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3583,9 +3583,9 @@ void OpDispatchBuilder::PF2IWOp(OpcodeArgs) {
   // Float to int32_t
   Src = _Vector_FToZS(Size, OpSize::i32Bit, Src);
 
-  // We now need to transpose the lower 16-bits of each element together
-  // Only needing to move the upper element down in this case
-  Src = _VUnZip(Size, OpSize::i16Bit, Src, Src);
+  // Truncate the 32-bit integers to 16-bit
+  // Saturate values outside the 16-bit range to smallest and largest 16-bit values
+  Src = _VSQXTN(Size, OpSize::i32Bit, Src);
 
   // Now we need to sign extend the 16bit value to 32-bit
   Src = _VSXTL(Size, OpSize::i16Bit, Src);

--- a/unittests/ASM/FEX_bugs/PF2IW_Saturate.asm
+++ b/unittests/ASM/FEX_bugs/PF2IW_Saturate.asm
@@ -1,0 +1,19 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM0": "0xFFFF800000007FFF"
+  },
+  "HostFeatures": ["3DNOW"]
+}
+%endif
+
+; +100000.0f > INT16_MAX -> saturate to 0x00007FFF
+; -100000.0f < INT16_MIN -> saturate to 0xFFFF8000
+pf2iw mm0, [rel data1]
+
+hlt
+
+align 8
+data1:
+dd 0x47C35000 ; +100000.0f
+dd 0xC7C35000 ; -100000.0f

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -60,7 +60,7 @@
         "strb w20, [x28, #1202]",
         "ldr d2, [x28, #1072]",
         "fcvtzs v2.2s, v2.2s",
-        "uzp1 v2.4h, v2.4h, v2.4h",
+        "sqxtn v2.4h, v2.4s",
         "sxtl v2.4s, v2.4h",
         "str d2, [x28, #1056]",
         "strh w20, [x28, #1064]"


### PR DESCRIPTION
The `pf2iw` instruction truncates the 32-bit integers to 16-bit signed integers.
When a value falls outside the 16-bit range, it is saturated to the smallest or largest 16-bit value instead.

FEX used `_VUnZip`, which correctly truncates but performs no saturation.
This PR instead uses `_VSQXTN`, which truncates and saturates to 16-bit in one step.