### PR TITLE
DiskCache: hash guest code according to its real extents

### DIFF
--- a/FEXCore/Source/Interface/Core/DiskCache.cpp
+++ b/FEXCore/Source/Interface/Core/DiskCache.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+#define XXH_STATIC_LINKING_ONLY
+
 #include "FEXCore/Config/Config.h"
 #include "FEXCore/fextl/string.h"
 #include "FEXHeaderUtils/Filesystem.h"
@@ -190,15 +192,15 @@ namespace DiskCache {
       const auto* FOZHeader = reinterpret_cast<const MesaFOZ::foz_payload_header*>(IndexDataStart + ReadOffset);
       ReadOffset += sizeof(MesaFOZ::foz_payload_header);
 
-      uint32_t IndexBlobSize = sizeof(MesaFOZ::mesa_index_db_file_entry) + sizeof(IndexExtraBlob);
+      uint64_t IndexBlobSize = sizeof(MesaFOZ::mesa_index_db_file_entry) + sizeof(IndexExtraBlobHeader);
 
-      if (FOZHeader->payload_size != IndexBlobSize || ReadOffset + FOZHeader->payload_size > IndexDataSize) {
+      if (FOZHeader->payload_size < IndexBlobSize || ReadOffset + FOZHeader->payload_size > IndexDataSize) {
         break;
       }
       const auto* IndexBlobCommon = reinterpret_cast<const MesaFOZ::mesa_index_db_file_entry*>(IndexDataStart + ReadOffset);
       ReadOffset += sizeof(MesaFOZ::mesa_index_db_file_entry);
-      const auto* IndexBlobExtra = reinterpret_cast<const IndexExtraBlob*>(IndexDataStart + ReadOffset);
-      ReadOffset += sizeof(IndexExtraBlob);
+      const auto* IndexBlobExtra = reinterpret_cast<const IndexExtraBlobHeader*>(IndexDataStart + ReadOffset);
+      ReadOffset += sizeof(IndexExtraBlobHeader);
 
       // skip corrupt (carefully) so we don't have to figure that out in the hot path later
       if (IndexBlobCommon->cache_db_file_offset > (uint64_t)CacheFOZSize ||
@@ -208,15 +210,35 @@ namespace DiskCache {
       if (IndexBlobExtra->GuestSize + sizeof(BlobFixedHeader) > IndexBlobCommon->size) {
         continue;
       }
+      IndexBlobSize += IndexBlobExtra->GuestExtentsCount * sizeof(uint32_t);
+      if (FOZHeader->payload_size != IndexBlobSize) {
+        break;
+      }
+      const auto* GuestExtents = reinterpret_cast<const uint32_t*>(IndexDataStart + ReadOffset);
+      ReadOffset += IndexBlobExtra->GuestExtentsCount * sizeof(uint32_t);
       if (FOZKey->bytes[39] != 0xFF) {
         uint64_t Key;
         std::from_chars(reinterpret_cast<const char*>(FOZKey->bytes), reinterpret_cast<const char*>(&FOZKey->bytes[16]), Key, 16);
         if (IndexBlobCommon->hash != Key) {
           continue;
         }
-        CacheIndex.insert(
-          {IndexBlobCommon->hash,
-           {this, IndexBlobCommon->cache_db_file_offset, IndexBlobCommon->size, IndexBlobExtra->GuestSize, IndexBlobExtra->GuestHash}});
+        IndexEntry NewEntry {this, IndexBlobCommon->cache_db_file_offset, IndexBlobCommon->size, IndexBlobExtra->GuestSize,
+                             IndexBlobExtra->GuestHash};
+        if (IndexBlobExtra->GuestExtentsCount) {
+          NewEntry.GuestExtents.resize(IndexBlobExtra->GuestExtentsCount);
+          memcpy(NewEntry.GuestExtents.data(), GuestExtents, IndexBlobExtra->GuestExtentsCount * sizeof(uint32_t));
+          bool ExtentsValid = true;
+          for (uint32_t i = 0; i < NewEntry.GuestExtents.size(); i += 2) {
+            if ((uint64_t)NewEntry.GuestExtents[i] + NewEntry.GuestExtents[i + 1] > IndexBlobExtra->GuestSize) {
+              ExtentsValid = false;
+              break;
+            }
+          }
+          if (!ExtentsValid) {
+            continue;
+          }
+        }
+        CacheIndex.insert({IndexBlobCommon->hash, {std::move(NewEntry)}});
       } else {
         FoundMetadata = true;
       }
@@ -238,7 +260,7 @@ namespace DiskCache {
   }
 
   bool IndexedDB::StoreCacheBlob(const MesaFOZ::foz_payload_key& Key, std::span<const uint8_t> Blob, Index& Index, std::mutex& IndexMutex,
-                                 IndexExtraBlob IndexBlob) {
+                                 std::span<const uint8_t> IndexBlob) {
     if (ReadOnly) {
       // shouldn't happen
       return false;
@@ -279,7 +301,7 @@ namespace DiskCache {
 
     std::span<const uint8_t> IndexBlobChunks[] = {
       {(const uint8_t*)&IndexEntry, sizeof(IndexEntry)},
-      {(const uint8_t*)&IndexBlob, sizeof(IndexBlob)},
+      IndexBlob,
     };
     uint64_t UnusedIndexBlobOffset = 0;
     if (!IndexFOZ.WriteBlob(Key, IndexBlobChunks, UnusedIndexBlobOffset)) {
@@ -296,8 +318,16 @@ namespace DiskCache {
       CacheFileSize = BlobOffset + Blob.size();
     }
 
+    const IndexExtraBlobHeader* IndexBlobHeader = reinterpret_cast<const IndexExtraBlobHeader*>(IndexBlob.data());
+
+    struct IndexEntry NewEntry {this, BlobOffset, (uint32_t)Blob.size(), IndexBlobHeader->GuestSize, IndexBlobHeader->GuestHash};
+    if (IndexBlobHeader->GuestExtentsCount) {
+      NewEntry.GuestExtents.resize(IndexBlobHeader->GuestExtentsCount);
+      memcpy(NewEntry.GuestExtents.data(), reinterpret_cast<const uint32_t*>(IndexBlob.data() + sizeof(IndexExtraBlobHeader)),
+             IndexBlobHeader->GuestExtentsCount * sizeof(uint32_t));
+    }
     std::lock_guard Guard(IndexMutex);
-    Index[Hash] = {this, BlobOffset, (uint32_t)Blob.size(), IndexBlob.GuestSize, IndexBlob.GuestHash};
+    Index.insert_or_assign(Hash, std::move(NewEntry));
     return true;
   }
 
@@ -373,7 +403,9 @@ namespace DiskCache {
       // we just opened a fresh cache, add a metadata blob
       MesaFOZ::foz_payload_key MetadataKey;
       memset(MetadataKey.bytes, 0xFF, sizeof(MetadataKey));
-      RWCacheDB->StoreCacheBlob(MetadataKey, {BucketBytes.data(), BucketBytes.size()}, Index, IndexLock, {});
+      IndexExtraBlobHeader MetaDataHeader = {};
+      RWCacheDB->StoreCacheBlob(MetadataKey, {BucketBytes.data(), BucketBytes.size()}, Index, IndexLock,
+                                {reinterpret_cast<uint8_t*>(&MetaDataHeader), sizeof(MetaDataHeader)});
       Index.clear();
     }
 
@@ -439,7 +471,24 @@ namespace DiskCache {
       return std::nullopt;
     }
 
-    XXH128_hash_t LiveGuestHash = XXH3_128bits(reinterpret_cast<void*>(GuestRIP), Entry.GuestSize);
+    XXH128_hash_t LiveGuestHash;
+
+    // if (Entry.GuestExtents.size()) {
+    //   LogMan::Msg::IFmt("lookup! length {:d}", Entry.GuestSize);
+    //   for(uint32_t i = 0; i < Entry.GuestExtents.size(); i+=2 ) {
+    //     LogMan::Msg::IFmt("extent {} {}", Entry.GuestExtents[i], Entry.GuestExtents[i]+Entry.GuestExtents[i+1]);
+    //   }
+    // }
+    if (Entry.GuestExtents.size() == 0) {
+      LiveGuestHash = XXH3_128bits(reinterpret_cast<void*>(GuestRIP), Entry.GuestSize);
+    } else {
+      XXH3_state_t HashState;
+      XXH3_128bits_reset(&HashState);
+      for (uint32_t i = 0; i < Entry.GuestExtents.size(); i += 2) {
+        XXH3_128bits_update(&HashState, reinterpret_cast<uint8_t*>(GuestRIP) + Entry.GuestExtents[i], Entry.GuestExtents[i + 1]);
+      }
+      LiveGuestHash = XXH3_128bits_digest(&HashState);
+    }
     if (!XXH128_isEqual(LiveGuestHash, Entry.GuestHash)) {
       // LogMan::Msg::IFmt("hash mismatch! length {:d}", Header.GuestSize);
       return std::nullopt;
@@ -501,13 +550,14 @@ namespace DiskCache {
     IndexedDB* DB;
     MesaFOZ::foz_payload_key Key;
     fextl::vector<uint8_t> Blob;
-    IndexExtraBlob IndexBlob;
-    CacheStoreWorkItem(DiskCache* Self, IndexedDB* DB, const MesaFOZ::foz_payload_key& Key, fextl::vector<uint8_t>&& Blob, IndexExtraBlob IndexBlob)
+    fextl::vector<uint8_t> IndexBlob;
+    CacheStoreWorkItem(DiskCache* Self, IndexedDB* DB, const MesaFOZ::foz_payload_key& Key, fextl::vector<uint8_t>&& Blob,
+                       fextl::vector<uint8_t>&& IndexBlob)
       : Self(Self)
       , DB(DB)
       , Key(Key)
       , Blob(std::move(Blob))
-      , IndexBlob(IndexBlob) {}
+      , IndexBlob(std::move(IndexBlob)) {}
     void Run() override {
       DB->StoreCacheBlob(Key, Blob, Self->Index, Self->IndexLock, IndexBlob);
     }
@@ -552,6 +602,38 @@ namespace DiskCache {
       }
     }
 
+    fextl::vector<uint32_t> ExactGuestCodeExtents;
+    uint64_t CurStartExtent = 0, CurEndExtent = 0;
+    const Frontend::Decoder::DecodedBlocks* LastBlock = nullptr;
+    for (auto& SubBlock : DecodedBlockInfo->Blocks) {
+      if (!CurStartExtent) {
+        CurStartExtent = SubBlock.Entry;
+        CurEndExtent = SubBlock.Entry + SubBlock.Size;
+      } else {
+        LOGMAN_THROW_A_FMT(SubBlock.Entry >= CurEndExtent, "DecodedBlocks not sorted or overlapping?");
+        if (SubBlock.Entry == CurEndExtent) {
+          CurEndExtent = SubBlock.Entry + SubBlock.Size;
+        } else {
+          ExactGuestCodeExtents.push_back(CurStartExtent - GuestRIP);
+          ExactGuestCodeExtents.push_back(CurEndExtent - CurStartExtent);
+          CurStartExtent = SubBlock.Entry;
+          CurEndExtent = SubBlock.Entry + SubBlock.Size;
+        }
+      }
+      LastBlock = &SubBlock;
+    }
+    if (LastBlock && (CurStartExtent != GuestRIP || CurEndExtent != GuestRIP + GuestCode.size())) {
+      ExactGuestCodeExtents.push_back(CurStartExtent - GuestRIP);
+      ExactGuestCodeExtents.push_back(CurEndExtent - CurStartExtent);
+    }
+
+    // if (ExactGuestCodeExtents.size()) {
+    //   LogMan::Msg::IFmt("store! length {:d}", GuestCode.size());
+    //   for(uint32_t i = 0; i < ExactGuestCodeExtents.size(); i+=2 ) {
+    //     LogMan::Msg::IFmt("extent {} {}", ExactGuestCodeExtents[i], ExactGuestCodeExtents[i]+ExactGuestCodeExtents[i+1]);
+    //   }
+    // }
+
     const uint32_t EntryPointCount = (uint32_t)CompiledCode.EntryPoints.size();
     const uint32_t TouchedGuestPagesCount = DecodedBlockInfo ? (uint32_t)DecodedBlockInfo->CodePages.size() : 0;
 
@@ -584,8 +666,18 @@ namespace DiskCache {
       .SmallRelocCount = SmallRelocCount,
       .ThunkRelocCount = ThunkRelocCount,
       .TouchedGuestPagesCount = TouchedGuestPagesCount,
-      .GuestHash = XXH3_128bits(GuestCode.data(), GuestCode.size()),
     };
+
+    if (ExactGuestCodeExtents.size() == 0) {
+      Header.GuestHash = XXH3_128bits(GuestCode.data(), GuestCode.size());
+    } else {
+      XXH3_state_t HashState;
+      XXH3_128bits_reset(&HashState);
+      for (uint32_t i = 0; i < ExactGuestCodeExtents.size(); i += 2) {
+        XXH3_128bits_update(&HashState, GuestCode.data() + ExactGuestCodeExtents[i], ExactGuestCodeExtents[i + 1]);
+      }
+      Header.GuestHash = XXH3_128bits_digest(&HashState);
+    }
     memcpy(BlobData + HeaderOffset, &Header, sizeof(Header));
     memcpy(BlobData + HostCodeOffset, CompiledCode.BlockBegin, CompiledCode.Size);
 
@@ -653,9 +745,15 @@ namespace DiskCache {
 
     memcpy(BlobData + GuestCodeOffset, GuestCode.data(), GuestCode.size());
 
-    IndexExtraBlob IndexBlob {Header.GuestHash, Header.GuestSize};
+    fextl::vector<uint8_t> IndexBlob;
+    IndexBlob.resize(sizeof(IndexExtraBlobHeader) + ExactGuestCodeExtents.size() * sizeof(uint32_t));
+
+    IndexExtraBlobHeader IndexBlobHeader {Header.GuestHash, Header.GuestSize, (uint32_t)ExactGuestCodeExtents.size()};
+    memcpy(IndexBlob.data(), &IndexBlobHeader, sizeof(IndexExtraBlobHeader));
+    memcpy(IndexBlob.data() + sizeof(IndexExtraBlobHeader), ExactGuestCodeExtents.data(), ExactGuestCodeExtents.size() * sizeof(uint32_t));
+
     // hand the rest off to the writer thread
-    Writer->QueueWork(fextl::make_unique<CacheStoreWorkItem>(this, RWCacheDB.get(), Key, std::move(Blob), IndexBlob));
+    Writer->QueueWork(fextl::make_unique<CacheStoreWorkItem>(this, RWCacheDB.get(), Key, std::move(Blob), std::move(IndexBlob)));
     return true;
   }
 

--- a/FEXCore/include/FEXCore/Core/DiskCache.h
+++ b/FEXCore/include/FEXCore/Core/DiskCache.h
@@ -52,11 +52,13 @@ namespace DiskCache {
     uint32_t Size;
     uint32_t GuestSize;
     XXH128_hash_t GuestHash;
+    fextl::vector<uint32_t> GuestExtents;
   };
 
-  struct __attribute__((packed)) IndexExtraBlob {
+  struct __attribute__((packed)) IndexExtraBlobHeader {
     XXH128_hash_t GuestHash;
     uint32_t GuestSize;
+    uint32_t GuestExtentsCount;
   };
 
   struct __attribute__((packed)) BlobFixedHeader {
@@ -150,7 +152,7 @@ namespace DiskCache {
     void PopulateIndex(Index& CacheIndex, bool& FoundMetadata);
     bool ReadCacheBlob(uint64_t Offset, std::span<uint8_t> OutBlob);
     bool StoreCacheBlob(const MesaFOZ::foz_payload_key& Key, std::span<const uint8_t> Blob, Index& CacheIndex, std::mutex& IndexMutex,
-                        IndexExtraBlob IndexBlob);
+                        std::span<const uint8_t> IndexBlob);
 
   private:
     // stores run on the Writer, so returning quick isn't as important
@@ -205,7 +207,7 @@ namespace DiskCache {
 
   // TODO: This header is in global installed header path, but uses internal headers.
   // Migrate this once that is fixed.
-  static constexpr uint16_t FormatVersion = 5;
+  static constexpr uint16_t FormatVersion = 6;
   FEX_DEFAULT_VISIBILITY uint16_t GetFormatVersion();
 
 } // namespace DiskCache

--- a/unittests/InstructionCountCI/AFP/H0F3A.json
+++ b/unittests/InstructionCountCI/AFP/H0F3A.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "roundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/Secondary.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vsqrtss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AFP/VEX_map3.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map3.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vroundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AVX128/FMA4.json
+++ b/unittests/InstructionCountCI/AVX128/FMA4.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -13,7 +13,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vmovntps [rax], xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
@@ -8,7 +8,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vfmadd132ss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vmovntdqa xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -11,7 +11,7 @@
       "SVE256",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -8,7 +8,7 @@
       "AFP",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vblendvps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F3A.json
+++ b/unittests/InstructionCountCI/Crypto/H0F3A.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "pclmulqdq xmm0, xmm1, 00000b": {

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -10,7 +10,7 @@
       "AFP",
       "RPRES"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "These 3DNow! instructions are optimal assuming that FEX doesn't SRA MMX registers",

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -13,7 +13,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/libnss.json
+++ b/unittests/InstructionCountCI/FEXOpt/libnss.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [],
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Chained add": {

--- a/unittests/InstructionCountCI/FlagM/H0F38.json
+++ b/unittests/InstructionCountCI/FlagM/H0F38.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "ptest xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "The Witcher 3": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Sonic Mania movie player": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "FMOD scalar loop": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "The Sims 1 hot block": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "add al, 1": {

--- a/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "ucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
@@ -11,7 +11,7 @@
       "AFP",
       "FCMA"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "ucomisd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -12,7 +12,7 @@
       "AFP",
       "CSSC"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -10,7 +10,7 @@
       "AFP",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map_group.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map_group.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "blsr eax, ebx": {

--- a/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -11,7 +11,7 @@
       "CSSC",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "pshufb mm0, mm1": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -8,7 +8,7 @@
       "AFP",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "SSE4.2 string instructions are skipped here.",

--- a/unittests/InstructionCountCI/H0F3A_SVE128.json
+++ b/unittests/InstructionCountCI/H0F3A_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "dpps xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/MOPS/Primary.json
+++ b/unittests/InstructionCountCI/MOPS/Primary.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "rep movsb": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "MOPS"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "Instructions in this table that are marked optimal don't have their flag calculation part of this assumption",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -9,7 +9,7 @@
       "FlagM",
       "FlagM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "pfrcpv mm0, mm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "rsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "rsqrtss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -8,7 +8,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Repeat.json
+++ b/unittests/InstructionCountCI/Repeat.json
@@ -6,7 +6,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {}
 }

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -33,7 +33,7 @@
       "      - 1b: ECX = MSB",
       "[7]   - Reserved"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "pcmpestrm xmm0, xmm1, 0_0_00_00_00b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Comment": [
     "MMX instructions are defined as optimal without SRA being used for these instructions.",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -7,7 +7,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "push fs": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "movupd xmm0, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "addsubpd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "psrlw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -12,7 +12,7 @@
       "FRINTTS",
       "CSSC"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "movss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "movsd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "addsubps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "cvtpd2dq xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "cvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "movmskps eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -13,7 +13,7 @@
       "FLAGM2",
       "FRINTTS"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -8,7 +8,7 @@
       "FCMA"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -13,7 +13,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vcvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map2_svebitperm.json
+++ b/unittests/InstructionCountCI/VEX_map2_svebitperm.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "pext eax, ebx, ecx": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -8,7 +8,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/X87ldst-SVE.json
+++ b/unittests/InstructionCountCI/X87ldst-SVE.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "RPRES"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "fstp tword [rax]": {

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/x87_32Bit.json
+++ b/unittests/InstructionCountCI/x87_32Bit.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "Multiple fld/fst": {

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/x87_f64_32Bit.json
+++ b/unittests/InstructionCountCI/x87_f64_32Bit.json
@@ -15,7 +15,7 @@
       "SVE256",
       "CSSC"
     ],
-    "BinaryCacheVersion": 5
+    "BinaryCacheVersion": 6
   },
   "Instructions": {
     "fstp dword [ebx*4+0x204a20]": {


### PR DESCRIPTION
Does less hashing, improves hit rate when there's data adjacent to code,
and/or when the SMC check makes us rebuild code that hasn't actually been
changed.