### PR TITLE
Frontend: Stop asserting on too long of an instruction

### DIFF
--- a/FEXCore/Source/Interface/Core/Frontend.cpp
+++ b/FEXCore/Source/Interface/Core/Frontend.cpp
@@ -114,9 +114,8 @@ bool Decoder::CheckRangeExecutable(uint64_t Address, uint64_t Size) {
 }
 
 uint8_t Decoder::ReadByte() {
-  LOGMAN_THROW_A_FMT(InstructionSize < MAX_INST_SIZE, "Max instruction size exceeded!");
   std::optional<uint8_t> Byte = PeekByte(0);
-  if (!Byte) {
+  if (!Byte || InstructionSize == MAX_INST_SIZE) {
     HitNonExecutableRange = true;
     // Pretend we read 0, the main decode loop will see HitNonExecutableRange and rollback the instruction.
     return 0;


### PR DESCRIPTION
Return the same as the NonExecutableRange for now. I have a unittest that is mostly correct with this change, just need to fixup some of the supplementary data.

For now push this change to get a bad assert removed that can happen during code discovery. I'll fix up the remaining details afterwards.