### PR TITLE
Preserve previous value of IE exception flag 

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -172,8 +172,9 @@ void OpDispatchBuilder::FIST(OpcodeArgs, bool Truncate) {
     Ref IsOverflow = _NZCVSelect01(CondClass::UGE);
 
     // Set Invalid Operation flag if overflow or special value
+    // The x87 exception flags are sticky. Preserve earlier result
     Ref InvalidFlag = _Or(OpSize::i64Bit, IsSpecial, IsOverflow);
-    SetRFLAG<FEXCore::X86State::X87FLAG_IE_LOC>(InvalidFlag);
+    SetRFLAG<FEXCore::X86State::X87FLAG_IE_LOC>(_Or(OpSize::i32Bit, GetRFLAG(FEXCore::X86State::X87FLAG_IE_LOC), InvalidFlag));
   }
 
   Data = _F80CVTInt(Size, Data, Truncate);
@@ -683,7 +684,8 @@ void OpDispatchBuilder::FCOMI(OpcodeArgs, IR::OpSize Width, bool Integer, OpDisp
   }
 
   // Set Invalid Operation flag when unordered (NaN comparison)
-  SetRFLAG<FEXCore::X86State::X87FLAG_IE_LOC>(HostFlag_Unordered);
+  // The x87 exception flags are sticky. Preserve earlier result
+  SetRFLAG<FEXCore::X86State::X87FLAG_IE_LOC>(_Or(OpSize::i32Bit, GetRFLAG(FEXCore::X86State::X87FLAG_IE_LOC), HostFlag_Unordered));
 
   if (PopTwice) {
     _PopStackDestroy();
@@ -708,7 +710,8 @@ void OpDispatchBuilder::FTST(OpcodeArgs) {
   SetRFLAG<FEXCore::X86State::X87FLAG_C3_LOC>(HostFlag_ZF);
 
   // Set Invalid Operation flag when unordered (NaN comparison)
-  SetRFLAG<FEXCore::X86State::X87FLAG_IE_LOC>(HostFlag_Unordered);
+  // The x87 exception flags are sticky. Preserve earlier result
+  SetRFLAG<FEXCore::X86State::X87FLAG_IE_LOC>(_Or(OpSize::i32Bit, GetRFLAG(FEXCore::X86State::X87FLAG_IE_LOC), HostFlag_Unordered));
 }
 
 void OpDispatchBuilder::X87OpHelper(OpcodeArgs, FEXCore::IR::IROps IROp, bool ZeroC2) {

--- a/FEXCore/include/FEXCore/Core/DiskCache.h
+++ b/FEXCore/include/FEXCore/Core/DiskCache.h
@@ -207,7 +207,7 @@ namespace DiskCache {
 
   // TODO: This header is in global installed header path, but uses internal headers.
   // Migrate this once that is fixed.
-  static constexpr uint16_t FormatVersion = 6;
+  static constexpr uint16_t FormatVersion = 7;
   FEX_DEFAULT_VISIBILITY uint16_t GetFormatVersion();
 
 } // namespace DiskCache

--- a/unittests/ASM/FEX_bugs/x87_IE_sticky.asm
+++ b/unittests/ASM/FEX_bugs/x87_IE_sticky.asm
@@ -1,0 +1,47 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "1",
+    "RBX": "1",
+    "RCX": "1"
+  }
+}
+%endif
+
+; FSW.IE is sticky
+; fcomi, ftst and fist (and fistp, fisttp) should not overwrite IE to 0, when IE is set to 1 already
+
+%macro set_ie 0
+  fldz
+  fldz
+  fdiv st0, st1 ; set IE
+%endmacro
+
+finit
+
+set_ie
+fldz
+fld1
+fcomi st1 ; 1.0 vs 0.0
+fnstsw ax
+and rax, 1 ; extract IE
+mov rbx, rax
+
+set_ie
+fld1
+ftst; 1.0 vs 0.0
+fnstsw ax
+and rax, 1 ; extract IE
+mov rcx, rax
+
+finit
+set_ie
+fld1
+fist word [rel .result]
+fnstsw ax
+and rax, 1 ; extract IE
+
+hlt
+
+align 4096
+.result: dw 0

--- a/unittests/InstructionCountCI/AFP/H0F3A.json
+++ b/unittests/InstructionCountCI/AFP/H0F3A.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "roundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/Secondary.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vsqrtss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AFP/VEX_map3.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map3.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vroundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AVX128/FMA4.json
+++ b/unittests/InstructionCountCI/AVX128/FMA4.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -13,7 +13,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vmovntps [rax], xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
@@ -8,7 +8,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vfmadd132ss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vmovntdqa xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -11,7 +11,7 @@
       "SVE256",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -8,7 +8,7 @@
       "AFP",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vblendvps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F3A.json
+++ b/unittests/InstructionCountCI/Crypto/H0F3A.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pclmulqdq xmm0, xmm1, 00000b": {

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -10,7 +10,7 @@
       "AFP",
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These 3DNow! instructions are optimal assuming that FEX doesn't SRA MMX registers",

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -13,7 +13,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/libnss.json
+++ b/unittests/InstructionCountCI/FEXOpt/libnss.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [],
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Chained add": {

--- a/unittests/InstructionCountCI/FlagM/H0F38.json
+++ b/unittests/InstructionCountCI/FlagM/H0F38.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "ptest xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "The Witcher 3": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Sonic Mania movie player": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "FMOD scalar loop": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "The Sims 1 hot block": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "add al, 1": {

--- a/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "ucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
@@ -11,7 +11,7 @@
       "AFP",
       "FCMA"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "ucomisd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -12,7 +12,7 @@
       "AFP",
       "CSSC"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -10,7 +10,7 @@
       "AFP",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map_group.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map_group.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "blsr eax, ebx": {

--- a/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -10,12 +10,12 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {
       "x86InstructionCount": 70,
-      "ExpectedInstructionCount": 413,
+      "ExpectedInstructionCount": 415,
       "x86Insts": [
         "sub esp,0x2c",
         "mov ecx,dword [esp + 0x34]",
@@ -477,6 +477,8 @@
         "eor w26, w20, #0x1",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x5 (5)",
@@ -506,7 +508,7 @@
     },
     "Block2": {
       "x86InstructionCount": 37,
-      "ExpectedInstructionCount": 215,
+      "ExpectedInstructionCount": 223,
       "x86Insts": [
         "sub esp,0x1c",
         "mov edx,dword [esp + 0x20]",
@@ -588,6 +590,8 @@
         "eor x21, x21, #0x1",
         "rmif x21, #63, #nzCv",
         "rmif x22, #62, #nZcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "csetm x20, ls",
         "dup v4.2d, x20",
@@ -629,6 +633,8 @@
         "eor x21, x21, #0x1",
         "rmif x21, #63, #nzCv",
         "rmif x22, #62, #nZcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "csetm x20, ls",
         "dup v5.2d, x20",
@@ -670,6 +676,8 @@
         "eor x21, x21, #0x1",
         "rmif x21, #63, #nzCv",
         "rmif x22, #62, #nZcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "csetm x20, ls",
         "dup v6.2d, x20",
@@ -741,6 +749,8 @@
         "eor w26, w20, #0x1",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x6 (6)",
@@ -1174,7 +1184,7 @@
     },
     "Block5": {
       "x86InstructionCount": 49,
-      "ExpectedInstructionCount": 303,
+      "ExpectedInstructionCount": 305,
       "x86Insts": [
         "fld dword [esp + 0x80]",
         "fsub dword [esp + 0x7c]",
@@ -1509,6 +1519,8 @@
         "eor w26, w20, #0x1",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "cset x20, hi",
         "strb w20, [x8, #48]",
@@ -1534,7 +1546,7 @@
     },
     "Block6": {
       "x86InstructionCount": 39,
-      "ExpectedInstructionCount": 295,
+      "ExpectedInstructionCount": 297,
       "x86Insts": [
         "push ebp",
         "push edi",
@@ -1841,6 +1853,8 @@
         "eor w26, w20, #0x1",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x4 (4)",

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -11,7 +11,7 @@
       "CSSC",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -71,7 +71,7 @@
       ]
     },
     "fcom dword [rax]": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xd8 !11b /2"
       ],
@@ -104,11 +104,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomp dword [rax]": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xd8 !11b /3"
       ],
@@ -141,6 +143,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -641,7 +645,7 @@
       ]
     },
     "fcom st0, st0": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 23,
       "Comment": [
         "0xd8 11b 0xd0 /2"
       ],
@@ -666,11 +670,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st1": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd1 /2"
       ],
@@ -699,11 +705,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st2": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd2 /2"
       ],
@@ -732,11 +740,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st3": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd3 /2"
       ],
@@ -765,11 +775,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st4": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd4 /2"
       ],
@@ -798,11 +810,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st5": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd5 /2"
       ],
@@ -831,11 +845,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st6": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd6 /2"
       ],
@@ -864,11 +880,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st7": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd7 /2"
       ],
@@ -897,11 +915,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomp st0, st0": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xd8 11b 0xd8 /3"
       ],
@@ -926,6 +946,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -938,7 +960,7 @@
       ]
     },
     "fcomp st0, st1": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xd8 11b 0xd9 /3"
       ],
@@ -967,6 +989,8 @@
         "strb wzr, [x28, #1049]",
         "strb w22, [x28, #1050]",
         "strb w24, [x28, #1054]",
+        "ldrb w23, [x28, #1040]",
+        "orr w22, w23, w22",
         "strb w22, [x28, #1040]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
@@ -977,7 +1001,7 @@
       ]
     },
     "fcomp st0, st2": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xda /3"
       ],
@@ -1006,6 +1030,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -1018,7 +1044,7 @@
       ]
     },
     "fcomp st0, st3": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xdb /3"
       ],
@@ -1047,6 +1073,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -1059,7 +1087,7 @@
       ]
     },
     "fcomp st0, st4": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xdc /3"
       ],
@@ -1088,6 +1116,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -1100,7 +1130,7 @@
       ]
     },
     "fcomp st0, st5": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xdd /3"
       ],
@@ -1129,6 +1159,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -1141,7 +1173,7 @@
       ]
     },
     "fcomp st0, st6": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xde /3"
       ],
@@ -1170,6 +1202,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -1182,7 +1216,7 @@
       ]
     },
     "fcomp st0, st7": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xdf /3"
       ],
@@ -1211,6 +1245,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -2489,7 +2525,7 @@
       ]
     },
     "ftst": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 25,
       "Comment": [
         "0xd9 11b 0xe4 /4"
       ],
@@ -2516,6 +2552,8 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
@@ -3110,7 +3148,7 @@
       ]
     },
     "ficom dword [rax]": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xda !11b /2"
       ],
@@ -3143,11 +3181,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "ficomp dword [rax]": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xda !11b /3"
       ],
@@ -3180,6 +3220,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -3920,7 +3962,7 @@
       ]
     },
     "fucompp": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xda 11b 0xe9 /5"
       ],
@@ -3949,6 +3991,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -4763,7 +4807,7 @@
       ]
     },
     "fucomi st0, st0": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 26,
       "Comment": [
         "0xdb 11b 0xe8 /5"
       ],
@@ -4791,11 +4835,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st1": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xe9 /5"
       ],
@@ -4827,11 +4873,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st2": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xea /5"
       ],
@@ -4863,11 +4911,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st3": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xeb /5"
       ],
@@ -4899,11 +4949,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st4": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xec /5"
       ],
@@ -4935,11 +4987,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st5": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xed /5"
       ],
@@ -4971,11 +5025,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st6": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xee /5"
       ],
@@ -5007,11 +5063,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomi st0, st7": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xef /5"
       ],
@@ -5043,11 +5101,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st0": {
-      "ExpectedInstructionCount": 24,
+      "ExpectedInstructionCount": 26,
       "Comment": [
         "0xdb 11b 0xf0 /6"
       ],
@@ -5075,11 +5135,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st1": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xf1 /6"
       ],
@@ -5111,11 +5173,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st2": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xf2 /6"
       ],
@@ -5147,11 +5211,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st3": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xf3 /6"
       ],
@@ -5183,11 +5249,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st4": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xf4 /6"
       ],
@@ -5219,11 +5287,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st5": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xf5 /6"
       ],
@@ -5255,11 +5325,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st6": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xf6 /6"
       ],
@@ -5291,11 +5363,13 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomi st0, st7": {
-      "ExpectedInstructionCount": 28,
+      "ExpectedInstructionCount": 30,
       "Comment": [
         "0xdb 11b 0xf7 /6"
       ],
@@ -5327,6 +5401,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
@@ -5387,7 +5463,7 @@
       ]
     },
     "fcom qword [rax]": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdc !11b /2"
       ],
@@ -5420,11 +5496,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomp qword [rax]": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdc !11b /3"
       ],
@@ -5457,6 +5535,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -7574,7 +7654,7 @@
       ]
     },
     "fucom st0": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 23,
       "Comment": [
         "0xdd 11b 0xe0 /4"
       ],
@@ -7599,11 +7679,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st1": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe1 /4"
       ],
@@ -7632,11 +7714,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st2": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe2 /4"
       ],
@@ -7665,11 +7749,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st3": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe3 /4"
       ],
@@ -7698,11 +7784,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st4": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe4 /4"
       ],
@@ -7731,11 +7819,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st5": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe5 /4"
       ],
@@ -7764,11 +7854,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st6": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe6 /4"
       ],
@@ -7797,11 +7889,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st7": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe7 /4"
       ],
@@ -7830,11 +7924,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomp st0": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdd 11b 0xe8 /5"
       ],
@@ -7859,6 +7955,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -7871,7 +7969,7 @@
       ]
     },
     "fucomp st1": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdd 11b 0xe9 /5"
       ],
@@ -7900,6 +7998,8 @@
         "strb wzr, [x28, #1049]",
         "strb w22, [x28, #1050]",
         "strb w24, [x28, #1054]",
+        "ldrb w23, [x28, #1040]",
+        "orr w22, w23, w22",
         "strb w22, [x28, #1040]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
@@ -7910,7 +8010,7 @@
       ]
     },
     "fucomp st2": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xea /5"
       ],
@@ -7939,6 +8039,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -7951,7 +8053,7 @@
       ]
     },
     "fucomp st3": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xeb /5"
       ],
@@ -7980,6 +8082,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -7992,7 +8096,7 @@
       ]
     },
     "fucomp st4": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xec /5"
       ],
@@ -8021,6 +8125,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -8033,7 +8139,7 @@
       ]
     },
     "fucomp st5": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xed /5"
       ],
@@ -8062,6 +8168,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -8074,7 +8182,7 @@
       ]
     },
     "fucomp st6": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xee /5"
       ],
@@ -8103,6 +8211,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -8115,7 +8225,7 @@
       ]
     },
     "fucomp st7": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xef /5"
       ],
@@ -8144,6 +8254,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -8212,7 +8324,7 @@
       ]
     },
     "ficom word [rax]": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xde !11b /2"
       ],
@@ -8245,11 +8357,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "ficomp word [rax]": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xde !11b /3"
       ],
@@ -8282,6 +8396,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -8906,7 +9022,7 @@
       ]
     },
     "fcompp": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xde 11b 0xd9 /3"
       ],
@@ -8935,6 +9051,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -9998,7 +10116,7 @@
       ]
     },
     "fisttp word [rax]": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdf !11b /1"
       ],
@@ -10016,6 +10134,8 @@
         "cmp x21, x24",
         "cset x21, hs",
         "orr x21, x22, x21",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -10037,7 +10157,7 @@
       ]
     },
     "fist word [rax]": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 25,
       "Comment": [
         "0xdf !11b /2"
       ],
@@ -10055,6 +10175,8 @@
         "cmp x20, x23",
         "cset x20, hs",
         "orr x20, x21, x20",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -10068,7 +10190,7 @@
       ]
     },
     "fistp word [rax]": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdf !11b /3"
       ],
@@ -10086,6 +10208,8 @@
         "cmp x21, x24",
         "cset x21, hs",
         "orr x21, x22, x21",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -10282,7 +10406,7 @@
       ]
     },
     "fucomip st0": {
-      "ExpectedInstructionCount": 32,
+      "ExpectedInstructionCount": 34,
       "Comment": [
         "0xdf 11b 0xe8 /5"
       ],
@@ -10310,6 +10434,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10322,7 +10448,7 @@
       ]
     },
     "fucomip st1": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 36,
       "Comment": [
         "0xdf 11b 0xe9 /5"
       ],
@@ -10354,6 +10480,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w23, [x28, #1040]",
+        "orr w22, w23, w22",
         "strb w22, [x28, #1040]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
@@ -10364,7 +10492,7 @@
       ]
     },
     "fucomip st2": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xea /5"
       ],
@@ -10396,6 +10524,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10408,7 +10538,7 @@
       ]
     },
     "fucomip st3": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xeb /5"
       ],
@@ -10440,6 +10570,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10452,7 +10584,7 @@
       ]
     },
     "fucomip st4": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xec /5"
       ],
@@ -10484,6 +10616,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10496,7 +10630,7 @@
       ]
     },
     "fucomip st5": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xed /5"
       ],
@@ -10528,6 +10662,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10540,7 +10676,7 @@
       ]
     },
     "fucomip st6": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xee /5"
       ],
@@ -10572,6 +10708,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10584,7 +10722,7 @@
       ]
     },
     "fucomip st7": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xef /5"
       ],
@@ -10616,6 +10754,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10628,7 +10768,7 @@
       ]
     },
     "fcomip st0": {
-      "ExpectedInstructionCount": 32,
+      "ExpectedInstructionCount": 34,
       "Comment": [
         "0xdf 11b 0xf0 /6"
       ],
@@ -10656,6 +10796,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10668,7 +10810,7 @@
       ]
     },
     "fcomip st1": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 36,
       "Comment": [
         "0xdf 11b 0xf1 /6"
       ],
@@ -10700,6 +10842,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w23, [x28, #1040]",
+        "orr w22, w23, w22",
         "strb w22, [x28, #1040]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
@@ -10710,7 +10854,7 @@
       ]
     },
     "fcomip st2": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xf2 /6"
       ],
@@ -10742,6 +10886,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10754,7 +10900,7 @@
       ]
     },
     "fcomip st3": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xf3 /6"
       ],
@@ -10786,6 +10932,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10798,7 +10946,7 @@
       ]
     },
     "fcomip st4": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xf4 /6"
       ],
@@ -10830,6 +10978,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10842,7 +10992,7 @@
       ]
     },
     "fcomip st5": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xf5 /6"
       ],
@@ -10874,6 +11024,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10886,7 +11038,7 @@
       ]
     },
     "fcomip st6": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xf6 /6"
       ],
@@ -10918,6 +11070,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10930,7 +11084,7 @@
       ]
     },
     "fcomip st7": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xf7 /6"
       ],
@@ -10962,6 +11116,8 @@
         "mov w27, #0x0",
         "rmif xzr, #0, #nzcV",
         "rmif xzr, #61, #Nzcv",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pshufb mm0, mm1": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -8,7 +8,7 @@
       "AFP",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "SSE4.2 string instructions are skipped here.",

--- a/unittests/InstructionCountCI/H0F3A_SVE128.json
+++ b/unittests/InstructionCountCI/H0F3A_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "dpps xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/MOPS/Primary.json
+++ b/unittests/InstructionCountCI/MOPS/Primary.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "rep movsb": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "MOPS"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "Instructions in this table that are marked optimal don't have their flag calculation part of this assumption",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -9,7 +9,7 @@
       "FlagM",
       "FlagM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pfrcpv mm0, mm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "rsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "rsqrtss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -8,7 +8,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Repeat.json
+++ b/unittests/InstructionCountCI/Repeat.json
@@ -6,7 +6,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {}
 }

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -33,7 +33,7 @@
       "      - 1b: ECX = MSB",
       "[7]   - Reserved"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pcmpestrm xmm0, xmm1, 0_0_00_00_00b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Comment": [
     "MMX instructions are defined as optimal without SRA being used for these instructions.",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -7,7 +7,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "push fs": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "movupd xmm0, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "addsubpd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "psrlw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -12,7 +12,7 @@
       "FRINTTS",
       "CSSC"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "movss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "movsd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "addsubps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvtpd2dq xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "cvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "movmskps eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -13,7 +13,7 @@
       "FLAGM2",
       "FRINTTS"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -8,7 +8,7 @@
       "FCMA"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -13,7 +13,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vcvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map2_svebitperm.json
+++ b/unittests/InstructionCountCI/VEX_map2_svebitperm.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "pext eax, ebx, ecx": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -8,7 +8,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/X87ldst-SVE.json
+++ b/unittests/InstructionCountCI/X87ldst-SVE.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "RPRES"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fstp tword [rax]": {

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -70,7 +70,7 @@
       ]
     },
     "fcom dword [rax]": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xd8 !11b /2"
       ],
@@ -103,11 +103,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomp dword [rax]": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xd8 !11b /3"
       ],
@@ -140,6 +142,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -640,7 +644,7 @@
       ]
     },
     "fcom st0, st0": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 23,
       "Comment": [
         "0xd8 11b 0xd0 /2"
       ],
@@ -665,11 +669,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st1": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd1 /2"
       ],
@@ -698,11 +704,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st2": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd2 /2"
       ],
@@ -731,11 +739,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st3": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd3 /2"
       ],
@@ -764,11 +774,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st4": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd4 /2"
       ],
@@ -797,11 +809,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st5": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd5 /2"
       ],
@@ -830,11 +844,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st6": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd6 /2"
       ],
@@ -863,11 +879,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcom st0, st7": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xd8 11b 0xd7 /2"
       ],
@@ -896,11 +914,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomp st0, st0": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xd8 11b 0xd8 /3"
       ],
@@ -925,6 +945,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -937,7 +959,7 @@
       ]
     },
     "fcomp st0, st1": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xd8 11b 0xd9 /3"
       ],
@@ -966,6 +988,8 @@
         "strb wzr, [x28, #1049]",
         "strb w22, [x28, #1050]",
         "strb w24, [x28, #1054]",
+        "ldrb w23, [x28, #1040]",
+        "orr w22, w23, w22",
         "strb w22, [x28, #1040]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
@@ -976,7 +1000,7 @@
       ]
     },
     "fcomp st0, st2": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xda /3"
       ],
@@ -1005,6 +1029,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -1017,7 +1043,7 @@
       ]
     },
     "fcomp st0, st3": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xdb /3"
       ],
@@ -1046,6 +1072,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -1058,7 +1086,7 @@
       ]
     },
     "fcomp st0, st4": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xdc /3"
       ],
@@ -1087,6 +1115,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -1099,7 +1129,7 @@
       ]
     },
     "fcomp st0, st5": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xdd /3"
       ],
@@ -1128,6 +1158,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -1140,7 +1172,7 @@
       ]
     },
     "fcomp st0, st6": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xde /3"
       ],
@@ -1169,6 +1201,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -1181,7 +1215,7 @@
       ]
     },
     "fcomp st0, st7": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xd8 11b 0xdf /3"
       ],
@@ -1210,6 +1244,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -2488,7 +2524,7 @@
       ]
     },
     "ftst": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 25,
       "Comment": [
         "0xd9 11b 0xe4 /4"
       ],
@@ -2515,6 +2551,8 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
@@ -3109,7 +3147,7 @@
       ]
     },
     "ficom dword [rax]": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xda !11b /2"
       ],
@@ -3142,11 +3180,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "ficomp dword [rax]": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xda !11b /3"
       ],
@@ -3179,6 +3219,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -3919,7 +3961,7 @@
       ]
     },
     "fucompp": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xda 11b 0xe9 /5"
       ],
@@ -3948,6 +3990,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -4762,7 +4806,7 @@
       ]
     },
     "fucomi st0, st0": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 28,
       "Comment": [
         "0xdb 11b 0xe8 /5"
       ],
@@ -4791,12 +4835,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st1": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xe9 /5"
       ],
@@ -4829,12 +4875,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st2": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xea /5"
       ],
@@ -4867,12 +4915,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st3": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xeb /5"
       ],
@@ -4905,12 +4955,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st4": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xec /5"
       ],
@@ -4943,12 +4995,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st5": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xed /5"
       ],
@@ -4981,12 +5035,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st6": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xee /5"
       ],
@@ -5019,12 +5075,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fucomi st0, st7": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xef /5"
       ],
@@ -5057,12 +5115,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st0": {
-      "ExpectedInstructionCount": 26,
+      "ExpectedInstructionCount": 28,
       "Comment": [
         "0xdb 11b 0xf0 /6"
       ],
@@ -5091,12 +5151,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st1": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xf1 /6"
       ],
@@ -5129,12 +5191,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st2": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xf2 /6"
       ],
@@ -5167,12 +5231,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st3": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xf3 /6"
       ],
@@ -5205,12 +5271,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st4": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xf4 /6"
       ],
@@ -5243,12 +5311,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st5": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xf5 /6"
       ],
@@ -5281,12 +5351,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st6": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xf6 /6"
       ],
@@ -5319,12 +5391,14 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
     },
     "fcomi st0, st7": {
-      "ExpectedInstructionCount": 30,
+      "ExpectedInstructionCount": 32,
       "Comment": [
         "0xdb 11b 0xf7 /6"
       ],
@@ -5357,6 +5431,8 @@
         "mov w27, #0x0",
         "bfi w23, w27, #28, #1",
         "bfi w23, w27, #31, #1",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "msr nzcv, x23"
       ]
@@ -5418,7 +5494,7 @@
       ]
     },
     "fcom qword [rax]": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdc !11b /2"
       ],
@@ -5451,11 +5527,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fcomp qword [rax]": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xdc !11b /3"
       ],
@@ -5488,6 +5566,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -7509,7 +7589,7 @@
       ]
     },
     "fucom st0": {
-      "ExpectedInstructionCount": 21,
+      "ExpectedInstructionCount": 23,
       "Comment": [
         "0xdd 11b 0xe0 /4"
       ],
@@ -7534,11 +7614,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st1": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe1 /4"
       ],
@@ -7567,11 +7649,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st2": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe2 /4"
       ],
@@ -7600,11 +7684,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st3": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe3 /4"
       ],
@@ -7633,11 +7719,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st4": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe4 /4"
       ],
@@ -7666,11 +7754,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st5": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe5 /4"
       ],
@@ -7699,11 +7789,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st6": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe6 /4"
       ],
@@ -7732,11 +7824,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucom st7": {
-      "ExpectedInstructionCount": 25,
+      "ExpectedInstructionCount": 27,
       "Comment": [
         "0xdd 11b 0xe7 /4"
       ],
@@ -7765,11 +7859,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "fucomp st0": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xdd 11b 0xe8 /5"
       ],
@@ -7794,6 +7890,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -7806,7 +7904,7 @@
       ]
     },
     "fucomp st1": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdd 11b 0xe9 /5"
       ],
@@ -7835,6 +7933,8 @@
         "strb wzr, [x28, #1049]",
         "strb w22, [x28, #1050]",
         "strb w24, [x28, #1054]",
+        "ldrb w23, [x28, #1040]",
+        "orr w22, w23, w22",
         "strb w22, [x28, #1040]",
         "strb w21, [x28, #1051]",
         "ldrb w21, [x28, #1202]",
@@ -7845,7 +7945,7 @@
       ]
     },
     "fucomp st2": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xea /5"
       ],
@@ -7874,6 +7974,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -7886,7 +7988,7 @@
       ]
     },
     "fucomp st3": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xeb /5"
       ],
@@ -7915,6 +8017,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -7927,7 +8031,7 @@
       ]
     },
     "fucomp st4": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xec /5"
       ],
@@ -7956,6 +8060,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -7968,7 +8074,7 @@
       ]
     },
     "fucomp st5": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xed /5"
       ],
@@ -7997,6 +8103,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -8009,7 +8117,7 @@
       ]
     },
     "fucomp st6": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xee /5"
       ],
@@ -8038,6 +8146,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -8050,7 +8160,7 @@
       ]
     },
     "fucomp st7": {
-      "ExpectedInstructionCount": 33,
+      "ExpectedInstructionCount": 35,
       "Comment": [
         "0xdd 11b 0xef /5"
       ],
@@ -8079,6 +8189,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -8147,7 +8259,7 @@
       ]
     },
     "ficom word [rax]": {
-      "ExpectedInstructionCount": 29,
+      "ExpectedInstructionCount": 31,
       "Comment": [
         "0xde !11b /2"
       ],
@@ -8180,11 +8292,13 @@
         "strb wzr, [x28, #1049]",
         "strb w20, [x28, #1050]",
         "strb w22, [x28, #1054]",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]"
       ]
     },
     "ficomp word [rax]": {
-      "ExpectedInstructionCount": 37,
+      "ExpectedInstructionCount": 39,
       "Comment": [
         "0xde !11b /3"
       ],
@@ -8217,6 +8331,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -8841,7 +8957,7 @@
       ]
     },
     "fcompp": {
-      "ExpectedInstructionCount": 35,
+      "ExpectedInstructionCount": 37,
       "Comment": [
         "0xde 11b 0xd9 /3"
       ],
@@ -8870,6 +8986,8 @@
         "strb wzr, [x28, #1049]",
         "strb w21, [x28, #1050]",
         "strb w23, [x28, #1054]",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -9933,7 +10051,7 @@
       ]
     },
     "fisttp word [rax]": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdf !11b /1"
       ],
@@ -9951,6 +10069,8 @@
         "cmp x21, x24",
         "cset x21, hs",
         "orr x21, x22, x21",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -9972,7 +10092,7 @@
       ]
     },
     "fist word [rax]": {
-      "ExpectedInstructionCount": 23,
+      "ExpectedInstructionCount": 25,
       "Comment": [
         "0xdf !11b /2"
       ],
@@ -9990,6 +10110,8 @@
         "cmp x20, x23",
         "cset x20, hs",
         "orr x20, x21, x20",
+        "ldrb w21, [x28, #1040]",
+        "orr w20, w21, w20",
         "strb w20, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -10003,7 +10125,7 @@
       ]
     },
     "fistp word [rax]": {
-      "ExpectedInstructionCount": 31,
+      "ExpectedInstructionCount": 33,
       "Comment": [
         "0xdf !11b /3"
       ],
@@ -10021,6 +10143,8 @@
         "cmp x21, x24",
         "cset x21, hs",
         "orr x21, x22, x21",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v2.16b",
@@ -10217,7 +10341,7 @@
       ]
     },
     "fucomip st0": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 36,
       "Comment": [
         "0xdf 11b 0xe8 /5"
       ],
@@ -10246,6 +10370,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10259,7 +10385,7 @@
       ]
     },
     "fucomip st1": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xe9 /5"
       ],
@@ -10292,6 +10418,8 @@
         "mov w27, #0x0",
         "bfi w30, w27, #28, #1",
         "bfi w30, w27, #31, #1",
+        "ldrb w23, [x28, #1040]",
+        "orr w22, w23, w22",
         "strb w22, [x28, #1040]",
         "msr nzcv, x30",
         "strb w21, [x28, #1051]",
@@ -10303,7 +10431,7 @@
       ]
     },
     "fucomip st2": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xea /5"
       ],
@@ -10336,6 +10464,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10349,7 +10479,7 @@
       ]
     },
     "fucomip st3": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xeb /5"
       ],
@@ -10382,6 +10512,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10395,7 +10527,7 @@
       ]
     },
     "fucomip st4": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xec /5"
       ],
@@ -10428,6 +10560,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10441,7 +10575,7 @@
       ]
     },
     "fucomip st5": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xed /5"
       ],
@@ -10474,6 +10608,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10487,7 +10623,7 @@
       ]
     },
     "fucomip st6": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xee /5"
       ],
@@ -10520,6 +10656,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10533,7 +10671,7 @@
       ]
     },
     "fucomip st7": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xef /5"
       ],
@@ -10566,6 +10704,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10579,7 +10719,7 @@
       ]
     },
     "fcomip st0": {
-      "ExpectedInstructionCount": 34,
+      "ExpectedInstructionCount": 36,
       "Comment": [
         "0xdf 11b 0xf0 /6"
       ],
@@ -10608,6 +10748,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10621,7 +10763,7 @@
       ]
     },
     "fcomip st1": {
-      "ExpectedInstructionCount": 36,
+      "ExpectedInstructionCount": 38,
       "Comment": [
         "0xdf 11b 0xf1 /6"
       ],
@@ -10654,6 +10796,8 @@
         "mov w27, #0x0",
         "bfi w30, w27, #28, #1",
         "bfi w30, w27, #31, #1",
+        "ldrb w23, [x28, #1040]",
+        "orr w22, w23, w22",
         "strb w22, [x28, #1040]",
         "msr nzcv, x30",
         "strb w21, [x28, #1051]",
@@ -10665,7 +10809,7 @@
       ]
     },
     "fcomip st2": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xf2 /6"
       ],
@@ -10698,6 +10842,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10711,7 +10857,7 @@
       ]
     },
     "fcomip st3": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xf3 /6"
       ],
@@ -10744,6 +10890,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10757,7 +10905,7 @@
       ]
     },
     "fcomip st4": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xf4 /6"
       ],
@@ -10790,6 +10938,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10803,7 +10953,7 @@
       ]
     },
     "fcomip st5": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xf5 /6"
       ],
@@ -10836,6 +10986,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10849,7 +11001,7 @@
       ]
     },
     "fcomip st6": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xf6 /6"
       ],
@@ -10882,6 +11034,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",
@@ -10895,7 +11049,7 @@
       ]
     },
     "fcomip st7": {
-      "ExpectedInstructionCount": 38,
+      "ExpectedInstructionCount": 40,
       "Comment": [
         "0xdf 11b 0xf7 /6"
       ],
@@ -10928,6 +11082,8 @@
         "mov w27, #0x0",
         "bfi w24, w27, #28, #1",
         "bfi w24, w27, #31, #1",
+        "ldrb w22, [x28, #1040]",
+        "orr w21, w22, w21",
         "strb w21, [x28, #1040]",
         "add w21, w20, #0x1 (1)",
         "and w21, w21, #0x7",

--- a/unittests/InstructionCountCI/x87_32Bit.json
+++ b/unittests/InstructionCountCI/x87_32Bit.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "Multiple fld/fst": {

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/x87_f64_32Bit.json
+++ b/unittests/InstructionCountCI/x87_f64_32Bit.json
@@ -15,7 +15,7 @@
       "SVE256",
       "CSSC"
     ],
-    "BinaryCacheVersion": 6
+    "BinaryCacheVersion": 7
   },
   "Instructions": {
     "fstp dword [ebx*4+0x204a20]": {


### PR DESCRIPTION
Per the SDM (8.1.3.3 x87 FPU Floating-Point Exception Flags): The x87 exception flags are "sticky" bits (once set, they remain set until explicitly cleared).

FEX did not preserve the old value of the `IE` exception flag for the `FCOMI` and `FTST` and `FIST` instructions.
This PR fixes this and adds a unittest.

I also updated InstcountCI and `FEXCore::DiskCache::FormatVersion` as i got a version mismatch for the binary cache. Not sure if this is correct.

Edit: Also added `FIST`. 