### PR TITLE
InstCountCI: Enforce DiskCache version matching 

### DIFF
--- a/FEXCore/Source/Interface/Core/DiskCache.cpp
+++ b/FEXCore/Source/Interface/Core/DiskCache.cpp
@@ -636,6 +636,9 @@ namespace DiskCache {
     return true;
   }
 
+  uint16_t GetFormatVersion() {
+    return FormatVersion;
+  }
 } // namespace DiskCache
 
 } // namespace FEXCore

--- a/FEXCore/include/FEXCore/Core/DiskCache.h
+++ b/FEXCore/include/FEXCore/Core/DiskCache.h
@@ -177,7 +177,6 @@ namespace DiskCache {
     uint64_t MakeBlobKey(const uint64_t ModuleOffset);
 
     FEXCore::Context::ContextImpl* CTX;
-    static const uint16_t FormatVersion = 3;
     XXH128_hash_t BucketHash;
     fextl::vector<fextl::unique_ptr<IndexedDB>> ROCacheDBs;
     fextl::unique_ptr<IndexedDB> RWCacheDB;
@@ -195,6 +194,11 @@ namespace DiskCache {
     FEX_CONFIG_OPT(BasePathOverride, DISKCACHEPATH);
     FEX_CONFIG_OPT(RODBNames, DISKCACHERODBNAMES);
   };
+
+  // TODO: This header is in global installed header path, but uses internal headers.
+  // Migrate this once that is fixed.
+  static constexpr uint16_t FormatVersion = 3;
+  FEX_DEFAULT_VISIBILITY uint16_t GetFormatVersion();
 
 } // namespace DiskCache
 

--- a/Scripts/InstructionCountParser.py
+++ b/Scripts/InstructionCountParser.py
@@ -96,6 +96,7 @@ def GetHostFeatures(data):
     return HostFeaturesData
 
 def parse_json_data(json_filepath, json_filename, json_data, output_binary_path):
+    BinaryCacheVersion = 0
     Bitness = 64
     EnabledHostFeatures = HostFeatures.FEATURE_ANY
     DisabledHostFeatures = HostFeatures.FEATURE_ANY
@@ -105,6 +106,9 @@ def parse_json_data(json_filepath, json_filename, json_data, output_binary_path)
         items = json_data["Features"]
         if ("Bitness" in items):
             Bitness = int(items["Bitness"])
+
+        if ("BinaryCacheVersion" in items):
+            BinaryCacheVersion = int(items["BinaryCacheVersion"])
 
         if ("EnabledHostFeatures" in items):
             EnabledHostFeatures = GetHostFeatures(items["EnabledHostFeatures"])
@@ -177,6 +181,7 @@ def parse_json_data(json_filepath, json_filename, json_data, output_binary_path)
         # struct TestInfo;
         # struct DataHeader {
         #   uint64_t Bitness;
+        #   uint64_t BinaryCacheVersion;
         #   uint64_t NumTests;
         #   uint64_t EnabledHostFeatures;
         #   uint64_t DisabledHostFeatures;
@@ -197,6 +202,7 @@ def parse_json_data(json_filepath, json_filename, json_data, output_binary_path)
 
     # Add the header
     MemData += struct.pack('Q', Bitness)
+    MemData += struct.pack('Q', BinaryCacheVersion)
     MemData += struct.pack('Q', len(TestDataMap))
     MemData += struct.pack('Q', EnabledHostFeatures.value)
     MemData += struct.pack('Q', DisabledHostFeatures.value)

--- a/Scripts/UpdateInstructionCountJson.py
+++ b/Scripts/UpdateInstructionCountJson.py
@@ -10,7 +10,10 @@ def insert_before(d, key, item):
     items.insert(list(d.keys()).index(key), item)
     return dict(items)
 
-def update_performance_numbers(performance_json_path, performance_json, new_json_numbers):
+def update_performance_numbers(performance_json_path, performance_json, new_json_numbers, new_cache_version):
+
+    performance_json["Features"]["BinaryCacheVersion"] = new_cache_version
+
     for key, items in new_json_numbers.items():
         if len(key) == 0:
             continue
@@ -64,11 +67,19 @@ def main():
         if not isinstance(performance_json_data, dict):
             raise TypeError('JSON data must be a dict')
 
-        new_json_numbers_data = json.loads(new_json_numbers_text)
+        new_json_numbers_base = json.loads(new_json_numbers_text)
+
+        features = new_json_numbers_base["Features"]
+        if not isinstance(features, dict):
+            raise TypeError('features JSON data must be a dict')
+
+        new_cache_version = features["BinaryCacheVersion"]
+
+        new_json_numbers_data = new_json_numbers_base["Instructions"]
         if not isinstance(new_json_numbers_data, dict):
             raise TypeError('JSON data must be a dict')
 
-        return update_performance_numbers(performance_json_path, performance_json_data, new_json_numbers_data)
+        return update_performance_numbers(performance_json_path, performance_json_data, new_json_numbers_data, new_cache_version)
     except ValueError as ve:
         logging.error(f'JSON error: {ve}')
         return 1

--- a/Source/Tools/CodeSizeValidation/Main.cpp
+++ b/Source/Tools/CodeSizeValidation/Main.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 #include "DummyHandlers.h"
 #include "Common/HostFeatures.h"
-#include "FEXCore/Core/Context.h"
-#include "FEXCore/Debug/InternalThreadState.h"
 #include <FEXCore/Config/Config.h>
+#include <FEXCore/Core/Context.h>
+#include <FEXCore/Debug/InternalThreadState.h>
+#include <FEXCore/fextl/fmt.h>
 #include <FEXCore/Utils/Allocator.h>
 #include <FEXCore/Utils/File.h>
 #include <FEXCore/Utils/FileLoading.h>
@@ -11,6 +12,10 @@
 #include <FEXCore/Utils/SignalScopeGuards.h>
 
 #include <sys/stat.h>
+
+namespace FEXCore::DiskCache {
+uint16_t GetFormatVersion();
+}
 
 namespace CodeSize {
 class CodeSizeValidation final {
@@ -224,6 +229,7 @@ struct TestInfo {
 
 struct TestHeader {
   uint64_t Bitness;
+  uint64_t BinaryCacheVersion;
   uint64_t NumTests {};
   uint64_t EnabledHostFeatures;
   uint64_t DisabledHostFeatures;
@@ -287,7 +293,34 @@ static bool TestInstructions(FEXCore::Context::Context* CTX, FEXCore::Core::Inte
     CurrentTest = reinterpret_cast<const TestInfo*>(&CurrentTest->Code[CurrentTest->CodeSize]);
   }
 
+  auto ExpectedFormatVersion = FEXCore::DiskCache::GetFormatVersion();
+  if (TestHeaderData->BinaryCacheVersion != ExpectedFormatVersion) {
+    // Disk cache binary version updated but failed to update instcount ci tracking.
+    LogMan::Msg::EFmt("Fail: TestHarness binary cache version is '{}' but test json is '{}'", ExpectedFormatVersion,
+                      TestHeaderData->BinaryCacheVersion);
+    LogMan::Msg::EFmt("Fail: Please run `ninja instcountci_tests ; ninja instcountci_update_tests` and commit with `git commit -m "
+                      "\"InstcountCI: Update\"` to update instcount CI files");
+    TestsPassed = false;
+  }
+
   if (UpdatedInstructionCountsPath) {
+    if (!TestsPassed && TestHeaderData->BinaryCacheVersion == ExpectedFormatVersion) {
+      // Binary cache versions matched but instructions mismatched. Need to update the format version.
+      // Print a message warning about this otherwise we'll forget about it.
+      LogMan::Msg::EFmt("Fail: Excuse me ma'am, sir, or other unworldly being that is running this software.");
+      LogMan::Msg::EFmt("Fail: InstcountCI results have changed but the FEXCore::DiskCache::FormatVersion hasn't been updated!");
+      LogMan::Msg::EFmt("Fail: This means with your change you are invalidating disk cache entries for everyone. Be sure to know the "
+                        "consequences!");
+      LogMan::Msg::EFmt("Fail: Please increment that number, recompile everything and rerun `ninja instcountci_tests ; ninja "
+                        "instcountci_update_tests`");
+      LogMan::Msg::EFmt("Fail: DiskCache version should be incremented from '{}' to '{}'", ExpectedFormatVersion, ExpectedFormatVersion + 1);
+
+      // Unlink the file, to ensure it doesn't update with `instcountci_update_tests`
+      unlink(UpdatedInstructionCountsPath);
+
+      return TestsPassed;
+    }
+
     // Unlink the file.
     unlink(UpdatedInstructionCountsPath);
 
@@ -301,6 +334,12 @@ static bool TestInstructions(FEXCore::Context::Context* CTX, FEXCore::Core::Inte
     }
 
     FD.Write("{\n", 2);
+
+    FD.Write(fextl::fmt::format("\t\"{}\": {{\n", "Features"));
+    FD.Write(fextl::fmt::format("\t\t\"{}\": {}\n", "BinaryCacheVersion", ExpectedFormatVersion));
+    FD.Write(fextl::fmt::format("\t}},\n"));
+
+    FD.Write(fextl::fmt::format("\t\"{}\": {{\n", "Instructions"));
 
     CurrentTest = TestsStart;
     for (size_t i = 0; i < TestHeaderData->NumTests; ++i) {
@@ -329,6 +368,8 @@ static bool TestInstructions(FEXCore::Context::Context* CTX, FEXCore::Core::Inte
 
     // Print a null member
     FD.Write(fextl::fmt::format("\t\"\": \"\""));
+
+    FD.Write(fextl::fmt::format("\t}}\n"));
 
     FD.Write("}\n", 2);
   }

--- a/unittests/InstructionCountCI/AFP/H0F3A.json
+++ b/unittests/InstructionCountCI/AFP/H0F3A.json
@@ -7,7 +7,8 @@
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "roundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
@@ -6,7 +6,8 @@
       "SVE256",
       "AFP"
     ],
-    "DisabledHostFeatures": []
+    "DisabledHostFeatures": [],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -8,7 +8,8 @@
     ],
     "DisabledHostFeatures": [
       "RPRES"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -6,7 +6,8 @@
       "SVE256",
       "AFP"
     ],
-    "DisabledHostFeatures": []
+    "DisabledHostFeatures": [],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/Secondary.json
@@ -7,7 +7,8 @@
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REP.json
@@ -8,7 +8,8 @@
       "SVE128",
       "SVE256",
       "RPRES"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
@@ -7,7 +7,8 @@
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -8,7 +8,8 @@
     ],
     "DisabledHostFeatures": [
       "RPRES"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vsqrtss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AFP/VEX_map3.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map3.json
@@ -6,7 +6,8 @@
       "SVE256",
       "AFP"
     ],
-    "DisabledHostFeatures": []
+    "DisabledHostFeatures": [],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vroundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AVX128/FMA4.json
+++ b/unittests/InstructionCountCI/AVX128/FMA4.json
@@ -6,7 +6,8 @@
       "AFP",
       "SVE256",
       "SVE128"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -12,7 +12,8 @@
       "FLAGM2",
       "SVE256",
       "SVE128"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
@@ -8,7 +8,8 @@
     "DisabledHostFeatures": [
       "SVE256",
       "SVE128"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
@@ -9,7 +9,8 @@
       "FLAGM",
       "FLAGM2",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vmovntps [rax], xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
@@ -9,7 +9,8 @@
       "AFP",
       "SVE128",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -8,7 +8,8 @@
       "FLAGM2",
       "SVE128",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
@@ -7,7 +7,8 @@
     "DisabledHostFeatures": [
       "SVE256",
       "SVE128"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vfmadd132ss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -9,7 +9,8 @@
       "FLAGM",
       "FLAGM2",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vmovntdqa xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -10,7 +10,8 @@
       "SVE128",
       "SVE256",
       "SVEBITPERM"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -6,7 +6,8 @@
       "AFP",
       "SVE256",
       "SVE128"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -7,7 +7,8 @@
     "DisabledHostFeatures": [
       "AFP",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vblendvps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -8,7 +8,8 @@
       "FLAGM2",
       "SVE256",
       "SVE128"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -8,7 +8,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -8,7 +8,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
@@ -8,7 +8,8 @@
     "DisabledHostFeatures": [
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F3A.json
+++ b/unittests/InstructionCountCI/Crypto/H0F3A.json
@@ -8,7 +8,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "pclmulqdq xmm0, xmm1, 00000b": {

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -9,7 +9,8 @@
       "SVE256",
       "AFP",
       "RPRES"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "These 3DNow! instructions are optimal assuming that FEX doesn't SRA MMX registers",

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -7,7 +7,8 @@
       "SVE256",
       "RPRES",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -7,7 +7,8 @@
       "SVE256",
       "RPRES",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -12,7 +12,8 @@
       "SVE256",
       "RPRES",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
@@ -10,7 +10,8 @@
       "SVE256",
       "RPRES",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -8,7 +8,8 @@
       "SVE128",
       "SVE256",
       "RPRES"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
@@ -13,7 +13,8 @@
       "SVE256",
       "RPRES",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
@@ -13,7 +13,8 @@
       "SVE256",
       "RPRES",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/libnss.json
+++ b/unittests/InstructionCountCI/FEXOpt/libnss.json
@@ -11,7 +11,8 @@
       "SVE256",
       "RPRES",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [],
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -8,7 +8,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Chained add": {

--- a/unittests/InstructionCountCI/FlagM/H0F38.json
+++ b/unittests/InstructionCountCI/FlagM/H0F38.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "ptest xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "The Witcher 3": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Sonic Mania movie player": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
@@ -9,7 +9,8 @@
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "FMOD scalar loop": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
@@ -12,7 +12,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "The Sims 1 hot block": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "add al, 1": {

--- a/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -10,7 +10,8 @@
       "SVE256",
       "RPRES",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "ucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -10,7 +10,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -10,7 +10,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
@@ -10,7 +10,8 @@
       "SVE256",
       "AFP",
       "FCMA"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "ucomisd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -11,7 +11,8 @@
       "RPRES",
       "AFP",
       "CSSC"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
@@ -11,7 +11,8 @@
       "SVE256",
       "RPRES",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -11,7 +11,8 @@
       "FCMA",
       "RPRES",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -9,7 +9,8 @@
     "DisabledHostFeatures": [
       "AFP",
       "SVEBITPERM"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map_group.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map_group.json
@@ -8,7 +8,8 @@
     ],
     "DisabledHostFeatures": [
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "blsr eax, ebx": {

--- a/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -9,7 +9,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -10,7 +10,8 @@
       "SVE256",
       "CSSC",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
@@ -12,7 +12,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
@@ -12,7 +12,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
@@ -12,7 +12,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
@@ -12,7 +12,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -12,7 +12,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -9,7 +9,8 @@
       "FLAGM",
       "FLAGM2",
       "CRYPTO"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "pshufb mm0, mm1": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -7,7 +7,8 @@
       "SVE256",
       "AFP",
       "CRYPTO"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "SSE4.2 string instructions are skipped here.",

--- a/unittests/InstructionCountCI/H0F3A_SVE128.json
+++ b/unittests/InstructionCountCI/H0F3A_SVE128.json
@@ -7,7 +7,8 @@
     "DisabledHostFeatures": [
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "dpps xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/MOPS/Primary.json
+++ b/unittests/InstructionCountCI/MOPS/Primary.json
@@ -10,7 +10,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "rep movsb": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -9,7 +9,8 @@
       "FLAGM",
       "FLAGM2",
       "MOPS"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -8,7 +8,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "Instructions in this table that are marked optimal don't have their flag calculation part of this assumption",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -8,7 +8,8 @@
       "AFP",
       "FlagM",
       "FlagM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -8,7 +8,8 @@
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "pfrcpv mm0, mm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -8,7 +8,8 @@
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "rsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -8,7 +8,8 @@
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "rsqrtss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -7,7 +7,8 @@
       "RPRES",
       "AFP"
     ],
-    "DisabledHostFeatures": []
+    "DisabledHostFeatures": [],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Repeat.json
+++ b/unittests/InstructionCountCI/Repeat.json
@@ -5,7 +5,8 @@
     "DisabledHostFeatures": [
       "SVE128",
       "SVE256"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {}
 }

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -32,7 +32,8 @@
       "      - 0b: ECX = LSB",
       "      - 1b: ECX = MSB",
       "[7]   - Reserved"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "pcmpestrm xmm0, xmm1, 0_0_00_00_00b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -11,7 +11,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Comment": [
     "MMX instructions are defined as optimal without SRA being used for these instructions.",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -10,7 +10,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -10,7 +10,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -6,7 +6,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "push fs": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -11,7 +11,8 @@
       "FCMA",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "movupd xmm0, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -8,7 +8,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "addsubpd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -7,7 +7,8 @@
     "DisabledHostFeatures": [
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "psrlw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -6,7 +6,8 @@
       "SVE256",
       "AFP"
     ],
-    "DisabledHostFeatures": []
+    "DisabledHostFeatures": [],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -11,7 +11,8 @@
       "FLAGM2",
       "FRINTTS",
       "CSSC"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "movss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -9,7 +9,8 @@
       "SVE256",
       "FCMA",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "movsd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -8,7 +8,8 @@
       "SVE128",
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "addsubps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -9,7 +9,8 @@
       "SVE256",
       "FCMA",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "cvtpd2dq xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -11,7 +11,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "cvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_SVE128.json
@@ -7,7 +7,8 @@
     "DisabledHostFeatures": [
       "SVE256",
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "movmskps eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -12,7 +12,8 @@
       "FLAGM",
       "FLAGM2",
       "FRINTTS"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -7,7 +7,8 @@
       "AFP",
       "FCMA"
     ],
-    "DisabledHostFeatures": []
+    "DisabledHostFeatures": [],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -12,7 +12,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vcvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -10,7 +10,8 @@
       "FLAGM",
       "FLAGM2",
       "SVEBITPERM"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map2_svebitperm.json
+++ b/unittests/InstructionCountCI/VEX_map2_svebitperm.json
@@ -10,7 +10,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "pext eax, ebx, ecx": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -7,7 +7,8 @@
     ],
     "DisabledHostFeatures": [
       "AFP"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -8,7 +8,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/X87ldst-SVE.json
+++ b/unittests/InstructionCountCI/X87ldst-SVE.json
@@ -10,7 +10,8 @@
       "FLAGM",
       "FLAGM2",
       "RPRES"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "fstp tword [rax]": {

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -9,7 +9,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/x87_32Bit.json
+++ b/unittests/InstructionCountCI/x87_32Bit.json
@@ -9,7 +9,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "Multiple fld/fst": {

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -11,7 +11,8 @@
       "AFP",
       "FLAGM",
       "FLAGM2"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/x87_f64_32Bit.json
+++ b/unittests/InstructionCountCI/x87_f64_32Bit.json
@@ -14,7 +14,8 @@
       "SVE128",
       "SVE256",
       "CSSC"
-    ]
+    ],
+    "BinaryCacheVersion": 3
   },
   "Instructions": {
     "fstp dword [ebx*4+0x204a20]": {


### PR DESCRIPTION
Two added failure modes here. If the disk cache version has changed then
the json files must be updated to the new version to ensure correct
tracking.

Additional failure mode is that codegen actually changed but the disk
cache version hasn't. This is the expected common failure mode and we
need to do additional work before updating json results. This just means
incrementing the disk cache version before updating the instcountci
results. Have a fairly lengthy error message to showcase how much of an
impact this might have.