### PR TITLE
DiskCache: disable with thunk relocs for now

### DIFF
--- a/FEXCore/Source/Interface/Core/DiskCache.cpp
+++ b/FEXCore/Source/Interface/Core/DiskCache.cpp
@@ -596,6 +596,8 @@ namespace DiskCache {
     uint32_t ThunkRelocCount = 0;
     for (const auto& Reloc : Relocations) {
       if (Reloc.Header.Type == CPU::RelocationTypes::RELOC_NAMED_THUNK_MOVE) {
+        // todo we miss the thunk bytes in the hash extents so need to bail for those for now
+        return false;
         ThunkRelocCount++;
       } else {
         SmallRelocCount++;


### PR DESCRIPTION
Block extents currently don't include some of their data.