### PR TITLE
Clear C1 for fcomi

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -680,6 +680,9 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs, IR::OpSize Width, bool Integer, OpDisp
     SetRFLAG<FEXCore::X86State::RFLAG_OF_RAW_LOC>(Constant(0));
     SetRFLAG<FEXCore::X86State::RFLAG_SF_RAW_LOC>(Constant(0));
     SetRFLAG<FEXCore::X86State::RFLAG_AF_RAW_LOC>(Constant(0));
+
+    // C1 set to 0
+    SetRFLAG<FEXCore::X86State::X87FLAG_C1_LOC>(Constant(0));
   }
 
   // Set Invalid Operation flag when unordered (NaN comparison)

--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87F64.cpp
@@ -368,6 +368,9 @@ void OpDispatchBuilder::FCOMIF64(OpcodeArgs, IR::OpSize Width, bool Integer, OpD
     HandleNZCVWrite();
     _F80CmpValue(b);
     ComissFlags();
+
+    // C1 set to 0
+    SetRFLAG<FEXCore::X86State::X87FLAG_C1_LOC>(Constant(0));
   }
 
   if (PopTwice) {

--- a/FEXCore/include/FEXCore/Core/DiskCache.h
+++ b/FEXCore/include/FEXCore/Core/DiskCache.h
@@ -207,7 +207,7 @@ namespace DiskCache {
 
   // TODO: This header is in global installed header path, but uses internal headers.
   // Migrate this once that is fixed.
-  static constexpr uint16_t FormatVersion = 6;
+  static constexpr uint16_t FormatVersion = 7;
   FEX_DEFAULT_VISIBILITY uint16_t GetFormatVersion();
 
 } // namespace DiskCache

--- a/unittests/ASM/FEX_bugs/fcomi_c1_clear.asm
+++ b/unittests/ASM/FEX_bugs/fcomi_c1_clear.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000000000000"
+  }
+}
+%endif
+
+fninit
+
+fld qword [rel two]
+fld qword [rel one]
+
+fldenv [rel env]
+
+fcomi st1
+
+fnstsw ax
+and rax, 0x0200 ; extract C1
+
+hlt
+
+one:
+    dq 1.0
+two:
+    dq 2.0
+
+env:
+    dd 0x037F ; FCW
+    dd 0x3200 ; FSW: C1=1
+    dd 0x0000 ; FTW

--- a/unittests/InstructionCountCI/AFP/H0F3A.json
+++ b/unittests/InstructionCountCI/AFP/H0F3A.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "roundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/Secondary.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vsqrtss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AFP/VEX_map3.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map3.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vroundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AVX128/FMA4.json
+++ b/unittests/InstructionCountCI/AVX128/FMA4.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -13,7 +13,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vmovntps [rax], xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
@@ -8,7 +8,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vfmadd132ss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vmovntdqa xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -11,7 +11,7 @@
       "SVE256",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -8,7 +8,7 @@
       "AFP",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vblendvps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F3A.json
+++ b/unittests/InstructionCountCI/Crypto/H0F3A.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pclmulqdq xmm0, xmm1, 00000b": {

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -10,7 +10,7 @@
       "AFP",
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These 3DNow! instructions are optimal assuming that FEX doesn't SRA MMX registers",

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -13,7 +13,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/libnss.json
+++ b/unittests/InstructionCountCI/FEXOpt/libnss.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [],
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Chained add": {

--- a/unittests/InstructionCountCI/FlagM/H0F38.json
+++ b/unittests/InstructionCountCI/FlagM/H0F38.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "ptest xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "The Witcher 3": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Sonic Mania movie player": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "FMOD scalar loop": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "The Sims 1 hot block": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "add al, 1": {

--- a/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "ucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
@@ -11,7 +11,7 @@
       "AFP",
       "FCMA"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "ucomisd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -12,7 +12,7 @@
       "AFP",
       "CSSC"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -10,7 +10,7 @@
       "AFP",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map_group.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map_group.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "blsr eax, ebx": {

--- a/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -10,12 +10,12 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {
       "x86InstructionCount": 70,
-      "ExpectedInstructionCount": 413,
+      "ExpectedInstructionCount": 414,
       "x86Insts": [
         "sub esp,0x2c",
         "mov ecx,dword [esp + 0x34]",
@@ -477,6 +477,7 @@
         "eor w26, w20, #0x1",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x5 (5)",
@@ -506,7 +507,7 @@
     },
     "Block2": {
       "x86InstructionCount": 37,
-      "ExpectedInstructionCount": 215,
+      "ExpectedInstructionCount": 219,
       "x86Insts": [
         "sub esp,0x1c",
         "mov edx,dword [esp + 0x20]",
@@ -588,6 +589,7 @@
         "eor x21, x21, #0x1",
         "rmif x21, #63, #nzCv",
         "rmif x22, #62, #nZcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "csetm x20, ls",
         "dup v4.2d, x20",
@@ -629,6 +631,7 @@
         "eor x21, x21, #0x1",
         "rmif x21, #63, #nzCv",
         "rmif x22, #62, #nZcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "csetm x20, ls",
         "dup v5.2d, x20",
@@ -670,6 +673,7 @@
         "eor x21, x21, #0x1",
         "rmif x21, #63, #nzCv",
         "rmif x22, #62, #nZcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "csetm x20, ls",
         "dup v6.2d, x20",
@@ -741,6 +745,7 @@
         "eor w26, w20, #0x1",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x6 (6)",
@@ -1174,7 +1179,7 @@
     },
     "Block5": {
       "x86InstructionCount": 49,
-      "ExpectedInstructionCount": 303,
+      "ExpectedInstructionCount": 304,
       "x86Insts": [
         "fld dword [esp + 0x80]",
         "fsub dword [esp + 0x7c]",
@@ -1509,6 +1514,7 @@
         "eor w26, w20, #0x1",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "cset x20, hi",
         "strb w20, [x8, #48]",
@@ -1534,7 +1540,7 @@
     },
     "Block6": {
       "x86InstructionCount": 39,
-      "ExpectedInstructionCount": 295,
+      "ExpectedInstructionCount": 296,
       "x86Insts": [
         "push ebp",
         "push edi",
@@ -1841,6 +1847,7 @@
         "eor w26, w20, #0x1",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x4 (4)",

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -11,7 +11,7 @@
       "CSSC",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -4763,7 +4763,7 @@
       ]
     },
     "fucomi st0, st0": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 25,
       "Comment": [
         "0xdb 11b 0xe8 /5"
       ],
@@ -4791,11 +4791,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st1": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xe9 /5"
       ],
@@ -4827,11 +4828,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st2": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xea /5"
       ],
@@ -4863,11 +4865,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st3": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xeb /5"
       ],
@@ -4899,11 +4902,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st4": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xec /5"
       ],
@@ -4935,11 +4939,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st5": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xed /5"
       ],
@@ -4971,11 +4976,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st6": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xee /5"
       ],
@@ -5007,11 +5013,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st7": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xef /5"
       ],
@@ -5043,11 +5050,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st0": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 25,
       "Comment": [
         "0xdb 11b 0xf0 /6"
       ],
@@ -5075,11 +5083,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st1": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xf1 /6"
       ],
@@ -5111,11 +5120,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st2": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xf2 /6"
       ],
@@ -5147,11 +5157,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st3": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xf3 /6"
       ],
@@ -5183,11 +5194,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st4": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xf4 /6"
       ],
@@ -5219,11 +5231,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st5": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xf5 /6"
       ],
@@ -5255,11 +5268,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st6": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xf6 /6"
       ],
@@ -5291,11 +5305,12 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st7": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 29,
       "Comment": [
         "0xdb 11b 0xf7 /6"
       ],
@@ -5327,6 +5342,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]"
       ]
     },
@@ -10282,7 +10298,7 @@
       ]
     },
     "fucomip st0": {
-      "ExpectedInstructionCount": 32,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdf 11b 0xe8 /5"
       ],
@@ -10310,6 +10326,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10322,7 +10339,7 @@
       ]
     },
     "fucomip st1": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdf 11b 0xe9 /5"
       ],
@@ -10354,6 +10371,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w22, [x28, #1040]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
@@ -10364,7 +10382,7 @@
       ]
     },
     "fucomip st2": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xea /5"
       ],
@@ -10396,6 +10414,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10408,7 +10427,7 @@
       ]
     },
     "fucomip st3": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xeb /5"
       ],
@@ -10440,6 +10459,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10452,7 +10472,7 @@
       ]
     },
     "fucomip st4": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xec /5"
       ],
@@ -10484,6 +10504,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10496,7 +10517,7 @@
       ]
     },
     "fucomip st5": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xed /5"
       ],
@@ -10528,6 +10549,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10540,7 +10562,7 @@
       ]
     },
     "fucomip st6": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xee /5"
       ],
@@ -10572,6 +10594,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10584,7 +10607,7 @@
       ]
     },
     "fucomip st7": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xef /5"
       ],
@@ -10616,6 +10639,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10628,7 +10652,7 @@
       ]
     },
     "fcomip st0": {
-      "ExpectedInstructionCount": 32,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdf 11b 0xf0 /6"
       ],
@@ -10656,6 +10680,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10668,7 +10693,7 @@
       ]
     },
     "fcomip st1": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdf 11b 0xf1 /6"
       ],
@@ -10700,6 +10725,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w22, [x28, #1040]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
@@ -10710,7 +10736,7 @@
       ]
     },
     "fcomip st2": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xf2 /6"
       ],
@@ -10742,6 +10768,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10754,7 +10781,7 @@
       ]
     },
     "fcomip st3": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xf3 /6"
       ],
@@ -10786,6 +10813,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10798,7 +10826,7 @@
       ]
     },
     "fcomip st4": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xf4 /6"
       ],
@@ -10830,6 +10858,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10842,7 +10871,7 @@
       ]
     },
     "fcomip st5": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xf5 /6"
       ],
@@ -10874,6 +10903,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10886,7 +10916,7 @@
       ]
     },
     "fcomip st6": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xf6 /6"
       ],
@@ -10918,6 +10948,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10930,7 +10961,7 @@
       ]
     },
     "fcomip st7": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xf7 /6"
       ],
@@ -10962,6 +10993,7 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
@@ -13,12 +13,12 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {
       "x86InstructionCount": 70,
-      "ExpectedInstructionCount": 107,
+      "ExpectedInstructionCount": 108,
       "x86Insts": [
         "sub esp,0x2c",
         "mov ecx,dword [esp + 0x34]",
@@ -175,6 +175,7 @@
         "fcmp d4, d6",
         "cset x26, vc",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x5 (5)",
         "and w20, w20, #0x7",
@@ -203,7 +204,7 @@
     },
     "Block2": {
       "x86InstructionCount": 37,
-      "ExpectedInstructionCount": 70,
+      "ExpectedInstructionCount": 74,
       "x86Insts": [
         "sub esp,0x1c",
         "mov edx,dword [esp + 0x20]",
@@ -257,6 +258,7 @@
         "strb wzr, [x28, #1049]",
         "fcmp d2, d3",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "csetm x20, ls",
         "dup v4.2d, x20",
         "bsl v4.16b, v3.16b, v2.16b",
@@ -269,6 +271,7 @@
         "strb wzr, [x28, #1049]",
         "fcmp d2, d3",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "csetm x20, ls",
         "dup v5.2d, x20",
         "bsl v5.16b, v3.16b, v2.16b",
@@ -281,6 +284,7 @@
         "strb wzr, [x28, #1049]",
         "fcmp d2, d3",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "csetm x20, ls",
         "dup v6.2d, x20",
         "bsl v6.16b, v3.16b, v2.16b",
@@ -294,6 +298,7 @@
         "fcmp d3, d3",
         "cset x26, vc",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x6 (6)",
         "and w20, w20, #0x7",
@@ -516,7 +521,7 @@
     },
     "Block5": {
       "x86InstructionCount": 49,
-      "ExpectedInstructionCount": 88,
+      "ExpectedInstructionCount": 89,
       "x86Insts": [
         "fld dword [esp + 0x80]",
         "fsub dword [esp + 0x7c]",
@@ -637,6 +642,7 @@
         "fcmp d2, d3",
         "cset x26, vc",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "cset x20, hi",
         "strb w20, [x8, #48]",
         "ldrb w4, [x8, #48]",
@@ -661,7 +667,7 @@
     },
     "Block6": {
       "x86InstructionCount": 39,
-      "ExpectedInstructionCount": 90,
+      "ExpectedInstructionCount": 91,
       "x86Insts": [
         "push ebp",
         "push edi",
@@ -764,6 +770,7 @@
         "fcmp d5, d6",
         "cset x26, vc",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x4 (4)",
         "and w20, w20, #0x7",

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -4090,7 +4090,7 @@
       ]
     },
     "fucomi st0, st0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "0xdb 11b 0xe8 /5"
       ],
@@ -4101,11 +4101,12 @@
         "fcmp d2, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xe9 /5"
       ],
@@ -4120,11 +4121,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xea /5"
       ],
@@ -4139,11 +4141,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st3": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xeb /5"
       ],
@@ -4158,11 +4161,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st4": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xec /5"
       ],
@@ -4177,11 +4181,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st5": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xed /5"
       ],
@@ -4196,11 +4201,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st6": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xee /5"
       ],
@@ -4215,11 +4221,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st7": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xef /5"
       ],
@@ -4234,11 +4241,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st0": {
-      "ExpectedInstructionCount": 7,
+      "ExpectedInstructionCount": 8,
       "Comment": [
         "0xdb 11b 0xf0 /6"
       ],
@@ -4249,11 +4257,12 @@
         "fcmp d2, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st1": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xf1 /6"
       ],
@@ -4268,11 +4277,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st2": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xf2 /6"
       ],
@@ -4287,11 +4297,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st3": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xf3 /6"
       ],
@@ -4306,11 +4317,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st4": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xf4 /6"
       ],
@@ -4325,11 +4337,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st5": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xf5 /6"
       ],
@@ -4344,11 +4357,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st6": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xf6 /6"
       ],
@@ -4363,11 +4377,12 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st7": {
-      "ExpectedInstructionCount": 11,
+      "ExpectedInstructionCount": 12,
       "Comment": [
         "0xdb 11b 0xf7 /6"
       ],
@@ -4382,7 +4397,8 @@
         "fcmp d3, d2",
         "cset x26, vc",
         "mov w27, #0x0",
-        "axflag"
+        "axflag",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fadd qword [rax]": {
@@ -8287,7 +8303,7 @@
       ]
     },
     "fucomip st0": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 16,
       "Comment": [
         "0xdf 11b 0xe8 /5"
       ],
@@ -8299,6 +8315,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8310,7 +8327,7 @@
       ]
     },
     "fucomip st1": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 18,
       "Comment": [
         "0xdf 11b 0xe9 /5"
       ],
@@ -8326,6 +8343,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
         "mov w22, #0x1",
@@ -8335,7 +8353,7 @@
       ]
     },
     "fucomip st2": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xea /5"
       ],
@@ -8351,6 +8369,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8362,7 +8381,7 @@
       ]
     },
     "fucomip st3": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xeb /5"
       ],
@@ -8378,6 +8397,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8389,7 +8409,7 @@
       ]
     },
     "fucomip st4": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xec /5"
       ],
@@ -8405,6 +8425,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8416,7 +8437,7 @@
       ]
     },
     "fucomip st5": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xed /5"
       ],
@@ -8432,6 +8453,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8443,7 +8465,7 @@
       ]
     },
     "fucomip st6": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xee /5"
       ],
@@ -8459,6 +8481,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8470,7 +8493,7 @@
       ]
     },
     "fucomip st7": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xef /5"
       ],
@@ -8486,6 +8509,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8497,7 +8521,7 @@
       ]
     },
     "fcomip st0": {
-      "ExpectedInstructionCount": 15,
+      "ExpectedInstructionCount": 16,
       "Comment": [
         "0xdf 11b 0xf0 /6"
       ],
@@ -8509,6 +8533,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8520,7 +8545,7 @@
       ]
     },
     "fcomip st1": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 18,
       "Comment": [
         "0xdf 11b 0xf1 /6"
       ],
@@ -8536,6 +8561,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
         "mov w22, #0x1",
@@ -8545,7 +8571,7 @@
       ]
     },
     "fcomip st2": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xf2 /6"
       ],
@@ -8561,6 +8587,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8572,7 +8599,7 @@
       ]
     },
     "fcomip st3": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xf3 /6"
       ],
@@ -8588,6 +8615,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8599,7 +8627,7 @@
       ]
     },
     "fcomip st4": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xf4 /6"
       ],
@@ -8615,6 +8643,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8626,7 +8655,7 @@
       ]
     },
     "fcomip st5": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xf5 /6"
       ],
@@ -8642,6 +8671,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8653,7 +8683,7 @@
       ]
     },
     "fcomip st6": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xf6 /6"
       ],
@@ -8669,6 +8699,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8680,7 +8711,7 @@
       ]
     },
     "fcomip st7": {
-      "ExpectedInstructionCount": 19,
+      "ExpectedInstructionCount": 20,
       "Comment": [
         "0xdf 11b 0xf7 /6"
       ],
@@ -8696,6 +8727,7 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "axflag",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pshufb mm0, mm1": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -8,7 +8,7 @@
       "AFP",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "SSE4.2 string instructions are skipped here.",

--- a/unittests/InstructionCountCI/H0F3A_SVE128.json
+++ b/unittests/InstructionCountCI/H0F3A_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "dpps xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/MOPS/Primary.json
+++ b/unittests/InstructionCountCI/MOPS/Primary.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "rep movsb": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "MOPS"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "Instructions in this table that are marked optimal don't have their flag calculation part of this assumption",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -9,7 +9,7 @@
       "FlagM",
       "FlagM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pfrcpv mm0, mm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "rsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "rsqrtss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -8,7 +8,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Repeat.json
+++ b/unittests/InstructionCountCI/Repeat.json
@@ -6,7 +6,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {}
 }

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -33,7 +33,7 @@
       "      - 1b: ECX = MSB",
       "[7]   - Reserved"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pcmpestrm xmm0, xmm1, 0_0_00_00_00b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "MMX instructions are defined as optimal without SRA being used for these instructions.",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -7,7 +7,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "push fs": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "movupd xmm0, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "addsubpd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "psrlw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -12,7 +12,7 @@
       "FRINTTS",
       "CSSC"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "movss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "movsd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "addsubps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtpd2dq xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "movmskps eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -13,7 +13,7 @@
       "FLAGM2",
       "FRINTTS"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -8,7 +8,7 @@
       "FCMA"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -13,7 +13,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vcvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map2_svebitperm.json
+++ b/unittests/InstructionCountCI/VEX_map2_svebitperm.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pext eax, ebx, ecx": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -8,7 +8,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/X87ldst-SVE.json
+++ b/unittests/InstructionCountCI/X87ldst-SVE.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fstp tword [rax]": {

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -4762,7 +4762,7 @@
       ]
     },
     "fucomi st0, st0": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdb 11b 0xe8 /5"
       ],
@@ -4791,12 +4791,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st1": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xe9 /5"
       ],
@@ -4829,12 +4830,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st2": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xea /5"
       ],
@@ -4867,12 +4869,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st3": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xeb /5"
       ],
@@ -4905,12 +4908,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st4": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xec /5"
       ],
@@ -4943,12 +4947,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st5": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xed /5"
       ],
@@ -4981,12 +4986,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st6": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xee /5"
       ],
@@ -5019,12 +5025,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st7": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xef /5"
       ],
@@ -5057,12 +5064,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st0": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdb 11b 0xf0 /6"
       ],
@@ -5091,12 +5099,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st1": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xf1 /6"
       ],
@@ -5129,12 +5138,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st2": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xf2 /6"
       ],
@@ -5167,12 +5177,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st3": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xf3 /6"
       ],
@@ -5205,12 +5216,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st4": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xf4 /6"
       ],
@@ -5243,12 +5255,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st5": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xf5 /6"
       ],
@@ -5281,12 +5294,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st6": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xf6 /6"
       ],
@@ -5319,12 +5333,13 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st7": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdb 11b 0xf7 /6"
       ],
@@ -5357,6 +5372,7 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
@@ -10217,7 +10233,7 @@
       ]
     },
     "fucomip st0": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdf 11b 0xe8 /5"
       ],
@@ -10246,6 +10262,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10259,7 +10276,7 @@
       ]
     },
     "fucomip st1": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xe9 /5"
       ],
@@ -10292,6 +10309,7 @@
         "mov w27, #0x0",
         "bfi w30, w27, #28, #1",
         "bfi w30, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w22, [x28, #1040]",
         "msr nzcv, x30",
         "strb w21, [x28, #1051]",
@@ -10303,7 +10321,7 @@
       ]
     },
     "fucomip st2": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xea /5"
       ],
@@ -10336,6 +10354,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10349,7 +10368,7 @@
       ]
     },
     "fucomip st3": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xeb /5"
       ],
@@ -10382,6 +10401,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10395,7 +10415,7 @@
       ]
     },
     "fucomip st4": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xec /5"
       ],
@@ -10428,6 +10448,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10441,7 +10462,7 @@
       ]
     },
     "fucomip st5": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xed /5"
       ],
@@ -10474,6 +10495,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10487,7 +10509,7 @@
       ]
     },
     "fucomip st6": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xee /5"
       ],
@@ -10520,6 +10542,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10533,7 +10556,7 @@
       ]
     },
     "fucomip st7": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xef /5"
       ],
@@ -10566,6 +10589,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10579,7 +10603,7 @@
       ]
     },
     "fcomip st0": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdf 11b 0xf0 /6"
       ],
@@ -10608,6 +10632,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10621,7 +10646,7 @@
       ]
     },
     "fcomip st1": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xdf 11b 0xf1 /6"
       ],
@@ -10654,6 +10679,7 @@
         "mov w27, #0x0",
         "bfi w30, w27, #28, #1",
         "bfi w30, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w22, [x28, #1040]",
         "msr nzcv, x30",
         "strb w21, [x28, #1051]",
@@ -10665,7 +10691,7 @@
       ]
     },
     "fcomip st2": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xf2 /6"
       ],
@@ -10698,6 +10724,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10711,7 +10738,7 @@
       ]
     },
     "fcomip st3": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xf3 /6"
       ],
@@ -10744,6 +10771,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10757,7 +10785,7 @@
       ]
     },
     "fcomip st4": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xf4 /6"
       ],
@@ -10790,6 +10818,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10803,7 +10832,7 @@
       ]
     },
     "fcomip st5": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xf5 /6"
       ],
@@ -10836,6 +10865,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10849,7 +10879,7 @@
       ]
     },
     "fcomip st6": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xf6 /6"
       ],
@@ -10882,6 +10912,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10895,7 +10926,7 @@
       ]
     },
     "fcomip st7": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdf 11b 0xf7 /6"
       ],
@@ -10928,6 +10959,7 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",

--- a/unittests/InstructionCountCI/x87_32Bit.json
+++ b/unittests/InstructionCountCI/x87_32Bit.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Multiple fld/fst": {

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -4111,7 +4111,7 @@
       ]
     },
     "fucomi st0, st0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "0xdb 11b 0xe8 /5"
       ],
@@ -4123,11 +4123,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xe9 /5"
       ],
@@ -4143,11 +4144,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st2": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xea /5"
       ],
@@ -4163,11 +4165,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st3": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xeb /5"
       ],
@@ -4183,11 +4186,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st4": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xec /5"
       ],
@@ -4203,11 +4207,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st5": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xed /5"
       ],
@@ -4223,11 +4228,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st6": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xee /5"
       ],
@@ -4243,11 +4249,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fucomi st0, st7": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xef /5"
       ],
@@ -4263,11 +4270,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st0": {
-      "ExpectedInstructionCount": 8,
+      "ExpectedInstructionCount": 9,
       "Comment": [
         "0xdb 11b 0xf0 /6"
       ],
@@ -4279,11 +4287,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st1": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xf1 /6"
       ],
@@ -4299,11 +4308,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st2": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xf2 /6"
       ],
@@ -4319,11 +4329,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st3": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xf3 /6"
       ],
@@ -4339,11 +4350,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st4": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xf4 /6"
       ],
@@ -4359,11 +4371,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st5": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xf5 /6"
       ],
@@ -4379,11 +4392,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st6": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xf6 /6"
       ],
@@ -4399,11 +4413,12 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fcomi st0, st7": {
-      "ExpectedInstructionCount": 12,
+      "ExpectedInstructionCount": 13,
       "Comment": [
         "0xdb 11b 0xf7 /6"
       ],
@@ -4419,7 +4434,8 @@
         "cset x26, vc",
         "mov w27, #0x0",
         "csetm x0, eq",
-        "ccmn x26, x0, #nzCv, le"
+        "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]"
       ]
     },
     "fadd qword [rax]": {
@@ -8345,7 +8361,7 @@
       ]
     },
     "fucomip st0": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xdf 11b 0xe8 /5"
       ],
@@ -8358,6 +8374,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8369,7 +8386,7 @@
       ]
     },
     "fucomip st1": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 19,
       "Comment": [
         "0xdf 11b 0xe9 /5"
       ],
@@ -8386,6 +8403,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
         "mov w22, #0x1",
@@ -8395,7 +8413,7 @@
       ]
     },
     "fucomip st2": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xea /5"
       ],
@@ -8412,6 +8430,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8423,7 +8442,7 @@
       ]
     },
     "fucomip st3": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xeb /5"
       ],
@@ -8440,6 +8459,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8451,7 +8471,7 @@
       ]
     },
     "fucomip st4": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xec /5"
       ],
@@ -8468,6 +8488,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8479,7 +8500,7 @@
       ]
     },
     "fucomip st5": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xed /5"
       ],
@@ -8496,6 +8517,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8507,7 +8529,7 @@
       ]
     },
     "fucomip st6": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xee /5"
       ],
@@ -8524,6 +8546,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8535,7 +8558,7 @@
       ]
     },
     "fucomip st7": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xef /5"
       ],
@@ -8552,6 +8575,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8563,7 +8587,7 @@
       ]
     },
     "fcomip st0": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xdf 11b 0xf0 /6"
       ],
@@ -8576,6 +8600,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8587,7 +8612,7 @@
       ]
     },
     "fcomip st1": {
-      "ExpectedInstructionCount": 18,
+      "ExpectedInstructionCount": 19,
       "Comment": [
         "0xdf 11b 0xf1 /6"
       ],
@@ -8604,6 +8629,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
         "mov w22, #0x1",
@@ -8613,7 +8639,7 @@
       ]
     },
     "fcomip st2": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xf2 /6"
       ],
@@ -8630,6 +8656,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8641,7 +8668,7 @@
       ]
     },
     "fcomip st3": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xf3 /6"
       ],
@@ -8658,6 +8685,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8669,7 +8697,7 @@
       ]
     },
     "fcomip st4": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xf4 /6"
       ],
@@ -8686,6 +8714,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8697,7 +8726,7 @@
       ]
     },
     "fcomip st5": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xf5 /6"
       ],
@@ -8714,6 +8743,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8725,7 +8755,7 @@
       ]
     },
     "fcomip st6": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xf6 /6"
       ],
@@ -8742,6 +8772,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",
@@ -8753,7 +8784,7 @@
       ]
     },
     "fcomip st7": {
-      "ExpectedInstructionCount": 20,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xdf 11b 0xf7 /6"
       ],
@@ -8770,6 +8801,7 @@
         "mov w27, #0x0",
         "csetm x0, eq",
         "ccmn x26, x0, #nzCv, le",
+        "strb wzr, [x28, #1049]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
         "strb w21, [x28, #1051]",

--- a/unittests/InstructionCountCI/x87_f64_32Bit.json
+++ b/unittests/InstructionCountCI/x87_f64_32Bit.json
@@ -15,7 +15,7 @@
       "SVE256",
       "CSSC"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fstp dword [ebx*4+0x204a20]": {


### PR DESCRIPTION
Clear the `C1` FPU flag for `fcomi` (per the SDM).