### PR TITLE
x87StackOptimizationPass: Generalize ST(0) tag invalidation on pop

### DIFF
--- a/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
@@ -272,7 +272,7 @@ private:
   Ref LoadStackValueAtOffset_Slow(uint8_t Offset = 0);
   void StoreStackValueAtOffset_Slow(Ref Value, uint8_t Offset = 0, bool SetValid = true);
   // Update Top value in slow path for a pop
-  void UpdateTopForPop_Slow();
+  void UpdateTopForPop_Slow(bool InvalidateTag = true);
   void UpdateTopForPush_Slow();
   // Synchronizes the current simulated stack with the actual values.
   // Returns a new value for Top, that's synchronized between the simulated stack
@@ -573,11 +573,15 @@ void X87StackOptimization::HandleBinopStack(IROps Op64, bool VFOp64, IROps Op80,
   HandleBinopValue(Op64, VFOp64, Op80, DestStackOffset, StackOffset2 != DestStackOffset, StackOffset1, StackNode, Reverse);
 }
 
-inline void X87StackOptimization::UpdateTopForPop_Slow() {
+inline void X87StackOptimization::UpdateTopForPop_Slow(bool InvalidateTag) {
   const auto PopContainer = [](auto& container) {
     const auto begin = std::begin(container);
     std::rotate(begin, std::next(begin), std::end(container));
   };
+
+  if (InvalidateTag) {
+    SetX87ValidTag(0, false);
+  }
 
   // Pop the top of the x87 stack
   GetOffsetTopWithCache_Slow(1);
@@ -1050,9 +1054,6 @@ void X87StackOptimization::Run(IREmitter* Emit) {
         break;
       }
       case OP_POPSTACKDESTROY: {
-        if (SlowPath) {
-          SetX87ValidTag(0, false);
-        }
         StackPop();
         break;
       }
@@ -1178,7 +1179,7 @@ void X87StackOptimization::Run(IREmitter* Emit) {
 
       case OP_INCSTACKTOP: {
         if (SlowPath) {
-          UpdateTopForPop_Slow();
+          UpdateTopForPop_Slow(false);
         } else {
           StackData.rotate(false);
         }

--- a/FEXCore/include/FEXCore/Core/DiskCache.h
+++ b/FEXCore/include/FEXCore/Core/DiskCache.h
@@ -207,7 +207,7 @@ namespace DiskCache {
 
   // TODO: This header is in global installed header path, but uses internal headers.
   // Migrate this once that is fixed.
-  static constexpr uint16_t FormatVersion = 10;
+  static constexpr uint16_t FormatVersion = 11;
   FEX_DEFAULT_VISIBILITY uint16_t GetFormatVersion();
 
 } // namespace DiskCache

--- a/unittests/ASM/FEX_bugs/fincstp_tag_word.asm
+++ b/unittests/ASM/FEX_bugs/fincstp_tag_word.asm
@@ -1,0 +1,24 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0xff"
+  }
+}
+%endif
+
+mov word [rel .fxsave_data + 0], 0x037f ; FCW
+mov byte [rel .fxsave_data + 4], 0xff   ; FTW
+
+; FSW = 0
+fxrstor [rel .fxsave_data]
+
+fincstp
+
+fxsave [rel .fxsave_data]
+movzx rax, byte [rel .fxsave_data + 4] ; FTW
+
+hlt
+
+align 4096
+.fxsave_data:
+times 64 dq 0

--- a/unittests/ASM/FEX_bugs/fpatan_PopStackTag.asm
+++ b/unittests/ASM/FEX_bugs/fpatan_PopStackTag.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x80"
+  }
+}
+%endif
+
+; FEX had a bug in the slow path of x87 stack-optimization pass:
+; popping the FPU stack never invalidated ST(0)
+;
+; Note this test only actually exercises the bug under the jit_1 run
+; since otherwise the fast path is taken
+
+fninit
+
+fld1
+fldl2e
+
+fpatan
+
+fxsave [rel .data]
+
+; FTW
+; Bit 6 (popped value) must be 0 now
+; Bit 7 (result) must be 1
+movzx eax, byte [rel .data + 4]
+
+hlt
+
+align 16
+.data:
+times 64 dq 0

--- a/unittests/ASM/FEX_bugs/fyl2x_PopStackTag.asm
+++ b/unittests/ASM/FEX_bugs/fyl2x_PopStackTag.asm
@@ -1,0 +1,33 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x80"
+  }
+}
+%endif
+
+; FEX had a bug in the slow path of x87 stack-optimization pass:
+; popping the FPU stack never invalidated ST(0)
+;
+; Note this test only actually exercises the bug under the jit_1 run
+; since otherwise the fast path is taken
+
+fninit
+
+fld1
+fld1
+
+fyl2x
+
+fxsave [rel .data]
+
+; FTW
+; Bit 6 (popped value) must be 0 now
+; Bit 7 (result) must be 1
+movzx eax, byte [rel .data + 4]
+
+hlt
+
+align 16
+.data:
+times 64 dq 0

--- a/unittests/InstructionCountCI/AFP/H0F3A.json
+++ b/unittests/InstructionCountCI/AFP/H0F3A.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "roundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/Secondary.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vsqrtss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AFP/VEX_map3.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map3.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vroundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AVX128/FMA4.json
+++ b/unittests/InstructionCountCI/AVX128/FMA4.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -13,7 +13,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vmovntps [rax], xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
@@ -8,7 +8,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vfmadd132ss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vmovntdqa xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -11,7 +11,7 @@
       "SVE256",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -8,7 +8,7 @@
       "AFP",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vblendvps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F3A.json
+++ b/unittests/InstructionCountCI/Crypto/H0F3A.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pclmulqdq xmm0, xmm1, 00000b": {

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -10,7 +10,7 @@
       "AFP",
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These 3DNow! instructions are optimal assuming that FEX doesn't SRA MMX registers",

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -13,7 +13,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/libnss.json
+++ b/unittests/InstructionCountCI/FEXOpt/libnss.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [],
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Chained add": {

--- a/unittests/InstructionCountCI/FlagM/H0F38.json
+++ b/unittests/InstructionCountCI/FlagM/H0F38.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "ptest xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "The Witcher 3": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Sonic Mania movie player": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "FMOD scalar loop": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "The Sims 1 hot block": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "add al, 1": {

--- a/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "ucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
@@ -11,7 +11,7 @@
       "AFP",
       "FCMA"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "ucomisd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -12,7 +12,7 @@
       "AFP",
       "CSSC"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -10,7 +10,7 @@
       "AFP",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map_group.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map_group.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "blsr eax, ebx": {

--- a/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -11,7 +11,7 @@
       "CSSC",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -2741,7 +2741,7 @@
       ]
     },
     "fyl2x": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 22,
       "Comment": [
         "0xd9 11b 0xf1 /6"
       ],
@@ -2751,8 +2751,8 @@
         "and w21, w21, #0x7",
         "add x22, x28, x21, lsl #4",
         "ldr q2, [x22, #1056]",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add x23, x28, x20, lsl #4",
+        "ldr q3, [x23, #1056]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v3.16b",
         "mov v1.16b, v2.16b",
@@ -2762,7 +2762,12 @@
         "ldr x30, [sp], #16",
         "mov v2.16b, v0.16b",
         "strb w21, [x28, #1051]",
-        "str q2, [x22, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fptan": {
@@ -2797,7 +2802,7 @@
       ]
     },
     "fpatan": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 22,
       "Comment": [
         "0xd9 11b 0xf3 /6"
       ],
@@ -2805,10 +2810,10 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x1 (1)",
-        "and w20, w20, #0x7",
-        "add x21, x28, x20, lsl #4",
-        "ldr q3, [x21, #1056]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x22, x28, x21, lsl #4",
+        "ldr q3, [x22, #1056]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v3.16b",
         "mov v1.16b, v2.16b",
@@ -2817,8 +2822,13 @@
         "blr x0",
         "ldr x30, [sp], #16",
         "mov v2.16b, v0.16b",
-        "strb w20, [x28, #1051]",
-        "str q2, [x21, #1056]"
+        "strb w21, [x28, #1051]",
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxtract": {
@@ -2934,7 +2944,7 @@
       ]
     },
     "fyl2xp1": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 22,
       "Comment": [
         "0xd9 11b 0xf9 /7"
       ],
@@ -2944,8 +2954,8 @@
         "and w21, w21, #0x7",
         "add x22, x28, x21, lsl #4",
         "ldr q2, [x22, #1056]",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add x23, x28, x20, lsl #4",
+        "ldr q3, [x23, #1056]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v3.16b",
         "mov v1.16b, v2.16b",
@@ -2955,7 +2965,12 @@
         "ldr x30, [sp], #16",
         "mov v2.16b, v0.16b",
         "strb w21, [x28, #1051]",
-        "str q2, [x22, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fsqrt": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -2161,7 +2161,7 @@
       ]
     },
     "fyl2x": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xd9 11b 0xf1 /6"
       ],
@@ -2171,8 +2171,8 @@
         "and w21, w21, #0x7",
         "add x22, x28, x21, lsl #4",
         "ldr d2, [x22, #1056]",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add x23, x28, x20, lsl #4",
+        "ldr d3, [x23, #1056]",
         "fmov d0, d3",
         "fmov d1, d2",
         "ldr x0, [x28, #3080]",
@@ -2181,7 +2181,12 @@
         "ldr x30, [sp], #16",
         "fmov d2, d0",
         "strb w21, [x28, #1051]",
-        "str d2, [x22, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fptan": {
@@ -2216,7 +2221,7 @@
       ]
     },
     "fpatan": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xd9 11b 0xf3 /6"
       ],
@@ -2224,10 +2229,10 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x1 (1)",
-        "and w20, w20, #0x7",
-        "add x21, x28, x20, lsl #4",
-        "ldr d3, [x21, #1056]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x22, x28, x21, lsl #4",
+        "ldr d3, [x22, #1056]",
         "fmov d0, d3",
         "fmov d1, d2",
         "ldr x0, [x28, #3072]",
@@ -2235,8 +2240,13 @@
         "blr x0",
         "ldr x30, [sp], #16",
         "fmov d2, d0",
-        "strb w20, [x28, #1051]",
-        "str d2, [x21, #1056]"
+        "strb w21, [x28, #1051]",
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxtract": {
@@ -2360,7 +2370,7 @@
       ]
     },
     "fyl2xp1": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xd9 11b 0xf9 /7"
       ],
@@ -2370,8 +2380,8 @@
         "and w21, w21, #0x7",
         "add x22, x28, x21, lsl #4",
         "ldr d2, [x22, #1056]",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add x23, x28, x20, lsl #4",
+        "ldr d3, [x23, #1056]",
         "fmov d0, d3",
         "fmov d1, d2",
         "ldr x0, [x28, #3088]",
@@ -2380,7 +2390,12 @@
         "ldr x30, [sp], #16",
         "fmov d2, d0",
         "strb w21, [x28, #1051]",
-        "str d2, [x22, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fsqrt": {

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pshufb mm0, mm1": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -8,7 +8,7 @@
       "AFP",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "SSE4.2 string instructions are skipped here.",

--- a/unittests/InstructionCountCI/H0F3A_SVE128.json
+++ b/unittests/InstructionCountCI/H0F3A_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "dpps xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/MOPS/Primary.json
+++ b/unittests/InstructionCountCI/MOPS/Primary.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "rep movsb": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "MOPS"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "Instructions in this table that are marked optimal don't have their flag calculation part of this assumption",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -9,7 +9,7 @@
       "FlagM",
       "FlagM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pfrcpv mm0, mm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "rsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "rsqrtss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -8,7 +8,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Repeat.json
+++ b/unittests/InstructionCountCI/Repeat.json
@@ -6,7 +6,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {}
 }

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -33,7 +33,7 @@
       "      - 1b: ECX = MSB",
       "[7]   - Reserved"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pcmpestrm xmm0, xmm1, 0_0_00_00_00b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Comment": [
     "MMX instructions are defined as optimal without SRA being used for these instructions.",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -7,7 +7,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "push fs": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "movupd xmm0, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "addsubpd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "psrlw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -12,7 +12,7 @@
       "FRINTTS",
       "CSSC"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "movss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "movsd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "addsubps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvtpd2dq xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "cvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "movmskps eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -13,7 +13,7 @@
       "FLAGM2",
       "FRINTTS"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -8,7 +8,7 @@
       "FCMA"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -13,7 +13,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vcvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map2_svebitperm.json
+++ b/unittests/InstructionCountCI/VEX_map2_svebitperm.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "pext eax, ebx, ecx": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -8,7 +8,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/X87ldst-SVE.json
+++ b/unittests/InstructionCountCI/X87ldst-SVE.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "RPRES"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fstp tword [rax]": {

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -2740,7 +2740,7 @@
       ]
     },
     "fyl2x": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 22,
       "Comment": [
         "0xd9 11b 0xf1 /6"
       ],
@@ -2750,8 +2750,8 @@
         "and w21, w21, #0x7",
         "add x22, x28, x21, lsl #4",
         "ldr q2, [x22, #1056]",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add x23, x28, x20, lsl #4",
+        "ldr q3, [x23, #1056]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v3.16b",
         "mov v1.16b, v2.16b",
@@ -2761,7 +2761,12 @@
         "ldr x30, [sp], #16",
         "mov v2.16b, v0.16b",
         "strb w21, [x28, #1051]",
-        "str q2, [x22, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fptan": {
@@ -2796,7 +2801,7 @@
       ]
     },
     "fpatan": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 22,
       "Comment": [
         "0xd9 11b 0xf3 /6"
       ],
@@ -2804,10 +2809,10 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x1 (1)",
-        "and w20, w20, #0x7",
-        "add x21, x28, x20, lsl #4",
-        "ldr q3, [x21, #1056]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x22, x28, x21, lsl #4",
+        "ldr q3, [x22, #1056]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v3.16b",
         "mov v1.16b, v2.16b",
@@ -2816,8 +2821,13 @@
         "blr x0",
         "ldr x30, [sp], #16",
         "mov v2.16b, v0.16b",
-        "strb w20, [x28, #1051]",
-        "str q2, [x21, #1056]"
+        "strb w21, [x28, #1051]",
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxtract": {
@@ -2933,7 +2943,7 @@
       ]
     },
     "fyl2xp1": {
-      "ExpectedInstructionCount": 17,
+      "ExpectedInstructionCount": 22,
       "Comment": [
         "0xd9 11b 0xf9 /7"
       ],
@@ -2943,8 +2953,8 @@
         "and w21, w21, #0x7",
         "add x22, x28, x21, lsl #4",
         "ldr q2, [x22, #1056]",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add x23, x28, x20, lsl #4",
+        "ldr q3, [x23, #1056]",
         "str x30, [sp, #-16]!",
         "mov v0.16b, v3.16b",
         "mov v1.16b, v2.16b",
@@ -2954,7 +2964,12 @@
         "ldr x30, [sp], #16",
         "mov v2.16b, v0.16b",
         "strb w21, [x28, #1051]",
-        "str q2, [x22, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fsqrt": {

--- a/unittests/InstructionCountCI/x87_32Bit.json
+++ b/unittests/InstructionCountCI/x87_32Bit.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "Multiple fld/fst": {

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -2179,7 +2179,7 @@
       ]
     },
     "fyl2x": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xd9 11b 0xf1 /6"
       ],
@@ -2189,8 +2189,8 @@
         "and w21, w21, #0x7",
         "add x22, x28, x21, lsl #4",
         "ldr d2, [x22, #1056]",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add x23, x28, x20, lsl #4",
+        "ldr d3, [x23, #1056]",
         "fmov d0, d3",
         "fmov d1, d2",
         "ldr x0, [x28, #3080]",
@@ -2199,7 +2199,12 @@
         "ldr x30, [sp], #16",
         "fmov d2, d0",
         "strb w21, [x28, #1051]",
-        "str d2, [x22, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fptan": {
@@ -2234,7 +2239,7 @@
       ]
     },
     "fpatan": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xd9 11b 0xf3 /6"
       ],
@@ -2242,10 +2247,10 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x1 (1)",
-        "and w20, w20, #0x7",
-        "add x21, x28, x20, lsl #4",
-        "ldr d3, [x21, #1056]",
+        "add w21, w20, #0x1 (1)",
+        "and w21, w21, #0x7",
+        "add x22, x28, x21, lsl #4",
+        "ldr d3, [x22, #1056]",
         "fmov d0, d3",
         "fmov d1, d2",
         "ldr x0, [x28, #3072]",
@@ -2253,8 +2258,13 @@
         "blr x0",
         "ldr x30, [sp], #16",
         "fmov d2, d0",
-        "strb w20, [x28, #1051]",
-        "str d2, [x21, #1056]"
+        "strb w21, [x28, #1051]",
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxtract": {
@@ -2378,7 +2388,7 @@
       ]
     },
     "fyl2xp1": {
-      "ExpectedInstructionCount": 16,
+      "ExpectedInstructionCount": 21,
       "Comment": [
         "0xd9 11b 0xf9 /7"
       ],
@@ -2388,8 +2398,8 @@
         "and w21, w21, #0x7",
         "add x22, x28, x21, lsl #4",
         "ldr d2, [x22, #1056]",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add x23, x28, x20, lsl #4",
+        "ldr d3, [x23, #1056]",
         "fmov d0, d3",
         "fmov d1, d2",
         "ldr x0, [x28, #3088]",
@@ -2398,7 +2408,12 @@
         "ldr x30, [sp], #16",
         "fmov d2, d0",
         "strb w21, [x28, #1051]",
-        "str d2, [x22, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x1",
+        "lsl w20, w22, w20",
+        "bic w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fsqrt": {

--- a/unittests/InstructionCountCI/x87_f64_32Bit.json
+++ b/unittests/InstructionCountCI/x87_f64_32Bit.json
@@ -15,7 +15,7 @@
       "SVE256",
       "CSSC"
     ],
-    "BinaryCacheVersion": 10
+    "BinaryCacheVersion": 11
   },
   "Instructions": {
     "fstp dword [ebx*4+0x204a20]": {


### PR DESCRIPTION
`FINCSTP` should only increment the x87 TOP pointer and not touch the tag word.
FEX's slow-path wired `FINCSTP` to the same helper used by a real stack pop which invalidates the tag of the register TOP.

Fixes it by making tag invalidation an explicit opt-in on that helper and adds an ASM unittest.