### PR TITLE
Clear C1 for fdecstp and fincstp

### DIFF
--- a/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
+++ b/FEXCore/Source/Interface/Core/OpcodeDispatcher/X87.cpp
@@ -727,6 +727,9 @@ void OpDispatchBuilder::X87ModifySTP(OpcodeArgs, bool Inc) {
   } else {
     _DecStackTop();
   }
+
+  // C1 set to 0
+  SetRFLAG<FEXCore::X86State::X87FLAG_C1_LOC>(Constant(0));
 }
 
 // Operations dealing with loading and storing environment pieces

--- a/FEXCore/include/FEXCore/Core/DiskCache.h
+++ b/FEXCore/include/FEXCore/Core/DiskCache.h
@@ -210,7 +210,7 @@ namespace DiskCache {
 
   // TODO: This header is in global installed header path, but uses internal headers.
   // Migrate this once that is fixed.
-  static constexpr uint16_t FormatVersion = 11;
+  static constexpr uint16_t FormatVersion = 12;
   FEX_DEFAULT_VISIBILITY uint16_t GetFormatVersion();
 
 } // namespace DiskCache

--- a/unittests/ASM/FEX_bugs/X87ModifySTP_C1.asm
+++ b/unittests/ASM/FEX_bugs/X87ModifySTP_C1.asm
@@ -1,0 +1,31 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x0000000000000000",
+    "RBX": "0x0000000000000000"
+  }
+}
+%endif
+
+
+fninit
+
+fldenv [rel env]
+fdecstp
+fnstsw ax
+and rax, 0x0200
+mov r8, rax
+
+fldenv [rel env]
+fincstp
+fnstsw ax
+and rax, 0x0200 
+mov rbx, rax
+mov rax, r8
+
+hlt
+
+env:
+    dd 0x037F ; FCW
+    dd 0x3200 ; FSW: C1=1
+    dd 0x0000 ; FTW

--- a/unittests/InstructionCountCI/AFP/H0F3A.json
+++ b/unittests/InstructionCountCI/AFP/H0F3A.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "roundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/Secondary.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vsqrtss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AFP/VEX_map3.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map3.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vroundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AVX128/FMA4.json
+++ b/unittests/InstructionCountCI/AVX128/FMA4.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -13,7 +13,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vmovntps [rax], xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
@@ -8,7 +8,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vfmadd132ss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vmovntdqa xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -11,7 +11,7 @@
       "SVE256",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -8,7 +8,7 @@
       "AFP",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vblendvps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F3A.json
+++ b/unittests/InstructionCountCI/Crypto/H0F3A.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "pclmulqdq xmm0, xmm1, 00000b": {

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -10,7 +10,7 @@
       "AFP",
       "RPRES"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "These 3DNow! instructions are optimal assuming that FEX doesn't SRA MMX registers",

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -13,7 +13,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/libnss.json
+++ b/unittests/InstructionCountCI/FEXOpt/libnss.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [],
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Chained add": {

--- a/unittests/InstructionCountCI/FlagM/H0F38.json
+++ b/unittests/InstructionCountCI/FlagM/H0F38.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "ptest xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "The Witcher 3": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Sonic Mania movie player": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "FMOD scalar loop": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "The Sims 1 hot block": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "add al, 1": {

--- a/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "ucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
@@ -11,7 +11,7 @@
       "AFP",
       "FCMA"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "ucomisd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -12,7 +12,7 @@
       "AFP",
       "CSSC"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -10,7 +10,7 @@
       "AFP",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map_group.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map_group.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "blsr eax, ebx": {

--- a/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -11,7 +11,7 @@
       "CSSC",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -2895,11 +2895,12 @@
       ]
     },
     "fdecstp": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xd9 11b 0xf6 /6"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x7 (7)",
         "and w20, w20, #0x7",
@@ -2907,11 +2908,12 @@
       ]
     },
     "fincstp": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xd9 11b 0xf7 /6"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10304,11 +10306,12 @@
       ]
     },
     "ffreep st0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc0 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10316,11 +10319,12 @@
       ]
     },
     "ffreep st1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc1 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10328,11 +10332,12 @@
       ]
     },
     "ffreep st2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc2 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10340,11 +10345,12 @@
       ]
     },
     "ffreep st3": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc3 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10352,11 +10358,12 @@
       ]
     },
     "ffreep st4": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc4 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10364,11 +10371,12 @@
       ]
     },
     "ffreep st5": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc5 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10376,11 +10384,12 @@
       ]
     },
     "ffreep st6": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc6 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10388,11 +10397,12 @@
       ]
     },
     "ffreep st7": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc7 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -2322,11 +2322,12 @@
       ]
     },
     "fdecstp": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xd9 11b 0xf6 /6"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x7 (7)",
         "and w20, w20, #0x7",
@@ -2334,11 +2335,12 @@
       ]
     },
     "fincstp": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xd9 11b 0xf7 /6"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8185,11 +8187,12 @@
       ]
     },
     "ffreep st0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc0 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8197,11 +8200,12 @@
       ]
     },
     "ffreep st1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc1 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8209,11 +8213,12 @@
       ]
     },
     "ffreep st2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc2 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8221,11 +8226,12 @@
       ]
     },
     "ffreep st3": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc3 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8233,11 +8239,12 @@
       ]
     },
     "ffreep st4": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc4 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8245,11 +8252,12 @@
       ]
     },
     "ffreep st5": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc5 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8257,11 +8265,12 @@
       ]
     },
     "ffreep st6": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc6 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8269,11 +8278,12 @@
       ]
     },
     "ffreep st7": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc7 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "pshufb mm0, mm1": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -8,7 +8,7 @@
       "AFP",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "SSE4.2 string instructions are skipped here.",

--- a/unittests/InstructionCountCI/H0F3A_SVE128.json
+++ b/unittests/InstructionCountCI/H0F3A_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "dpps xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/MOPS/Primary.json
+++ b/unittests/InstructionCountCI/MOPS/Primary.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "rep movsb": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "MOPS"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "Instructions in this table that are marked optimal don't have their flag calculation part of this assumption",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -9,7 +9,7 @@
       "FlagM",
       "FlagM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "pfrcpv mm0, mm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "rsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "rsqrtss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -8,7 +8,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Repeat.json
+++ b/unittests/InstructionCountCI/Repeat.json
@@ -6,7 +6,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {}
 }

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -33,7 +33,7 @@
       "      - 1b: ECX = MSB",
       "[7]   - Reserved"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "pcmpestrm xmm0, xmm1, 0_0_00_00_00b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Comment": [
     "MMX instructions are defined as optimal without SRA being used for these instructions.",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -7,7 +7,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "push fs": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "movupd xmm0, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "addsubpd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "psrlw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -12,7 +12,7 @@
       "FRINTTS",
       "CSSC"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "movss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "movsd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "addsubps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "cvtpd2dq xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "cvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "movmskps eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -13,7 +13,7 @@
       "FLAGM2",
       "FRINTTS"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -8,7 +8,7 @@
       "FCMA"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -13,7 +13,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vcvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map2_svebitperm.json
+++ b/unittests/InstructionCountCI/VEX_map2_svebitperm.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "pext eax, ebx, ecx": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -8,7 +8,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/X87ldst-SVE.json
+++ b/unittests/InstructionCountCI/X87ldst-SVE.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "RPRES"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "fstp tword [rax]": {

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -2894,11 +2894,12 @@
       ]
     },
     "fdecstp": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xd9 11b 0xf6 /6"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x7 (7)",
         "and w20, w20, #0x7",
@@ -2906,11 +2907,12 @@
       ]
     },
     "fincstp": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xd9 11b 0xf7 /6"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10239,11 +10241,12 @@
       ]
     },
     "ffreep st0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc0 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10251,11 +10254,12 @@
       ]
     },
     "ffreep st1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc1 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10263,11 +10267,12 @@
       ]
     },
     "ffreep st2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc2 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10275,11 +10280,12 @@
       ]
     },
     "ffreep st3": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc3 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10287,11 +10293,12 @@
       ]
     },
     "ffreep st4": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc4 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10299,11 +10306,12 @@
       ]
     },
     "ffreep st5": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc5 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10311,11 +10319,12 @@
       ]
     },
     "ffreep st6": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc6 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -10323,11 +10332,12 @@
       ]
     },
     "ffreep st7": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc7 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",

--- a/unittests/InstructionCountCI/x87_32Bit.json
+++ b/unittests/InstructionCountCI/x87_32Bit.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "Multiple fld/fst": {

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -2340,11 +2340,12 @@
       ]
     },
     "fdecstp": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xd9 11b 0xf6 /6"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x7 (7)",
         "and w20, w20, #0x7",
@@ -2352,11 +2353,12 @@
       ]
     },
     "fincstp": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xd9 11b 0xf7 /6"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8243,11 +8245,12 @@
       ]
     },
     "ffreep st0": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc0 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8255,11 +8258,12 @@
       ]
     },
     "ffreep st1": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc1 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8267,11 +8271,12 @@
       ]
     },
     "ffreep st2": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc2 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8279,11 +8284,12 @@
       ]
     },
     "ffreep st3": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc3 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8291,11 +8297,12 @@
       ]
     },
     "ffreep st4": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc4 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8303,11 +8310,12 @@
       ]
     },
     "ffreep st5": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc5 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8315,11 +8323,12 @@
       ]
     },
     "ffreep st6": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc6 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",
@@ -8327,11 +8336,12 @@
       ]
     },
     "ffreep st7": {
-      "ExpectedInstructionCount": 4,
+      "ExpectedInstructionCount": 5,
       "Comment": [
         "0xdf 11b 0xc7 /0"
       ],
       "ExpectedArm64ASM": [
+        "strb wzr, [x28, #1049]",
         "ldrb w20, [x28, #1051]",
         "add w20, w20, #0x1 (1)",
         "and w20, w20, #0x7",

--- a/unittests/InstructionCountCI/x87_f64_32Bit.json
+++ b/unittests/InstructionCountCI/x87_f64_32Bit.json
@@ -15,7 +15,7 @@
       "SVE256",
       "CSSC"
     ],
-    "BinaryCacheVersion": 11
+    "BinaryCacheVersion": 12
   },
   "Instructions": {
     "fstp dword [ebx*4+0x204a20]": {


### PR DESCRIPTION
C1 should be cleared to 0 for the fdecstp and fincstp instructions (SDM).