### PR TITLE
JIT: Assert out when debug features are enabled when caching is also enabled

### DIFF
--- a/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/BranchOps.cpp
@@ -355,6 +355,8 @@ DEF_OP(Thunk) {
 }
 
 DEF_OP(ValidateCode) {
+  // This isn't relocation aware as it's a debug feature.
+  LOGMAN_THROW_A_FMT(SupportCodeRelocations == false, "Can't ValidateCode when requiring code relocations/caching!");
   auto Op = IROp->C<IR::IROp_ValidateCode>();
   auto OldCode = Op->CodeOriginal.data();
   auto Base = GetReg(Op->Header.Args[0]).X();

--- a/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
+++ b/FEXCore/Source/Interface/Core/JIT/MiscOps.cpp
@@ -211,6 +211,8 @@ DEF_OP(Print) {
 }
 
 DEF_OP(PrintMsg) {
+  // This isn't relocation aware as it's a debug feature.
+  LOGMAN_THROW_A_FMT(SupportCodeRelocations == false, "Can't PrintMsg when requiring code relocations/caching!");
   auto Op = IROp->C<IR::IROp_PrintMsg>();
 
   PushDynamicRegs(TMP1);


### PR DESCRIPTION
These operations are mutually exclusive and can't be used with each other. Assert on them to ensure it doesn't occure.