### PR TITLE
Windows: Fix syscall regression

### DIFF
--- a/Source/Windows/ARM64EC/Module.S
+++ b/Source/Windows/ARM64EC/Module.S
@@ -108,11 +108,15 @@ ExitFunctionSuspendPoint:
   Name:; \
     adrp x16, WineSyscallDispatcher; \
     ldr x16, [x16, HASH:lo12:WineSyscallDispatcher]; \
+    cbz x16, 1f; \
     mov x9, x30; \
     adrp x8, WineIdName; \
     ldr x8, [x8, HASH:lo12:WineIdName]; \
     blr x16; \
     ret; \
+  1:; \
+    svc HASH WindowsId; \
+    ret
 
   // Allows for continuing from a full native context, as the NTDLL NtContinue export takes in an x64 context with EC and
   // the conversion to that loses the ARM64EC ABI-disallowed registers that FEX uses.


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/FEX-Emu/FEX/pull/5889, causing crashes early in process start when using FEX on Windows.

I suspect that removing these lines in that PR was an accident, but I am not sure exactly what the intention was.