### PR TITLE
Config: Fix assertion being hit in config generation

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -155,6 +155,7 @@
       "DiskCacheFileMapping": {
         "Type": "bool",
         "Default": "true",
+        "AffectsCodeGen": "false",
         "Desc": [
           "Maps cache files for faster reading"
         ]


### PR DESCRIPTION
Looks like we had one config option accidentally slip through