### PR TITLE
Add SMCChecks=mtrack_proactive to unprotect code pages before read

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -468,7 +468,8 @@
           "Checks code for modification before execution.",
           "\tnone: No checks",
           "\tmtrack: Page tracking based invalidation (default)",
-          "\tfull: Validate code before every run (slow)"
+          "\tfull: Validate code before every run (slow)",
+          "\tmtrack_proactive: mtrack, and unprotect guest buffers before the kernel writes to them"
         ]
       },
       "TSOEnabled": {
@@ -646,4 +647,3 @@
     }
   }
 }
-

--- a/FEXCore/include/FEXCore/Config/Config.h
+++ b/FEXCore/include/FEXCore/Config/Config.h
@@ -28,6 +28,8 @@ namespace Handler {
       return "1";
     } else if (Value == "full") {
       return "2";
+    } else if (Value == "mtrack_proactive") {
+      return "3";
     }
     return "0";
   }
@@ -46,6 +48,10 @@ enum ConfigSMCChecks {
   CONFIG_SMC_NONE,
   CONFIG_SMC_MTRACK,
   CONFIG_SMC_FULL,
+  // mtrack, plus guest buffers are unprotected before the kernel is asked to write into them.
+  // Appended rather than ordered next to mtrack so the numeric values of the other modes,
+  // which configuration files may spell out directly, keep their meaning.
+  CONFIG_SMC_MTRACK_PROACTIVE,
 };
 
 enum class LayerType {

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls.h
@@ -253,6 +253,12 @@ public:
   void TrackMprotect(FEXCore::Core::InternalThreadState* Thread, void* addr, size_t len, int prot);
   void TrackMadvise(FEXCore::Core::InternalThreadState* Thread, uintptr_t Base, uintptr_t Size, int advice);
 
+  // Both mtrack modes write-protect pages that code has been translated from; they differ only
+  // in whether host writes into guest memory lift that protection up front.
+  bool PageTrackingSMCChecks() {
+    return SMCChecks == FEXCore::Config::CONFIG_SMC_MTRACK || SMCChecks == FEXCore::Config::CONFIG_SMC_MTRACK_PROACTIVE;
+  }
+
   void InvalidateCodeRangeIfNecessary(FEXCore::Core::InternalThreadState* Thread, uint64_t Base, uint64_t Length, bool CheckPendingVMAResources) {
     if (SMCChecks != FEXCore::Config::CONFIG_SMC_NONE) {
       TM.InvalidateGuestCodeRange(Thread, Base, Length);
@@ -283,6 +289,7 @@ public:
 
   ///// VMA (Virtual Memory Area) tracking /////
   static bool HandleSegfault(FEXCore::Core::InternalThreadState* Thread, int Signal, void* info, void* ucontext);
+  void UnprotectSMCWriteRange(FEXCore::Core::InternalThreadState* Thread, void* Address, size_t Length);
   void MarkGuestExecutableRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) override;
   void InvalidateGuestCodeRange(FEXCore::Core::InternalThreadState* Thread, uint64_t Start, uint64_t Length) override;
   std::optional<FEXCore::ExecutableFileSectionInfo>
@@ -368,6 +375,9 @@ private:
 
   fextl::unique_ptr<FEX::HLE::MemAllocator> Alloc32Handler {};
   std::atomic<uint64_t> AnonSharedId {1};
+
+  bool UnprotectSMCRangeLocked(FEXCore::Core::InternalThreadState* Thread, uintptr_t Base, uintptr_t Top);
+  bool UnprotectSMCPageLocked(FEXCore::Core::InternalThreadState* Thread, uintptr_t Address);
 };
 
 #define SYSCALL_ERRNO()              \

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/Syscalls/Passthrough.cpp
@@ -209,8 +209,26 @@ uint64_t SyscallPassthrough7(FEXCore::Core::CpuStateFrame* Frame, uint64_t arg1,
 }
 #endif
 
+static uint64_t Read(FEXCore::Core::CpuStateFrame* Frame, int fd, void* buf, size_t count) {
+  // FEX write-protects guest pages it has translated code from and relies on SIGSEGV to
+  // invalidate and unprotect them. A host syscall cannot raise that signal, so a read whose
+  // destination is protected fails with EFAULT instead of faulting.
+  //
+  // Unprotect up front rather than recovering after the fact. Reissuing a read is not
+  // generally safe -- a datagram socket drops the message when the copy faults, eventfd and
+  // timerfd clear their counters first, /proc/kmsg advances the log cursor -- and deciding
+  // which descriptors are replayable means classifying every file_operations in the kernel.
+  // Doing the work before the syscall removes that question entirely.
+  //
+  // This does nothing unless SMCChecks is mtrack_proactive, which is opted into per
+  // application, so no other guest pays for it.
+  _SyscallHandler->UnprotectSMCWriteRange(Frame->Thread, buf, count);
+
+  return SyscallPassthrough3<SYSCALL_DEF(read)>(Frame, fd, reinterpret_cast<uint64_t>(buf), count);
+}
+
 static void RegisterCommon(FEX::HLE::SyscallHandler* Handler) {
-  REGISTER_SYSCALL_IMPL(read, SyscallPassthrough3<SYSCALL_DEF(read)>);
+  REGISTER_SYSCALL_IMPL(read, Read);
   REGISTER_SYSCALL_IMPL(write, SyscallPassthrough3<SYSCALL_DEF(write)>);
   REGISTER_SYSCALL_IMPL(lseek, SyscallPassthrough3<SYSCALL_DEF(lseek)>);
   REGISTER_SYSCALL_IMPL(sched_yield, SyscallPassthrough0<SYSCALL_DEF(sched_yield)>);

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -12,6 +12,7 @@ $end_info$
 #include "Common/FEXServerClient.h"
 #include "Common/FileMappingBaseAddress.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <sys/file.h>
 #include <sys/mman.h>
@@ -39,6 +40,110 @@ static void HandleSegfaultForCodeCacheFinalization(FEXCore::Core::InternalThread
   if (!RangeToFinalize.empty()) {
     Thread.CTX->GetCodeCache().FinalizeCodePages(Code, RangeToFinalize);
   }
+}
+
+// Restores write permission over [Base, Top) and invalidates any code translated from it,
+// undoing what MarkGuestExecutableRange applied. Returns whether the range intersected a
+// mapping the guest may write to; false means a write here is a genuine guest fault rather
+// than an SMC one.
+//
+// This iterates VMA entries rather than pages, mirroring MarkGuestExecutableRange. A mapping
+// therefore costs one invalidation and one mprotect however many pages of it the range spans,
+// and pages belonging to no mapping are skipped instead of probed one at a time.
+//
+// Every writable mapping in range is unprotected, without trying to narrow that to mappings
+// that look like they could hold code. Executability cannot be inferred after the fact: under
+// the READ_IMPLIES_EXEC personality a readable mapping is translatable, and the guest can clear
+// that personality with personality(2) before issuing the read, leaving a protected mapping
+// that no longer looks executable. Narrowing correctly would mean tracking which ranges are
+// actually protected.
+bool SyscallHandler::UnprotectSMCRangeLocked(FEXCore::Core::InternalThreadState* Thread, uintptr_t Base, uintptr_t Top) {
+  auto UnprotectRegion = [](uintptr_t Start, uintptr_t Length) {
+    auto Result = mprotect(reinterpret_cast<void*>(Start), Length, PROT_READ | PROT_WRITE);
+    LogMan::Throw::AFmt(Result == 0, "mprotect({}, {}) failed", Start, Length);
+  };
+
+  bool Unprotected = false;
+
+  // Find the first mapping at or after the range ends, or ::end(), then walk backwards.
+  auto Mapping = VMATracking.VMAs.lower_bound(Top);
+
+  while (Mapping != VMATracking.VMAs.begin()) {
+    Mapping--;
+
+    const auto MapBase = Mapping->first;
+    const auto MapTop = MapBase + Mapping->second.Length;
+
+    if (MapTop <= Base) {
+      // Mapping ends before the range starts, exit
+      break;
+    }
+
+    // MarkGuestExecutableRange only ever protects mappings the guest can write to.
+    if (!Mapping->second.Prot.Writable) {
+      continue;
+    }
+
+    const auto RangeBase = std::max(MapBase, Base);
+    const auto RangeSize = std::min(MapTop, Top) - RangeBase;
+    Unprotected = true;
+
+    if (Mapping->second.Flags.Shared) {
+      LOGMAN_THROW_A_FMT(Mapping->second.Resource, "VMA tracking error");
+
+      const auto OffsetBase = RangeBase - MapBase + Mapping->second.Offset;
+      const auto OffsetTop = OffsetBase + RangeSize;
+
+      auto VMA = Mapping->second.Resource->FirstVMA;
+      LOGMAN_THROW_A_FMT(VMA, "VMA tracking error");
+
+      do {
+        const auto VMAOffsetBase = VMA->Offset;
+        const auto VMAOffsetTop = VMA->Offset + VMA->Length;
+
+        if (VMAOffsetBase < OffsetTop && VMAOffsetTop > OffsetBase) {
+          const auto MirroredOffset = std::max(VMAOffsetBase, OffsetBase);
+          const auto MirroredSize = std::min(OffsetTop, VMAOffsetTop) - MirroredOffset;
+          const auto MirroredBase = MirroredOffset - VMAOffsetBase + VMA->Base;
+
+          if (VMA->Prot.Writable) {
+            TM.InvalidateGuestCodeRange(Thread, MirroredBase, MirroredSize, UnprotectRegion);
+          } else {
+            TM.InvalidateGuestCodeRange(Thread, MirroredBase, MirroredSize);
+          }
+        }
+      } while ((VMA = VMA->ResourceNextVMA));
+    } else {
+      TM.InvalidateGuestCodeRange(Thread, RangeBase, RangeSize, UnprotectRegion);
+    }
+
+    FEXCORE_PROFILE_INSTANT_INCREMENT(Thread, AccumulatedSMCCount, 1);
+  }
+
+  return Unprotected;
+}
+
+bool SyscallHandler::UnprotectSMCPageLocked(FEXCore::Core::InternalThreadState* Thread, uintptr_t Address) {
+  const auto PageBase = FEXCore::AlignDown(Address, FEXCore::Utils::FEX_PAGE_SIZE);
+  return UnprotectSMCRangeLocked(Thread, PageBase, PageBase + FEXCore::Utils::FEX_PAGE_SIZE);
+}
+
+// A host write into guest memory cannot raise the SIGSEGV that normally lifts an SMC
+// protection, so the kernel reports EFAULT instead. Callers about to hand a guest buffer to
+// the kernel as a destination use this to lift the protection up front.
+void SyscallHandler::UnprotectSMCWriteRange(FEXCore::Core::InternalThreadState* Thread, void* Address, size_t Length) {
+  if (SMCChecks != FEXCore::Config::CONFIG_SMC_MTRACK_PROACTIVE || Length == 0) {
+    return;
+  }
+
+  const auto Start = reinterpret_cast<uintptr_t>(Address);
+  const auto End = Start + Length;
+  if (End < Start) {
+    return;
+  }
+
+  auto Lock = FEXCore::GuardSignalDeferringSection<std::shared_lock>(VMATracking.Mutex, Thread);
+  UnprotectSMCRangeLocked(Thread, Start & FEXCore::Utils::FEX_PAGE_MASK, FEXCore::AlignUp(End, FEXCore::Utils::FEX_PAGE_SIZE));
 }
 
 // Handles segfaults from:
@@ -77,43 +182,9 @@ bool SyscallHandler::HandleSegfault(FEXCore::Core::InternalThreadState* Thread, 
       return true;
     }
 
-    // If the mapping wasn't writable, it can't be handled here
-    if (!Entry->second.Prot.Writable) {
+    if (!_SyscallHandler->UnprotectSMCPageLocked(Thread, FaultAddress)) {
       return false;
     }
-
-    auto FaultBase = FEXCore::AlignDown(FaultAddress, FEXCore::Utils::FEX_PAGE_SIZE);
-
-    auto UnprotectRegionCallback = [](uintptr_t Start, uintptr_t Length) {
-      auto rv = mprotect((void*)Start, Length, PROT_READ | PROT_WRITE);
-      LogMan::Throw::AFmt(rv == 0, "mprotect({}, {}) failed", Start, Length);
-    };
-
-    if (Entry->second.Flags.Shared) {
-      LOGMAN_THROW_A_FMT(Entry->second.Resource, "VMA tracking error");
-
-      auto Offset = FaultBase - Entry->first + Entry->second.Offset;
-
-      auto VMA = Entry->second.Resource->FirstVMA;
-      LOGMAN_THROW_A_FMT(VMA, "VMA tracking error");
-
-      // Flush all mirrors, remap the page writable as needed
-      do {
-        if (VMA->Offset <= Offset && (VMA->Offset + VMA->Length) > Offset) {
-          auto FaultBaseMirrored = Offset - VMA->Offset + VMA->Base;
-
-          if (VMA->Prot.Writable) {
-            _SyscallHandler->TM.InvalidateGuestCodeRange(Thread, FaultBaseMirrored, FEXCore::Utils::FEX_PAGE_SIZE, UnprotectRegionCallback);
-          } else {
-            _SyscallHandler->TM.InvalidateGuestCodeRange(Thread, FaultBaseMirrored, FEXCore::Utils::FEX_PAGE_SIZE);
-          }
-        }
-      } while ((VMA = VMA->ResourceNextVMA));
-    } else {
-      _SyscallHandler->TM.InvalidateGuestCodeRange(Thread, FaultBase, FEXCore::Utils::FEX_PAGE_SIZE, UnprotectRegionCallback);
-    }
-
-    FEXCORE_PROFILE_INSTANT_INCREMENT(Thread, AccumulatedSMCCount, 1);
 
     auto CTX = Thread->CTX;
     if (CTX->IsAddressInCodeBuffer(Thread, ArchHelpers::Context::GetPc(ucontext)) && !CTX->IsCurrentBlockSingleInst(Thread) &&
@@ -138,7 +209,7 @@ void SyscallHandler::MarkGuestExecutableRange(FEXCore::Core::InternalThreadState
   const auto Top = FEXCore::AlignUp(Start + Length, FEXCore::Utils::FEX_PAGE_SIZE);
 
   {
-    if (SMCChecks != FEXCore::Config::CONFIG_SMC_MTRACK) {
+    if (!PageTrackingSMCChecks()) {
       return;
     }
 


### PR DESCRIPTION
Under SMCChecks=mtrack, FEX write-protects a guest page once it has translated code from it and relies on SIGSEGV to invalidate and unprotect. A host kernel write into guest memory (e.g., read syscall) does not raise that signal, so the syscall reports EFAULT and the program fails.

This problem could be solved with a co-operative kernel, which means that the kernel needs to be enlighted with FEX and can deliver a message to FEX when read hits EFAULT, then that would give FEX a chance to unprotect and allow the kernel to retry. However, this is impossible on vanilla kernel.

Considering that issuing read-like syscalls to modify code is rarely done by applications, this PP adds a new SMCCheck called mtrack_proactive. When the mode is selected, FEX always checks if a read's range overlaps protected code ranges and if so, it unprotects first. This might have negative perf impact if an application issues lots of reads, but compared to SMCChecks=full, this is most likely faster.

Fix #5874