### PR TITLE
HostFeatures: Reenable 3DNow! now that it is fixed

### DIFF
--- a/Source/Common/HostFeatures.cpp
+++ b/Source/Common/HostFeatures.cpp
@@ -537,6 +537,7 @@ void FetchHostFeatures(FEX::CPUFeatures& Features, FEXCore::HostFeatures& HostFe
   }
 #endif
 
+  HostFeatures.Supports3DNow = true;
   HostFeatures.SupportsAVX = true;
   HostFeatures.SupportsAES256 = HostFeatures.SupportsAVX && HostFeatures.SupportsAES;
   HostFeatures.SupportsPreserveAllABI = FEX_HAS_PRESERVE_ALL_ATTR;
@@ -552,15 +553,6 @@ void FetchHostFeatures(FEX::CPUFeatures& Features, FEXCore::HostFeatures& HostFe
   if (!HostFeatures.SupportsAtomics) {
     WARN_ONCE_FMT("Host CPU doesn't support atomics. Expect bad performance");
   }
-
-#ifdef _WIN32
-  // Disable 3DNow! by default to better match the set of extensions exposed on modern CPUs.
-  // This works around a bug that manifests in some games using native d3dx9 DLLs (most easily reproduced in WoW64 builds).
-  // For example, Fallout: New Vegas and some old EA games will run with a blackscreen.
-  HostFeatures.Supports3DNow = false;
-#else
-  HostFeatures.Supports3DNow = true;
-#endif
 
 #ifdef ARCHITECTURE_arm64
   // Test if this CPU supports float exception trapping by attempting to enable


### PR DESCRIPTION
With PR #5863, the bug that was breaking rendering in d3dx9 and Fallout New Vegas is now resolved. This means we can now enable the feature by default again as all known bugs are resolved.

With 3DNow! and full x87 softfloat enabled in FO:NV inside of the starting house. The game is running at around 40-43FPS, doing ~22.6 to 34 million soft float operations per second.

With 3DNow! disabled the game is running 30-31FPS, doing ~24-50 million softfloat operations per second.

In both cases if x87 reduced precision is enabled then the game is running at around 108-113FPS with zero softfloat instances getting counted. Can't see the performance difference at that speed.