### PR TITLE
DiskCache: allow relocations within the same ELF image

### DIFF
--- a/FEXCore/Source/Interface/Core/DiskCache.cpp
+++ b/FEXCore/Source/Interface/Core/DiskCache.cpp
@@ -825,6 +825,11 @@ namespace DiskCache {
         if (Target >= Region->BeginVA && Target < Region->EndVA) {
           continue;
         }
+        // let it through if it's inside the same ELF image? (like bss)
+        if (Region->FileInfo.MappedSize && Target >= Region->FileStartVA && Target < Region->FileStartVA + Region->FileInfo.MappedSize) {
+          continue;
+        }
+
         auto TargetSection = CTX->SyscallHandler->LookupExecutableFileSection(Thread, Target);
         if (!TargetSection || TargetSection->FileInfo.FileId != Region->FileInfo.FileId) {
           // we don't know where it's pointing, so we don't know how to encode the offset, so we can't cache atm

--- a/FEXCore/include/FEXCore/Core/CodeCache.h
+++ b/FEXCore/include/FEXCore/Core/CodeCache.h
@@ -51,6 +51,7 @@ struct ExecutableFileInfo {
   uint64_t FileId = 0;
   fextl::string Filename;
   fextl::robin_map<uint32_t, GuestRelocationType> Relocations;
+  uint64_t MappedSize = 0;
 };
 
 // Information associated with a specific section of an executable file

--- a/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
+++ b/Source/Tools/LinuxEmulation/LinuxSyscalls/SyscallsSMCTracking.cpp
@@ -636,6 +636,22 @@ SyscallHandler::TrackMmap(FEXCore::Core::InternalThreadState* Thread, uint64_t a
             }
           }
 
+          uint64_t MinAddress = 0;
+          uint64_t MaxAddress = 0;
+          for (auto& ProgramHeader : Resource->ProgramHeaders) {
+            if (ProgramHeader.p_type == PT_LOAD) {
+              if (!MinAddress && !MaxAddress) {
+                MinAddress = ProgramHeader.p_vaddr;
+                MaxAddress = ProgramHeader.p_vaddr + ProgramHeader.p_memsz;
+              }
+              MinAddress = std::min(MinAddress, ProgramHeader.p_vaddr);
+              MaxAddress = std::max(MaxAddress, ProgramHeader.p_vaddr + ProgramHeader.p_memsz);
+            }
+          }
+          if (MaxAddress > MinAddress) {
+            Resource->MappedFile->MappedSize = MaxAddress - MinAddress;
+          }
+
           LOGMAN_THROW_A_FMT(Resource->ProgramHeaders.empty() || offset == 0, "Expected file offset 0 for the first mapping of an ELF "
                                                                               "file");
         }


### PR DESCRIPTION
We would check the FileID of mapped sections, but BSS is an anonymous mapping. Grab the ELF image extents when we parse the file, and add an additional check to the relocation filter to bail out additional relocs if we know that size.