### PR TITLE
FEXCore/Frontend: Ensure instruction sizes account for sha256 in thunk op

### DIFF
--- a/FEXCore/Source/Interface/Core/DiskCache.cpp
+++ b/FEXCore/Source/Interface/Core/DiskCache.cpp
@@ -596,8 +596,6 @@ namespace DiskCache {
     uint32_t ThunkRelocCount = 0;
     for (const auto& Reloc : Relocations) {
       if (Reloc.Header.Type == CPU::RelocationTypes::RELOC_NAMED_THUNK_MOVE) {
-        // todo we miss the thunk bytes in the hash extents so need to bail for those for now
-        return false;
         ThunkRelocCount++;
       } else {
         SmallRelocCount++;

--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -638,10 +638,7 @@ Decoder::DecodedBlockStatus Decoder::NormalOp(const FEXCore::X86Tables::X86InstI
     CurrentDest->Data.GPR.GPR = MapVEXToReg(Options.vvvv, HasXMMDst);
   }
 
-  if (Bytes != 0) {
-    LOGMAN_THROW_A_FMT(Bytes <= 8, "Number of bytes should be <= 8 for literal src");
-
-
+  if (Bytes <= 8 && Bytes > 0) {
     auto [Literal, IsRelocation] = ReadData(Bytes);
     if (IsRelocation) {
       DecodeInst->Src[CurrentSrc].Type = DecodedOperand::OpType::LiteralRelocation;
@@ -666,6 +663,11 @@ Decoder::DecodedBlockStatus Decoder::NormalOp(const FEXCore::X86Tables::X86InstI
       DecodeInst->Src[CurrentSrc].Data.Literal.Value = Literal;
     }
 
+    Bytes = 0;
+  } else {
+    // All real x86 instructions have byte sizes that are 8-bytes or less.
+    // Thunk instruction has an additional 32-byte SHA256 payload that needs to be accounted for.
+    InstructionSize += Bytes;
     Bytes = 0;
   }
 

--- a/FEXCore/Source/Interface/Core/Frontend.h
+++ b/FEXCore/Source/Interface/Core/Frontend.h
@@ -151,6 +151,7 @@ private:
 
   static constexpr size_t MAX_INST_SIZE = 15;
   uint8_t InstructionSize {};
+  // Contains the full decoded instruction, unless it is a `Thunk` instruction.
   std::array<uint8_t, MAX_INST_SIZE> Instruction;
   uint8_t LastEscapePrefix {};
   FEXCore::X86Tables::DecodedInst* DecodeInst;

--- a/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
+++ b/FEXCore/Source/Interface/Core/X86Tables/SecondaryTables.cpp
@@ -303,7 +303,7 @@ constexpr std::array<X86InstInfo, MAX_SECOND_TABLE_SIZE> SecondBaseOps = []() co
     {0x3E, 1, X86InstInfo{"CALLBACKRET",  TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                                          0}},
 
     // This was originally used by VIA to jump to its alternative instruction set. Used for OP_THUNK
-    {0x3F, 1, X86InstInfo{"ALTINST",      TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            0}},
+    {0x3F, 1, X86InstInfo{"ALTINST",      TYPE_INST, FLAGS_BLOCK_END | FLAGS_NO_OVERLAY | FLAGS_SETS_RIP,                                                            sizeof(IR::SHA256Sum)}},
 #endif
   };
 


### PR DESCRIPTION
Fixes the hashing mechanism from DiskCache.cpp, allowing it to properly handle thunk relocations.

Fixes #5896