### PR TITLE
Common/Config: Fixes Cache directory when `STEAM_COMPAT_SHADER_PATH` on Win32

### DIFF
--- a/Source/Common/Config.cpp
+++ b/Source/Common/Config.cpp
@@ -714,7 +714,6 @@ fextl::string GetCacheDirectory() {
     return CacheOverride;
   }
 
-#ifndef _WIN32
 #ifdef FEX_STEAM_SUPPORT
   const char* SteamDataPath = getenv("STEAM_COMPAT_SHADER_PATH");
   if (SteamDataPath) {
@@ -722,6 +721,7 @@ fextl::string GetCacheDirectory() {
   }
 #endif
 
+#ifndef _WIN32
   auto HomeDir = GetHomeDirectory();
   const char* CacheXDG = getenv("XDG_CACHE_HOME");
   return (CacheXDG ? fextl::string {CacheXDG} : (fextl::string {HomeDir} + "/.cache")) + "/fex-emu/";


### PR DESCRIPTION
Moves cache data from %APPDATA% to wherever `STEAM_COMPAT_SHADER_PATH` points. Turns out this was easier than expected.

Basically moving disk cache from:
- `compatdata/<AppID>/pfx/drive_c/users/steamuser/AppData/Local/fex-emu/DiskCache/`

to:

- `shadercache/<AppID>/fex-emu/DiskCache/`

Fixes #5913


Of course if `STEAM_COMPAT_SHADER_PATH` isn't set, then it ends up in AppData again.