### PR TITLE
Fix PFACC producing wrong results due to missing MMX-sized path in VFAddP

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/VectorOps.cpp
@@ -1297,6 +1297,7 @@ DEF_OP(VFAddP) {
   const auto Op = IROp->C<IR::IROp_VFAddP>();
   const auto OpSize = IROp->Size;
 
+  const auto IsScalar = OpSize == IR::OpSize::i64Bit;
   const auto Is256Bit = OpSize == IR::OpSize::i256Bit;
   LOGMAN_THROW_A_FMT(!Is256Bit || HostSupportsSVE256, "Need SVE256 support in order to use {} with 256-bit operation", __func__);
 
@@ -1327,6 +1328,8 @@ DEF_OP(VFAddP) {
 
     // Merge upper half with lower half.
     splice<ARMEmitter::OpType::Destructive>(ARMEmitter::SubRegSize::i64Bit, Dst.Z(), PRED_TMP_16B, Dst.Z(), VTMP2.Z());
+  } else if (IsScalar) {
+    faddp(SubRegSize, Dst.D(), VectorLower.D(), VectorUpper.D());
   } else {
     faddp(SubRegSize, Dst.Q(), VectorLower.Q(), VectorUpper.Q());
   }

--- a/unittests/ASM/FEX_bugs/PFACC_MMXWidth.asm
+++ b/unittests/ASM/FEX_bugs/PFACC_MMXWidth.asm
@@ -1,0 +1,25 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM0": "0x40e0000040400000"
+  },
+  "HostFeatures": ["3DNOW"]
+}
+%endif
+
+femms
+movq mm0, [rel .dst_value]
+movq mm1, [rel .src_value]
+
+pfacc mm0, mm1
+
+hlt
+
+align 8
+.dst_value:
+dd 0x3f800000 ; 1.0
+dd 0x40000000 ; 2.0
+
+.src_value:
+dd 0x40400000 ; 3.0
+dd 0x40800000 ; 4.0

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -145,7 +145,7 @@
         "ldr d3, [x28, #1072]",
         "dup v4.2s, v2.s[1]",
         "fsub s2, s2, s4",
-        "faddp v3.4s, v3.4s, v3.4s",
+        "faddp v3.2s, v3.2s, v3.2s",
         "mov v2.s[1], v3.s[0]",
         "str d2, [x28, #1056]",
         "strh w20, [x28, #1064]"


### PR DESCRIPTION
The `pfacc` instruction operates on 64-bit MMX registers and  lowers to `VFAddP`.
`VFAddP` emitted a 128-bit `faddp` regardless of the operand width causing `pfacc` to produce an incorrect result in the upper 32bits.

This PR adds a 64-bit `faddp` path to `VFAddP` for MMX-sized operands mirroring the existing functionality already used by `VAddP`.