### PR TITLE
Fix pf2id overflow saturation

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher.h
@@ -799,6 +799,7 @@ public:
   void VPFCMPOp(OpcodeArgs, uint8_t CompType);
   void PI2FWOp(OpcodeArgs);
   void PF2IWOp(OpcodeArgs);
+  void PF2IDOp(OpcodeArgs);
 
   void PMULHRWOp(OpcodeArgs);
 

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/DDDTables.h
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/DDDTables.h
@@ -7,7 +7,7 @@ constexpr DispatchTableEntry OpDispatch_DDDTable[] = {
   {0x0C, 1, &OpDispatchBuilder::PI2FWOp},
   {0x0D, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::Vector_CVT_Int_To_Float, OpSize::i32Bit, false, false>},
   {0x1C, 1, &OpDispatchBuilder::PF2IWOp},
-  {0x1D, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::Vector_CVT_Float_To_Int, OpSize::i32Bit, false, false>},
+  {0x1D, 1, &OpDispatchBuilder::PF2IDOp},
 
   {0x86, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::VectorUnaryOp, IR::OP_VFRECPPRECISION, OpSize::i32Bit>},
   {0x87, 1, &OpDispatchBuilder::Bind<&OpDispatchBuilder::RSqrt3DNowOp, false>},

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/Vector.cpp
@@ -3592,6 +3592,16 @@ void OpDispatchBuilder::PF2IWOp(OpcodeArgs) {
   StoreResultFPR_WithOpSize(Op, Op->Dest, Src, Size);
 }
 
+void OpDispatchBuilder::PF2IDOp(OpcodeArgs) {
+  Ref Src = LoadSourceFPR(Op, Op->Src[0], Op->Flags);
+
+  const auto Size = OpSizeFromDst(Op);
+
+  Src = _Vector_FToZS(Size, OpSize::i32Bit, Src);
+
+  StoreResultFPR_WithOpSize(Op, Op->Dest, Src, Size);
+}
+
 void OpDispatchBuilder::PMULHRWOp(OpcodeArgs) {
   const auto Size = OpSizeFromSrc(Op);
 

--- a/unittests/ASM/FEX_bugs/PF2ID_Saturate.asm
+++ b/unittests/ASM/FEX_bugs/PF2ID_Saturate.asm
@@ -1,0 +1,19 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "MM0": "0x800000007FFFFFFF"
+  },
+  "HostFeatures": ["3DNOW"]
+}
+%endif
+
+; +3000000000.0f > INT32_MAX -> saturate to 0x7FFFFFFF
+; -3000000000.0f < INT32_MIN -> saturate to 0x80000000
+pf2id mm0, [rel data1]
+
+hlt
+
+align 8
+data1:
+dd 0x4F32D05E ; +3000000000.0f
+dd 0xCF32D05E ; -3000000000.0f

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -67,7 +67,7 @@
       ]
     },
     "pf2id mm0, mm1": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 7,
       "Comment": [
         "0x0f 0x0f 0x1d"
       ],
@@ -76,7 +76,6 @@
         "mov w20, #0xffff",
         "strb w20, [x28, #1202]",
         "ldr d2, [x28, #1072]",
-        "frint32z v2.4s, v2.4s",
         "fcvtzs v2.2s, v2.2s",
         "str d2, [x28, #1056]",
         "strh w20, [x28, #1064]"


### PR DESCRIPTION
The `pf2id` instruction converts packed 32-bit floats to 32-bit integers, truncating toward zero.
When a value falls outside the 32-bit range, it saturates to the smallest or largest 32-bit value instead.

FEX dispatches `pf2id` through the same handler used for SSE's equivalent (`Vector_CVT_Float_To_Int`), which always saturates any out of range value to the integer-indefinite value 0x80000000.
This PR creates a separate handler for `pf2id` that converts directly via `_Vector_FToZS`.