### PR TITLE
Mark both operands valid in the tag word for FXCH

### DIFF
--- a/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
+++ b/FEXCore/Source/Interface/IR/Passes/x87StackOptimizationPass.cpp
@@ -1074,8 +1074,8 @@ void X87StackOptimization::Run(IREmitter* Emit) {
           // Slow path: do actual memory operations
           Ref ValueTop = LoadStackValue();
           Ref ValueOffset = LoadStackValue(Offset);
-          StoreStackValue(ValueOffset);
-          StoreStackValue(ValueTop, Offset);
+          StoreStackValue(ValueOffset, 0, true);
+          StoreStackValue(ValueTop, Offset, true);
         } else {
           // Fast path: swap complete StackMemberInfo preserving Source metadata
           StackData.setTop(StackMemberOffset, 0);

--- a/FEXCore/include/FEXCore/Core/DiskCache.h
+++ b/FEXCore/include/FEXCore/Core/DiskCache.h
@@ -210,7 +210,7 @@ namespace DiskCache {
 
   // TODO: This header is in global installed header path, but uses internal headers.
   // Migrate this once that is fixed.
-  static constexpr uint16_t FormatVersion = 12;
+  static constexpr uint16_t FormatVersion = 13;
   FEX_DEFAULT_VISIBILITY uint16_t GetFormatVersion();
 
 } // namespace DiskCache

--- a/unittests/ASM/FEX_bugs/fxch_tag_word.asm
+++ b/unittests/ASM/FEX_bugs/fxch_tag_word.asm
@@ -1,0 +1,40 @@
+%ifdef CONFIG
+{
+  "RegData": {
+    "RAX": "0x3",
+    "RBX": "0x81"
+  }
+}
+%endif
+
+; FXCH: empty and empty operands -> mark both valid
+fxrstor [rel .fxsave_data]
+fxch st0, st1
+
+fxsave [rel .save]
+movzx eax, byte [rel .save + 4]
+
+; FXCH: valid and empty operands -> mark both valid
+finit
+fldz
+fxch st0, st1
+
+fxsave [rel .save2]
+movzx ebx, byte [rel .save2 + 4]
+
+hlt
+
+align 16
+.fxsave_data:
+dw 0x037f       ; FCW
+dw 0x0000       ; FSW
+dw 0x0000       ; FTW
+times 506 db 0
+
+align 16
+.save:
+times 64 dq 0
+
+align 16
+.save2:
+times 64 dq 0

--- a/unittests/InstructionCountCI/AFP/H0F3A.json
+++ b/unittests/InstructionCountCI/AFP/H0F3A.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "roundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REP.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/SVE256/Secondary_REPNE.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary.json
+++ b/unittests/InstructionCountCI/AFP/Secondary.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "cvtpi2ps xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REP.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "cvtsi2ss xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/AFP/Secondary_REPNE.json
@@ -8,7 +8,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "cvtsi2sd xmm0, eax": {

--- a/unittests/InstructionCountCI/AFP/VEX_map1.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map1.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "RPRES"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vsqrtss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AFP/VEX_map3.json
+++ b/unittests/InstructionCountCI/AFP/VEX_map3.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vroundss xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/AVX128/FMA4.json
+++ b/unittests/InstructionCountCI/AVX128/FMA4.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vfmaddsubps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1.json
@@ -13,7 +13,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vmovntps [rax], xmm0": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map1_flagm.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_AFP.json
@@ -8,7 +8,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vfmadd132ss xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_SVE128.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vmovntdqa xmm0, [rax]": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map2_flagm.json
@@ -11,7 +11,7 @@
       "SVE256",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3.json
@@ -7,7 +7,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map3_SVE128.json
@@ -8,7 +8,7 @@
       "AFP",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vblendvps xmm0, xmm1, xmm2, xmm3": {

--- a/unittests/InstructionCountCI/AVX128/VEX_map_group.json
+++ b/unittests/InstructionCountCI/AVX128/VEX_map_group.json
@@ -9,7 +9,7 @@
       "SVE256",
       "SVE128"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/Atomics.json
+++ b/unittests/InstructionCountCI/Atomics.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/Crypto/H0F38.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
+++ b/unittests/InstructionCountCI/Crypto/H0F38_SVE128.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "sha1nexte xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Crypto/H0F3A.json
+++ b/unittests/InstructionCountCI/Crypto/H0F3A.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "pclmulqdq xmm0, xmm1, 00000b": {

--- a/unittests/InstructionCountCI/DDD.json
+++ b/unittests/InstructionCountCI/DDD.json
@@ -10,7 +10,7 @@
       "AFP",
       "RPRES"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "These 3DNow! instructions are optimal assuming that FEX doesn't SRA MMX registers",

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/AddressingLimitations_32Bit.json
@@ -8,7 +8,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "Instructions that explicitly push against the limits of ARM's loadstore instructions"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst.json
@@ -13,7 +13,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_32bit.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_AFP.json
@@ -9,7 +9,7 @@
       "SVE256",
       "RPRES"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
+++ b/unittests/InstructionCountCI/FEXOpt/MultiInst_TSO_32bit.json
@@ -14,7 +14,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "These are instruction combinations that could be more optimal if FEX optimized for them"

--- a/unittests/InstructionCountCI/FEXOpt/libnss.json
+++ b/unittests/InstructionCountCI/FEXOpt/libnss.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [],
   "Instructions": {

--- a/unittests/InstructionCountCI/FlagM/Atomics.json
+++ b/unittests/InstructionCountCI/FlagM/Atomics.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "lock add byte [rax], cl": {

--- a/unittests/InstructionCountCI/FlagM/FlagOpts.json
+++ b/unittests/InstructionCountCI/FlagM/FlagOpts.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Chained add": {

--- a/unittests/InstructionCountCI/FlagM/H0F38.json
+++ b/unittests/InstructionCountCI/FlagM/H0F38.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "ptest xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "The Witcher 3": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Sonic Mania movie player": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_AFP.json
@@ -10,7 +10,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "FMOD scalar loop": {

--- a/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/HotBlocks_TSO_32Bit.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "The Sims 1 hot block": {

--- a/unittests/InstructionCountCI/FlagM/Primary.json
+++ b/unittests/InstructionCountCI/FlagM/Primary.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/PrimaryGroup.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "add al, 1": {

--- a/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/FlagM/Primary_32Bit.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/FlagM/Secondary.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary.json
@@ -11,7 +11,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "ucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/FlagM/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_OpSize.json
@@ -11,7 +11,7 @@
       "AFP",
       "FCMA"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "ucomisd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP.json
@@ -12,7 +12,7 @@
       "AFP",
       "CSSC"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
+++ b/unittests/InstructionCountCI/FlagM/Secondary_REP_CSSC.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "popcnt ax, bx": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map1.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map1.json
@@ -12,7 +12,7 @@
       "RPRES",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vucomiss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map2.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map2.json
@@ -10,7 +10,7 @@
       "AFP",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vtestps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/FlagM/VEX_map_group.json
+++ b/unittests/InstructionCountCI/FlagM/VEX_map_group.json
@@ -9,7 +9,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "blsr eax, ebx": {

--- a/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Crysis2Max-fmodel.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87-HalfLife.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Oblivion.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87-Psychonauts.json
@@ -10,7 +10,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87.json
+++ b/unittests/InstructionCountCI/FlagM/x87.json
@@ -11,7 +11,7 @@
       "CSSC",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -2364,7 +2364,7 @@
       ]
     },
     "fxch st0, st1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xc9 /1"
       ],
@@ -2372,17 +2372,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x1 (1)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x303",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xca /1"
       ],
@@ -2390,17 +2397,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x2 (2)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x2 (2)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x505",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st3": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcb /1"
       ],
@@ -2408,17 +2422,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x3 (3)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x3 (3)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x909",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st4": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcc /1"
       ],
@@ -2426,17 +2447,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x4 (4)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x4 (4)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x1111",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st5": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcd /1"
       ],
@@ -2444,17 +2472,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x5 (5)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x5 (5)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x2121",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st6": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xce /1"
       ],
@@ -2462,17 +2497,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x6 (6)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x6 (6)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x4141",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st7": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcf /1"
       ],
@@ -2480,13 +2522,20 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x7 (7)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x7 (7)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x8181",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fnop": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Crysis2Max-fmodel.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-HalfLife.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Oblivion.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64-Psychonauts.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Block1": {

--- a/unittests/InstructionCountCI/FlagM/x87_f64.json
+++ b/unittests/InstructionCountCI/FlagM/x87_f64.json
@@ -13,7 +13,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -1774,7 +1774,7 @@
       ]
     },
     "fxch st0, st1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xc9 /1"
       ],
@@ -1782,17 +1782,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x1 (1)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x303",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xca /1"
       ],
@@ -1800,17 +1807,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x2 (2)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x2 (2)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x505",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st3": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcb /1"
       ],
@@ -1818,17 +1832,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x3 (3)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x3 (3)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x909",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st4": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcc /1"
       ],
@@ -1836,17 +1857,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x4 (4)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x4 (4)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x1111",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st5": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcd /1"
       ],
@@ -1854,17 +1882,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x5 (5)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x5 (5)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x2121",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st6": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xce /1"
       ],
@@ -1872,17 +1907,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x6 (6)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x6 (6)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x4141",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st7": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcf /1"
       ],
@@ -1890,13 +1932,20 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x7 (7)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x7 (7)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x8181",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fnop": {

--- a/unittests/InstructionCountCI/H0F38.json
+++ b/unittests/InstructionCountCI/H0F38.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "pshufb mm0, mm1": {

--- a/unittests/InstructionCountCI/H0F3A.json
+++ b/unittests/InstructionCountCI/H0F3A.json
@@ -8,7 +8,7 @@
       "AFP",
       "CRYPTO"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "SSE4.2 string instructions are skipped here.",

--- a/unittests/InstructionCountCI/H0F3A_SVE128.json
+++ b/unittests/InstructionCountCI/H0F3A_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "dpps xmm0, xmm1, 00000000b": {

--- a/unittests/InstructionCountCI/MOPS/Primary.json
+++ b/unittests/InstructionCountCI/MOPS/Primary.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "rep movsb": {

--- a/unittests/InstructionCountCI/Primary.json
+++ b/unittests/InstructionCountCI/Primary.json
@@ -10,7 +10,7 @@
       "FLAGM2",
       "MOPS"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "add bl, cl": {

--- a/unittests/InstructionCountCI/PrimaryGroup.json
+++ b/unittests/InstructionCountCI/PrimaryGroup.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "Instructions in this table that are marked optimal don't have their flag calculation part of this assumption",

--- a/unittests/InstructionCountCI/Primary_32Bit.json
+++ b/unittests/InstructionCountCI/Primary_32Bit.json
@@ -9,7 +9,7 @@
       "FlagM",
       "FlagM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "push es": {

--- a/unittests/InstructionCountCI/RPRES/DDD.json
+++ b/unittests/InstructionCountCI/RPRES/DDD.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "pfrcpv mm0, mm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "rsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/Secondary_REP_AFP.json
@@ -9,7 +9,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "rsqrtss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
+++ b/unittests/InstructionCountCI/RPRES/VEX_map1_AFP.json
@@ -8,7 +8,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vrsqrtps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Repeat.json
+++ b/unittests/InstructionCountCI/Repeat.json
@@ -6,7 +6,7 @@
       "SVE128",
       "SVE256"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {}
 }

--- a/unittests/InstructionCountCI/SSE42_Strings.json
+++ b/unittests/InstructionCountCI/SSE42_Strings.json
@@ -33,7 +33,7 @@
       "      - 1b: ECX = MSB",
       "[7]   - Reserved"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "pcmpestrm xmm0, xmm1, 0_0_00_00_00b": {

--- a/unittests/InstructionCountCI/Secondary.json
+++ b/unittests/InstructionCountCI/Secondary.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Comment": [
     "MMX instructions are defined as optimal without SRA being used for these instructions.",

--- a/unittests/InstructionCountCI/SecondaryGroup.json
+++ b/unittests/InstructionCountCI/SecondaryGroup.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "sgdt [rax]": {

--- a/unittests/InstructionCountCI/SecondaryModRM.json
+++ b/unittests/InstructionCountCI/SecondaryModRM.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "xgetbv": {

--- a/unittests/InstructionCountCI/Secondary_32Bit.json
+++ b/unittests/InstructionCountCI/Secondary_32Bit.json
@@ -7,7 +7,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "push fs": {

--- a/unittests/InstructionCountCI/Secondary_OpSize.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "movupd xmm0, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "addsubpd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "psrlw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
+++ b/unittests/InstructionCountCI/Secondary_OpSize_SVE256.json
@@ -7,7 +7,7 @@
       "AFP"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "pmulhuw xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP.json
+++ b/unittests/InstructionCountCI/Secondary_REP.json
@@ -12,7 +12,7 @@
       "FRINTTS",
       "CSSC"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "movss xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "movsd xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_FCMA.json
@@ -9,7 +9,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "addsubps xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_REPNE_SVE128.json
@@ -10,7 +10,7 @@
       "FCMA",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "cvtpd2dq xmm0, xmm1": {

--- a/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
+++ b/unittests/InstructionCountCI/Secondary_REP_FRINTTS.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "cvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/Secondary_SVE128.json
+++ b/unittests/InstructionCountCI/Secondary_SVE128.json
@@ -8,7 +8,7 @@
       "SVE256",
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "movmskps eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1.json
+++ b/unittests/InstructionCountCI/VEX_map1.json
@@ -13,7 +13,7 @@
       "FLAGM2",
       "FRINTTS"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vmovups xmm0, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map1_FCMA.json
+++ b/unittests/InstructionCountCI/VEX_map1_FCMA.json
@@ -8,7 +8,7 @@
       "FCMA"
     ],
     "DisabledHostFeatures": [],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vaddsubpd xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
+++ b/unittests/InstructionCountCI/VEX_map1_FRINTTS.json
@@ -13,7 +13,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vcvttss2si eax, xmm0": {

--- a/unittests/InstructionCountCI/VEX_map2.json
+++ b/unittests/InstructionCountCI/VEX_map2.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "SVEBITPERM"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vpshufb xmm0, xmm1, xmm2": {

--- a/unittests/InstructionCountCI/VEX_map2_svebitperm.json
+++ b/unittests/InstructionCountCI/VEX_map2_svebitperm.json
@@ -11,7 +11,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "pext eax, ebx, ecx": {

--- a/unittests/InstructionCountCI/VEX_map3.json
+++ b/unittests/InstructionCountCI/VEX_map3.json
@@ -8,7 +8,7 @@
     "DisabledHostFeatures": [
       "AFP"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vpermq ymm0, ymm1, 1": {

--- a/unittests/InstructionCountCI/VEX_map_group.json
+++ b/unittests/InstructionCountCI/VEX_map_group.json
@@ -9,7 +9,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "vpsrlw xmm0, xmm1, 0": {

--- a/unittests/InstructionCountCI/X87ldst-SVE.json
+++ b/unittests/InstructionCountCI/X87ldst-SVE.json
@@ -11,7 +11,7 @@
       "FLAGM2",
       "RPRES"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "fstp tword [rax]": {

--- a/unittests/InstructionCountCI/x87.json
+++ b/unittests/InstructionCountCI/x87.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -2363,7 +2363,7 @@
       ]
     },
     "fxch st0, st1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xc9 /1"
       ],
@@ -2371,17 +2371,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x1 (1)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x303",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xca /1"
       ],
@@ -2389,17 +2396,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x2 (2)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x2 (2)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x505",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st3": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcb /1"
       ],
@@ -2407,17 +2421,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x3 (3)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x3 (3)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x909",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st4": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcc /1"
       ],
@@ -2425,17 +2446,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x4 (4)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x4 (4)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x1111",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st5": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcd /1"
       ],
@@ -2443,17 +2471,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x5 (5)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x5 (5)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x2121",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st6": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xce /1"
       ],
@@ -2461,17 +2496,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x6 (6)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x6 (6)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x4141",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st7": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcf /1"
       ],
@@ -2479,13 +2521,20 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr q2, [x21, #1056]",
-        "add w20, w20, #0x7 (7)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr q3, [x20, #1056]",
+        "add w22, w20, #0x7 (7)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr q3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str q3, [x21, #1056]",
-        "str q2, [x20, #1056]"
+        "str q2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x8181",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fnop": {

--- a/unittests/InstructionCountCI/x87_32Bit.json
+++ b/unittests/InstructionCountCI/x87_32Bit.json
@@ -10,7 +10,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "Multiple fld/fst": {

--- a/unittests/InstructionCountCI/x87_f64.json
+++ b/unittests/InstructionCountCI/x87_f64.json
@@ -12,7 +12,7 @@
       "FLAGM",
       "FLAGM2"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "fadd dword [rax]": {
@@ -1791,7 +1791,7 @@
       ]
     },
     "fxch st0, st1": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xc9 /1"
       ],
@@ -1799,17 +1799,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x1 (1)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x1 (1)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x303",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st2": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xca /1"
       ],
@@ -1817,17 +1824,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x2 (2)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x2 (2)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x505",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st3": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcb /1"
       ],
@@ -1835,17 +1849,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x3 (3)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x3 (3)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x909",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st4": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcc /1"
       ],
@@ -1853,17 +1874,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x4 (4)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x4 (4)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x1111",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st5": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcd /1"
       ],
@@ -1871,17 +1899,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x5 (5)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x5 (5)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x2121",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st6": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xce /1"
       ],
@@ -1889,17 +1924,24 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x6 (6)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x6 (6)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x4141",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fxch st0, st7": {
-      "ExpectedInstructionCount": 10,
+      "ExpectedInstructionCount": 17,
       "Comment": [
         "0xd9 11b 0xcf /1"
       ],
@@ -1907,13 +1949,20 @@
         "ldrb w20, [x28, #1051]",
         "add x21, x28, x20, lsl #4",
         "ldr d2, [x21, #1056]",
-        "add w20, w20, #0x7 (7)",
-        "and w20, w20, #0x7",
-        "add x20, x28, x20, lsl #4",
-        "ldr d3, [x20, #1056]",
+        "add w22, w20, #0x7 (7)",
+        "and w22, w22, #0x7",
+        "add x22, x28, x22, lsl #4",
+        "ldr d3, [x22, #1056]",
         "strb wzr, [x28, #1049]",
         "str d3, [x21, #1056]",
-        "str d2, [x20, #1056]"
+        "str d2, [x22, #1056]",
+        "ldrb w21, [x28, #1202]",
+        "mov w22, #0x8",
+        "sub w20, w22, w20",
+        "mov w22, #0x8181",
+        "lsr w20, w22, w20",
+        "orr w20, w21, w20",
+        "strb w20, [x28, #1202]"
       ]
     },
     "fnop": {

--- a/unittests/InstructionCountCI/x87_f64_32Bit.json
+++ b/unittests/InstructionCountCI/x87_f64_32Bit.json
@@ -15,7 +15,7 @@
       "SVE256",
       "CSSC"
     ],
-    "BinaryCacheVersion": 12
+    "BinaryCacheVersion": 13
   },
   "Instructions": {
     "fstp dword [ebx*4+0x204a20]": {


### PR DESCRIPTION
FXCH's slow path swapped register values but never updated the FPU tag word, so a register that started empty incorrectly stayed tagged empty after the swap.