### PR TITLE
DiskCache: initial anon caching

### DIFF
--- a/FEXCore/Source/Interface/Config/Config.json.in
+++ b/FEXCore/Source/Interface/Config/Config.json.in
@@ -168,6 +168,14 @@
           "Don't cache blocks with relocations pointing outside of any known region"
         ]
       },
+      "DiskCacheAnonCaching": {
+        "Type": "bool",
+        "Default": "true",
+        "AffectsCodeGen": "false",
+        "Desc": [
+          "Attempt to cache anonymous code"
+        ]
+      },
       "DiskCachePath": {
         "Type": "str",
         "Default": "",

--- a/FEXCore/Source/Interface/Core/Core.cpp
+++ b/FEXCore/Source/Interface/Core/Core.cpp
@@ -542,7 +542,7 @@ ContextImpl::GenerateIR(FEXCore::Core::InternalThreadState* Thread, uint64_t Gue
   if (!HasCustomIR) {
     const auto* GuestCode = reinterpret_cast<const uint8_t*>(GuestRIP);
 
-    Thread->FrontendDecoder->DecodeInstructionsAtEntry(Thread, GuestCode, GuestRIP, MaxInst);
+    Thread->FrontendDecoder->DecodeLoop(GuestCode);
 
     const auto* BlockInfo = Thread->FrontendDecoder->GetDecodedBlockInfo();
     const auto& CodeBlocks = BlockInfo->Blocks;
@@ -883,13 +883,16 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
     return HostCode;
   }
 
+  Thread->FrontendDecoder->SetupDecodeInstructionsAtEntry(Thread, GuestRIP, MaxInst);
+
   std::optional<ExecutableFileSectionInfo> Region = SyscallHandler->LookupExecutableFileSection(Thread, GuestRIP);
   std::optional<DiskCache::CodeHitData> Hit;
+  std::optional<uint64_t> DiskCacheGuestCodeKey;
   bool DiskCacheHitRelocationsApplied = false;
   bool LoadDiskCacheCode = true;
-  if (Region && Region->FileStartVA != 0) {
+  {
     FEXCORE_PROFILE_ACCUMULATION(Thread, AccumulatedDiskCacheLookupTime);
-    Hit = DiskCache.Lookup(Thread, *Region, GuestRIP);
+    Hit = DiskCache.Lookup(Thread, Region, GuestRIP, DiskCacheGuestCodeKey);
     if (Hit) {
       DiskCacheHitRelocationsApplied =
         CodeCache.ApplyPackedCodeRelocations(GuestRIP, std::as_writable_bytes(Hit->HostCode), Hit->SmallRelocs, Hit->ThunkRelocs, false);
@@ -917,6 +920,7 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
           LOGMAN_THROW_A_FMT(CachedHostCode != 0, "Couldn't find GuestRIP in Disk Cache entrypoints!");
 
           FEXCORE_PROFILE_INSTANT_INCREMENT(Thread, AccumulatedDiskCacheHitCount, 1);
+          Thread->FrontendDecoder->DelayedDisownBuffer();
           return CachedHostCode;
         }
       }
@@ -994,16 +998,19 @@ uintptr_t ContextImpl::CompileBlock(FEXCore::Core::CpuStateFrame* Frame, uint64_
   }
 
   // Disk Cache
-  if (Region && Region->FileStartVA != 0 && !CodeCache.IsGeneratingCache) {
-    std::span<const FEXCore::CPU::Relocation> Relocations;
-    if (DebugData && DebugData->Relocations) {
-      Relocations = *DebugData->Relocations;
+  if (!CodeCache.IsGeneratingCache) {
+    if (DiskCacheGuestCodeKey) {
+      std::span<const FEXCore::CPU::Relocation> Relocations;
+      if (DebugData && DebugData->Relocations) {
+        Relocations = *DebugData->Relocations;
+      }
+      std::span<const uint8_t> GuestCode = {reinterpret_cast<const uint8_t*>(StartAddr), Length};
+      const Frontend::Decoder::DecodedBlockInformation* BlockInfo =
+        NeedsAddGuestCodeRanges ? Thread->FrontendDecoder->GetDecodedBlockInfo() : nullptr;
+      DiskCache.Store(Thread, Region, GuestRIP, *DiskCacheGuestCodeKey, GuestCode, CompiledCode, Relocations, BlockInfo);
     }
-    std::span<const uint8_t> GuestCode = {reinterpret_cast<const uint8_t*>(StartAddr), Length};
-    const Frontend::Decoder::DecodedBlockInformation* BlockInfo = NeedsAddGuestCodeRanges ? Thread->FrontendDecoder->GetDecodedBlockInfo() : nullptr;
-    DiskCache.Store(Thread, *Region, GuestRIP, GuestCode, CompiledCode, Relocations, BlockInfo);
 
-    if (CodeMapWriter) {
+    if (CodeMapWriter && Region && Region->FileStartVA != 0) {
       CodeMapWriter->AppendBlock(*Region, GuestRIP);
     }
   }
@@ -1030,6 +1037,7 @@ uintptr_t ContextImpl::CompileSingleStep(FEXCore::Core::CpuStateFrame* Frame, ui
   // Invalidate might take a unique lock on this, to guarantee that during invalidation no code gets compiled
   auto lk = GuardSignalDeferringSection<std::shared_lock>(CodeInvalidationMutex, Thread);
 
+  Thread->FrontendDecoder->SetupDecodeInstructionsAtEntry(Thread, GuestRIP, 1);
   auto [CompiledCode, DebugData, StartAddr, Length, _] = CompileCode(Thread, GuestRIP, 1);
   auto CodePtr = CompiledCode.EntryPoints[GuestRIP];
   if (CodePtr == nullptr) {

--- a/FEXCore/Source/Interface/Core/DiskCache.cpp
+++ b/FEXCore/Source/Interface/Core/DiskCache.cpp
@@ -2,6 +2,8 @@
 
 #define XXH_STATIC_LINKING_ONLY
 
+#include "FEXCore/Utils/TypeDefines.h"
+#include "Interface/Core/Frontend.h"
 #include "FEXCore/Config/Config.h"
 #include "FEXCore/fextl/string.h"
 #include "FEXHeaderUtils/Filesystem.h"
@@ -237,6 +239,9 @@ namespace DiskCache {
           if (!ExtentsValid) {
             continue;
           }
+        } else {
+          NewEntry.GuestExtents.push_back(0);
+          NewEntry.GuestExtents.push_back(IndexBlobExtra->GuestSize);
         }
         CacheIndex.insert({IndexBlobCommon->hash, {std::move(NewEntry)}});
       } else {
@@ -325,6 +330,9 @@ namespace DiskCache {
       NewEntry.GuestExtents.resize(IndexBlobHeader->GuestExtentsCount);
       memcpy(NewEntry.GuestExtents.data(), reinterpret_cast<const uint32_t*>(IndexBlob.data() + sizeof(IndexExtraBlobHeader)),
              IndexBlobHeader->GuestExtentsCount * sizeof(uint32_t));
+    } else {
+      NewEntry.GuestExtents.push_back(0);
+      NewEntry.GuestExtents.push_back(IndexBlobHeader->GuestSize);
     }
     std::lock_guard Guard(IndexMutex);
     Index.insert_or_assign(Hash, std::move(NewEntry));
@@ -431,22 +439,44 @@ namespace DiskCache {
     }
   }
 
-  uint64_t DiskCache::MakeBlobKey(const uint64_t ModuleOffset) {
+  uint64_t DiskCache::MakeBlobKey(const uint64_t CodeKey) {
     struct {
-      uint64_t ModuleOffset;
+      uint64_t CodeKey;
       XXH128_hash_t BucketHash;
-    } BlobKeyBytes = {ModuleOffset, BucketHash};
+    } BlobKeyBytes = {CodeKey, BucketHash};
 
     return XXH3_64bits(&BlobKeyBytes, sizeof(BlobKeyBytes));
   }
 
-  std::optional<CodeHitData> DiskCache::Lookup(Core::InternalThreadState* Thread, const ExecutableFileSectionInfo& Region, uint64_t GuestRIP) {
+  std::optional<CodeHitData> DiskCache::Lookup(Core::InternalThreadState* Thread, std::optional<ExecutableFileSectionInfo> Region,
+                                               uint64_t GuestRIP, std::optional<uint64_t>& GuestCodeKey) {
     if (!IsReadingDiskCache()) {
       return std::nullopt;
     }
-    uint64_t ModuleOffset = GuestRIP - Region.FileStartVA;
+    if (Region && Region->FileStartVA) {
+      GuestCodeKey = GuestRIP - Region->FileStartVA;
+    } else {
+      if (!AnonCaching) {
+        return std::nullopt;
+      }
+      Thread->FrontendDecoder->DecodeLoop(reinterpret_cast<const uint8_t*>(GuestRIP), AnonPrefixGuestBytes);
+      XXH3_state_t HashState;
+      XXH3_64bits_reset(&HashState);
+      for (auto& SubBlock : Thread->FrontendDecoder->GetDecodedBlockInfo()->Blocks) {
+        XXH3_64bits_update(&HashState, reinterpret_cast<const uint8_t*>(SubBlock.Entry), SubBlock.Size);
+        if (SubBlock.BlockStatus != Frontend::Decoder::DecodedBlockStatus::SUCCESS) {
+          return std::nullopt;
+        }
+      }
+      GuestCodeKey = XXH3_64bits_digest(&HashState);
+      // if (TotalSize < AnonPrefixGuestBytes) {
+      //   GuestCodeKey = 0;
+      //   return std::nullopt;
+      // }
+      // LogMan::Msg::IFmt("anon lookup! length {:d} {}", GuestCodeKey, TotalSize);
+    }
 
-    uint64_t Hash = MakeBlobKey(ModuleOffset);
+    uint64_t Hash = MakeBlobKey(*GuestCodeKey);
 
     IndexEntry Entry;
     {
@@ -479,16 +509,22 @@ namespace DiskCache {
     //     LogMan::Msg::IFmt("extent {} {}", Entry.GuestExtents[i], Entry.GuestExtents[i]+Entry.GuestExtents[i+1]);
     //   }
     // }
-    if (Entry.GuestExtents.size() == 0) {
-      LiveGuestHash = XXH3_128bits(reinterpret_cast<void*>(GuestRIP), Entry.GuestSize);
-    } else {
-      XXH3_state_t HashState;
-      XXH3_128bits_reset(&HashState);
-      for (uint32_t i = 0; i < Entry.GuestExtents.size(); i += 2) {
-        XXH3_128bits_update(&HashState, reinterpret_cast<uint8_t*>(GuestRIP) + Entry.GuestExtents[i], Entry.GuestExtents[i + 1]);
+    fextl::vector<uint64_t> GuestPages;
+
+    XXH3_state_t HashState;
+    XXH3_128bits_reset(&HashState);
+    for (uint32_t i = 0; i < Entry.GuestExtents.size(); i += 2) {
+      XXH3_128bits_update(&HashState, reinterpret_cast<uint8_t*>(GuestRIP) + Entry.GuestExtents[i], Entry.GuestExtents[i + 1]);
+      uint64_t FirstPage = (Entry.GuestExtents[i] + GuestRIP) & Utils::FEX_PAGE_MASK;
+      uint64_t LastPage = (Entry.GuestExtents[i] + Entry.GuestExtents[i + 1] + GuestRIP) & Utils::FEX_PAGE_MASK;
+      for (uint64_t Page = FirstPage; Page <= LastPage; Page += Utils::FEX_PAGE_SIZE) {
+        if (GuestPages.size() == 0 || Page != GuestPages.back()) {
+          GuestPages.push_back(Page);
+        }
       }
-      LiveGuestHash = XXH3_128bits_digest(&HashState);
     }
+    LiveGuestHash = XXH3_128bits_digest(&HashState);
+
     if (!XXH128_isEqual(LiveGuestHash, Entry.GuestHash)) {
       // LogMan::Msg::IFmt("hash mismatch! length {:d}", Header.GuestSize);
       return std::nullopt;
@@ -498,8 +534,10 @@ namespace DiskCache {
     // this seems to be a full hit, pull from disk and check the entry is big enough to have everything (except GuestCode)
     CodeHitData HitData;
     uint32_t EntrySizeWithoutGuestCode = Entry.Size - Entry.GuestSize;
-    HitData.Blob.resize(EntrySizeWithoutGuestCode);
-    if (!Entry.DB->ReadCacheBlob(Entry.Offset, HitData.Blob)) {
+    HitData.Blob.resize(GuestPages.size() * sizeof(uint64_t) + EntrySizeWithoutGuestCode);
+    memcpy(HitData.Blob.data(), GuestPages.data(), GuestPages.size() * sizeof(uint64_t));
+    uint32_t BlobOffset = GuestPages.size() * sizeof(uint64_t);
+    if (!Entry.DB->ReadCacheBlob(Entry.Offset, {HitData.Blob.data() + BlobOffset, EntrySizeWithoutGuestCode})) {
       return std::nullopt;
     }
 
@@ -507,11 +545,11 @@ namespace DiskCache {
       return std::nullopt;
     }
     BlobFixedHeader Header;
-    memcpy(&Header, HitData.Blob.data(), sizeof(Header));
+    memcpy(&Header, HitData.Blob.data() + BlobOffset, sizeof(Header));
+    BlobOffset += sizeof(Header);
 
     uint32_t SizeNeeded = sizeof(Header) + Header.HostSize + Header.EntryPointCount * (sizeof(uint64_t) + sizeof(uint32_t));
-    SizeNeeded += Header.SmallRelocCount * sizeof(BlobSmallRelocation) + Header.ThunkRelocCount * sizeof(BlobThunkRelocation) +
-                  Header.TouchedGuestPagesCount * sizeof(uint64_t);
+    SizeNeeded += Header.SmallRelocCount * sizeof(BlobSmallRelocation) + Header.ThunkRelocCount * sizeof(BlobThunkRelocation);
     if (EntrySizeWithoutGuestCode != SizeNeeded) {
       return std::nullopt;
     }
@@ -520,12 +558,8 @@ namespace DiskCache {
       return std::nullopt;
     }
 
-    uint32_t BlobOffset = sizeof(Header);
-
     HitData.HostCode = {HitData.Blob.data() + BlobOffset, Header.HostSize};
     BlobOffset += Header.HostSize;
-    HitData.GuestPages = {reinterpret_cast<uint64_t*>(HitData.Blob.data() + BlobOffset), Header.TouchedGuestPagesCount};
-    BlobOffset += Header.TouchedGuestPagesCount * sizeof(uint64_t);
     HitData.EntryPointRIPs = {reinterpret_cast<uint64_t*>(HitData.Blob.data() + BlobOffset), Header.EntryPointCount};
     BlobOffset += Header.EntryPointCount * sizeof(uint64_t);
     HitData.EntryPointHostOffsets = {reinterpret_cast<const uint32_t*>(HitData.Blob.data() + BlobOffset), Header.EntryPointCount};
@@ -535,9 +569,8 @@ namespace DiskCache {
     HitData.ThunkRelocs = {reinterpret_cast<const BlobThunkRelocation*>(HitData.Blob.data() + BlobOffset), Header.ThunkRelocCount};
     BlobOffset += Header.ThunkRelocCount * sizeof(BlobThunkRelocation);
 
-    for (auto& PageOffset : HitData.GuestPages) {
-      PageOffset += GuestRIP;
-    }
+    HitData.GuestPages = {reinterpret_cast<uint64_t*>(HitData.Blob.data()), GuestPages.size()};
+
     for (auto& EntryPointRip : HitData.EntryPointRIPs) {
       EntryPointRip += GuestRIP;
     }
@@ -563,8 +596,8 @@ namespace DiskCache {
     }
   };
 
-  bool DiskCache::Store(Core::InternalThreadState* Thread, const ExecutableFileSectionInfo& Region, uint64_t GuestRIP,
-                        std::span<const uint8_t> GuestCode, const CPU::CPUBackend::CompiledCode& CompiledCode,
+  bool DiskCache::Store(Core::InternalThreadState* Thread, std::optional<ExecutableFileSectionInfo> Region, uint64_t GuestRIP,
+                        uint64_t GuestCodeKey, std::span<const uint8_t> GuestCode, const CPU::CPUBackend::CompiledCode& CompiledCode,
                         std::span<const FEXCore::CPU::Relocation> Relocations, const Frontend::Decoder::DecodedBlockInformation* DecodedBlockInfo) {
     if (!IsWritingDiskCache()) {
       return false;
@@ -572,20 +605,19 @@ namespace DiskCache {
     if (!DecodedBlockInfo) {
       return false;
     }
-
     // check for any reloc targets outside of our jurisdiction
     // todo what are they exactly? caching those blocks is great when it works, so need to figure this out and make finer-grained if we can
-    if (RelocationFilter) {
+    if (RelocationFilter && Region) {
       for (const auto& Reloc : Relocations) {
         if (Reloc.Header.Type != CPU::RelocationTypes::RELOC_GUEST_RIP_LITERAL && Reloc.Header.Type != CPU::RelocationTypes::RELOC_GUEST_RIP_MOVE) {
           continue;
         }
         uint64_t Target = Reloc.GuestRIP.GuestRIP;
-        if (Target >= Region.BeginVA && Target < Region.EndVA) {
+        if (Target >= Region->BeginVA && Target < Region->EndVA) {
           continue;
         }
         auto TargetSection = CTX->SyscallHandler->LookupExecutableFileSection(Thread, Target);
-        if (!TargetSection || TargetSection->FileInfo.FileId != Region.FileInfo.FileId) {
+        if (!TargetSection || TargetSection->FileInfo.FileId != Region->FileInfo.FileId) {
           // we don't know where it's pointing, so we don't know how to encode the offset, so we can't cache atm
           return false;
         }
@@ -606,6 +638,9 @@ namespace DiskCache {
     uint64_t CurStartExtent = 0, CurEndExtent = 0;
     const Frontend::Decoder::DecodedBlocks* LastBlock = nullptr;
     for (auto& SubBlock : DecodedBlockInfo->Blocks) {
+      if (SubBlock.BlockStatus != Frontend::Decoder::DecodedBlockStatus::SUCCESS) {
+        return false;
+      }
       if (!CurStartExtent) {
         CurStartExtent = SubBlock.Entry;
         CurEndExtent = SubBlock.Entry + SubBlock.Size;
@@ -635,12 +670,10 @@ namespace DiskCache {
     // }
 
     const uint32_t EntryPointCount = (uint32_t)CompiledCode.EntryPoints.size();
-    const uint32_t TouchedGuestPagesCount = DecodedBlockInfo ? (uint32_t)DecodedBlockInfo->CodePages.size() : 0;
 
     const size_t HeaderOffset = 0;
     const size_t HostCodeOffset = HeaderOffset + sizeof(BlobFixedHeader);
-    const size_t TouchedGuestPagesOffset = HostCodeOffset + CompiledCode.Size;
-    const size_t EntryPointRIPsOffset = TouchedGuestPagesOffset + TouchedGuestPagesCount * sizeof(uint64_t);
+    const size_t EntryPointRIPsOffset = HostCodeOffset + CompiledCode.Size;
     const size_t EntryPointHostOffsetsOffset = EntryPointRIPsOffset + EntryPointCount * sizeof(uint64_t);
     const size_t SmallRelocsOffset = EntryPointHostOffsetsOffset + EntryPointCount * sizeof(uint32_t);
     const size_t ThunkRelocsOffset = SmallRelocsOffset + SmallRelocCount * sizeof(BlobSmallRelocation);
@@ -652,9 +685,7 @@ namespace DiskCache {
     Blob.resize(TotalSize);
     uint8_t* BlobData = Blob.data();
 
-    uint64_t ModuleOffset = GuestRIP - Region.FileStartVA;
-
-    uint64_t BlobKey = MakeBlobKey(ModuleOffset);
+    uint64_t BlobKey = MakeBlobKey(GuestCodeKey);
     MesaFOZ::foz_payload_key Key = {};
     fextl::string BlobName = fextl::fmt::format("{:016x}", BlobKey);
     memcpy(Key.bytes, BlobName.data(), BlobName.size());
@@ -665,7 +696,6 @@ namespace DiskCache {
       .EntryPointCount = EntryPointCount,
       .SmallRelocCount = SmallRelocCount,
       .ThunkRelocCount = ThunkRelocCount,
-      .TouchedGuestPagesCount = TouchedGuestPagesCount,
     };
 
     if (ExactGuestCodeExtents.size() == 0) {
@@ -680,13 +710,6 @@ namespace DiskCache {
     }
     memcpy(BlobData + HeaderOffset, &Header, sizeof(Header));
     memcpy(BlobData + HostCodeOffset, CompiledCode.BlockBegin, CompiledCode.Size);
-
-    // relocate touched pages relative to GuestRIP
-    auto* PageOffsets = reinterpret_cast<uint64_t*>(BlobData + TouchedGuestPagesOffset);
-    uint32_t PageIdx = 0;
-    for (auto GuestPage : DecodedBlockInfo->CodePages) {
-      PageOffsets[PageIdx++] = GuestPage - GuestRIP;
-    }
 
     // pack and relocate entrypoints
     auto* EntryRIPs = reinterpret_cast<uint64_t*>(BlobData + EntryPointRIPsOffset);

--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -1380,107 +1380,67 @@ const Decoder::DecodeStream Decoder::AdjustAddrForSpecialRegion(const uint8_t* _
 }
 
 bool Decoder::CheckIfCacheable(FEXCore::Core::InternalThreadState& Thread, const uint8_t* InstStream, uint64_t PC, uint64_t MaxInst) {
-  DecodeInstructionsAtEntry(&Thread, InstStream, PC, MaxInst);
+  SetupDecodeInstructionsAtEntry(&Thread, PC, MaxInst);
+  DecodeLoop(InstStream);
   bool Uncacheable = HitBadRelocation;
   DelayedDisownBuffer();
   return !Uncacheable;
 }
 
-void Decoder::DecodeInstructionsAtEntry(FEXCore::Core::InternalThreadState* Thread, const uint8_t* _InstStream, uint64_t PC, uint64_t MaxInst) {
-  FEXCORE_PROFILE_SCOPED("DecodeInstructions");
-  BlockInfo.TotalInstructionCount = 0;
-  BlockInfo.Blocks.clear();
-  VisitedBlocks.clear();
-  // Reset internal state management
-  DecodedSize = 0;
-  MaxCondBranchForward = 0;
-  MaxCondBranchBackwards = ~0ULL;
-  DecodedBuffer = PoolObject.ReownOrClaimBuffer();
+void Decoder::DecodeLoop(const uint8_t* _InstStream, uint64_t GuestSizePause) {
+  while (!FinalInstruction && (Paused || !BlocksToDecode.empty())) {
+    bool Pausing = false;
+    fextl::vector<DecodedBlocks>::iterator BlockIt;
+    if (!Paused || BlockResume == -1) {
+      auto BlockDecodeIt = BlocksToDecode.begin();
+      uint64_t RIPToDecode = *BlockDecodeIt;
+      BlocksToDecode.erase(BlockDecodeIt);
+      VisitedBlocks.emplace(RIPToDecode);
 
-  // Decode operating mode from thread's CS segment.
-  const auto CSSegment = Core::CPUState::GetSegmentFromIndex(Thread->CurrentFrame->State, Thread->CurrentFrame->State.cs_idx);
-  BlockInfo.Is64BitMode = CSSegment->L == 1;
-  LOGMAN_THROW_A_FMT(BlockInfo.Is64BitMode == CTX->Config.Is64BitMode, "Expected operating mode to not change at runtime!");
+      auto BlockSuccIt = std::lower_bound(BlockInfo.Blocks.begin(), BlockInfo.Blocks.end(), RIPToDecode,
+                                          [](const auto& a, uint64_t Address) { return a.Entry < Address; });
 
-  EntryPoint = PC;
-  BlockInfo.EntryPoints = {PC};
+      LOGMAN_THROW_A_FMT(BlockSuccIt == BlockInfo.Blocks.end() || BlockSuccIt->Entry != RIPToDecode, "unexpected");
 
-  uint64_t TotalInstructions {};
+      NextBlockStartAddress = ~0ULL;
+      if (!BlocksToDecode.empty()) {
+        // We just erased the lowest, the front is then the second lowest
+        NextBlockStartAddress = *BlocksToDecode.begin();
+      }
+      if (BlockSuccIt != BlockInfo.Blocks.end() && BlockSuccIt->Entry < NextBlockStartAddress) {
+        NextBlockStartAddress = BlockSuccIt->Entry;
+      }
 
-  SectionMinAddress = 0;
-  SectionMaxAddress = ~0ULL;
-  Relocations = nullptr;
+      LOGMAN_THROW_A_FMT(NextBlockStartAddress == ~0ULL || NextBlockStartAddress > RIPToDecode, "unexpected");
 
-  if (CTX->GetCodeCache().IsGeneratingCache || EnableCodeCacheValidation) {
-    // If generating cache, attempt to load section bounds and relocations
-    if (auto SectionInfo = CTX->SyscallHandler->LookupExecutableFileSection(Thread, EntryPoint)) {
-      SectionMinAddress = SectionInfo->FileStartVA;
-      SectionMaxAddress = SectionInfo->EndVA;
-      Relocations = &SectionInfo->FileInfo.Relocations;
-    }
-  }
+      // Insert the block now so it can be looked up and split if necessary on a backward edge
+      BlockIt = BlockInfo.Blocks.emplace(BlockSuccIt);
 
-  DecodedMinAddress = EntryPoint;
-  DecodedMaxAddress = EntryPoint;
+      BlockIt->Entry = RIPToDecode;
+      BlockIt->Size = 0;
+      BlockIt->IsEntryPoint = EntryBlock;
 
-  // Entry is a jump target
-  BlocksToDecode = {PC};
+      PCOffset = 0;
+      BlockStartOffset = DecodedSize;
+      EraseBlock = true; // Unset once the block contains an instruction
 
-  uint64_t CurrentCodePage = PC & FEXCore::Utils::FEX_PAGE_MASK;
+      BlockIt->DecodedInstructions = &DecodedBuffer[BlockStartOffset];
+      BlockIt->NumInstructions = 0;
 
-  BlockInfo.CodePages = {CurrentCodePage};
-
-  if (MaxInst == 0) {
-    MaxInst = CTX->Config.MaxInstPerBlock;
-  }
-
-  bool EntryBlock {true};
-  bool FinalInstruction {false};
-
-  while (!FinalInstruction && !BlocksToDecode.empty()) {
-    auto BlockDecodeIt = BlocksToDecode.begin();
-    uint64_t RIPToDecode = *BlockDecodeIt;
-    BlocksToDecode.erase(BlockDecodeIt);
-    VisitedBlocks.emplace(RIPToDecode);
-
-    auto BlockSuccIt = std::lower_bound(BlockInfo.Blocks.begin(), BlockInfo.Blocks.end(), RIPToDecode,
-                                        [](const auto& a, uint64_t Address) { return a.Entry < Address; });
-
-    LOGMAN_THROW_A_FMT(BlockSuccIt == BlockInfo.Blocks.end() || BlockSuccIt->Entry != RIPToDecode, "unexpected");
-
-    NextBlockStartAddress = ~0ULL;
-    if (!BlocksToDecode.empty()) {
-      // We just erased the lowest, the front is then the second lowest
-      NextBlockStartAddress = *BlocksToDecode.begin();
-    }
-    if (BlockSuccIt != BlockInfo.Blocks.end() && BlockSuccIt->Entry < NextBlockStartAddress) {
-      NextBlockStartAddress = BlockSuccIt->Entry;
+      // Do a bit of pointer math to figure out where we are in code
+      InstStream = AdjustAddrForSpecialRegion(_InstStream, EntryPoint, RIPToDecode);
+    } else if (BlockResume != -1) {
+      BlockIt = BlockInfo.Blocks.begin() + BlockResume;
+      BlockResume = -1;
     }
 
-    LOGMAN_THROW_A_FMT(NextBlockStartAddress == ~0ULL || NextBlockStartAddress > RIPToDecode, "unexpected");
-
-    // Insert the block now so it can be looked up and split if necessary on a backward edge
-    auto BlockIt = BlockInfo.Blocks.emplace(BlockSuccIt);
-
-    BlockIt->Entry = RIPToDecode;
-    BlockIt->Size = 0;
-    BlockIt->IsEntryPoint = EntryBlock;
-
-    uint64_t PCOffset = 0;
-    uint64_t BlockStartOffset = DecodedSize;
-    bool EraseBlock = true; // Unset once the block contains an instruction
-
-    BlockIt->DecodedInstructions = &DecodedBuffer[BlockStartOffset];
-    BlockIt->NumInstructions = 0;
-
-    // Do a bit of pointer math to figure out where we are in code
-    InstStream = AdjustAddrForSpecialRegion(_InstStream, EntryPoint, RIPToDecode);
+    Paused = false;
 
     while (1) {
       InstructionSize = 0;
 
       // MAX_INST_SIZE assumes worst case
-      auto OpAddress = RIPToDecode + PCOffset;
+      auto OpAddress = BlockIt->Entry + PCOffset;
       auto OpMaxAddress = OpAddress + MAX_INST_SIZE;
 
       auto OpMinPage = OpAddress & FEXCore::Utils::FEX_PAGE_MASK;
@@ -1548,6 +1508,15 @@ void Decoder::DecodeInstructionsAtEntry(FEXCore::Core::InternalThreadState* Thre
         break;
       }
 
+      if (GuestSizePause) {
+        if (GuestSizePause > DecodeInst->InstSize) {
+          GuestSizePause -= DecodeInst->InstSize;
+        } else {
+          GuestSizePause = 0;
+          Pausing = true;
+        }
+      }
+
       // Check if we need to end the entire multiblock
       FinalInstruction = DecodedSize >= MaxInst || DecodedSize >= DefaultDecodedBufferSize || TotalInstructions >= MaxInst;
       if (FinalInstruction) {
@@ -1569,6 +1538,17 @@ void Decoder::DecodeInstructionsAtEntry(FEXCore::Core::InternalThreadState* Thre
 
       PCOffset += DecodeInst->InstSize;
       InstStream += DecodeInst->InstSize;
+
+      if (Pausing) {
+        Pausing = false;
+        Paused = true;
+        BlockResume = BlockIt - BlockInfo.Blocks.begin();
+        break;
+      }
+    }
+
+    if (Paused) {
+      break;
     }
 
     // NOTE: BlockIt is only valid here in the EraseBlock case
@@ -1580,6 +1560,16 @@ void Decoder::DecodeInstructionsAtEntry(FEXCore::Core::InternalThreadState* Thre
 
     CurrentBlockTargets.clear();
     EntryBlock = false;
+
+    if (Pausing && !BlocksToDecode.empty() && !FinalInstruction) {
+      Paused = true;
+      BlockResume = -1;
+      break;
+    }
+  }
+
+  if (Paused) {
+    return;
   }
 
   BlockInfo.TotalInstructionCount = TotalInstructions;
@@ -1587,6 +1577,60 @@ void Decoder::DecodeInstructionsAtEntry(FEXCore::Core::InternalThreadState* Thre
   for (auto& Block : BlockInfo.Blocks) {
     Block.IsEntryPoint = BlockInfo.EntryPoints.contains(Block.Entry);
   }
+}
+
+void Decoder::SetupDecodeInstructionsAtEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t PC, uint64_t MaxInst) {
+  FEXCORE_PROFILE_SCOPED("DecodeInstructions");
+  BlockInfo.TotalInstructionCount = 0;
+  BlockInfo.Blocks.clear();
+  VisitedBlocks.clear();
+  // Reset internal state management
+  Paused = false;
+  BlockResume = -1;
+  DecodedSize = 0;
+  if (MaxInst == 0) {
+    MaxInst = CTX->Config.MaxInstPerBlock;
+  }
+  this->MaxInst = MaxInst;
+  MaxCondBranchForward = 0;
+  MaxCondBranchBackwards = ~0ULL;
+  DecodedBuffer = PoolObject.ReownOrClaimBuffer();
+
+  // Decode operating mode from thread's CS segment.
+  const auto CSSegment = Core::CPUState::GetSegmentFromIndex(Thread->CurrentFrame->State, Thread->CurrentFrame->State.cs_idx);
+  BlockInfo.Is64BitMode = CSSegment->L == 1;
+  LOGMAN_THROW_A_FMT(BlockInfo.Is64BitMode == CTX->Config.Is64BitMode, "Expected operating mode to not change at runtime!");
+
+  EntryPoint = PC;
+  BlockInfo.EntryPoints = {PC};
+
+  TotalInstructions = 0;
+
+  SectionMinAddress = 0;
+  SectionMaxAddress = ~0ULL;
+  Relocations = nullptr;
+
+  if (CTX->GetCodeCache().IsGeneratingCache || EnableCodeCacheValidation) {
+    // If generating cache, attempt to load section bounds and relocations
+    if (auto SectionInfo = CTX->SyscallHandler->LookupExecutableFileSection(Thread, EntryPoint)) {
+      SectionMinAddress = SectionInfo->FileStartVA;
+      SectionMaxAddress = SectionInfo->EndVA;
+      Relocations = &SectionInfo->FileInfo.Relocations;
+    }
+  }
+
+  DecodedMinAddress = EntryPoint;
+  DecodedMaxAddress = EntryPoint;
+
+  // Entry is a jump target
+  BlocksToDecode = {PC};
+
+  CurrentCodePage = PC & FEXCore::Utils::FEX_PAGE_MASK;
+
+  BlockInfo.CodePages = {CurrentCodePage};
+
+  EntryBlock = true;
+  FinalInstruction = false;
 }
 
 } // namespace FEXCore::Frontend

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -54,7 +54,8 @@ public:
   Decoder(FEXCore::Core::InternalThreadState* Thread);
   bool CheckIfCacheable(FEXCore::Core::InternalThreadState&, const uint8_t* InstStream, uint64_t PC, uint64_t MaxInst);
 
-  void DecodeInstructionsAtEntry(FEXCore::Core::InternalThreadState* Thread, const uint8_t* InstStream, uint64_t PC, uint64_t MaxInst);
+  void SetupDecodeInstructionsAtEntry(FEXCore::Core::InternalThreadState* Thread, uint64_t PC, uint64_t MaxInst);
+  void DecodeLoop(const uint8_t* InstStream, uint64_t GuestPause = 0);
 
   const DecodedBlockInformation* GetDecodedBlockInfo() const {
     return &BlockInfo;
@@ -117,6 +118,16 @@ private:
   FEXCore::X86Tables::DecodedInst* DecodedBuffer {};
   Utils::PoolBufferWithTimedRetirement<FEXCore::X86Tables::DecodedInst*, 5000, 500> PoolObject;
   size_t DecodedSize {};
+  uint64_t TotalInstructions {};
+  uint64_t CurrentCodePage {};
+  bool EntryBlock {};
+  bool FinalInstruction {};
+  uint64_t MaxInst {};
+  bool Paused {};
+  int64_t BlockResume = -1;
+  uint64_t PCOffset {};
+  uint64_t BlockStartOffset {};
+  bool EraseBlock {};
 
   uint64_t ExecutableRangeBase {};
   uint64_t ExecutableRangeEnd {};

--- a/FEXCore/include/FEXCore/Core/DiskCache.h
+++ b/FEXCore/include/FEXCore/Core/DiskCache.h
@@ -67,7 +67,6 @@ namespace DiskCache {
     uint32_t EntryPointCount;
     uint32_t SmallRelocCount;
     uint32_t ThunkRelocCount;
-    uint32_t TouchedGuestPagesCount;
     XXH128_hash_t GuestHash;
   };
 
@@ -99,7 +98,7 @@ namespace DiskCache {
   struct CodeHitData {
     fextl::vector<uint8_t> Blob;
     std::span<uint8_t> HostCode;
-    std::span<uint64_t> GuestPages;
+    std::span<const uint64_t> GuestPages;
     std::span<uint64_t> EntryPointRIPs;
     std::span<const uint32_t> EntryPointHostOffsets;
     std::span<const BlobSmallRelocation> SmallRelocs;
@@ -170,8 +169,9 @@ namespace DiskCache {
   public:
     void Init(FEXCore::Context::ContextImpl* CTX);
 
-    std::optional<CodeHitData> Lookup(Core::InternalThreadState* Thread, const ExecutableFileSectionInfo& Region, uint64_t GuestRIP);
-    bool Store(Core::InternalThreadState* Thread, const ExecutableFileSectionInfo& Region, uint64_t GuestRIP,
+    std::optional<CodeHitData> Lookup(Core::InternalThreadState* Thread, std::optional<ExecutableFileSectionInfo> Region, uint64_t GuestRIP,
+                                      std::optional<uint64_t>& GuestCodeKey);
+    bool Store(Core::InternalThreadState* Thread, std::optional<ExecutableFileSectionInfo> Region, uint64_t GuestRIP, uint64_t GuestCodeKey,
                std::span<const uint8_t> GuestCode, const CPU::CPUBackend::CompiledCode& CompiledCode,
                std::span<const FEXCore::CPU::Relocation> Relocations, const Frontend::Decoder::DecodedBlockInformation* DecodedBlockInfo);
 
@@ -201,13 +201,16 @@ namespace DiskCache {
     FEX_CONFIG_OPT(EnableDiskCache, DISKCACHE);
     FEX_CONFIG_OPT(MapDiskCacheFiles, DISKCACHEFILEMAPPING);
     FEX_CONFIG_OPT(RelocationFilter, DISKCACHERELOCATIONFILTER);
+    FEX_CONFIG_OPT(AnonCaching, DISKCACHEANONCACHING);
     FEX_CONFIG_OPT(BasePathOverride, DISKCACHEPATH);
     FEX_CONFIG_OPT(RODBNames, DISKCACHERODBNAMES);
   };
 
+  static constexpr uint16_t AnonPrefixGuestBytes = 64;
+
   // TODO: This header is in global installed header path, but uses internal headers.
   // Migrate this once that is fixed.
-  static constexpr uint16_t FormatVersion = 10;
+  static constexpr uint16_t FormatVersion = 11;
   FEX_DEFAULT_VISIBILITY uint16_t GetFormatVersion();
 
 } // namespace DiskCache

--- a/unittests/InstructionCountCI/AFP/H0F3A.json
+++ b/unittests/InstructionCountCI/AFP/H0F3A.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "roundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/Secondary.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vsqrtss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AFP/VEX_map3.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map3.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vroundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AVX128/FMA4.json
+++ b/unittests/InstructionCountCI/AVX128/FMA4.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -13,7 +13,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vmovntps [rax], xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
@@ -8,7 +8,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vfmadd132ss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vmovntdqa xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -11,7 +11,7 @@
       "SVE256",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -8,7 +8,7 @@
       "AFP",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vblendvps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F3A.json
+++ b/unittests/InstructionCountCI/Crypto/H0F3A.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pclmulqdq xmm0, xmm1, 00000b": {

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -10,7 +10,7 @@
       "AFP",
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These 3DNow! instructions are optimal assuming that FEX doesn't SRA MMX registers",

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -13,7 +13,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/libnss.json
+++ b/unittests/InstructionCountCI/FEXOpt/libnss.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [],
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Chained add": {

--- a/unittests/InstructionCountCI/FlagM/H0F38.json
+++ b/unittests/InstructionCountCI/FlagM/H0F38.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "ptest xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "The Witcher 3": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Sonic Mania movie player": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "FMOD scalar loop": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "The Sims 1 hot block": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "add al, 1": {

--- a/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "ucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
@@ -11,7 +11,7 @@
       "AFP",
       "FCMA"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "ucomisd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -12,7 +12,7 @@
       "AFP",
       "CSSC"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -10,7 +10,7 @@
       "AFP",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map_group.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map_group.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "blsr eax, ebx": {

--- a/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -11,7 +11,7 @@
       "CSSC",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pshufb mm0, mm1": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -8,7 +8,7 @@
       "AFP",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "SSE4.2 string instructions are skipped here.",

--- a/unittests/InstructionCountCI/H0F3A_SVE128.json
+++ b/unittests/InstructionCountCI/H0F3A_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "dpps xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/MOPS/Primary.json
+++ b/unittests/InstructionCountCI/MOPS/Primary.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "rep movsb": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "MOPS"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "Instructions in this table that are marked optimal don't have their flag calculation part of this assumption",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -9,7 +9,7 @@
       "FlagM",
       "FlagM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pfrcpv mm0, mm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "rsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "rsqrtss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -8,7 +8,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Repeat.json
+++ b/unittests/InstructionCountCI/Repeat.json
@@ -6,7 +6,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {}
 }

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -33,7 +33,7 @@
       "      - 1b: ECX = MSB",
       "[7]   - Reserved"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pcmpestrm xmm0, xmm1, 0_0_00_00_00b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "MMX instructions are defined as optimal without SRA being used for these instructions.",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -7,7 +7,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "push fs": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "movupd xmm0, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "addsubpd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "psrlw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -12,7 +12,7 @@
       "FRINTTS",
       "CSSC"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "movss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "movsd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "addsubps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtpd2dq xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "movmskps eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -13,7 +13,7 @@
       "FLAGM2",
       "FRINTTS"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -8,7 +8,7 @@
       "FCMA"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -13,7 +13,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vcvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map2_svebitperm.json
+++ b/unittests/InstructionCountCI/VEX_map2_svebitperm.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pext eax, ebx, ecx": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -8,7 +8,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/X87ldst-SVE.json
+++ b/unittests/InstructionCountCI/X87ldst-SVE.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fstp tword [rax]": {

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/x87_32Bit.json
+++ b/unittests/InstructionCountCI/x87_32Bit.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Multiple fld/fst": {

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fadd dword [rax]": {

--- a/unittests/InstructionCountCI/x87_f64_32Bit.json
+++ b/unittests/InstructionCountCI/x87_f64_32Bit.json
@@ -15,7 +15,7 @@
       "SVE256",
       "CSSC"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fstp dword [ebx*4+0x204a20]": {


### PR DESCRIPTION
Decode a few bytes in advance to get a hashable prefix to use as key.

Generate touched pages dynamically since they can be misaligned now, as the cached-hit guest code isn't necessarily in the same spot as the store was.